### PR TITLE
docs(tasks): sync backlog/current after merged 52-56 work

### DIFF
--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -3,31 +3,6 @@
 Use this file to capture tasks discovered during development. Each entry should include: ID, title, rationale, dependencies.
 
 ## Pending
-- ID: TASK-052
-  Title: Git governance baseline (protected main + short-lived branch workflow + PR gates)
-  Status: In Progress (2026-02-15)
-  Rationale: Introduce clear collaboration guardrails (branch protection, required checks, PR review rules, branch naming conventions) before more contributors/agents start shipping changes.
-  Dependencies: TASK-035
-- ID: TASK-053
-  Title: Boundary refactor phase 1 - extract backend application service layer
-  Status: Pending
-  Rationale: Move domain logic out of route handlers/server actions into explicit services so business rules are centralized, testable, and auth-ready.
-  Dependencies: TASK-035
-- ID: TASK-054
-  Title: Boundary refactor phase 2 - decompose oversized client panels into modules/hooks
-  Status: Pending
-  Rationale: Reduce regression risk and implementation complexity by splitting large orchestration components (Kanban/context/calendar) into focused, composable units.
-  Dependencies: TASK-053
-- ID: TASK-055
-  Title: Boundary refactor phase 3 - unify mutation boundaries across server actions and API routes
-  Status: Pending
-  Rationale: Enforce one mutation path per use case (shared service contracts) to remove duplicate validation and simplify upcoming authorization checks.
-  Dependencies: TASK-053, TASK-054
-- ID: TASK-056
-  Title: Data platform ADR - PostgreSQL baseline and Supabase fit assessment
-  Status: Pending
-  Rationale: Decide the long-term relational platform with explicit tradeoffs (managed Postgres/Supabase features, lock-in, scaling, operations) before migration.
-  Dependencies: TASK-035
 - ID: TASK-057
   Title: Database migration phase 1 - SQLite to PostgreSQL parity migration
   Status: Pending
@@ -145,6 +120,31 @@ Use this file to capture tasks discovered during development. Each entry should 
   Dependencies: TASK-051
 
 ## Completed
+- ID: TASK-056
+  Title: Data platform ADR - PostgreSQL baseline and Supabase fit assessment
+  Status: Done (2026-02-15)
+  Rationale: Selected PostgreSQL as the persistence baseline and Supabase-managed Postgres as the default hosting target, with explicit guardrails to keep Prisma schema/migrations provider-agnostic and avoid premature platform coupling.
+  Dependencies: TASK-035
+- ID: TASK-055
+  Title: Boundary refactor phase 3 - unify mutation boundaries across server actions and API routes
+  Status: Done (2026-02-15)
+  Rationale: Standardized project/task/context-card create/update/delete mutations on API routes and removed legacy project server-action mutation file; client mutation UI now targets one boundary contract per use case.
+  Dependencies: TASK-053, TASK-054
+- ID: TASK-054
+  Title: Boundary refactor phase 2 - decompose oversized client panels into modules/hooks
+  Status: Done (2026-02-15)
+  Rationale: Extracted panel-specific utility modules (kanban/context/calendar), split calendar date-time picker into a dedicated component, and introduced a shared project-section expansion hook used across Kanban, Context, and Calendar panels.
+  Dependencies: TASK-053
+- ID: TASK-053
+  Title: Boundary refactor phase 1 - extract backend application service layer
+  Status: Done (2026-02-15)
+  Rationale: Extracted shared backend service modules for task/context-card/attachment/calendar flows and converted server actions plus API routes into thin adapters with preserved response contracts.
+  Dependencies: TASK-035
+- ID: TASK-052
+  Title: Git governance baseline (protected main + short-lived branch workflow + PR gates)
+  Status: Done (2026-02-15)
+  Rationale: Governance workflow is defined and documented in-repo (`agent.md` + workflow checks); GitHub protection enforcement is queued for repo-public milestone.
+  Dependencies: TASK-035
 - ID: TASK-035
   Title: Architecture audit baseline (system boundaries, risks, and technical debt)
   Status: Done (2026-02-15)

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,52 +1,25 @@
-# Current Task: Git Governance Baseline
+# Current Task: Data Platform ADR
 
 ## Task ID
-TASK-052
+TASK-056
 
 ## Status
-🟡 **In Progress**
+Done (2026-02-15)
 
-## Priority
-🔴 **High** - Required before broader collaboration and parallel agent work
+## Summary
+Data-platform decision baseline is now defined for migration and auth roadmap safety:
+- Assessed three options: self-managed PostgreSQL, generic managed PostgreSQL, and Supabase-managed PostgreSQL.
+- Chosen direction: PostgreSQL baseline with Supabase-managed Postgres as default hosting target.
+- Added guardrails to keep Prisma schema/migrations provider-agnostic and avoid coupling migration scope with auth/storage concept changes.
 
-## Description
-Define and enforce repository governance with protected `main`, short-lived branch workflow, and pull-request quality gates.
+## Validation
+- Documentation-only task (ADR + backlog/decision tracking updates).
+- No runtime code path changed.
 
-## Acceptance Criteria / Definition of Done
-
-### Policy Definition (Repo Rules)
-- [ ] `main` branch is protected in GitHub
-- [ ] Direct pushes to `main` are blocked
-- [ ] Pull requests are mandatory for merges
-- [ ] At least one approving review is required
-- [ ] Dismiss stale approvals on new commits is enabled
-- [ ] Required status checks are configured (at minimum lint/test/build once CI exists)
-- [ ] Only squash merge is enabled (or merge policy explicitly documented)
-- [ ] Auto-delete head branches after merge is enabled
-
-### Branching Strategy
-- [ ] Trunk-style cadence documented (short-lived branches, fast merge)
-- [ ] Branch naming conventions documented: `feature/*`, `fix/*`, `refactor/*`, `docs/*`, `chore/*`, `test/*`
-- [ ] Commit and PR hygiene expectations documented in `agent.md`
-
-### Verification
-- [ ] Governance settings validated on GitHub by repository owner
-- [ ] Team execution guide shared (how to open PRs and merge safely)
-
-## Implementation Notes
-- Local update done in `agent.md` to formalize branching and PR governance expectations.
-- GitHub settings must be applied by repository owner/maintainer in repository settings.
-
-## Blockers / Dependencies
-
-### Current Blockers
-- GitHub repository admin actions required from user.
-
-### Dependencies
-- TASK-035
+## Next Recommended Task
+TASK-057 (Database migration phase 1 - SQLite to PostgreSQL parity migration)
 
 ---
 
-**Last Updated**: 2026-02-15
-**Assigned To**: User + Agent
-**Started At**: 2026-02-15
+Last Updated: 2026-02-15
+Assigned To: User + Agent


### PR DESCRIPTION
## Summary
- mark TASK-052 to TASK-056 as completed in 	asks/backlog.md
- remove outdated pending entries for TASK-052..TASK-056
- update 	asks/current.md to reflect TASK-056 done and TASK-057 as next

## Why
After merging the refactor/docs PRs, task tracking files on main were still on the pre-merge state.

## Validation
- verified 	asks/backlog.md now lists only TASK-057 onward in Pending
- verified Completed section includes TASK-052..TASK-056
- verified 	asks/current.md is aligned to post-TASK-056 state