### PR TITLE
TASK-070: add direct-to-R2 upload task to backlog

### DIFF
--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -4,6 +4,11 @@ Use this file to capture tasks discovered during development. Each entry should 
 
 ## Pending
 ### Execution Queue (Now / Next)
+- ID: TASK-070
+  Title: Attachment uploads phase 2 - direct-to-R2 upload pipeline (serverless-safe)
+  Status: Pending
+  Rationale: Eliminate Vercel request-body limits (`413 FUNCTION_PAYLOAD_TOO_LARGE`) by moving file transfer off app API routes to a direct upload flow (pre-signed upload URL + finalize metadata endpoint), while preserving attachment validation, authorization, and auditability.
+  Dependencies: TASK-065, TASK-069
 - ID: TASK-062
   Title: UI decomposition phase - split oversized dashboard components into focused modules
   Status: Pending


### PR DESCRIPTION
## Summary
- add TASK-070 to the execution queue as the next item
- capture the current 413 FUNCTION_PAYLOAD_TOO_LARGE driver on Vercel
- define direct-to-R2 upload (presigned upload + finalize metadata) as the target approach

## Why
Large file uploads currently fail through serverless API routes. This task records the next implementation step explicitly so we can deliver a durable fix.
