### PR TITLE
[codex] TASK-050 high-priority security remediation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,11 @@ FROM node:20-bullseye AS base
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN npm ci \
+  --fetch-retries=5 \
+  --fetch-retry-factor=2 \
+  --fetch-retry-mintimeout=20000 \
+  --fetch-retry-maxtimeout=120000
 
 COPY . .
 ARG DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/nexusdash?schema=public

--- a/adr/decisions.md
+++ b/adr/decisions.md
@@ -16,6 +16,13 @@ Keep UI-only or task-only notes in `journal.md`.
 
 ## Active Decisions
 
+## 2026-04-10 - Close TASK-050 security gaps with DB-backed abuse controls, hashed sessions, and request-time agent credential liveness
+- Status: Accepted
+- Context: `TASK-049` ranked perimeter abuse control, plaintext human sessions at rest, and agent bearer revocation lag as the top remaining security findings, and the repo already operates as a stateless Next.js/PostgreSQL system.
+- Decision: Added PostgreSQL-backed auth abuse buckets for public auth/token-entry paths, moved human sessions to hashed token storage with explicit legacy-session invalidation during migration, and made agent bearer-token use contingent on current credential liveness during request usage logging.
+- Consequences: Public auth/token exchange now has an authoritative cross-instance abuse-control baseline, legacy human sessions are signed out once during rollout, and credential rotate/revoke now takes effect immediately for already-issued bearer tokens.
+- Links: `adr/task-050-security-remediation-adr.md`, `tasks/current.md`, `prisma/migrations/20260410110000_task050_security_remediation/migration.sql`
+
 ## 2026-03-31 - Ship agent access v1 as project-scoped API credentials exchanged into short-lived bearer tokens
 - Status: Accepted
 - Context: TASK-059 needs safe non-human access without reusing browser sessions, while preserving the current human session model, RLS visibility boundary, and project-scoped authorization guarantees.

--- a/adr/task-050-security-remediation-adr.md
+++ b/adr/task-050-security-remediation-adr.md
@@ -1,0 +1,148 @@
+# TASK-050 Security Remediation ADR
+
+Date: 2026-04-10
+Status: Accepted
+
+## 1) Decision Summary
+
+TASK-050 closes the top three findings from `TASK-049` by adding a
+database-backed abuse-control baseline for public auth and token exchange,
+hashing human session tokens at rest, and treating agent bearer tokens as
+valid only while the underlying credential remains live at request time.
+
+## 2) Context
+
+- `TASK-049` ranked three concrete gaps above the rest of the security backlog:
+  public auth/token abuse controls, plaintext human sessions at rest, and
+  agent bearer revocation lag.
+- The app runs in a stateless Next.js/Vercel-style model backed by PostgreSQL.
+  Any mitigation that depends on per-instance memory would be inconsistent
+  across requests and deployments.
+- Existing auth controls already hash password-reset tokens, verification
+  tokens, and agent API-key secrets, so plaintext session storage had become
+  the weakest token-handling path.
+- Agent access already relied on short-lived signed access tokens, but
+  `TASK-049` correctly identified that rotate/revoke was only authoritative for
+  future exchanges, not for already-issued bearer tokens.
+
+## 3) Options Considered
+
+### Option A - In-memory abuse throttling plus legacy session compatibility
+- Pros:
+  - Fast to add.
+  - No database schema changes for rate-limit buckets.
+  - Could preserve existing user sessions transparently.
+- Cons:
+  - Not authoritative across stateless app instances or preview/production
+    scale-out.
+  - Legacy plaintext session compatibility would preserve the at-rest theft
+    risk until old rows naturally expired.
+  - Harder to reason about and test consistently.
+- Verdict:
+  - Rejected.
+
+### Option B - External cache/Redis abuse controls plus explicit session migration
+- Pros:
+  - Strong distributed rate limiting.
+  - Good operational fit for high-volume traffic.
+  - Could preserve future headroom if abuse-control complexity grows.
+- Cons:
+  - Introduces new infrastructure the repo does not currently require.
+  - Expands TASK-050 from a remediation sprint into a platform change.
+  - Adds setup and deployment coupling without first proving the baseline need.
+- Verdict:
+  - Deferred.
+
+### Option C - PostgreSQL-backed abuse buckets, hashed sessions, request-time agent liveness checks
+- Pros:
+  - Fits the existing stateless + PostgreSQL architecture.
+  - Makes abuse controls authoritative across all app instances.
+  - Eliminates plaintext session storage immediately.
+  - Makes rotate/revoke authoritative for already-issued bearer tokens without
+    abandoning short token TTLs.
+- Cons:
+  - Adds database writes on abuse paths and agent requests.
+  - Requires a one-time invalidation of legacy plaintext-backed human sessions.
+  - Increases auth-path coupling to the database.
+- Verdict:
+  - Selected.
+
+## 4) Decision
+
+We selected Option C.
+
+The implementation introduces `AuthRateLimitBucket` as the shared abuse-control
+store keyed by scope plus hashed identifiers. Public auth and token-exchange
+flows consume or check quota through that table rather than in-memory state.
+
+Human session tokens are now hashed with SHA-256 before persistence and looked
+up by hash on every authenticated request. Instead of carrying dual-format
+session compatibility indefinitely, the migration explicitly deletes legacy
+session rows so the weaker plaintext storage model does not survive the rollout.
+
+Agent bearer tokens remain short-lived, but they are no longer accepted solely
+by signature plus expiry. Request-time usage now requires the current
+credential row to still be active, unexpired, unrevoked, and not rotated after
+the bearer token was issued.
+
+## 5) Consequences
+
+- Technical impact:
+  - Auth and token-exchange entry points now have shared abuse-control state in
+    PostgreSQL.
+  - Session persistence changes from raw token lookup to hashed-token lookup.
+  - Agent request logging becomes the credential-liveness enforcement point.
+- Operational impact:
+  - Deploying the migration signs out existing human sessions once.
+  - Failed sign-in and failed agent token exchange attempts gain structured
+    telemetry and audit visibility without storing raw secrets.
+  - Preview/production behavior stays aligned because the controls are DB-based.
+- Risks and mitigations:
+  - Risk: abuse-control writes could become noisy under sustained attack.
+    Mitigation: use coarse fixed windows, hashed keys, bounded metadata, and
+    keep the design simple enough to replace with Redis later if needed.
+  - Risk: deleting legacy sessions causes a one-time user logout.
+    Mitigation: document the behavior explicitly and prefer a clean cut over
+    indefinite plaintext-session compatibility.
+  - Risk: request-time credential checks add a DB dependency to every agent
+    request.
+    Mitigation: keep short TTLs, reuse the existing request-usage checkpoint,
+    and fail closed if the credential state cannot be confirmed.
+
+## 6) Rollout / Migration Plan
+
+1. Add the auth abuse bucket schema and the new audit action.
+2. Rename session storage to `sessionTokenHash` and delete legacy session rows
+   during the migration.
+3. Route sign-in, sign-up, password reset, verification resend, and agent token
+   exchange through the shared abuse-control service.
+4. Enforce credential liveness during authenticated agent request usage.
+5. Validate the change set with lint, tests, coverage, build, CI, and preview
+   deployment.
+
+## 7) Validation Requirements
+
+- Tests:
+  - unit coverage for hashed session storage semantics
+  - denial-path tests for auth abuse controls
+  - denial-path tests for throttled agent token exchange
+  - request-usage tests for revoked/rotated credential rejection
+- Monitoring/health checks:
+  - review failed sign-in and token-exchange telemetry shape
+  - confirm preview deploy and CI remain green
+- Manual verification:
+  - ensure human sign-in/sign-up still work normally
+  - ensure password reset and verification resend keep enumeration-safe UX
+  - ensure rotated/revoked agent credentials fail immediately for reused bearer
+    tokens
+
+## 8) Links
+
+- `tasks/current.md`
+- `tasks/task-049-security-assessment-and-threat-model.md`
+- `adr/decisions.md`
+- `journal.md`
+- `lib/services/auth-abuse-control-service.ts`
+- `lib/services/session-service.ts`
+- `lib/services/project-agent-access-service.ts`
+- `prisma/migrations/20260410110000_task050_security_remediation/migration.sql`

--- a/agent.md
+++ b/agent.md
@@ -18,6 +18,9 @@ make the task brief explicit before deep implementation:
 - capture deploy/review workflow assumptions when preview or production behavior
   is part of acceptance
 - link the relevant runbook when preview validation is expected
+- ensure `tasks/current.md` has explicit `Acceptance Criteria` and
+  `Definition Of Done` sections; if either is missing or too vague, add or
+  tighten them before implementation starts
 
 If `tasks/current.md` is complete or invalid, pick the next `Pending` item in `tasks/backlog.md`, then update `tasks/current.md` before implementation.
 
@@ -88,3 +91,9 @@ A task is complete only when:
 1. Acceptance criteria in `tasks/current.md` are satisfied.
 2. Required validation is green.
 3. Tracking docs (`tasks/current.md`, `journal.md`, `adr/decisions.md` when applicable) are updated and consistent.
+
+Additional rule:
+- Every active task brief must explicitly state both `Acceptance Criteria` and
+  `Definition Of Done`.
+- If a task is missing either section, the agent must add them before treating
+  the task as ready for implementation.

--- a/app/api/auth/agent/token/route.ts
+++ b/app/api/auth/agent/token/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { readClientIpAddress, resolveRequestId } from "@/lib/auth/api-guard";
+import {
+  readClientIpAddressFromHeaders,
+  resolveRequestIdFromHeaders,
+  readUserAgentFromHeaders,
+} from "@/lib/http/request-metadata";
 import { logServerWarning } from "@/lib/observability/logger";
 import { exchangeAgentApiKeyForAccessToken } from "@/lib/services/project-agent-access-service";
 
@@ -43,9 +47,9 @@ export async function POST(request: NextRequest) {
 
   const result = await exchangeAgentApiKeyForAccessToken({
     apiKey,
-    requestId: resolveRequestId(request),
-    ipAddress: readClientIpAddress(request),
-    userAgent: request.headers.get("user-agent"),
+    requestId: resolveRequestIdFromHeaders(request.headers),
+    ipAddress: readClientIpAddressFromHeaders(request.headers),
+    userAgent: readUserAgentFromHeaders(request.headers),
   });
 
   if (!result.ok) {

--- a/app/api/auth/callback/[provider]/route.ts
+++ b/app/api/auth/callback/[provider]/route.ts
@@ -3,11 +3,11 @@ import { NextRequest, NextResponse } from "next/server";
 import {
   getPrimarySessionCookieOptions,
 } from "@/lib/auth/session-cookie";
+import { PRIMARY_SESSION_COOKIE_NAME } from "@/lib/auth/session-constants";
 import { isProductionEnvironment } from "@/lib/env.server";
 import { resolveRequestOriginFromHeaders } from "@/lib/http/request-origin";
 import { logServerError } from "@/lib/observability/logger";
 import { authenticateWithSocialProvider } from "@/lib/services/social-auth-service";
-import { PRIMARY_SESSION_COOKIE_NAME } from "@/lib/services/session-service";
 import {
   isSocialAuthProvider,
   normalizeHomeAuthForm,

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { SESSION_COOKIE_NAMES } from "@/lib/auth/session-constants";
 import { isProductionEnvironment } from "@/lib/env.server";
 import { normalizeReturnToPath } from "@/lib/navigation/return-to";
 import { logServerError } from "@/lib/observability/logger";
 import {
-  SESSION_COOKIE_NAMES,
   deleteSessionByToken,
   readSessionTokensFromCookieReader,
 } from "@/lib/services/session-service";

--- a/app/forgot-password/actions.ts
+++ b/app/forgot-password/actions.ts
@@ -3,11 +3,26 @@
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
+import {
+  AuthRateLimitScope,
+  buildAuthRateLimitKey,
+  buildCompositeAuthRateLimitKey,
+  consumeAuthAbuseQuota,
+  type AuthAbuseSignal,
+} from "@/lib/services/auth-abuse-control-service";
+import { normalizeEmail } from "@/lib/services/account-security-policy";
+import {
+  readClientIpAddressFromHeaders,
+  readUserAgentFromHeaders,
+  resolveRequestIdFromHeaders,
+} from "@/lib/http/request-metadata";
 import { resolveRequestOriginFromHeaders } from "@/lib/http/request-origin";
 import { logServerError, logServerWarning } from "@/lib/observability/logger";
 import { requestPasswordResetForEmail } from "@/lib/services/password-reset-service";
 
 const FORGOT_PASSWORD_PATH = "/forgot-password";
+const PASSWORD_RESET_WINDOW_MS = 15 * 60 * 1000;
+const PASSWORD_RESET_BLOCK_MS = 15 * 60 * 1000;
 
 function readText(formData: FormData, key: string): string {
   const value = formData.get(key);
@@ -22,11 +37,77 @@ function redirectWithStatus(status: string): never {
   redirect(`${FORGOT_PASSWORD_PATH}?status=${status}`);
 }
 
+function buildPasswordResetSignals(input: {
+  email: string;
+  ipAddress: string | null;
+}): AuthAbuseSignal[] {
+  const signals: AuthAbuseSignal[] = [];
+  const ipKey = buildAuthRateLimitKey("password-reset:ip", input.ipAddress);
+  const emailKey = buildAuthRateLimitKey("password-reset:email", input.email);
+  const ipEmailKey = buildCompositeAuthRateLimitKey("password-reset:ip-email", [
+    input.ipAddress,
+    input.email,
+  ]);
+
+  if (ipKey) {
+    signals.push({
+      key: ipKey,
+      maxAttempts: 6,
+      windowMs: PASSWORD_RESET_WINDOW_MS,
+      blockMs: PASSWORD_RESET_BLOCK_MS,
+    });
+  }
+
+  if (emailKey) {
+    signals.push({
+      key: emailKey,
+      maxAttempts: 5,
+      windowMs: PASSWORD_RESET_WINDOW_MS,
+      blockMs: PASSWORD_RESET_BLOCK_MS,
+    });
+  }
+
+  if (ipEmailKey) {
+    signals.push({
+      key: ipEmailKey,
+      maxAttempts: 4,
+      windowMs: PASSWORD_RESET_WINDOW_MS,
+      blockMs: PASSWORD_RESET_BLOCK_MS,
+    });
+  }
+
+  return signals;
+}
+
 export async function requestPasswordResetAction(formData: FormData): Promise<void> {
   const email = readText(formData, "email");
+  const requestHeaders = await headers();
+  const requestId = resolveRequestIdFromHeaders(requestHeaders);
+  const ipAddress = readClientIpAddressFromHeaders(requestHeaders);
+  const userAgent = readUserAgentFromHeaders(requestHeaders);
+  const abuseControl = await consumeAuthAbuseQuota({
+    scope: AuthRateLimitScope.password_reset,
+    signals: buildPasswordResetSignals({
+      email: normalizeEmail(email),
+      ipAddress,
+    }),
+  });
+  if (!abuseControl.ok) {
+    logServerWarning(
+      "requestPasswordResetAction.throttled",
+      "Password reset request throttled.",
+      {
+        requestId,
+        ipAddress,
+        userAgent,
+        retryAfterSeconds: abuseControl.retryAfterSeconds,
+      }
+    );
+    redirectWithStatus("request-submitted");
+  }
 
   try {
-    const requestOrigin = resolveRequestOriginFromHeaders(await headers());
+    const requestOrigin = resolveRequestOriginFromHeaders(requestHeaders);
     const result = await requestPasswordResetForEmail({
       emailRaw: email,
       requestOrigin,

--- a/app/home-auth-actions.ts
+++ b/app/home-auth-actions.ts
@@ -6,6 +6,11 @@ import { redirect } from "next/navigation";
 import { getSessionUserIdFromServer } from "@/lib/auth/session-user";
 import { setPrimarySessionCookie } from "@/lib/auth/session-cookie";
 import { isLiveProductionDeployment } from "@/lib/env.server";
+import {
+  readClientIpAddressFromHeaders,
+  readUserAgentFromHeaders,
+  resolveRequestIdFromHeaders,
+} from "@/lib/http/request-metadata";
 import { resolveRequestOriginFromHeaders } from "@/lib/http/request-origin";
 import { appendQueryToPath, normalizeReturnToPath } from "@/lib/navigation/return-to";
 import { logServerError, logServerWarning } from "@/lib/observability/logger";
@@ -82,12 +87,16 @@ export async function signInAction(formData: FormData): Promise<void> {
 
   const email = readText(formData, "email");
   const password = readText(formData, "password");
+  const requestHeaders = await headers();
 
   let result: Awaited<ReturnType<typeof signInWithEmailPassword>>;
   try {
     result = await signInWithEmailPassword({
       emailRaw: email,
       passwordRaw: password,
+      requestId: resolveRequestIdFromHeaders(requestHeaders),
+      ipAddress: readClientIpAddressFromHeaders(requestHeaders),
+      userAgent: readUserAgentFromHeaders(requestHeaders),
     });
   } catch (error) {
     logServerError("signInAction", error);
@@ -129,6 +138,7 @@ export async function signUpAction(formData: FormData): Promise<void> {
   const username = readText(formData, "username");
   const password = readText(formData, "password");
   const confirmPassword = readText(formData, "confirmPassword");
+  const requestHeaders = await headers();
 
   let result: Awaited<ReturnType<typeof signUpWithEmailPassword>>;
   try {
@@ -137,6 +147,9 @@ export async function signUpAction(formData: FormData): Promise<void> {
       usernameRaw: username,
       passwordRaw: password,
       passwordConfirmationRaw: confirmPassword,
+      requestId: resolveRequestIdFromHeaders(requestHeaders),
+      ipAddress: readClientIpAddressFromHeaders(requestHeaders),
+      userAgent: readUserAgentFromHeaders(requestHeaders),
     });
   } catch (error) {
     logServerError("signUpAction", error);
@@ -160,7 +173,7 @@ export async function signUpAction(formData: FormData): Promise<void> {
 
   let issueResult: Awaited<ReturnType<typeof issueEmailVerificationForUser>>;
   try {
-    const requestOrigin = resolveRequestOriginFromHeaders(await headers());
+    const requestOrigin = resolveRequestOriginFromHeaders(requestHeaders);
     issueResult = await issueEmailVerificationForUser({
       actorUserId: result.data.userId,
       requestOrigin,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -65,6 +65,8 @@ const ERROR_MESSAGES: Record<string, string> = {
     "Password must include uppercase, lowercase, number, and symbol characters.",
   "password-confirmation-mismatch": "Passwords do not match.",
   "invalid-credentials": "Incorrect email or password.",
+  "too-many-attempts":
+    "Too many authentication attempts. Please wait a few minutes and retry.",
   "email-in-use": "An account with this email already exists.",
   "auth-unavailable": "Authentication is temporarily unavailable. Please retry.",
   "social-provider-disabled":

--- a/app/verify-email/actions.ts
+++ b/app/verify-email/actions.ts
@@ -4,6 +4,18 @@ import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
 import { getSessionUserIdFromServer } from "@/lib/auth/session-user";
+import {
+  AuthRateLimitScope,
+  buildAuthRateLimitKey,
+  buildCompositeAuthRateLimitKey,
+  consumeAuthAbuseQuota,
+  type AuthAbuseSignal,
+} from "@/lib/services/auth-abuse-control-service";
+import {
+  readClientIpAddressFromHeaders,
+  readUserAgentFromHeaders,
+  resolveRequestIdFromHeaders,
+} from "@/lib/http/request-metadata";
 import { resolveRequestOriginFromHeaders } from "@/lib/http/request-origin";
 import { appendQueryToPath, normalizeReturnToPath } from "@/lib/navigation/return-to";
 import { logServerError, logServerWarning } from "@/lib/observability/logger";
@@ -15,6 +27,8 @@ import {
 const HOME_PATH = "/?form=signin";
 const VERIFY_EMAIL_PATH = "/verify-email";
 const PROJECTS_PATH = "/projects";
+const VERIFICATION_RESEND_WINDOW_MS = 15 * 60 * 1000;
+const VERIFICATION_RESEND_BLOCK_MS = 15 * 60 * 1000;
 
 function redirectWithError(error: string): never {
   redirect(`${VERIFY_EMAIL_PATH}?error=${error}`);
@@ -35,6 +49,8 @@ function resolveReturnToPath(formData?: FormData): string {
 
 function mapIssueError(error: string): string {
   switch (error) {
+    case "too-many-attempts":
+      return "resend-throttled";
     case "resend-cooldown":
       return "resend-cooldown";
     case "resend-limit-reached":
@@ -48,6 +64,48 @@ function mapIssueError(error: string): string {
   }
 }
 
+function buildVerificationResendSignals(input: {
+  actorUserId: string;
+  ipAddress: string | null;
+}): AuthAbuseSignal[] {
+  const signals: AuthAbuseSignal[] = [];
+  const ipKey = buildAuthRateLimitKey("verification-resend:ip", input.ipAddress);
+  const userKey = buildAuthRateLimitKey("verification-resend:user", input.actorUserId);
+  const ipUserKey = buildCompositeAuthRateLimitKey("verification-resend:ip-user", [
+    input.ipAddress,
+    input.actorUserId,
+  ]);
+
+  if (ipKey) {
+    signals.push({
+      key: ipKey,
+      maxAttempts: 6,
+      windowMs: VERIFICATION_RESEND_WINDOW_MS,
+      blockMs: VERIFICATION_RESEND_BLOCK_MS,
+    });
+  }
+
+  if (userKey) {
+    signals.push({
+      key: userKey,
+      maxAttempts: 4,
+      windowMs: VERIFICATION_RESEND_WINDOW_MS,
+      blockMs: VERIFICATION_RESEND_BLOCK_MS,
+    });
+  }
+
+  if (ipUserKey) {
+    signals.push({
+      key: ipUserKey,
+      maxAttempts: 3,
+      windowMs: VERIFICATION_RESEND_WINDOW_MS,
+      blockMs: VERIFICATION_RESEND_BLOCK_MS,
+    });
+  }
+
+  return signals;
+}
+
 export async function resendVerificationEmailAction(formData?: FormData): Promise<void> {
   const returnToPath = resolveReturnToPath(formData);
   const actorUserId = await getSessionUserIdFromServer();
@@ -56,8 +114,39 @@ export async function resendVerificationEmailAction(formData?: FormData): Promis
   }
 
   let result: Awaited<ReturnType<typeof issueEmailVerificationForUser>>;
+  const requestHeaders = await headers();
+  const requestId = resolveRequestIdFromHeaders(requestHeaders);
+  const ipAddress = readClientIpAddressFromHeaders(requestHeaders);
+  const userAgent = readUserAgentFromHeaders(requestHeaders);
+  const abuseControl = await consumeAuthAbuseQuota({
+    scope: AuthRateLimitScope.verification_resend,
+    signals: buildVerificationResendSignals({
+      actorUserId,
+      ipAddress,
+    }),
+  });
+  if (!abuseControl.ok) {
+    logServerWarning(
+      "resendVerificationEmailAction.throttled",
+      "Verification resend throttled.",
+      {
+        actorUserId,
+        requestId,
+        ipAddress,
+        userAgent,
+        retryAfterSeconds: abuseControl.retryAfterSeconds,
+      }
+    );
+    redirect(
+      appendQueryToPath(VERIFY_EMAIL_PATH, {
+        error: "resend-throttled",
+        returnTo: returnToPath,
+      })
+    );
+  }
+
   try {
-    const requestOrigin = resolveRequestOriginFromHeaders(await headers());
+    const requestOrigin = resolveRequestOriginFromHeaders(requestHeaders);
     result = await issueEmailVerificationForUser({
       actorUserId,
       requestOrigin,

--- a/app/verify-email/page.tsx
+++ b/app/verify-email/page.tsx
@@ -36,6 +36,8 @@ const ERROR_MESSAGES: Record<string, string> = {
   "resend-cooldown": `Please wait about ${EMAIL_VERIFICATION_RESEND_COOLDOWN_SECONDS} seconds before requesting another email.`,
   "resend-limit-reached":
     "You reached the resend limit for today. Please try again tomorrow.",
+  "resend-throttled":
+    "Too many verification resend attempts. Please wait a few minutes and retry.",
   "verification-email-send-failed":
     "Could not send verification email right now. Please retry shortly.",
   "verification-pending":

--- a/components/project-dashboard/project-dashboard-owner-actions.shared.ts
+++ b/components/project-dashboard/project-dashboard-owner-actions.shared.ts
@@ -199,6 +199,8 @@ export function formatAgentAuditAction(action: AgentAuditAction): string {
       return "Credential revoked";
     case "token_exchanged":
       return "Token exchanged";
+    case "token_exchange_failed":
+      return "Token exchange failed";
     case "request_used":
       return "Request used";
     default:

--- a/journal.md
+++ b/journal.md
@@ -13,6 +13,11 @@ Use it for important implementation milestones, blockers, validation runs, and r
 ## Recent Entries (Most Relevant)
 
 ### 2026-04-10
+- Type: Validation
+- Summary: Investigated a broken TASK-050 preview and traced `GET /` runtime failures to Prisma's `@prisma/adapter-pg` path interpreting `sslmode=require` as certificate-verifying TLS against the Supabase pooler; fixed the runtime client to add `uselibpqcompat=true` for `sslmode=require`, which matches libpq semantics and restores preview connectivity.
+- Evidence: `npx vercel logs https://nexus-dash-87wiabtci-dorian-agaesses-projects.vercel.app --no-follow --since 6h --level error --expand`; `npx vercel curl / --deployment https://nexus-dash-87wiabtci-dorian-agaesses-projects.vercel.app`; one-off `pg` reproduction against preview `DATABASE_URL` showing raw connection failure and success after appending `uselibpqcompat=true`; updated `lib/env.server.ts`, `lib/prisma.ts`, and `tests/lib/env.server.test.ts`; validated with `npm test -- --run tests/lib/env.server.test.ts`, `npm run lint`, and `npm run build`.
+
+### 2026-04-10
 - Type: Governance
 - Summary: Tightened the TASK-050 execution contract by adding explicit expected output, acceptance criteria, and definition of done, and updated the repo operating guide so future task briefs must include acceptance criteria plus DoD before implementation starts.
 - Evidence: Updated `tasks/current.md` and `agent.md`.

--- a/journal.md
+++ b/journal.md
@@ -12,6 +12,31 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ## Recent Entries (Most Relevant)
 
+### 2026-04-10
+- Type: Governance
+- Summary: Tightened the TASK-050 execution contract by adding explicit expected output, acceptance criteria, and definition of done, and updated the repo operating guide so future task briefs must include acceptance criteria plus DoD before implementation starts.
+- Evidence: Updated `tasks/current.md` and `agent.md`.
+
+### 2026-04-10
+- Type: Execution
+- Summary: TASK-050 implemented the ranked security remediation slice from `TASK-049` by adding PostgreSQL-backed abuse controls on public auth/token exchange paths, hashing human session tokens at rest, and enforcing request-time credential liveness for agent bearer-token usage.
+- Evidence: Updated `lib/services/auth-abuse-control-service.ts`, `lib/services/credential-auth-service.ts`, `app/forgot-password/actions.ts`, `app/verify-email/actions.ts`, `lib/services/session-service.ts`, `lib/services/project-agent-access-service.ts`, `lib/auth/api-guard.ts`, `app/api/auth/agent/token/route.ts`, `prisma/schema.prisma`, and migration `prisma/migrations/20260410110000_task050_security_remediation/migration.sql`.
+
+### 2026-04-10
+- Type: Governance
+- Summary: TASK-050 security implementation was locked with an explicit architecture record covering DB-backed abuse buckets, one-time legacy session invalidation, and immediate-effect agent credential liveness checks.
+- Evidence: Added `adr/task-050-security-remediation-adr.md` and updated `adr/decisions.md`.
+
+### 2026-04-10
+- Type: Validation
+- Summary: TASK-050 local validation passed for lint, unit tests, coverage, and production build after syncing the Prisma 7 / Next 16 toolchain in this checkout and regenerating the Prisma client on a Node 20.19 runtime.
+- Evidence: `npm run lint`; `npm test`; `npm run test:coverage`; `$env:DATABASE_URL='postgresql://user:pass@localhost:5432/postgres'; $env:DIRECT_URL='postgresql://user:pass@127.0.0.1:5433/postgres'; $env:VERCEL_ENV='preview'; $env:RESEND_API_KEY='test-resend-key'; $env:GOOGLE_TOKEN_ENCRYPTION_KEY='0123456789abcdef0123456789abcdef'; $env:AGENT_TOKEN_SIGNING_SECRET='0123456789abcdef0123456789abcdef'; npm run build`; `npx prisma generate`.
+
+### 2026-04-10
+- Type: Blocker
+- Summary: TASK-050 local Playwright smoke validation remains environment-blocked because the PostgreSQL fixture service expected at `127.0.0.1:5432` is unreachable in this workstation session.
+- Evidence: `$env:DATABASE_URL='postgresql://user:pass@127.0.0.1:5432/postgres'; $env:DIRECT_URL='postgresql://user:pass@127.0.0.1:5433/postgres'; $env:VERCEL_ENV='preview'; $env:RESEND_API_KEY='test-resend-key'; $env:GOOGLE_TOKEN_ENCRYPTION_KEY='0123456789abcdef0123456789abcdef'; $env:AGENT_TOKEN_SIGNING_SECRET='0123456789abcdef0123456789abcdef'; npm run test:e2e` built successfully, then all 6 Playwright specs failed with `PrismaClientKnownRequestError: Can't reach database server at 127.0.0.1:5432`.
+
 ### 2026-04-09
 - Type: Validation
 - Summary: The repaired rerun on Dependabot PR `#133` finally created fresh retry PR `#153` and dispatched the required workflows, but GitHub branch protection still showed no required checks on the PR until the same successful results were mirrored into commit statuses for the repair-branch head SHA.

--- a/lib/agent-access.ts
+++ b/lib/agent-access.ts
@@ -16,6 +16,7 @@ export type AgentAuditAction =
   | "credential_rotated"
   | "credential_revoked"
   | "token_exchanged"
+  | "token_exchange_failed"
   | "request_used";
 
 export const MAX_AGENT_CREDENTIAL_LABEL_LENGTH = 80;

--- a/lib/auth/api-guard.ts
+++ b/lib/auth/api-guard.ts
@@ -1,4 +1,3 @@
-import crypto from "node:crypto";
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
@@ -9,6 +8,10 @@ import {
   getRuntimeEnvironment,
   isLiveProductionDeployment,
 } from "@/lib/env.server";
+import {
+  readClientIpAddressFromHeaders,
+  resolveRequestIdFromHeaders,
+} from "@/lib/http/request-metadata";
 import { logServerError } from "@/lib/observability/logger";
 import {
   recordAgentRequestUsage,
@@ -63,8 +66,7 @@ interface ApiPrincipalFailure {
 export type ApiPrincipalResult = ApiPrincipalSuccess | ApiPrincipalFailure;
 
 export function resolveRequestId(request: NextRequest | Request): string {
-  const requestId = request.headers.get("x-request-id")?.trim();
-  return requestId && requestId.length > 0 ? requestId : crypto.randomUUID();
+  return resolveRequestIdFromHeaders(request.headers);
 }
 
 function readBearerToken(request: NextRequest | Request): string | null {
@@ -87,18 +89,7 @@ function hasBearerToken(request: NextRequest | Request): boolean {
 }
 
 export function readClientIpAddress(request: NextRequest | Request): string | null {
-  const forwardedFor = request.headers.get("x-forwarded-for");
-  if (forwardedFor) {
-    const firstAddress = forwardedFor
-      .split(",")
-      .map((entry) => entry.trim())
-      .find((entry) => entry.length > 0);
-    if (firstAddress) {
-      return firstAddress;
-    }
-  }
-
-  return request.headers.get("x-real-ip")?.trim() ?? null;
+  return readClientIpAddressFromHeaders(request.headers);
 }
 
 async function requireVerifiedSessionApiUser(
@@ -197,6 +188,7 @@ export async function requireApiPrincipal(
         ownerUserId: verifiedToken.data.ownerUserId,
         projectId: verifiedToken.data.projectId,
         tokenId: verifiedToken.data.tokenId,
+        issuedAt: verifiedToken.data.issuedAt,
         requestId,
         ipAddress: readClientIpAddress(request),
         userAgent: request.headers.get("user-agent"),

--- a/lib/auth/session-constants.ts
+++ b/lib/auth/session-constants.ts
@@ -1,0 +1,12 @@
+export const PRIMARY_SESSION_COOKIE_NAME = "nexusdash.session-token";
+export const LEGACY_SESSION_COOKIE_NAMES = [
+  "__Secure-authjs.session-token",
+  "authjs.session-token",
+  "__Secure-next-auth.session-token",
+  "next-auth.session-token",
+] as const;
+export const SESSION_COOKIE_NAMES = [
+  PRIMARY_SESSION_COOKIE_NAME,
+  ...LEGACY_SESSION_COOKIE_NAMES,
+] as const;
+export const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;

--- a/lib/auth/session-cookie.ts
+++ b/lib/auth/session-cookie.ts
@@ -4,7 +4,7 @@ import { isProductionEnvironment } from "@/lib/env.server";
 import {
   PRIMARY_SESSION_COOKIE_NAME,
   SESSION_MAX_AGE_SECONDS,
-} from "@/lib/services/session-service";
+} from "@/lib/auth/session-constants";
 
 type PrimarySessionCookieOptions = {
   httpOnly: true;

--- a/lib/env.server.ts
+++ b/lib/env.server.ts
@@ -104,6 +104,29 @@ export function getDatabaseRuntimeConfig(
   };
 }
 
+export function getPrismaPgRuntimeConnectionString(): string {
+  const databaseUrl = getRequiredServerEnv("DATABASE_URL");
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(databaseUrl);
+  } catch {
+    return databaseUrl;
+  }
+
+  const sslMode = (parsedUrl.searchParams.get("sslmode") ?? "").toLowerCase();
+  if (sslMode !== "require") {
+    return databaseUrl;
+  }
+
+  if ((parsedUrl.searchParams.get("uselibpqcompat") ?? "").length > 0) {
+    return parsedUrl.toString();
+  }
+
+  parsedUrl.searchParams.set("uselibpqcompat", "true");
+  return parsedUrl.toString();
+}
+
 export interface SupabaseClientRuntimeConfig {
   url: string;
   publishableKey: string;

--- a/lib/http/request-metadata.ts
+++ b/lib/http/request-metadata.ts
@@ -12,7 +12,8 @@ export function readClientIpAddressFromHeaders(headers: Headers): string | null 
     }
   }
 
-  return headers.get("x-real-ip")?.trim() ?? null;
+  const realIp = headers.get("x-real-ip")?.trim();
+  return realIp && realIp.length > 0 ? realIp : null;
 }
 
 export function resolveRequestIdFromHeaders(headers: Headers): string {

--- a/lib/http/request-metadata.ts
+++ b/lib/http/request-metadata.ts
@@ -1,0 +1,26 @@
+import crypto from "node:crypto";
+
+export function readClientIpAddressFromHeaders(headers: Headers): string | null {
+  const forwardedFor = headers.get("x-forwarded-for");
+  if (forwardedFor) {
+    const firstAddress = forwardedFor
+      .split(",")
+      .map((entry) => entry.trim())
+      .find((entry) => entry.length > 0);
+    if (firstAddress) {
+      return firstAddress;
+    }
+  }
+
+  return headers.get("x-real-ip")?.trim() ?? null;
+}
+
+export function resolveRequestIdFromHeaders(headers: Headers): string {
+  const requestId = headers.get("x-request-id")?.trim();
+  return requestId && requestId.length > 0 ? requestId : crypto.randomUUID();
+}
+
+export function readUserAgentFromHeaders(headers: Headers): string | null {
+  const userAgent = headers.get("user-agent")?.trim();
+  return userAgent && userAgent.length > 0 ? userAgent : null;
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,12 +1,16 @@
 import { PrismaClient } from "@prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 
+import { getPrismaPgRuntimeConnectionString } from "@/lib/env.server";
+
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
 };
 
 function createPrismaClient(): PrismaClient {
-  const adapter = new PrismaPg(process.env.DATABASE_URL ?? "");
+  const adapter = new PrismaPg({
+    connectionString: getPrismaPgRuntimeConnectionString(),
+  });
   return new PrismaClient({ adapter });
 }
 

--- a/lib/services/auth-abuse-control-service.ts
+++ b/lib/services/auth-abuse-control-service.ts
@@ -26,6 +26,8 @@ interface AuthAbuseLimited {
 
 export type AuthAbuseCheckResult = AuthAbuseAllowed | AuthAbuseLimited;
 
+const BUCKET_RETENTION_WINDOW_MULTIPLIER = 4;
+
 function hashRateLimitValue(value: string): string {
   return createHash("sha256").update(value).digest("base64url");
 }
@@ -183,6 +185,38 @@ async function incrementSignalBucket(input: {
   return rows[0] ?? { blockedUntil: null };
 }
 
+async function pruneExpiredBuckets(input: {
+  db: DbClient;
+  scope: AuthRateLimitScope;
+  signals: AuthAbuseSignal[];
+  now: Date;
+}): Promise<void> {
+  const retentionWindowMs = input.signals.reduce((longestWindow, signal) => {
+    const signalRetentionMs =
+      Math.max(signal.windowMs, signal.blockMs) * BUCKET_RETENTION_WINDOW_MULTIPLIER;
+    return Math.max(longestWindow, signalRetentionMs);
+  }, 0);
+
+  if (retentionWindowMs <= 0) {
+    return;
+  }
+
+  const cutoff = new Date(input.now.getTime() - retentionWindowMs);
+
+  await input.db.authRateLimitBucket.deleteMany({
+    where: {
+      scope: input.scope,
+      key: {
+        in: input.signals.map((signal) => signal.key),
+      },
+      windowStart: {
+        lt: cutoff,
+      },
+      OR: [{ blockedUntil: null }, { blockedUntil: { lt: input.now } }],
+    },
+  });
+}
+
 export async function checkAuthAbuseControls(input: {
   scope: AuthRateLimitScope;
   signals: AuthAbuseSignal[];
@@ -222,6 +256,13 @@ export async function consumeAuthAbuseQuota(input: {
   if (!existingBlock.ok) {
     return existingBlock;
   }
+
+  await pruneExpiredBuckets({
+    db,
+    scope: input.scope,
+    signals,
+    now,
+  });
 
   const runIncrementSequence = async (transactionDb: DbClient) => {
     const results: Array<{ blockedUntil: Date | null }> = [];

--- a/lib/services/auth-abuse-control-service.ts
+++ b/lib/services/auth-abuse-control-service.ts
@@ -1,0 +1,300 @@
+import { createHash } from "node:crypto";
+
+import { AuthRateLimitScope, Prisma } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+
+type DbClient = typeof prisma | Prisma.TransactionClient;
+
+export { AuthRateLimitScope };
+
+export interface AuthAbuseSignal {
+  key: string;
+  maxAttempts: number;
+  windowMs: number;
+  blockMs: number;
+}
+
+interface AuthAbuseAllowed {
+  ok: true;
+}
+
+interface AuthAbuseLimited {
+  ok: false;
+  retryAfterSeconds: number;
+}
+
+export type AuthAbuseCheckResult = AuthAbuseAllowed | AuthAbuseLimited;
+
+function hashRateLimitValue(value: string): string {
+  return createHash("sha256").update(value).digest("base64url");
+}
+
+function normalizeKeyValue(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmedValue = value.trim();
+  return trimmedValue.length > 0 ? trimmedValue : null;
+}
+
+export function buildAuthRateLimitKey(
+  namespace: string,
+  value: string | null | undefined
+): string | null {
+  const normalizedValue = normalizeKeyValue(value);
+  if (!normalizedValue) {
+    return null;
+  }
+
+  return `${namespace}:${hashRateLimitValue(normalizedValue)}`;
+}
+
+export function buildCompositeAuthRateLimitKey(
+  namespace: string,
+  values: Array<string | null | undefined>
+): string | null {
+  const normalizedValues = values
+    .map((value) => normalizeKeyValue(value))
+    .filter((value): value is string => Boolean(value));
+
+  if (normalizedValues.length !== values.length) {
+    return null;
+  }
+
+  return `${namespace}:${hashRateLimitValue(normalizedValues.join("|"))}`;
+}
+
+function floorWindowStart(now: Date, windowMs: number): Date {
+  return new Date(Math.floor(now.getTime() / windowMs) * windowMs);
+}
+
+function resolveRetryAfterSeconds(blockedUntil: Date, now: Date): number {
+  return Math.max(1, Math.ceil((blockedUntil.getTime() - now.getTime()) / 1000));
+}
+
+function validateSignals(signals: AuthAbuseSignal[]): AuthAbuseSignal[] {
+  return signals.filter(
+    (signal) =>
+      signal.key.trim().length > 0 &&
+      Number.isInteger(signal.maxAttempts) &&
+      signal.maxAttempts > 0 &&
+      Number.isInteger(signal.windowMs) &&
+      signal.windowMs > 0 &&
+      Number.isInteger(signal.blockMs) &&
+      signal.blockMs > 0
+  );
+}
+
+async function findActiveBlocks(input: {
+  db: DbClient;
+  scope: AuthRateLimitScope;
+  signals: AuthAbuseSignal[];
+  now: Date;
+}): Promise<AuthAbuseCheckResult> {
+  const keys = validateSignals(input.signals).map((signal) => signal.key);
+  if (keys.length === 0) {
+    return { ok: true };
+  }
+
+  const activeBlocks = await input.db.authRateLimitBucket.findMany({
+    where: {
+      scope: input.scope,
+      key: {
+        in: keys,
+      },
+      blockedUntil: {
+        gt: input.now,
+      },
+    },
+    select: {
+      blockedUntil: true,
+    },
+  });
+
+  if (activeBlocks.length === 0) {
+    return { ok: true };
+  }
+
+  const latestBlockedUntil = activeBlocks.reduce((latest, row) => {
+    if (!row.blockedUntil) {
+      return latest;
+    }
+
+    if (!latest || row.blockedUntil.getTime() > latest.getTime()) {
+      return row.blockedUntil;
+    }
+
+    return latest;
+  }, null as Date | null);
+
+  if (!latestBlockedUntil) {
+    return { ok: true };
+  }
+
+  return {
+    ok: false,
+    retryAfterSeconds: resolveRetryAfterSeconds(latestBlockedUntil, input.now),
+  };
+}
+
+async function incrementSignalBucket(input: {
+  db: DbClient;
+  scope: AuthRateLimitScope;
+  signal: AuthAbuseSignal;
+  now: Date;
+}): Promise<{ blockedUntil: Date | null }> {
+  const windowStart = floorWindowStart(input.now, input.signal.windowMs);
+  const blockedUntil = new Date(input.now.getTime() + input.signal.blockMs);
+  const rows = await input.db.$queryRaw<Array<{ blockedUntil: Date | null }>>(
+    Prisma.sql`
+      INSERT INTO "AuthRateLimitBucket" (
+        "scope",
+        "key",
+        "windowStart",
+        "attemptCount",
+        "blockedUntil",
+        "createdAt",
+        "updatedAt"
+      )
+      VALUES (
+        CAST(${input.scope} AS "AuthRateLimitScope"),
+        ${input.signal.key},
+        ${windowStart},
+        1,
+        ${input.signal.maxAttempts <= 1 ? blockedUntil : null},
+        CURRENT_TIMESTAMP,
+        CURRENT_TIMESTAMP
+      )
+      ON CONFLICT ("scope", "key", "windowStart")
+      DO UPDATE SET
+        "attemptCount" = "AuthRateLimitBucket"."attemptCount" + 1,
+        "blockedUntil" = CASE
+          WHEN "AuthRateLimitBucket"."attemptCount" + 1 >= ${input.signal.maxAttempts}
+            THEN ${blockedUntil}
+          ELSE "AuthRateLimitBucket"."blockedUntil"
+        END,
+        "updatedAt" = CURRENT_TIMESTAMP
+      RETURNING "blockedUntil"
+    `
+  );
+
+  return rows[0] ?? { blockedUntil: null };
+}
+
+export async function checkAuthAbuseControls(input: {
+  scope: AuthRateLimitScope;
+  signals: AuthAbuseSignal[];
+  now?: Date;
+  db?: DbClient;
+}): Promise<AuthAbuseCheckResult> {
+  const now = input.now ?? new Date();
+  const db = input.db ?? prisma;
+  return findActiveBlocks({
+    db,
+    scope: input.scope,
+    signals: input.signals,
+    now,
+  });
+}
+
+export async function consumeAuthAbuseQuota(input: {
+  scope: AuthRateLimitScope;
+  signals: AuthAbuseSignal[];
+  now?: Date;
+  db?: DbClient;
+}): Promise<AuthAbuseCheckResult> {
+  const now = input.now ?? new Date();
+  const db = input.db ?? prisma;
+  const signals = validateSignals(input.signals);
+
+  if (signals.length === 0) {
+    return { ok: true };
+  }
+
+  const existingBlock = await findActiveBlocks({
+    db,
+    scope: input.scope,
+    signals,
+    now,
+  });
+  if (!existingBlock.ok) {
+    return existingBlock;
+  }
+
+  const runIncrementSequence = async (transactionDb: DbClient) => {
+    const results: Array<{ blockedUntil: Date | null }> = [];
+    for (const signal of signals) {
+      results.push(
+        await incrementSignalBucket({
+          db: transactionDb,
+          scope: input.scope,
+          signal,
+          now,
+        })
+      );
+    }
+
+    return results;
+  };
+
+  const results =
+    db === prisma
+      ? await prisma.$transaction((transactionDb) => runIncrementSequence(transactionDb))
+      : await runIncrementSequence(db);
+
+  const newestBlock = results.reduce((latest, result) => {
+    if (!result.blockedUntil || result.blockedUntil.getTime() <= now.getTime()) {
+      return latest;
+    }
+
+    if (!latest || result.blockedUntil.getTime() > latest.getTime()) {
+      return result.blockedUntil;
+    }
+
+    return latest;
+  }, null as Date | null);
+
+  if (!newestBlock) {
+    return { ok: true };
+  }
+
+  return {
+    ok: false,
+    retryAfterSeconds: resolveRetryAfterSeconds(newestBlock, now),
+  };
+}
+
+export async function registerAuthAbuseFailure(input: {
+  scope: AuthRateLimitScope;
+  signals: AuthAbuseSignal[];
+  now?: Date;
+  db?: DbClient;
+}): Promise<AuthAbuseCheckResult> {
+  return consumeAuthAbuseQuota(input);
+}
+
+export async function clearAuthAbuseControls(input: {
+  scope: AuthRateLimitScope;
+  keys: Array<string | null | undefined>;
+  db?: DbClient;
+}): Promise<void> {
+  const db = input.db ?? prisma;
+  const keys = input.keys
+    .map((key) => normalizeKeyValue(key))
+    .filter((key): key is string => Boolean(key));
+
+  if (keys.length === 0) {
+    return;
+  }
+
+  await db.authRateLimitBucket.deleteMany({
+    where: {
+      scope: input.scope,
+      key: {
+        in: keys,
+      },
+    },
+  });
+}

--- a/lib/services/credential-auth-service.ts
+++ b/lib/services/credential-auth-service.ts
@@ -36,6 +36,8 @@ export {
 };
 
 const MAX_USERNAME_GENERATION_ATTEMPTS = 12;
+const MAX_IP_ADDRESS_LENGTH = 64;
+const MAX_USER_AGENT_LENGTH = 512;
 
 type AuthFailureCode =
   | "invalid-email"
@@ -125,6 +127,27 @@ function isUsernameDiscriminatorConstraint(error: unknown): boolean {
     targets.includes("username") &&
     targets.includes("usernameDiscriminator")
   );
+}
+
+function normalizeTrimmedString(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmedValue = value.trim();
+  return trimmedValue.length > 0 ? trimmedValue : null;
+}
+
+function normalizeBoundedString(
+  value: string | null | undefined,
+  maxLength: number
+): string | null {
+  const trimmedValue = normalizeTrimmedString(value);
+  if (!trimmedValue) {
+    return null;
+  }
+
+  return trimmedValue.slice(0, maxLength);
 }
 
 const FIFTEEN_MINUTES_MS = 15 * 60 * 1000;
@@ -232,8 +255,8 @@ async function resolveSignInFailure(input: {
 
   logServerWarning("credentialAuth.signInFailed", "Email/password sign-in failed.", {
     requestId: input.requestId ?? null,
-    ipAddress: input.ipAddress ?? null,
-    userAgent: input.userAgent ?? null,
+    ipAddress: normalizeBoundedString(input.ipAddress ?? null, MAX_IP_ADDRESS_LENGTH),
+    userAgent: normalizeBoundedString(input.userAgent ?? null, MAX_USER_AGENT_LENGTH),
     reason: input.reason,
     accountKey: buildAuthRateLimitKey("sign-in:email", input.email),
     throttled: !abuseResult.ok,
@@ -267,8 +290,8 @@ export async function signUpWithEmailPassword(input: {
   if (!abuseControlResult.ok) {
     logServerWarning("credentialAuth.signUpThrottled", "Email/password sign-up throttled.", {
       requestId: input.requestId ?? null,
-      ipAddress: input.ipAddress ?? null,
-      userAgent: input.userAgent ?? null,
+      ipAddress: normalizeBoundedString(input.ipAddress ?? null, MAX_IP_ADDRESS_LENGTH),
+      userAgent: normalizeBoundedString(input.userAgent ?? null, MAX_USER_AGENT_LENGTH),
       retryAfterSeconds: abuseControlResult.retryAfterSeconds,
     });
     return { ok: false, error: "too-many-attempts" };
@@ -358,8 +381,8 @@ export async function signInWithEmailPassword(input: {
   if (!abuseCheck.ok) {
     logServerWarning("credentialAuth.signInThrottled", "Email/password sign-in throttled.", {
       requestId: input.requestId ?? null,
-      ipAddress: input.ipAddress ?? null,
-      userAgent: input.userAgent ?? null,
+      ipAddress: normalizeBoundedString(input.ipAddress ?? null, MAX_IP_ADDRESS_LENGTH),
+      userAgent: normalizeBoundedString(input.userAgent ?? null, MAX_USER_AGENT_LENGTH),
       accountKey: buildAuthRateLimitKey("sign-in:email", email),
       retryAfterSeconds: abuseCheck.retryAfterSeconds,
     });
@@ -417,10 +440,25 @@ export async function signInWithEmailPassword(input: {
     });
   }
 
-  await clearAuthAbuseControls({
-    scope: AuthRateLimitScope.sign_in,
-    keys: abuseSignals.map((signal) => signal.key),
-  });
+  try {
+    await clearAuthAbuseControls({
+      scope: AuthRateLimitScope.sign_in,
+      keys: abuseSignals.map((signal) => signal.key),
+    });
+  } catch (error) {
+    logServerWarning(
+      "credentialAuth.signInAbuseControlsClearFailed",
+      "Failed to clear auth abuse controls after successful email/password sign-in.",
+      {
+        requestId: input.requestId ?? null,
+        ipAddress: normalizeBoundedString(input.ipAddress ?? null, MAX_IP_ADDRESS_LENGTH),
+        userAgent: normalizeBoundedString(input.userAgent ?? null, MAX_USER_AGENT_LENGTH),
+        accountKey: buildAuthRateLimitKey("sign-in:email", email),
+        userId: user.id,
+        error,
+      }
+    );
+  }
 
   return issueSession({
     userId: user.id,

--- a/lib/services/credential-auth-service.ts
+++ b/lib/services/credential-auth-service.ts
@@ -1,4 +1,16 @@
+import { AuthRateLimitScope } from "@prisma/client";
+
 import { prisma } from "@/lib/prisma";
+import { logServerWarning } from "@/lib/observability/logger";
+import {
+  buildAuthRateLimitKey,
+  buildCompositeAuthRateLimitKey,
+  checkAuthAbuseControls,
+  clearAuthAbuseControls,
+  consumeAuthAbuseQuota,
+  registerAuthAbuseFailure,
+  type AuthAbuseSignal,
+} from "@/lib/services/auth-abuse-control-service";
 import { isPreviewDeployment } from "@/lib/env.server";
 import { createSessionForUser } from "@/lib/services/session-service";
 import { hashPassword, verifyPassword } from "@/lib/services/password-service";
@@ -34,7 +46,8 @@ type AuthFailureCode =
   | "password-requirements-not-met"
   | "password-confirmation-mismatch"
   | "email-in-use"
-  | "invalid-credentials";
+  | "invalid-credentials"
+  | "too-many-attempts";
 
 interface AuthSuccess {
   ok: true;
@@ -114,13 +127,153 @@ function isUsernameDiscriminatorConstraint(error: unknown): boolean {
   );
 }
 
+const FIFTEEN_MINUTES_MS = 15 * 60 * 1000;
+const THIRTY_MINUTES_MS = 30 * 60 * 1000;
+
+function buildSignInSignals(input: {
+  email: string;
+  ipAddress?: string | null;
+}): AuthAbuseSignal[] {
+  const signals: AuthAbuseSignal[] = [];
+  const ipKey = buildAuthRateLimitKey("sign-in:ip", input.ipAddress);
+  const emailKey = buildAuthRateLimitKey("sign-in:email", input.email);
+  const ipEmailKey = buildCompositeAuthRateLimitKey("sign-in:ip-email", [
+    input.ipAddress ?? null,
+    input.email,
+  ]);
+
+  if (ipKey) {
+    signals.push({
+      key: ipKey,
+      maxAttempts: 12,
+      windowMs: FIFTEEN_MINUTES_MS,
+      blockMs: FIFTEEN_MINUTES_MS,
+    });
+  }
+
+  if (emailKey) {
+    signals.push({
+      key: emailKey,
+      maxAttempts: 8,
+      windowMs: FIFTEEN_MINUTES_MS,
+      blockMs: THIRTY_MINUTES_MS,
+    });
+  }
+
+  if (ipEmailKey) {
+    signals.push({
+      key: ipEmailKey,
+      maxAttempts: 5,
+      windowMs: FIFTEEN_MINUTES_MS,
+      blockMs: THIRTY_MINUTES_MS,
+    });
+  }
+
+  return signals;
+}
+
+function buildSignUpSignals(input: {
+  email: string;
+  ipAddress?: string | null;
+}): AuthAbuseSignal[] {
+  const signals: AuthAbuseSignal[] = [];
+  const ipKey = buildAuthRateLimitKey("sign-up:ip", input.ipAddress);
+  const emailKey = buildAuthRateLimitKey("sign-up:email", input.email);
+  const ipEmailKey = buildCompositeAuthRateLimitKey("sign-up:ip-email", [
+    input.ipAddress ?? null,
+    input.email,
+  ]);
+
+  if (ipKey) {
+    signals.push({
+      key: ipKey,
+      maxAttempts: 8,
+      windowMs: THIRTY_MINUTES_MS,
+      blockMs: THIRTY_MINUTES_MS,
+    });
+  }
+
+  if (emailKey) {
+    signals.push({
+      key: emailKey,
+      maxAttempts: 5,
+      windowMs: THIRTY_MINUTES_MS,
+      blockMs: THIRTY_MINUTES_MS,
+    });
+  }
+
+  if (ipEmailKey) {
+    signals.push({
+      key: ipEmailKey,
+      maxAttempts: 4,
+      windowMs: THIRTY_MINUTES_MS,
+      blockMs: THIRTY_MINUTES_MS,
+    });
+  }
+
+  return signals;
+}
+
+async function resolveSignInFailure(input: {
+  email: string;
+  ipAddress?: string | null;
+  requestId?: string | null;
+  userAgent?: string | null;
+  reason: string;
+}): Promise<AuthFailure> {
+  const signals = buildSignInSignals({
+    email: input.email,
+    ipAddress: input.ipAddress,
+  });
+  const abuseResult = await registerAuthAbuseFailure({
+    scope: AuthRateLimitScope.sign_in,
+    signals,
+  });
+
+  logServerWarning("credentialAuth.signInFailed", "Email/password sign-in failed.", {
+    requestId: input.requestId ?? null,
+    ipAddress: input.ipAddress ?? null,
+    userAgent: input.userAgent ?? null,
+    reason: input.reason,
+    accountKey: buildAuthRateLimitKey("sign-in:email", input.email),
+    throttled: !abuseResult.ok,
+    retryAfterSeconds: abuseResult.ok ? null : abuseResult.retryAfterSeconds,
+  });
+
+  return {
+    ok: false,
+    error: abuseResult.ok ? "invalid-credentials" : "too-many-attempts",
+  };
+}
+
 export async function signUpWithEmailPassword(input: {
   emailRaw: string;
   usernameRaw: string;
   passwordRaw: string;
   passwordConfirmationRaw: string;
+  ipAddress?: string | null;
+  requestId?: string | null;
+  userAgent?: string | null;
 }): Promise<EmailPasswordAuthResult> {
   const email = normalizeEmail(input.emailRaw);
+  const abuseSignals = buildSignUpSignals({
+    email,
+    ipAddress: input.ipAddress,
+  });
+  const abuseControlResult = await consumeAuthAbuseQuota({
+    scope: AuthRateLimitScope.sign_up,
+    signals: abuseSignals,
+  });
+  if (!abuseControlResult.ok) {
+    logServerWarning("credentialAuth.signUpThrottled", "Email/password sign-up throttled.", {
+      requestId: input.requestId ?? null,
+      ipAddress: input.ipAddress ?? null,
+      userAgent: input.userAgent ?? null,
+      retryAfterSeconds: abuseControlResult.retryAfterSeconds,
+    });
+    return { ok: false, error: "too-many-attempts" };
+  }
+
   if (!validateEmail(email)) {
     return { ok: false, error: "invalid-email" };
   }
@@ -189,15 +342,49 @@ export async function signUpWithEmailPassword(input: {
 export async function signInWithEmailPassword(input: {
   emailRaw: string;
   passwordRaw: string;
+  ipAddress?: string | null;
+  requestId?: string | null;
+  userAgent?: string | null;
 }): Promise<EmailPasswordAuthResult> {
   const email = normalizeEmail(input.emailRaw);
+  const abuseSignals = buildSignInSignals({
+    email,
+    ipAddress: input.ipAddress,
+  });
+  const abuseCheck = await checkAuthAbuseControls({
+    scope: AuthRateLimitScope.sign_in,
+    signals: abuseSignals,
+  });
+  if (!abuseCheck.ok) {
+    logServerWarning("credentialAuth.signInThrottled", "Email/password sign-in throttled.", {
+      requestId: input.requestId ?? null,
+      ipAddress: input.ipAddress ?? null,
+      userAgent: input.userAgent ?? null,
+      accountKey: buildAuthRateLimitKey("sign-in:email", email),
+      retryAfterSeconds: abuseCheck.retryAfterSeconds,
+    });
+    return { ok: false, error: "too-many-attempts" };
+  }
+
   if (!validateEmail(email)) {
-    return { ok: false, error: "invalid-email" };
+    return resolveSignInFailure({
+      email,
+      ipAddress: input.ipAddress,
+      requestId: input.requestId,
+      userAgent: input.userAgent,
+      reason: "invalid-email",
+    });
   }
 
   const passwordValidation = validatePasswordLength(input.passwordRaw);
   if (passwordValidation !== "ok") {
-    return { ok: false, error: "invalid-credentials" };
+    return resolveSignInFailure({
+      email,
+      ipAddress: input.ipAddress,
+      requestId: input.requestId,
+      userAgent: input.userAgent,
+      reason: "password-validation-failed",
+    });
   }
 
   const user = await prisma.user.findUnique({
@@ -210,13 +397,30 @@ export async function signInWithEmailPassword(input: {
   });
 
   if (!user?.passwordHash) {
-    return { ok: false, error: "invalid-credentials" };
+    return resolveSignInFailure({
+      email,
+      ipAddress: input.ipAddress,
+      requestId: input.requestId,
+      userAgent: input.userAgent,
+      reason: "user-not-found",
+    });
   }
 
   const passwordMatches = await verifyPassword(input.passwordRaw, user.passwordHash);
   if (!passwordMatches) {
-    return { ok: false, error: "invalid-credentials" };
+    return resolveSignInFailure({
+      email,
+      ipAddress: input.ipAddress,
+      requestId: input.requestId,
+      userAgent: input.userAgent,
+      reason: "password-mismatch",
+    });
   }
+
+  await clearAuthAbuseControls({
+    scope: AuthRateLimitScope.sign_in,
+    keys: abuseSignals.map((signal) => signal.key),
+  });
 
   return issueSession({
     userId: user.id,

--- a/lib/services/project-agent-access-service.ts
+++ b/lib/services/project-agent-access-service.ts
@@ -18,9 +18,19 @@ import {
   type AgentCredentialStatus,
   type AgentScope,
 } from "@/lib/agent-access";
+import {
+  AuthRateLimitScope,
+  buildAuthRateLimitKey,
+  buildCompositeAuthRateLimitKey,
+  checkAuthAbuseControls,
+  clearAuthAbuseControls,
+  registerAuthAbuseFailure,
+  type AuthAbuseSignal,
+} from "@/lib/services/auth-abuse-control-service";
 import { getAgentAccessTokenTtlSeconds } from "@/lib/env.server";
 import { issueAgentAccessToken } from "@/lib/auth/agent-token-service";
 import { prisma } from "@/lib/prisma";
+import { logServerWarning } from "@/lib/observability/logger";
 import { verifySecret, hashSecret } from "@/lib/services/password-service";
 import { requireProjectRole } from "@/lib/services/project-access-service";
 import { withActorRlsContext } from "@/lib/services/rls-context";
@@ -31,6 +41,8 @@ const AGENT_CREDENTIAL_SECRET_BYTES = 32;
 const MAX_AGENT_CREDENTIAL_EXPIRY_DAYS = 365;
 const MAX_IP_ADDRESS_LENGTH = 64;
 const MAX_USER_AGENT_LENGTH = 512;
+const AGENT_TOKEN_EXCHANGE_WINDOW_MS = 15 * 60 * 1000;
+const AGENT_TOKEN_EXCHANGE_BLOCK_MS = 15 * 60 * 1000;
 
 interface ServiceError {
   ok: false;
@@ -298,6 +310,7 @@ function buildAuditMetadata(input: {
   tokenId?: string;
   httpMethod?: string | null;
   path?: string | null;
+  failureReason?: string | null;
 }) {
   return {
     scopes: input.scopes ?? null,
@@ -306,7 +319,118 @@ function buildAuditMetadata(input: {
     tokenId: input.tokenId ?? null,
     httpMethod: normalizeTrimmedString(input.httpMethod ?? null),
     path: normalizeTrimmedString(input.path ?? null),
+    failureReason: normalizeTrimmedString(input.failureReason ?? null),
   };
+}
+
+function buildAgentTokenExchangeSignals(input: {
+  ipAddress?: string | null;
+  publicId?: string | null;
+}): AuthAbuseSignal[] {
+  const signals: AuthAbuseSignal[] = [];
+  const ipKey = buildAuthRateLimitKey("agent-token:ip", input.ipAddress);
+  const publicIdKey = buildAuthRateLimitKey(
+    "agent-token:public-id",
+    input.publicId ?? null
+  );
+  const ipPublicIdKey = buildCompositeAuthRateLimitKey("agent-token:ip-public-id", [
+    input.ipAddress ?? null,
+    input.publicId ?? null,
+  ]);
+
+  if (ipKey) {
+    signals.push({
+      key: ipKey,
+      maxAttempts: 15,
+      windowMs: AGENT_TOKEN_EXCHANGE_WINDOW_MS,
+      blockMs: AGENT_TOKEN_EXCHANGE_BLOCK_MS,
+    });
+  }
+
+  if (publicIdKey) {
+    signals.push({
+      key: publicIdKey,
+      maxAttempts: 8,
+      windowMs: AGENT_TOKEN_EXCHANGE_WINDOW_MS,
+      blockMs: AGENT_TOKEN_EXCHANGE_BLOCK_MS,
+    });
+  }
+
+  if (ipPublicIdKey) {
+    signals.push({
+      key: ipPublicIdKey,
+      maxAttempts: 5,
+      windowMs: AGENT_TOKEN_EXCHANGE_WINDOW_MS,
+      blockMs: AGENT_TOKEN_EXCHANGE_BLOCK_MS,
+    });
+  }
+
+  return signals;
+}
+
+async function recordFailedAgentTokenExchange(input: {
+  credential?: {
+    id: string;
+    projectId: string;
+    createdByUserId: string;
+    publicId: string;
+    expiresAt: Date | null;
+    scopeGrants: Array<{ scope: ApiCredentialScope }>;
+  } | null;
+  requestId?: string | null;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  reason: string;
+}): Promise<void> {
+  logServerWarning(
+    "projectAgentAccess.tokenExchangeFailed",
+    "Agent token exchange failed.",
+    {
+      requestId: input.requestId ?? null,
+      ipAddress: input.ipAddress ?? null,
+      userAgent: input.userAgent ?? null,
+      publicId: input.credential?.publicId ?? null,
+      reason: input.reason,
+    }
+  );
+
+  if (!input.credential) {
+    return;
+  }
+
+  try {
+    await prisma.authAuditEvent.create({
+      data: {
+        projectId: input.credential.projectId,
+        credentialId: input.credential.id,
+        actorUserId: input.credential.createdByUserId,
+        actorKind: "agent",
+        action: "token_exchange_failed",
+        requestId: normalizeTrimmedString(input.requestId ?? null),
+        ipAddress: normalizeBoundedString(input.ipAddress ?? null, MAX_IP_ADDRESS_LENGTH),
+        userAgent: normalizeBoundedString(input.userAgent ?? null, MAX_USER_AGENT_LENGTH),
+        metadata: buildAuditMetadata({
+          scopes: input.credential.scopeGrants.map((grant) =>
+            mapDbScopeToAgentScope(grant.scope)
+          ),
+          publicId: input.credential.publicId,
+          expiresAt: input.credential.expiresAt,
+          failureReason: input.reason,
+        }),
+      },
+    });
+  } catch (error) {
+    logServerWarning(
+      "projectAgentAccess.tokenExchangeFailedAudit",
+      "Could not persist failed token exchange audit event.",
+      {
+        requestId: input.requestId ?? null,
+        publicId: input.credential.publicId,
+        reason: input.reason,
+        error,
+      }
+    );
+  }
 }
 
 async function createCredentialRecordWithUniquePublicId(
@@ -827,8 +951,59 @@ export async function exchangeAgentApiKeyForAccessToken(input: {
   }>
 > {
   const parsedApiKey = parseRawAgentApiKey(input.apiKey);
+  const abuseSignals = buildAgentTokenExchangeSignals({
+    ipAddress: input.ipAddress,
+    publicId: parsedApiKey?.publicId ?? null,
+  });
+  const abuseCheck = await checkAuthAbuseControls({
+    scope: AuthRateLimitScope.agent_token_exchange,
+    signals: abuseSignals,
+  });
+  if (!abuseCheck.ok) {
+    const throttledCredential = parsedApiKey
+      ? await prisma.apiCredential.findUnique({
+          where: {
+            publicId: parsedApiKey.publicId,
+          },
+          select: {
+            id: true,
+            projectId: true,
+            createdByUserId: true,
+            publicId: true,
+            expiresAt: true,
+            scopeGrants: {
+              orderBy: [{ scope: "asc" }],
+              select: {
+                scope: true,
+              },
+            },
+          },
+        })
+      : null;
+
+    await recordFailedAgentTokenExchange({
+      credential: throttledCredential,
+      requestId: input.requestId,
+      ipAddress: input.ipAddress,
+      userAgent: input.userAgent,
+      reason: "too-many-attempts",
+    });
+    return createError(429, "too-many-attempts");
+  }
+
   if (!parsedApiKey) {
-    return createError(401, "invalid-api-key");
+    const failureResult = await registerAuthAbuseFailure({
+      scope: AuthRateLimitScope.agent_token_exchange,
+      signals: abuseSignals,
+    });
+    await recordFailedAgentTokenExchange({
+      credential: null,
+      requestId: input.requestId,
+      ipAddress: input.ipAddress,
+      userAgent: input.userAgent,
+      reason: "malformed-api-key",
+    });
+    return createError(failureResult.ok ? 401 : 429, failureResult.ok ? "invalid-api-key" : "too-many-attempts");
   }
 
   const credential = await prisma.apiCredential.findUnique({
@@ -854,20 +1029,58 @@ export async function exchangeAgentApiKeyForAccessToken(input: {
   });
 
   if (!credential) {
-    return createError(401, "invalid-api-key");
+    const failureResult = await registerAuthAbuseFailure({
+      scope: AuthRateLimitScope.agent_token_exchange,
+      signals: abuseSignals,
+    });
+    await recordFailedAgentTokenExchange({
+      credential: null,
+      requestId: input.requestId,
+      ipAddress: input.ipAddress,
+      userAgent: input.userAgent,
+      reason: "credential-not-found",
+    });
+    return createError(failureResult.ok ? 401 : 429, failureResult.ok ? "invalid-api-key" : "too-many-attempts");
   }
 
   const secretMatches = await verifySecret(parsedApiKey.secret, credential.secretHash);
   if (!secretMatches) {
-    return createError(401, "invalid-api-key");
+    const failureResult = await registerAuthAbuseFailure({
+      scope: AuthRateLimitScope.agent_token_exchange,
+      signals: abuseSignals,
+    });
+    await recordFailedAgentTokenExchange({
+      credential,
+      requestId: input.requestId,
+      ipAddress: input.ipAddress,
+      userAgent: input.userAgent,
+      reason: "secret-mismatch",
+    });
+    return createError(failureResult.ok ? 401 : 429, failureResult.ok ? "invalid-api-key" : "too-many-attempts");
   }
 
   if (
     credential.revokedAt ||
     (credential.expiresAt && credential.expiresAt.getTime() <= Date.now())
   ) {
-    return createError(401, "invalid-api-key");
+    const failureResult = await registerAuthAbuseFailure({
+      scope: AuthRateLimitScope.agent_token_exchange,
+      signals: abuseSignals,
+    });
+    await recordFailedAgentTokenExchange({
+      credential,
+      requestId: input.requestId,
+      ipAddress: input.ipAddress,
+      userAgent: input.userAgent,
+      reason: credential.revokedAt ? "credential-revoked" : "credential-expired",
+    });
+    return createError(failureResult.ok ? 401 : 429, failureResult.ok ? "invalid-api-key" : "too-many-attempts");
   }
+
+  await clearAuthAbuseControls({
+    scope: AuthRateLimitScope.agent_token_exchange,
+    keys: abuseSignals.map((signal) => signal.key),
+  });
 
   const scopes = credential.scopeGrants.map((grant) =>
     mapDbScopeToAgentScope(grant.scope)
@@ -921,6 +1134,7 @@ export async function recordAgentRequestUsage(input: {
   ownerUserId: string;
   projectId: string;
   tokenId: string;
+  issuedAt: Date;
   requestId?: string | null;
   ipAddress?: string | null;
   userAgent?: string | null;
@@ -935,14 +1149,35 @@ export async function recordAgentRequestUsage(input: {
 
   const requestTimestamp = new Date();
   try {
-    await prisma.$transaction([
-      prisma.apiCredential.update({
-        where: { id: credentialId },
+    const authorizedUpdate = await prisma.$transaction(async (tx) => {
+      const updateResult = await tx.apiCredential.updateMany({
+        where: {
+          id: credentialId,
+          projectId: input.projectId,
+          createdByUserId: ownerUserId,
+          revokedAt: null,
+          AND: [
+            {
+              OR: [{ expiresAt: null }, { expiresAt: { gt: requestTimestamp } }],
+            },
+            {
+              OR: [
+                { lastRotatedAt: null },
+                { lastRotatedAt: { lte: input.issuedAt } },
+              ],
+            },
+          ],
+        },
         data: {
           lastUsedAt: requestTimestamp,
         },
-      }),
-      prisma.authAuditEvent.create({
+      });
+
+      if (updateResult.count !== 1) {
+        return false;
+      }
+
+      await tx.authAuditEvent.create({
         data: {
           projectId: input.projectId,
           credentialId,
@@ -958,8 +1193,14 @@ export async function recordAgentRequestUsage(input: {
             path: input.path ?? null,
           }),
         },
-      }),
-    ]);
+      });
+
+      return true;
+    });
+
+    if (!authorizedUpdate) {
+      return createError(401, "unauthorized");
+    }
   } catch (error) {
     const prismaErrorCode = readPrismaErrorCode(error);
     if (prismaErrorCode === "P2025" || prismaErrorCode === "P2003") {

--- a/lib/services/project-agent-access-service.ts
+++ b/lib/services/project-agent-access-service.ts
@@ -382,13 +382,22 @@ async function recordFailedAgentTokenExchange(input: {
   userAgent?: string | null;
   reason: string;
 }): Promise<void> {
+  const normalizedIpAddress = normalizeBoundedString(
+    input.ipAddress ?? null,
+    MAX_IP_ADDRESS_LENGTH
+  );
+  const normalizedUserAgent = normalizeBoundedString(
+    input.userAgent ?? null,
+    MAX_USER_AGENT_LENGTH
+  );
+
   logServerWarning(
     "projectAgentAccess.tokenExchangeFailed",
     "Agent token exchange failed.",
     {
       requestId: input.requestId ?? null,
-      ipAddress: input.ipAddress ?? null,
-      userAgent: input.userAgent ?? null,
+      ipAddress: normalizedIpAddress,
+      userAgent: normalizedUserAgent,
       publicId: input.credential?.publicId ?? null,
       reason: input.reason,
     }
@@ -1077,10 +1086,25 @@ export async function exchangeAgentApiKeyForAccessToken(input: {
     return createError(failureResult.ok ? 401 : 429, failureResult.ok ? "invalid-api-key" : "too-many-attempts");
   }
 
-  await clearAuthAbuseControls({
-    scope: AuthRateLimitScope.agent_token_exchange,
-    keys: abuseSignals.map((signal) => signal.key),
-  });
+  try {
+    await clearAuthAbuseControls({
+      scope: AuthRateLimitScope.agent_token_exchange,
+      keys: abuseSignals.map((signal) => signal.key),
+    });
+  } catch (error) {
+    logServerWarning(
+      "projectAgentAccess.tokenExchangeAbuseControlsClearFailed",
+      "Failed to clear auth abuse controls after successful agent token exchange.",
+      {
+        requestId: input.requestId ?? null,
+        ipAddress: normalizeBoundedString(input.ipAddress ?? null, MAX_IP_ADDRESS_LENGTH),
+        userAgent: normalizeBoundedString(input.userAgent ?? null, MAX_USER_AGENT_LENGTH),
+        publicId: credential.publicId,
+        credentialId: credential.id,
+        error,
+      }
+    );
+  }
 
   const scopes = credential.scopeGrants.map((grant) =>
     mapDbScopeToAgentScope(grant.scope)

--- a/lib/services/session-service.ts
+++ b/lib/services/session-service.ts
@@ -1,19 +1,10 @@
 import crypto from "node:crypto";
 
 import { prisma } from "@/lib/prisma";
-
-export const PRIMARY_SESSION_COOKIE_NAME = "nexusdash.session-token";
-export const LEGACY_SESSION_COOKIE_NAMES = [
-  "__Secure-authjs.session-token",
-  "authjs.session-token",
-  "__Secure-next-auth.session-token",
-  "next-auth.session-token",
-] as const;
-export const SESSION_COOKIE_NAMES = [
-  PRIMARY_SESSION_COOKIE_NAME,
-  ...LEGACY_SESSION_COOKIE_NAMES,
-] as const;
-export const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+import {
+  SESSION_COOKIE_NAMES,
+  SESSION_MAX_AGE_SECONDS,
+} from "@/lib/auth/session-constants";
 
 type CookieReader = (name: string) => string | null;
 
@@ -24,6 +15,10 @@ function normalizeSessionToken(value: string | null): string | null {
 
   const trimmedValue = value.trim();
   return trimmedValue.length > 0 ? trimmedValue : null;
+}
+
+export function hashSessionToken(sessionToken: string): string {
+  return crypto.createHash("sha256").update(sessionToken).digest("base64url");
 }
 
 export function readSessionTokenFromCookieReader(readCookie: CookieReader): string | null {
@@ -83,8 +78,10 @@ export async function resolveSessionUserIdByToken(
     return null;
   }
 
+  const sessionTokenHash = hashSessionToken(normalizedToken);
+
   const session = await prisma.session.findUnique({
-    where: { sessionToken: normalizedToken },
+    where: { sessionTokenHash },
     select: {
       userId: true,
       expires: true,
@@ -112,11 +109,12 @@ export async function createSessionForUser(userId: string): Promise<{
   }
 
   const sessionToken = crypto.randomBytes(32).toString("base64url");
+  const sessionTokenHash = hashSessionToken(sessionToken);
   const expiresAt = new Date(Date.now() + SESSION_MAX_AGE_SECONDS * 1000);
 
   await prisma.session.create({
     data: {
-      sessionToken,
+      sessionTokenHash,
       userId: normalizedUserId,
       expires: expiresAt,
     },
@@ -134,8 +132,10 @@ export async function deleteSessionByToken(sessionToken: string): Promise<void> 
     return;
   }
 
+  const sessionTokenHash = hashSessionToken(normalizedToken);
+
   await prisma.session.deleteMany({
-    where: { sessionToken: normalizedToken },
+    where: { sessionTokenHash },
   });
 }
 
@@ -149,8 +149,11 @@ export async function deleteAllOtherSessionsForUser(
   }
 
   const normalizedTokenToKeep = normalizeSessionToken(sessionTokenToKeep);
+  const sessionTokenHashToKeep = normalizedTokenToKeep
+    ? hashSessionToken(normalizedTokenToKeep)
+    : null;
 
-  if (!normalizedTokenToKeep) {
+  if (!sessionTokenHashToKeep) {
     await prisma.session.deleteMany({
       where: { userId: normalizedUserId },
     });
@@ -161,7 +164,7 @@ export async function deleteAllOtherSessionsForUser(
     where: {
       userId: normalizedUserId,
       NOT: {
-        sessionToken: normalizedTokenToKeep,
+        sessionTokenHash: sessionTokenHashToKeep,
       },
     },
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2028,6 +2028,111 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.2.tgz",
+      "integrity": "sha512-B92G3ulrwmkDSEJEp9+XzGLex5wC1knrmCSIylyVeiAtCIfvEJYiN3v5kXPlYt5R4RFlsfO/v++aKV63Acrugg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.2.tgz",
+      "integrity": "sha512-7ZwSgNKJNQiwW0CKhNm9B1WS2L1Olc4B2XY0hPYCAL3epFnugMhuw5TMWzMilQ3QCZcCHoYm9NGWTHbr5REFxw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.2.tgz",
+      "integrity": "sha512-c3m8kBHMziMgo2fICOP/cd/5YlrxDU5YYjAJeQLyFsCqVF8xjOTH/QYG4a2u48CvvZZSj1eHQfBCbyh7kBr30Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.2.tgz",
+      "integrity": "sha512-VKLuscm0P/mIfzt+SDdn2+8TNNJ7f0qfEkA+az7OqQbjzKdBxAHs0UvuiVoCtbwX+dqMEL9U54b5wQ/aN3dHeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.2.tgz",
+      "integrity": "sha512-kU3OPHJq6sBUjOk7wc5zJ7/lipn8yGldMoAv4z67j6ov6Xo/JvzA7L7LCsyzzsXmgLEhk3Qkpwqaq/1+XpNR3g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.2.tgz",
+      "integrity": "sha512-CKXRILyErMtUftp+coGcZ38ZwE/Aqq45VMCcRLr2I4OXKrgxIBDXHnBgeX/UMil0S09i2JXaDL3Q+TN8D/cKmg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.2.tgz",
+      "integrity": "sha512-sS/jSk5VUoShUqINJFvNjVT7JfR5ORYj/+/ZpOYbbIohv/lQfduWnGAycq2wlknbOql2xOR0DoV0s6Xfcy49+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@next/swc-win32-x64-msvc": {
       "version": "16.2.2",
       "cpu": [

--- a/prisma/migrations/20260410110000_task050_security_remediation/migration.sql
+++ b/prisma/migrations/20260410110000_task050_security_remediation/migration.sql
@@ -20,7 +20,7 @@ CREATE TABLE "AuthRateLimitBucket" (
   "attemptCount" INTEGER NOT NULL DEFAULT 0,
   "blockedUntil" TIMESTAMPTZ(6),
   "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  "updatedAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMPTZ(6) NOT NULL,
 
   CONSTRAINT "AuthRateLimitBucket_pkey" PRIMARY KEY ("scope", "key", "windowStart")
 );

--- a/prisma/migrations/20260410110000_task050_security_remediation/migration.sql
+++ b/prisma/migrations/20260410110000_task050_security_remediation/migration.sql
@@ -1,0 +1,32 @@
+DELETE FROM "Session";
+
+ALTER TABLE "Session" RENAME COLUMN "sessionToken" TO "sessionTokenHash";
+ALTER INDEX "Session_sessionToken_key" RENAME TO "Session_sessionTokenHash_key";
+
+ALTER TYPE "AuthAuditAction" ADD VALUE 'token_exchange_failed';
+
+CREATE TYPE "AuthRateLimitScope" AS ENUM (
+  'sign_in',
+  'sign_up',
+  'password_reset',
+  'verification_resend',
+  'agent_token_exchange'
+);
+
+CREATE TABLE "AuthRateLimitBucket" (
+  "scope" "AuthRateLimitScope" NOT NULL,
+  "key" VARCHAR(191) NOT NULL,
+  "windowStart" TIMESTAMPTZ(6) NOT NULL,
+  "attemptCount" INTEGER NOT NULL DEFAULT 0,
+  "blockedUntil" TIMESTAMPTZ(6),
+  "createdAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "AuthRateLimitBucket_pkey" PRIMARY KEY ("scope", "key", "windowStart")
+);
+
+CREATE INDEX "AuthRateLimitBucket_scope_key_blockedUntil_idx"
+  ON "AuthRateLimitBucket"("scope", "key", "blockedUntil");
+
+CREATE INDEX "AuthRateLimitBucket_createdAt_idx"
+  ON "AuthRateLimitBucket"("createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -90,12 +90,12 @@ model Account {
 }
 
 model Session {
-  id           String   @id @default(cuid())
-  sessionToken String   @unique
-  userId       String
-  expires      DateTime
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  id               String   @id @default(cuid())
+  sessionTokenHash String   @unique
+  userId           String
+  expires          DateTime
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -318,7 +318,16 @@ enum AuthAuditAction {
   credential_rotated
   credential_revoked
   token_exchanged
+  token_exchange_failed
   request_used
+}
+
+enum AuthRateLimitScope {
+  sign_in
+  sign_up
+  password_reset
+  verification_resend
+  agent_token_exchange
 }
 
 model ApiCredential {
@@ -379,4 +388,18 @@ model AuthAuditEvent {
   @@index([projectId, createdAt])
   @@index([credentialId, createdAt])
   @@index([actorUserId, createdAt])
+}
+
+model AuthRateLimitBucket {
+  scope        AuthRateLimitScope
+  key          String    @db.VarChar(191)
+  windowStart  DateTime  @db.Timestamptz(6)
+  attemptCount Int       @default(0)
+  blockedUntil DateTime? @db.Timestamptz(6)
+  createdAt    DateTime  @default(now()) @db.Timestamptz(6)
+  updatedAt    DateTime  @updatedAt @db.Timestamptz(6)
+
+  @@id([scope, key, windowStart])
+  @@index([scope, key, blockedUntil])
+  @@index([createdAt])
 }

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -4,16 +4,6 @@ Use this file to capture tasks discovered during development. Each entry should 
 
 ## Pending
 ### Execution Queue (Now / Next)
-- ID: TASK-116
-  Title: Dependabot and CI automation - workflow hygiene, safe auto-merge, and bounded red-PR repair agent
-  Status: Pending
-  Rationale: Keep dependency maintenance trustworthy without stealing focus from product delivery by hardening workflow hygiene, automatically merging only proven-safe update lanes after full CI, and adding a bounded repair agent for failing/manual-review Dependabot PRs that works through repo-owned superseding branches and human review.
-  Dependencies: TASK-038, TASK-041, TASK-042, TASK-061
-- ID: TASK-049
-  Title: Security baseline phase 1 - OWASP-focused assessment and threat model
-  Status: Pending
-  Rationale: Perform a structured review of attack surface and rank risks by impact/likelihood to guide remediation scope.
-  Dependencies: TASK-020, TASK-039
 - ID: TASK-050
   Title: Security baseline phase 2 - high-priority remediation sprint
   Status: Pending
@@ -155,6 +145,16 @@ Use this file to capture tasks discovered during development. Each entry should 
   Dependencies: TASK-051
 
 ## Completed
+- ID: TASK-116
+  Title: Dependabot and CI automation - workflow hygiene, safe auto-merge, and bounded red-PR repair agent
+  Status: Done (2026-04-09)
+  Rationale: Completed the Dependabot operating model end to end by keeping safe lanes auto-mergeable after full CI, validating the weekly Copilot repair lane on live red PRs, automatically producing green repo-owned superseding PRs, and closing the original Dependabot PRs to preserve a single review surface.
+  Dependencies: TASK-038, TASK-041, TASK-042, TASK-061
+- ID: TASK-049
+  Title: Security baseline phase 1 - OWASP-focused assessment and threat model
+  Status: Done (2026-04-09)
+  Rationale: Completed the OWASP-focused security assessment and threat model, refreshed it against the merged dependency/workflow baseline, and produced the ranked remediation scope that now feeds TASK-050.
+  Dependencies: TASK-020, TASK-039
 - ID: TASK-061
   Title: Dependency security baseline - vulnerability remediation and scan cadence definition
   Status: Done (2026-04-04)

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,7 +4,7 @@
 TASK-050
 
 ## Status
-Ready to start
+In progress
 
 ## Objective
 Implement the highest-priority security fixes identified by the completed
@@ -24,6 +24,65 @@ before moving further into feature delivery.
 - preserve existing CI and preview validation standards while making these
   changes
 
+## Expected Output
+- repo code changes that close the top three ranked findings from
+  `TASK-049`
+- any required Prisma migration(s) and compatibility handling for session-token
+  storage changes
+- regression coverage for the new abuse controls, session-token behavior, and
+  agent revocation semantics
+- documentation updates that capture any new runtime assumptions, follow-up
+  constraints, or verification notes needed for `TASK-051`
+
+## Acceptance Criteria
+- Public auth and token-entry surfaces have a real abuse-control baseline for
+  the implemented perimeter:
+  - sign-in
+  - sign-up
+  - forgot-password request
+  - verification-email resend
+  - `POST /api/auth/agent/token`
+- Abuse-control behavior is fail-closed on clear overuse while preserving
+  stable, non-leaky user-facing responses and bounded logging metadata.
+- Failed sign-in and failed agent token-exchange attempts become observable
+  through structured telemetry and/or audit records with request correlation,
+  without storing raw secrets.
+- Human session tokens are no longer stored in plaintext at rest.
+- Session lookup, sign-out, and session revocation flows continue to work
+  correctly after the session-token storage change.
+- Legacy plaintext-backed sessions are handled explicitly by the implementation:
+  either migrated safely or invalidated/rotated with the chosen behavior
+  documented in this task and the journal.
+- Already-issued agent bearer tokens no longer remain valid solely because
+  their signature and expiry are still valid; bearer-token use must also honor
+  current credential liveness/revocation state.
+- Existing valid human auth flows and valid agent flows continue to work after
+  the remediation pass.
+- The task remains code-first and does not expand into a new broad security
+  assessment or unrelated hardening scope.
+
+## Definition Of Done
+1. The ranked remediation scope from `tasks/task-049-security-assessment-and-threat-model.md`
+   findings 1-3 is implemented in code.
+2. Automated coverage is added or updated for the changed behavior, including
+   denial-path assertions for abuse controls, session-token lookup/storage
+   semantics, and revoked/rotated agent bearer-token use.
+3. Required tracking docs are updated and consistent:
+   - `tasks/current.md`
+   - `journal.md`
+   - `README.md` and/or runbooks when runtime behavior or operator expectations
+     change
+4. Validation is completed with evidence captured:
+   - `npm run lint`
+   - `npm test`
+   - `npm run test:coverage`
+   - `npm run build`
+   - `npm run test:e2e` when the local PostgreSQL-backed fixture path is
+     available; if it is not available, the blocker and fallback validation
+     path must be recorded explicitly
+5. Residual risk and any verification-only follow-up work are left clearly
+   bounded for `TASK-051` rather than staying implicit.
+
 ## Dependencies
 - `TASK-048`
 - `TASK-049`
@@ -34,8 +93,16 @@ before moving further into feature delivery.
 - Use the findings and prioritization from
   `tasks/task-049-security-assessment-and-threat-model.md`.
 - Follow-up verification and closure reporting remain in `TASK-051`.
+- Implementation decision record:
+  - `adr/task-050-security-remediation-adr.md`
+- Chosen migration behavior for plaintext legacy sessions:
+  - invalidate existing human sessions during rollout rather than preserve
+    dual-format session lookup compatibility indefinitely
+- Abuse-control baseline storage:
+  - PostgreSQL-backed fixed-window buckets keyed by hashed identifiers so the
+    controls remain authoritative across stateless app instances
 
 ---
 
-Last Updated: 2026-04-09
+Last Updated: 2026-04-10
 Assigned To: User + Agent

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,143 +1,39 @@
-# Current Task: TASK-116 Dependabot Operating Model - Green Auto-Merge + Weekly Copilot Repair Lane
+# Current Task: TASK-050 Security Baseline Phase 2 - High-Priority Remediation Sprint
 
 ## Task ID
-TASK-116
+TASK-050
 
 ## Status
-Implementation in progress, rerun replacement-PR follow-up in progress
+Ready to start
 
 ## Objective
-Turn Dependabot into a low-friction maintenance lane instead of a delivery
-distraction by:
-- keeping Dependabot cadence separate from feature/product PR flow
-- auto-merging green Dependabot PRs after full CI when they are in the safe
-  lane
-- treating red Dependabot PRs as one explicit manual-review lane
-- running a weekly scheduled GitHub Copilot CLI custom-agent pass on those red
-  PRs so it can repair them on repo-owned superseding branches, comment and
-  close the originals once superseded, and leave the final review decision to
-  humans
+Implement the highest-priority security fixes identified by the completed
+`TASK-049` assessment so the project closes its most material exposure gaps
+before moving further into feature delivery.
 
 ## Why This Task Matters
-- `TASK-061` enabled recurring Dependabot updates for npm and GitHub Actions.
-- The useful part of Dependabot is automated update proposal, not forcing us
-  to spend feature-review attention on maintenance PRs every day.
-- The repository now needs a cleaner operating model that keeps green bot PRs
-  out of the way and gives red bot PRs a deliberate weekly AI-assisted
-  review/fix lane that does not bleed into product PRs.
+- `TASK-049` produced a ranked remediation list instead of a vague audit.
+- The next security value is now in code changes, not more assessment.
+- This task is the bridge between the validated hardening baseline from
+  `TASK-048` / `TASK-116` and a stronger production-ready security posture.
 
-## Scope Snapshot
-- Landed baseline:
-  - Dependabot branch naming works without weakening the human branch contract
-  - safe grouped Dependabot lanes can auto-merge after full CI
-  - blocked upgrade cases already proved the need for repo-owned superseding
-    PRs (`#127`, `#128`)
-  - the repo can already classify manual-review Dependabot PRs separately from
-    safe-lane PRs
-- Clarified next slice:
-  - replace the event-driven red-PR repair idea with a weekly scheduled repair
-    workflow
-  - run GitHub Copilot CLI with a dedicated repository custom agent profile
-  - scan only open red/manual-review Dependabot PRs
-  - require any agent fix to land on a repo-owned superseding PR
-  - close the original Dependabot PR once the superseding PR exists so there is
-    only one merge surface
-  - keep all final merge decisions human-owned
-- Dedicated design note: `tasks/task-116-dependabot-operating-model.md`
+## Initial Focus
+- implement abuse-control baseline on the public auth and token-exchange paths
+- harden session-token storage semantics
+- reduce revocation lag on agent bearer-token usage where feasible
+- preserve existing CI and preview validation standards while making these
+  changes
 
-## Acceptance Snapshot
-- Dependabot runs on its own cadence, separate from feature/product PR flow.
-- Green safe-lane Dependabot PRs can merge automatically after required checks
-  pass.
-- Red/manual-review Dependabot PRs are the only Dependabot PRs considered by
-  the scheduled weekly Copilot repair lane.
-- The scheduled repair lane works only on Dependabot-created PRs.
-- Copilot-generated fixes land on repo-owned superseding PRs rather than
-  mutating the original bot branch.
-- Original Dependabot PRs are commented and then closed once a superseding PR
-  exists, preventing accidental merge on the wrong surface.
-- Superseding PRs are never auto-merged by the automation.
-
-## Validation / Evidence Expectations
-- Repo guidance should explain the two-lane Dependabot model clearly:
-  green auto-merge vs red weekly Copilot repair.
-- The implementation note should explain how red PRs are selected, how a
-  superseding PR is opened, when the original bot PR is closed, and why merge
-  stays human-owned.
-- We should record the GitHub-side prerequisites for Copilot CLI automation:
-  the `COPILOT_ACTIONS_TOKEN` secret, the repository custom agent profile, and
-  the fact that model selection intentionally falls back to Auto in the weekly
-  workflow.
-- Live workflow validation must prove more than a green Actions run:
-  the weekly lane must either produce a repo-owned superseding PR or emit a
-  machine-readable defer path from Copilot rather than failing before agent
-  execution.
-- Manual workflow dispatch should support a force-rerun path for a specific
-  Dependabot PR so we can re-validate an already-marked PR head without
-  weakening the default dedupe behavior.
-- The repair workflow must preserve its own validated orchestration code across
-  the Dependabot branch checkout, or it will silently execute stale repair
-  logic from the target bot branch instead.
-- Finalize must handle both Copilot edit shapes:
-  uncommitted working-tree changes and already-committed repair branches.
-- Generated superseding PRs must not stop at "created":
-  they need the repository's required checks explicitly dispatched, because
-  PRs created by `GITHUB_TOKEN` do not automatically trigger new workflow runs.
-- Those dispatched runs must also be mirrored back into commit statuses using
-  the required check names, because GitHub branch protection is not treating
-  the raw `workflow_dispatch` runs as merge-satisfying PR checks on the
-  generated repair branches.
-- Generated superseding PRs should explain themselves clearly for maintainers:
-  why they exist, which Dependabot PR they supersede, which files changed,
-  the rough diff size, and which validation commands Copilot reported.
-- Repair branches must be built from current `main` plus the Dependabot update,
-  not from the stale Dependabot branch head alone, or they will miss the
-  latest workflow definitions and any post-merge task fixes already on `main`.
-- If a repair rerun targets a PR that already produced a closed superseding PR,
-  the automation should mint a fresh retry branch/PR instead of failing on
-  GitHub's non-reopenable closed review surface.
+## Dependencies
+- `TASK-048`
+- `TASK-049`
+- `TASK-043`
 
 ## Notes
-- This remains a workflow/dependency-maintenance task under `TASK-116`, not a
-  reopening of `TASK-061`.
-- The current `main` baseline is coherent, but it does not yet match this
-  clarified weekly Copilot repair model.
-- A live main-branch smoke test on Dependabot PR `#133` proved the workflow
-  safety fallback works, but also exposed that the job was executing the stale
-  `scripts/dependabot_repair_agent.py` from the Dependabot branch after
-  checkout, which meant no prompt file was ever prepared for Copilot.
-- The TASK-116 follow-up branch now patches four live issues surfaced during
-  investigation:
-  - stable repair tooling is materialized before checking out the Dependabot
-    branch
-  - the copied orchestrator script resolves the repo root from
-    `GITHUB_WORKSPACE`
-  - targeted workflow dispatch can force-rerun an already-marked PR head
-  - finalize accepts both dirty repair branches and repair branches where
-    Copilot already created a local commit, with bounded replacement-PR bodies
-    to avoid `gh pr create` failures on verbose summaries
-- The latest live main-branch run proved a new blocker after those fixes:
-  Copilot successfully produced repo-owned replacement PR `#148`, but the
-  branch protections stayed pending because the PR was created by
-  `GITHUB_TOKEN`, which does not auto-trigger the required PR workflows.
-- The next follow-up slice is therefore to dispatch the required
-  `Check Branch Name` and `Quality Gates` workflows explicitly after creating a
-  superseding PR and to tighten the generated PR body so maintainers can
-  quickly understand what the repair lane actually changed.
-- Live rerun evidence on `#133` exposed one more integration bug after `#149`:
-  the repair branch was still being created directly from the old Dependabot
-  head, so the generated PR branch did not actually contain the new
-  `workflow_dispatch` workflow definitions from `main`; GitHub therefore
-  rejected the dispatch and the lane closed superseding PR `#150`.
-- The next live rerun on `#133` exposed a final reuse bug after `#151`: GitHub
-  refused to reopen closed superseding PR `#150`, so the repair lane now needs
-  to treat closed generated PRs as historical artifacts and open a fresh retry
-  review surface instead of trying to reuse the old one.
-- The repaired rerun on `#133` then proved the generated PR surface itself was
-  good (`#153`), but also exposed one more GitHub integration gap: the
-  explicitly dispatched workflows completed successfully while the PR still
-  showed no required checks, so the lane must mirror those successful results
-  into commit statuses for the repair branch head SHA.
+- Treat this as a code-first remediation task, not another assessment pass.
+- Use the findings and prioritization from
+  `tasks/task-049-security-assessment-and-threat-model.md`.
+- Follow-up verification and closure reporting remain in `TASK-051`.
 
 ---
 

--- a/tests/api/agent-token.route.test.ts
+++ b/tests/api/agent-token.route.test.ts
@@ -99,6 +99,28 @@ describe("POST /api/auth/agent/token", () => {
     });
   });
 
+  test("returns 429 when abuse controls throttle token exchange", async () => {
+    projectAgentAccessServiceMock.exchangeAgentApiKeyForAccessToken.mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      error: "too-many-attempts",
+    });
+
+    const request = new Request("http://localhost/api/auth/agent/token", {
+      method: "POST",
+      headers: {
+        authorization: "ApiKey nda_public.secret",
+      },
+    });
+
+    const response = await POST(request as never);
+
+    expect(response.status).toBe(429);
+    await expect(readJson(response)).resolves.toEqual({
+      error: "too-many-attempts",
+    });
+  });
+
   test("returns 400 for invalid json payloads", async () => {
     const request = new Request("http://localhost/api/auth/agent/token", {
       method: "POST",

--- a/tests/api/auth-logout.route.test.ts
+++ b/tests/api/auth-logout.route.test.ts
@@ -22,10 +22,13 @@ const loggerMock = vi.hoisted(() => ({
 }));
 
 vi.mock("@/lib/services/session-service", () => ({
-  SESSION_COOKIE_NAMES: sessionServiceMock.SESSION_COOKIE_NAMES,
   deleteSessionByToken: sessionServiceMock.deleteSessionByToken,
   readSessionTokensFromCookieReader:
     sessionServiceMock.readSessionTokensFromCookieReader,
+}));
+
+vi.mock("@/lib/auth/session-constants", () => ({
+  SESSION_COOKIE_NAMES: sessionServiceMock.SESSION_COOKIE_NAMES,
 }));
 
 vi.mock("@/lib/env.server", () => ({

--- a/tests/app/forgot-password-actions.test.ts
+++ b/tests/app/forgot-password-actions.test.ts
@@ -5,6 +5,18 @@ const redirectMock = vi.hoisted(() => vi.fn());
 const logServerErrorMock = vi.hoisted(() => vi.fn());
 const logServerWarningMock = vi.hoisted(() => vi.fn());
 const requestPasswordResetForEmailMock = vi.hoisted(() => vi.fn());
+const abuseControlServiceMock = vi.hoisted(() => ({
+  buildAuthRateLimitKey: vi.fn((namespace: string, value: string | null | undefined) =>
+    value ? `${namespace}:${value}` : null
+  ),
+  buildCompositeAuthRateLimitKey: vi.fn(
+    (namespace: string, values: Array<string | null | undefined>) =>
+      values.every((value) => typeof value === "string" && value.trim().length > 0)
+        ? `${namespace}:${values.join("|")}`
+        : null
+  ),
+  consumeAuthAbuseQuota: vi.fn(),
+}));
 
 vi.mock("next/headers", () => ({
   headers: headersMock,
@@ -18,6 +30,15 @@ vi.mock("@/lib/services/password-reset-service", () => ({
   requestPasswordResetForEmail: requestPasswordResetForEmailMock,
 }));
 
+vi.mock("@/lib/services/auth-abuse-control-service", () => ({
+  buildAuthRateLimitKey: abuseControlServiceMock.buildAuthRateLimitKey,
+  buildCompositeAuthRateLimitKey: abuseControlServiceMock.buildCompositeAuthRateLimitKey,
+  consumeAuthAbuseQuota: abuseControlServiceMock.consumeAuthAbuseQuota,
+  AuthRateLimitScope: {
+    password_reset: "password_reset",
+  },
+}));
+
 vi.mock("@/lib/observability/logger", () => ({
   logServerError: logServerErrorMock,
   logServerWarning: logServerWarningMock,
@@ -28,6 +49,7 @@ import { requestPasswordResetAction } from "@/app/forgot-password/actions";
 describe("forgot-password actions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    abuseControlServiceMock.consumeAuthAbuseQuota.mockResolvedValue({ ok: true });
     headersMock.mockReturnValue(
       new Headers([
         ["x-forwarded-proto", "https"],
@@ -57,6 +79,22 @@ describe("forgot-password actions", () => {
       emailRaw: "user@example.com",
       requestOrigin: "https://nexus-dash.app",
     });
+  });
+
+  test("stays enumeration-safe when the abuse-control baseline throttles the request", async () => {
+    abuseControlServiceMock.consumeAuthAbuseQuota.mockResolvedValueOnce({
+      ok: false,
+      retryAfterSeconds: 600,
+    });
+
+    const formData = new FormData();
+    formData.set("email", "user@example.com");
+
+    await expect(requestPasswordResetAction(formData)).rejects.toThrow(
+      "NEXT_REDIRECT:/forgot-password?status=request-submitted"
+    );
+    expect(requestPasswordResetForEmailMock).not.toHaveBeenCalled();
+    expect(logServerWarningMock).toHaveBeenCalled();
   });
 
   test("logs warning but preserves enumeration-safe redirect on service failure", async () => {

--- a/tests/app/home-auth-actions.test.ts
+++ b/tests/app/home-auth-actions.test.ts
@@ -303,6 +303,9 @@ describe("home auth actions", () => {
       emailRaw: "user@example.com",
       passwordRaw: "password123",
       passwordConfirmationRaw: "password123",
+      requestId: expect.any(String),
+      ipAddress: null,
+      userAgent: null,
     });
 
     expect(cookieStoreMock.set).toHaveBeenCalledWith(
@@ -349,6 +352,38 @@ describe("home auth actions", () => {
       requestOrigin: "https://nexus-dash.app",
       returnToPath: "/invite/project/invite-1",
     });
+  });
+
+  test("signInAction redirects with too-many-attempts when auth abuse controls trip", async () => {
+    credentialAuthMock.signInWithEmailPassword.mockResolvedValueOnce({
+      ok: false,
+      error: "too-many-attempts",
+    });
+
+    const formData = new FormData();
+    formData.set("email", "user@example.com");
+    formData.set("password", "password123");
+
+    await expect(signInAction(formData)).rejects.toThrow(
+      "NEXT_REDIRECT:/?form=signin&error=too-many-attempts"
+    );
+  });
+
+  test("signUpAction redirects with too-many-attempts when auth abuse controls trip", async () => {
+    credentialAuthMock.signUpWithEmailPassword.mockResolvedValueOnce({
+      ok: false,
+      error: "too-many-attempts",
+    });
+
+    const formData = new FormData();
+    formData.set("username", "test.user");
+    formData.set("email", "user@example.com");
+    formData.set("password", "password123");
+    formData.set("confirmPassword", "password123");
+
+    await expect(signUpAction(formData)).rejects.toThrow(
+      "NEXT_REDIRECT:/?form=signup&error=too-many-attempts"
+    );
   });
 
   test("signUpAction bypasses verification screen outside live production", async () => {

--- a/tests/app/verify-email-actions.test.ts
+++ b/tests/app/verify-email-actions.test.ts
@@ -13,6 +13,18 @@ const headersMock = vi.hoisted(() => vi.fn());
 const redirectMock = vi.hoisted(() => vi.fn());
 const logServerErrorMock = vi.hoisted(() => vi.fn());
 const logServerWarningMock = vi.hoisted(() => vi.fn());
+const abuseControlServiceMock = vi.hoisted(() => ({
+  buildAuthRateLimitKey: vi.fn((namespace: string, value: string | null | undefined) =>
+    value ? `${namespace}:${value}` : null
+  ),
+  buildCompositeAuthRateLimitKey: vi.fn(
+    (namespace: string, values: Array<string | null | undefined>) =>
+      values.every((value) => typeof value === "string" && value.trim().length > 0)
+        ? `${namespace}:${values.join("|")}`
+        : null
+  ),
+  consumeAuthAbuseQuota: vi.fn(),
+}));
 
 vi.mock("next/headers", () => ({
   headers: headersMock,
@@ -31,6 +43,15 @@ vi.mock("@/lib/services/email-verification-service", () => ({
   issueEmailVerificationForUser: emailVerificationMock.issueEmailVerificationForUser,
 }));
 
+vi.mock("@/lib/services/auth-abuse-control-service", () => ({
+  buildAuthRateLimitKey: abuseControlServiceMock.buildAuthRateLimitKey,
+  buildCompositeAuthRateLimitKey: abuseControlServiceMock.buildCompositeAuthRateLimitKey,
+  consumeAuthAbuseQuota: abuseControlServiceMock.consumeAuthAbuseQuota,
+  AuthRateLimitScope: {
+    verification_resend: "verification_resend",
+  },
+}));
+
 vi.mock("@/lib/observability/logger", () => ({
   logServerError: logServerErrorMock,
   logServerWarning: logServerWarningMock,
@@ -44,6 +65,7 @@ import {
 describe("verify-email actions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    abuseControlServiceMock.consumeAuthAbuseQuota.mockResolvedValue({ ok: true });
     sessionUserMock.getSessionUserIdFromServer.mockResolvedValue("user-1");
     emailVerificationMock.issueEmailVerificationForUser.mockResolvedValue({
       ok: true,
@@ -121,6 +143,19 @@ describe("verify-email actions", () => {
       "resendVerificationEmailAction",
       expect.any(Error)
     );
+  });
+
+  test("resendVerificationEmailAction redirects with resend-throttled when abuse controls trip", async () => {
+    abuseControlServiceMock.consumeAuthAbuseQuota.mockResolvedValueOnce({
+      ok: false,
+      retryAfterSeconds: 600,
+    });
+
+    await expect(resendVerificationEmailAction()).rejects.toThrow(
+      "NEXT_REDIRECT:/verify-email?error=resend-throttled&returnTo=%2Fprojects"
+    );
+    expect(emailVerificationMock.issueEmailVerificationForUser).not.toHaveBeenCalled();
+    expect(logServerWarningMock).toHaveBeenCalled();
   });
 
   test("continueAfterVerificationAction redirects to projects for verified users", async () => {

--- a/tests/e2e/helpers/auth-helpers.ts
+++ b/tests/e2e/helpers/auth-helpers.ts
@@ -2,10 +2,13 @@ import crypto from "node:crypto";
 
 import type { Page } from "@playwright/test";
 
-import { prisma } from "../../../lib/prisma";
 import {
   PRIMARY_SESSION_COOKIE_NAME,
   SESSION_MAX_AGE_SECONDS,
+} from "../../../lib/auth/session-constants";
+import { prisma } from "../../../lib/prisma";
+import {
+  hashSessionToken,
 } from "../../../lib/services/session-service";
 
 function uniqueSuffix(): string {
@@ -50,7 +53,7 @@ export async function signInAsVerifiedUser(page: Page): Promise<void> {
   await prisma.session.create({
     data: {
       userId: user.id,
-      sessionToken,
+      sessionTokenHash: hashSessionToken(sessionToken),
       expires: expiresAt,
     },
   });

--- a/tests/e2e/password-recovery.spec.ts
+++ b/tests/e2e/password-recovery.spec.ts
@@ -3,6 +3,7 @@ import { createHash, randomBytes } from "node:crypto";
 import { expect, test } from "@playwright/test";
 
 import { prisma } from "../../lib/prisma";
+import { hashSessionToken } from "../../lib/services/session-service";
 import { hashPassword } from "../../lib/services/password-service";
 
 function uniqueSuffix(): string {
@@ -83,7 +84,7 @@ test.describe("password recovery flow", () => {
     await prisma.session.create({
       data: {
         userId: user.id,
-        sessionToken: existingSessionToken,
+        sessionTokenHash: hashSessionToken(existingSessionToken),
         expires: new Date(Date.now() + 24 * 60 * 60 * 1000),
       },
     });

--- a/tests/lib/api-guard.test.ts
+++ b/tests/lib/api-guard.test.ts
@@ -247,6 +247,7 @@ describe("api-guard", () => {
       ownerUserId: "owner-1",
       projectId: "project-1",
       tokenId: "token-1",
+      issuedAt: new Date("2026-03-31T09:00:00.000Z"),
       requestId: "request-123",
       ipAddress: "198.51.100.24",
       userAgent: "Vitest",

--- a/tests/lib/credential-auth-service.test.ts
+++ b/tests/lib/credential-auth-service.test.ts
@@ -16,12 +16,32 @@ const passwordServiceMock = vi.hoisted(() => ({
   verifyPassword: vi.fn(),
 }));
 
+const abuseControlServiceMock = vi.hoisted(() => ({
+  buildAuthRateLimitKey: vi.fn((namespace: string, value: string | null | undefined) =>
+    value ? `${namespace}:${value}` : null
+  ),
+  buildCompositeAuthRateLimitKey: vi.fn(
+    (namespace: string, values: Array<string | null | undefined>) =>
+      values.every((value) => typeof value === "string" && value.trim().length > 0)
+        ? `${namespace}:${values.join("|")}`
+        : null
+  ),
+  checkAuthAbuseControls: vi.fn(),
+  clearAuthAbuseControls: vi.fn(),
+  consumeAuthAbuseQuota: vi.fn(),
+  registerAuthAbuseFailure: vi.fn(),
+}));
+
 const cryptoMock = vi.hoisted(() => ({
   randomInt: vi.fn(),
 }));
 
 const envMock = vi.hoisted(() => ({
   isPreviewDeployment: vi.fn(() => false),
+}));
+
+const loggerMock = vi.hoisted(() => ({
+  logServerWarning: vi.fn(),
 }));
 
 vi.mock("node:crypto", () => ({
@@ -41,8 +61,21 @@ vi.mock("@/lib/services/password-service", () => ({
   verifyPassword: passwordServiceMock.verifyPassword,
 }));
 
+vi.mock("@/lib/services/auth-abuse-control-service", () => ({
+  buildAuthRateLimitKey: abuseControlServiceMock.buildAuthRateLimitKey,
+  buildCompositeAuthRateLimitKey: abuseControlServiceMock.buildCompositeAuthRateLimitKey,
+  checkAuthAbuseControls: abuseControlServiceMock.checkAuthAbuseControls,
+  clearAuthAbuseControls: abuseControlServiceMock.clearAuthAbuseControls,
+  consumeAuthAbuseQuota: abuseControlServiceMock.consumeAuthAbuseQuota,
+  registerAuthAbuseFailure: abuseControlServiceMock.registerAuthAbuseFailure,
+}));
+
 vi.mock("@/lib/env.server", () => ({
   isPreviewDeployment: envMock.isPreviewDeployment,
+}));
+
+vi.mock("@/lib/observability/logger", () => ({
+  logServerWarning: loggerMock.logServerWarning,
 }));
 
 import {
@@ -60,6 +93,10 @@ describe("credential-auth-service", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     envMock.isPreviewDeployment.mockReturnValue(false);
+    abuseControlServiceMock.checkAuthAbuseControls.mockResolvedValue({ ok: true });
+    abuseControlServiceMock.consumeAuthAbuseQuota.mockResolvedValue({ ok: true });
+    abuseControlServiceMock.registerAuthAbuseFailure.mockResolvedValue({ ok: true });
+    abuseControlServiceMock.clearAuthAbuseControls.mockResolvedValue(undefined);
     sessionServiceMock.createSessionForUser.mockResolvedValue({
       sessionToken: "session-token",
       expiresAt: new Date("2026-03-01T00:00:00.000Z"),
@@ -425,5 +462,60 @@ describe("credential-auth-service", () => {
         expiresAt: new Date("2026-03-01T00:00:00.000Z"),
       },
     });
+  });
+
+  test("signUp returns too-many-attempts when abuse controls are exceeded", async () => {
+    abuseControlServiceMock.consumeAuthAbuseQuota.mockResolvedValueOnce({
+      ok: false,
+      retryAfterSeconds: 600,
+    });
+
+    const result = await signUpWithEmailPassword({
+      usernameRaw: "test.user",
+      emailRaw: "user@example.com",
+      passwordRaw: VALID_SIGN_UP_PASSWORD,
+      passwordConfirmationRaw: VALID_SIGN_UP_PASSWORD,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "too-many-attempts",
+    });
+  });
+
+  test("signIn returns too-many-attempts when preflight abuse controls are active", async () => {
+    abuseControlServiceMock.checkAuthAbuseControls.mockResolvedValueOnce({
+      ok: false,
+      retryAfterSeconds: 600,
+    });
+
+    const result = await signInWithEmailPassword({
+      emailRaw: "user@example.com",
+      passwordRaw: "password123",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "too-many-attempts",
+    });
+  });
+
+  test("signIn escalates to too-many-attempts when a failed login trips the limiter", async () => {
+    prismaMock.user.findUnique.mockResolvedValueOnce(null);
+    abuseControlServiceMock.registerAuthAbuseFailure.mockResolvedValueOnce({
+      ok: false,
+      retryAfterSeconds: 600,
+    });
+
+    const result = await signInWithEmailPassword({
+      emailRaw: "user@example.com",
+      passwordRaw: "password123",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "too-many-attempts",
+    });
+    expect(loggerMock.logServerWarning).toHaveBeenCalled();
   });
 });

--- a/tests/lib/credential-auth-service.test.ts
+++ b/tests/lib/credential-auth-service.test.ts
@@ -464,6 +464,45 @@ describe("credential-auth-service", () => {
     });
   });
 
+  test("signIn still succeeds when abuse-control cleanup fails after valid credentials", async () => {
+    prismaMock.user.findUnique.mockResolvedValueOnce({
+      id: "user-1",
+      passwordHash: "hash-1",
+    });
+    passwordServiceMock.verifyPassword.mockResolvedValueOnce(true);
+    abuseControlServiceMock.clearAuthAbuseControls.mockRejectedValueOnce(
+      new Error("cleanup-down")
+    );
+
+    const result = await signInWithEmailPassword({
+      emailRaw: "user@example.com",
+      passwordRaw: "password123",
+      requestId: "request-1",
+      ipAddress: "198.51.100.12",
+      userAgent: "Vitest",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        userId: "user-1",
+        emailVerified: false,
+        sessionToken: "session-token",
+        expiresAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+    });
+    expect(loggerMock.logServerWarning).toHaveBeenCalledWith(
+      "credentialAuth.signInAbuseControlsClearFailed",
+      expect.any(String),
+      expect.objectContaining({
+        requestId: "request-1",
+        ipAddress: "198.51.100.12",
+        userAgent: "Vitest",
+        userId: "user-1",
+      })
+    );
+  });
+
   test("signUp returns too-many-attempts when abuse controls are exceeded", async () => {
     abuseControlServiceMock.consumeAuthAbuseQuota.mockResolvedValueOnce({
       ok: false,

--- a/tests/lib/env.server.test.ts
+++ b/tests/lib/env.server.test.ts
@@ -5,6 +5,7 @@ import {
   getAgentTokenRuntimeConfig,
   getDatabaseRuntimeConfig,
   getOptionalServerEnv,
+  getPrismaPgRuntimeConnectionString,
   getRequiredServerEnv,
   getRuntimeEnvironment,
   getStorageRuntimeConfig,
@@ -157,6 +158,39 @@ describe("env.server", () => {
       databaseUrl: "postgresql://primary-host:5432/appdb",
       directUrl: "postgresql://read-replica-host:5432/appdb",
     });
+  });
+
+  test("adds libpq compatibility for prisma pg runtime when sslmode=require", () => {
+    vi.stubEnv(
+      "DATABASE_URL",
+      "postgresql://runtime-user:pwd@project.pooler.supabase.com:5432/postgres?sslmode=require"
+    );
+
+    expect(getPrismaPgRuntimeConnectionString()).toBe(
+      "postgresql://runtime-user:pwd@project.pooler.supabase.com:5432/postgres?sslmode=require&uselibpqcompat=true"
+    );
+  });
+
+  test("preserves existing prisma pg libpq compatibility flag", () => {
+    vi.stubEnv(
+      "DATABASE_URL",
+      "postgresql://runtime-user:pwd@project.pooler.supabase.com:5432/postgres?sslmode=require&uselibpqcompat=true"
+    );
+
+    expect(getPrismaPgRuntimeConnectionString()).toBe(
+      "postgresql://runtime-user:pwd@project.pooler.supabase.com:5432/postgres?sslmode=require&uselibpqcompat=true"
+    );
+  });
+
+  test("leaves prisma pg runtime url unchanged when sslmode is verify-full", () => {
+    vi.stubEnv(
+      "DATABASE_URL",
+      "postgresql://runtime-user:pwd@project.pooler.supabase.com:5432/postgres?sslmode=verify-full"
+    );
+
+    expect(getPrismaPgRuntimeConnectionString()).toBe(
+      "postgresql://runtime-user:pwd@project.pooler.supabase.com:5432/postgres?sslmode=verify-full"
+    );
   });
 
   test("returns null when supabase pair is fully empty/unset", () => {

--- a/tests/lib/project-agent-access-exchange.test.ts
+++ b/tests/lib/project-agent-access-exchange.test.ts
@@ -20,6 +20,25 @@ const agentTokenServiceMock = vi.hoisted(() => ({
   issueAgentAccessToken: vi.fn(),
 }));
 
+const abuseControlServiceMock = vi.hoisted(() => ({
+  buildAuthRateLimitKey: vi.fn((namespace: string, value: string | null | undefined) =>
+    value ? `${namespace}:${value}` : null
+  ),
+  buildCompositeAuthRateLimitKey: vi.fn(
+    (namespace: string, values: Array<string | null | undefined>) =>
+      values.every((value) => typeof value === "string" && value.trim().length > 0)
+        ? `${namespace}:${values.join("|")}`
+        : null
+  ),
+  checkAuthAbuseControls: vi.fn(),
+  clearAuthAbuseControls: vi.fn(),
+  registerAuthAbuseFailure: vi.fn(),
+}));
+
+const loggerMock = vi.hoisted(() => ({
+  logServerWarning: vi.fn(),
+}));
+
 vi.mock("@/lib/prisma", () => ({
   prisma: prismaMock,
 }));
@@ -30,6 +49,21 @@ vi.mock("@/lib/services/password-service", () => ({
 
 vi.mock("@/lib/auth/agent-token-service", () => ({
   issueAgentAccessToken: agentTokenServiceMock.issueAgentAccessToken,
+}));
+
+vi.mock("@/lib/services/auth-abuse-control-service", () => ({
+  buildAuthRateLimitKey: abuseControlServiceMock.buildAuthRateLimitKey,
+  buildCompositeAuthRateLimitKey: abuseControlServiceMock.buildCompositeAuthRateLimitKey,
+  checkAuthAbuseControls: abuseControlServiceMock.checkAuthAbuseControls,
+  clearAuthAbuseControls: abuseControlServiceMock.clearAuthAbuseControls,
+  registerAuthAbuseFailure: abuseControlServiceMock.registerAuthAbuseFailure,
+  AuthRateLimitScope: {
+    agent_token_exchange: "agent_token_exchange",
+  },
+}));
+
+vi.mock("@/lib/observability/logger", () => ({
+  logServerWarning: loggerMock.logServerWarning,
 }));
 
 import { exchangeAgentApiKeyForAccessToken } from "@/lib/services/project-agent-access-service";
@@ -44,6 +78,9 @@ describe("exchangeAgentApiKeyForAccessToken", () => {
       __mock: "authAuditEvent.create",
     });
     prismaMock.$transaction.mockResolvedValue([]);
+    abuseControlServiceMock.checkAuthAbuseControls.mockResolvedValue({ ok: true });
+    abuseControlServiceMock.registerAuthAbuseFailure.mockResolvedValue({ ok: true });
+    abuseControlServiceMock.clearAuthAbuseControls.mockResolvedValue(undefined);
     passwordServiceMock.verifySecret.mockResolvedValue(true);
     agentTokenServiceMock.issueAgentAccessToken.mockReturnValue({
       accessToken: "issued-token",
@@ -116,6 +153,26 @@ describe("exchangeAgentApiKeyForAccessToken", () => {
           },
         },
       },
+    });
+  });
+
+  test("returns too-many-attempts when abuse controls are already active", async () => {
+    abuseControlServiceMock.checkAuthAbuseControls.mockResolvedValueOnce({
+      ok: false,
+      retryAfterSeconds: 600,
+    });
+
+    const result = await exchangeAgentApiKeyForAccessToken({
+      apiKey: "nda_public.secret-value",
+      requestId: "request-123",
+      ipAddress: "198.51.100.12",
+      userAgent: "Vitest",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 429,
+      error: "too-many-attempts",
     });
   });
 });

--- a/tests/lib/project-agent-access-exchange.test.ts
+++ b/tests/lib/project-agent-access-exchange.test.ts
@@ -175,4 +175,52 @@ describe("exchangeAgentApiKeyForAccessToken", () => {
       error: "too-many-attempts",
     });
   });
+
+  test("still issues a token when abuse-control cleanup fails after a valid exchange", async () => {
+    prismaMock.apiCredential.findUnique.mockResolvedValueOnce({
+      id: "credential-1",
+      label: "Preview validation bot",
+      secretHash: "hashed-secret",
+      publicId: "nda_public",
+      projectId: "project-1",
+      createdByUserId: "owner-1",
+      expiresAt: null,
+      revokedAt: null,
+      scopeGrants: [{ scope: ApiCredentialScope.task_read }],
+    });
+    abuseControlServiceMock.clearAuthAbuseControls.mockRejectedValueOnce(
+      new Error("cleanup-down")
+    );
+
+    const result = await exchangeAgentApiKeyForAccessToken({
+      apiKey: "nda_public.secret-value",
+      requestId: "request-123",
+      ipAddress: "198.51.100.12",
+      userAgent: "Vitest",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      status: 200,
+      data: {
+        accessToken: "issued-token",
+        tokenType: "Bearer",
+        expiresAt: "2026-03-31T10:10:00.000Z",
+        expiresInSeconds: 600,
+        projectId: "project-1",
+        scopes: ["task:read"],
+      },
+    });
+    expect(loggerMock.logServerWarning).toHaveBeenCalledWith(
+      "projectAgentAccess.tokenExchangeAbuseControlsClearFailed",
+      expect.any(String),
+      expect.objectContaining({
+        requestId: "request-123",
+        ipAddress: "198.51.100.12",
+        userAgent: "Vitest",
+        credentialId: "credential-1",
+        publicId: "nda_public",
+      })
+    );
+  });
 });

--- a/tests/lib/project-agent-access-service.test.ts
+++ b/tests/lib/project-agent-access-service.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 const prismaMock = vi.hoisted(() => ({
   $transaction: vi.fn(),
   apiCredential: {
-    update: vi.fn(),
+    updateMany: vi.fn(),
   },
   authAuditEvent: {
     create: vi.fn(),
@@ -19,23 +19,24 @@ import { recordAgentRequestUsage } from "@/lib/services/project-agent-access-ser
 describe("project-agent-access-service", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    prismaMock.apiCredential.update.mockReturnValue({
-      __mock: "apiCredential.update",
+    prismaMock.apiCredential.updateMany.mockResolvedValue({
+      count: 1,
     });
-    prismaMock.authAuditEvent.create.mockReturnValue({
-      __mock: "authAuditEvent.create",
-    });
-    prismaMock.$transaction.mockResolvedValue([]);
+    prismaMock.$transaction.mockImplementation(async (callback: (tx: typeof prismaMock) => unknown) =>
+      callback(prismaMock)
+    );
   });
 
   test("returns unauthorized when the backing credential disappears before usage is recorded", async () => {
-    prismaMock.$transaction.mockRejectedValueOnce({ code: "P2025" });
+    prismaMock.apiCredential.updateMany.mockResolvedValueOnce({ count: 0 });
+    const issuedAt = new Date("2026-03-31T09:00:00.000Z");
 
     const result = await recordAgentRequestUsage({
       credentialId: "credential-1",
       ownerUserId: "owner-1",
       projectId: "project-1",
       tokenId: "token-1",
+      issuedAt,
       requestId: "request-1",
       httpMethod: "GET",
       path: "/api/projects/project-1/tasks",
@@ -45,6 +46,25 @@ describe("project-agent-access-service", () => {
       ok: false,
       status: 401,
       error: "unauthorized",
+    });
+    expect(prismaMock.apiCredential.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: "credential-1",
+        projectId: "project-1",
+        createdByUserId: "owner-1",
+        revokedAt: null,
+        AND: [
+          {
+            OR: [{ expiresAt: null }, { expiresAt: { gt: expect.any(Date) } }],
+          },
+          {
+            OR: [{ lastRotatedAt: null }, { lastRotatedAt: { lte: issuedAt } }],
+          },
+        ],
+      },
+      data: {
+        lastUsedAt: expect.any(Date),
+      },
     });
   });
 
@@ -56,6 +76,7 @@ describe("project-agent-access-service", () => {
       ownerUserId: "owner-1",
       projectId: "project-1",
       tokenId: "token-1",
+      issuedAt: new Date("2026-03-31T09:00:00.000Z"),
       requestId: "request-1",
       httpMethod: "GET",
       path: "/api/projects/project-1/tasks",

--- a/tests/lib/request-metadata.test.ts
+++ b/tests/lib/request-metadata.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "vitest";
+
+import { readClientIpAddressFromHeaders } from "@/lib/http/request-metadata";
+
+describe("request-metadata", () => {
+  test("returns null when x-real-ip is blank after trimming", () => {
+    const headers = new Headers([["x-real-ip", "   "]]);
+
+    expect(readClientIpAddressFromHeaders(headers)).toBeNull();
+  });
+
+  test("prefers the first non-empty forwarded-for entry", () => {
+    const headers = new Headers([["x-forwarded-for", " 198.51.100.1, 203.0.113.5 "]]);
+
+    expect(readClientIpAddressFromHeaders(headers)).toBe("198.51.100.1");
+  });
+});

--- a/tests/lib/session-service-storage.test.ts
+++ b/tests/lib/session-service-storage.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  session: {
+    findUnique: vi.fn(),
+    create: vi.fn(),
+    deleteMany: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock("node:crypto", async () => {
+  const actual = await vi.importActual<typeof import("node:crypto")>("node:crypto");
+
+  return {
+    ...actual,
+    randomBytes: vi.fn(() => Buffer.from("a".repeat(32))),
+  };
+});
+
+import {
+  createSessionForUser,
+  deleteAllOtherSessionsForUser,
+  deleteSessionByToken,
+  hashSessionToken,
+  resolveSessionUserIdByToken,
+} from "@/lib/services/session-service";
+
+describe("session-service secure storage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("resolves sessions by hashed token lookup", async () => {
+    prismaMock.session.findUnique.mockResolvedValueOnce({
+      userId: "user-1",
+      expires: new Date(Date.now() + 60_000),
+    });
+
+    const result = await resolveSessionUserIdByToken("session-token");
+
+    expect(result).toBe("user-1");
+    expect(prismaMock.session.findUnique).toHaveBeenCalledWith({
+      where: {
+        sessionTokenHash: hashSessionToken("session-token"),
+      },
+      select: {
+        userId: true,
+        expires: true,
+      },
+    });
+  });
+
+  test("creates sessions with hashed storage but returns the raw token", async () => {
+    prismaMock.session.create.mockResolvedValueOnce({});
+
+    const result = await createSessionForUser("user-1");
+
+    expect(result.sessionToken.length).toBeGreaterThan(0);
+    expect(prismaMock.session.create).toHaveBeenCalledWith({
+      data: {
+        sessionTokenHash: hashSessionToken(result.sessionToken),
+        userId: "user-1",
+        expires: expect.any(Date),
+      },
+    });
+  });
+
+  test("deletes sessions by hashed token", async () => {
+    await deleteSessionByToken("session-token");
+
+    expect(prismaMock.session.deleteMany).toHaveBeenCalledWith({
+      where: {
+        sessionTokenHash: hashSessionToken("session-token"),
+      },
+    });
+  });
+
+  test("keeps only the hashed current session during bulk revocation", async () => {
+    await deleteAllOtherSessionsForUser("user-1", "session-token");
+
+    expect(prismaMock.session.deleteMany).toHaveBeenCalledWith({
+      where: {
+        userId: "user-1",
+        NOT: {
+          sessionTokenHash: hashSessionToken("session-token"),
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## What changed
Implemented the ranked remediation slice from TASK-049 across the public auth and agent-access perimeter.

This PR:
- adds DB-backed abuse controls for sign-in, sign-up, forgot-password, verification resend, and `POST /api/auth/agent/token`
- records failed sign-in and failed agent token exchange activity without storing raw secrets
- hashes human session tokens at rest and switches session lookup/revocation to hashed-token semantics
- invalidates legacy plaintext-backed human sessions during migration instead of keeping indefinite dual-format compatibility
- makes already-issued agent bearer tokens honor current credential liveness during request-time usage checks
- records the architecture choices in `adr/decisions.md`, a dedicated TASK-050 ADR, `journal.md`, and the current task brief

## Why
TASK-049 identified three top remaining gaps:
1. no real public auth/token abuse-control baseline
2. plaintext human sessions at rest
3. agent bearer tokens staying valid until TTL even after rotate/revoke

This PR closes those three findings without expanding into unrelated hardening scope.

## Impact
- public auth and token exchange now fail closed on obvious overuse with bounded metadata and stable user-facing responses
- database reads alone no longer expose active human session tokens
- rotating or revoking an agent credential now cuts off already-issued bearer-token use immediately at request time
- one-time rollout effect: existing human sessions are invalidated by the session-token migration

## Validation
- `npm run lint`
- `npm test`
- `npm run test:coverage`
- `npx prisma generate`
- `npm run build` with safe preview-style env overrides

## Known local blocker
- `npm run test:e2e` remains blocked in this workstation session because Prisma cannot reach the expected PostgreSQL fixture service at `127.0.0.1:5432`
- CI/preview should provide the authoritative e2e signal for this branch
