### PR TITLE
[task-120] Harden Dependabot repair follow-up

### DIFF
--- a/.github/workflows/dependabot-auto-triage.yml
+++ b/.github/workflows/dependabot-auto-triage.yml
@@ -75,22 +75,22 @@ jobs:
             || true
 
   merge-safe-pr:
-    name: Merge safe Dependabot PR after green checks
+    name: Reconcile safe Dependabot PR state after checks
     if: >
       github.event_name == 'workflow_run' &&
       github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success' &&
       startsWith(github.event.workflow_run.head_branch, 'dependabot/')
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
       pull-requests: write
     env:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ github.token }}
 
     steps:
-      - name: Merge safe Dependabot PR
+      - name: Reconcile safe Dependabot labels and merge green PRs
         shell: bash
         run: |
           PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
@@ -121,6 +121,8 @@ jobs:
           fi
 
           HAS_AUTO_LABEL=""
+          HAS_MANUAL_LABEL=""
+          FAILING_COUNT=""
           INCOMPLETE_COUNT=""
           MERGE_STATE=""
 
@@ -136,6 +138,35 @@ jobs:
 
             if ! HAS_AUTO_LABEL="$(echo "$PR_JSON" | jq -r '[.labels[].name] | index("dependabot:auto-merge") != null')"; then
               echo "Failed to parse auto-merge label for PR #$PR_NUMBER (attempt $attempt/6)."
+              if [[ "$attempt" -lt 6 ]]; then
+                sleep 10
+                continue
+              fi
+              exit 1
+            fi
+
+            if ! HAS_MANUAL_LABEL="$(echo "$PR_JSON" | jq -r '[.labels[].name] | index("dependabot:manual-review") != null')"; then
+              echo "Failed to parse manual-review label for PR #$PR_NUMBER (attempt $attempt/6)."
+              if [[ "$attempt" -lt 6 ]]; then
+                sleep 10
+                continue
+              fi
+              exit 1
+            fi
+
+            if ! FAILING_COUNT="$(echo "$PR_JSON" | jq --argjson required "$REQUIRED_CHECK_NAMES_JSON" '
+              [
+                $required[] as $required_name
+                | (
+                    [.statusCheckRollup[] | select(.name == $required_name)]
+                    | map(select(.status == "COMPLETED" and .conclusion != "SUCCESS" and .conclusion != "NEUTRAL" and .conclusion != "SKIPPED"))
+                    | length
+                  )
+                | select(. > 0)
+              ]
+              | length
+            ')"; then
+              echo "Failed to parse failing checks for PR #$PR_NUMBER (attempt $attempt/6)."
               if [[ "$attempt" -lt 6 ]]; then
                 sleep 10
                 continue
@@ -175,16 +206,31 @@ jobs:
               exit 1
             fi
 
+            if [[ "$FAILING_COUNT" != "0" ]]; then
+              break
+            fi
+
             if [[ "$HAS_AUTO_LABEL" == "true" && "$INCOMPLETE_COUNT" == "0" && ( "$MERGE_STATE" == "CLEAN" || "$MERGE_STATE" == "HAS_HOOKS" ) ]]; then
               break
             fi
 
-            echo "PR #$PR_NUMBER is not ready yet (attempt $attempt/6): has_auto_label=$HAS_AUTO_LABEL incomplete_count=$INCOMPLETE_COUNT merge_state=$MERGE_STATE"
+            echo "PR #$PR_NUMBER is not ready yet (attempt $attempt/6): has_auto_label=$HAS_AUTO_LABEL has_manual_label=$HAS_MANUAL_LABEL failing_count=$FAILING_COUNT incomplete_count=$INCOMPLETE_COUNT merge_state=$MERGE_STATE"
 
             if [[ "$attempt" -lt 6 ]]; then
               sleep 10
             fi
           done
+
+          if [[ "$FAILING_COUNT" != "0" ]]; then
+            if [[ "$HAS_AUTO_LABEL" == "true" || "$HAS_MANUAL_LABEL" != "true" ]]; then
+              gh pr edit "$PR_NUMBER" \
+                --add-label "dependabot:manual-review" \
+                --remove-label "dependabot:auto-merge"
+            fi
+
+            echo "PR #$PR_NUMBER has failing required checks and was moved to the manual-review lane."
+            exit 0
+          fi
 
           if [[ "$HAS_AUTO_LABEL" != "true" ]]; then
             echo "PR #$PR_NUMBER is not in the safe auto-merge lane."

--- a/.github/workflows/dependabot-auto-triage.yml
+++ b/.github/workflows/dependabot-auto-triage.yml
@@ -159,10 +159,16 @@ jobs:
                 $required[] as $required_name
                 | (
                     [.statusCheckRollup[] | select(.name == $required_name)]
-                    | map(select(.status == "COMPLETED" and .conclusion != "SUCCESS" and .conclusion != "NEUTRAL" and .conclusion != "SKIPPED"))
-                    | length
+                    | sort_by(.completedAt // .startedAt // .detailsUrl // "")
+                    | last
                   )
-                | select(. > 0)
+                | select(
+                    . != null
+                    and .status == "COMPLETED"
+                    and .conclusion != "SUCCESS"
+                    and .conclusion != "NEUTRAL"
+                    and .conclusion != "SKIPPED"
+                  )
               ]
               | length
             ')"; then
@@ -179,10 +185,17 @@ jobs:
                 $required[] as $required_name
                 | (
                     [.statusCheckRollup[] | select(.name == $required_name)]
-                    | if length == 0 then
+                    | sort_by(.completedAt // .startedAt // .detailsUrl // "")
+                    | last
+                    | if . == null then
                         true
                       else
-                        any(.status != "COMPLETED" or .conclusion != "SUCCESS")
+                        .status != "COMPLETED"
+                        or (
+                          .conclusion != "SUCCESS"
+                          and .conclusion != "NEUTRAL"
+                          and .conclusion != "SKIPPED"
+                        )
                       end
                   )
                 | select(. == true)

--- a/.github/workflows/dependabot-repair-agent.yml
+++ b/.github/workflows/dependabot-repair-agent.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Define repair paths
         run: |
-          BASE_DIR="$RUNNER_TEMP/dependabot-repair/${{ matrix.target.number }}"
+          BASE_DIR="$GITHUB_WORKSPACE/tmp/dependabot-repair/${{ matrix.target.number }}"
           {
             echo "REPAIR_CONTEXT_DIR=$BASE_DIR"
             echo "REPAIR_ORCHESTRATOR_PATH=$BASE_DIR/dependabot_repair_agent.py"
@@ -258,4 +258,5 @@ jobs:
             --head-sha "$HEAD_SHA" \
             --replacement-branch "$REPAIR_BRANCH" \
             --baseline-sha "$REPAIR_BASELINE_SHA" \
-            --result-path "$REPAIR_CONTEXT_DIR/result.json"
+            --result-path "$REPAIR_CONTEXT_DIR/result.json" \
+            --copilot-output-path "$REPAIR_CONTEXT_DIR/copilot-output.log"

--- a/README.md
+++ b/README.md
@@ -268,11 +268,12 @@ Required GitHub secrets:
 - `.github/workflows/dependency-security.yml`: scheduled every Monday at 07:00 UTC and runnable on demand
 - `.github/dependabot.yml`: weekly npm + GitHub Actions dependency update cadence
 - `.github/workflows/dependabot-auto-triage.yml`: labels and auto-approves safe
-  Dependabot lanes, then auto-merges them after the required PR checks pass
+  Dependabot lanes, reclassifies failed safe-lane PRs back into manual review,
+  then auto-merges them after the required PR checks pass
 - `.github/workflows/dependabot-repair-agent.yml`: weekly scheduled GitHub
-  Copilot CLI repair lane for failing manual-review Dependabot PRs; it may
-  create repo-owned superseding PRs and close the original Dependabot PRs, but
-  it never merges the superseding PRs automatically
+  Copilot CLI repair lane for failing Dependabot PRs; it may create repo-owned
+  superseding PRs and close the original Dependabot PRs, but it never merges
+  the superseding PRs automatically
 
 Dependabot automation policy:
 - grouped GitHub Actions updates are considered safe auto-merge candidates
@@ -284,7 +285,10 @@ Dependabot automation policy:
     `tailwindcss-animate`, `sanitize-html`, `emojibase-data`)
 - majors and excluded high-churn dependencies stay in manual review
 - a weekly Copilot repair lane may triage failing/manual-review Dependabot PRs:
-  - it runs only for Dependabot-created `dependabot/*` PRs in the manual-review lane
+  - red safe-lane PRs are reclassified out of `dependabot:auto-merge` once
+    required checks fail
+  - it scans open red Dependabot-created `dependabot/*` PRs, so stale labels do
+    not block repair follow-up
   - it uses a repository custom Copilot agent profile plus a scheduled GitHub
     Actions workflow
   - when it repairs an update, it opens a repo-owned superseding PR and closes

--- a/journal.md
+++ b/journal.md
@@ -13,6 +13,11 @@ Use it for important implementation milestones, blockers, validation runs, and r
 ## Recent Entries (Most Relevant)
 
 ### 2026-04-13
+- Type: Validation
+- Summary: TASK-120 follow-up validated on PR `#167` with all required checks green, Copilot review comments addressed/resolved, and a manual preview deploy confirmed from branch `fix/task-120-dependabot-repair-followup`.
+- Evidence: PR `#167`; commits `9271309` and `5629103`; green runs `24343300501` (`check-name`) and `24343300445` (`Quality Core`, `E2E Smoke`, `Container Image`); resolved review threads `PRRT_kwDORPDIrs56hcqG`, `PRRT_kwDORPDIrs56hcqw`, and `PRRT_kwDORPDIrs56hcrA`; preview deploy run `24343028393` checked out `fix/task-120-dependabot-repair-followup` and published `https://nexus-dash-itlv8pqfw-dorian-agaesses-projects.vercel.app`.
+
+### 2026-04-13
 - Type: Execution
 - Summary: TASK-120 hardened the Dependabot follow-up flow by reclassifying failed safe-lane PRs out of `dependabot:auto-merge`, broadening the repair scanner to any red Dependabot PR, and moving the Copilot repair context into the repo so the agent can finally write/read its machine-readable result.
 - Evidence: Updated `.github/workflows/dependabot-auto-triage.yml`, `.github/workflows/dependabot-repair-agent.yml`, `scripts/dependabot_repair_agent.py`, `README.md`, `tasks/current.md`, and `tasks/backlog.md`; fix addresses live red PR behavior seen on Dependabot PRs `#162`, `#163`, and `#164`.

--- a/journal.md
+++ b/journal.md
@@ -12,6 +12,11 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ## Recent Entries (Most Relevant)
 
+### 2026-04-13
+- Type: Execution
+- Summary: TASK-120 hardened the Dependabot follow-up flow by reclassifying failed safe-lane PRs out of `dependabot:auto-merge`, broadening the repair scanner to any red Dependabot PR, and moving the Copilot repair context into the repo so the agent can finally write/read its machine-readable result.
+- Evidence: Updated `.github/workflows/dependabot-auto-triage.yml`, `.github/workflows/dependabot-repair-agent.yml`, `scripts/dependabot_repair_agent.py`, `README.md`, `tasks/current.md`, and `tasks/backlog.md`; fix addresses live red PR behavior seen on Dependabot PRs `#162`, `#163`, and `#164`.
+
 ### 2026-04-10
 - Type: Validation
 - Summary: Investigated a broken TASK-050 preview and traced `GET /` runtime failures to Prisma's `@prisma/adapter-pg` path interpreting `sslmode=require` as certificate-verifying TLS against the Supabase pooler; fixed the runtime client to add `uselibpqcompat=true` for `sslmode=require`, which matches libpq semantics and restores preview connectivity.

--- a/scripts/dependabot_repair_agent.py
+++ b/scripts/dependabot_repair_agent.py
@@ -80,10 +80,6 @@ def is_dependabot_pr(pr: dict[str, Any]) -> bool:
     )
 
 
-def label_names(pr: dict[str, Any]) -> set[str]:
-    return {label["name"] for label in pr.get("labels", [])}
-
-
 def pr_has_failure(pr: dict[str, Any]) -> bool:
     latest_checks: dict[str, dict[str, Any]] = {}
     latest_keys: dict[str, str] = {}
@@ -232,14 +228,56 @@ def diff_shortstat_against_main() -> str:
     return git("diff", "--shortstat", "origin/main...HEAD").strip()
 
 
-def load_result(path: Path) -> dict[str, Any]:
+def default_result_summary() -> str:
+    return (
+        "The Copilot repair lane did not produce a machine-readable result. "
+        "Leaving this Dependabot PR open for manual review."
+    )
+
+
+def inferred_result_from_copilot_output(path: Path | None) -> dict[str, Any] | None:
+    if path is None or not path.exists():
+        return None
+
+    text = path.read_text(encoding="utf-8")
+    decision_match = re.search(r'"decision"\s*:\s*"(fixed|defer)"', text)
+    if not decision_match:
+        return None
+
+    summary_match = re.search(r'"summary"\s*:\s*"((?:[^"\\]|\\.)*)"', text)
+    summary = (
+        json.loads(f'"{summary_match.group(1)}"')
+        if summary_match
+        else "Recovered the repair decision from Copilot output after the result file could not be written."
+    )
+
+    validation_match = re.search(r'"validation"\s*:\s*(\[[\s\S]*?\])', text)
+    validation: list[str] = []
+    if validation_match:
+        try:
+            parsed_validation = json.loads(validation_match.group(1))
+        except json.JSONDecodeError:
+            parsed_validation = []
+        validation = [str(item).strip() for item in parsed_validation if str(item).strip()]
+
+    return {
+        "decision": decision_match.group(1),
+        "summary": (
+            f"{summary}\n\nRecovered the decision from Copilot output because the result file was unavailable."
+        ).strip(),
+        "validation": validation,
+    }
+
+
+def load_result(path: Path, *, copilot_output_path: Path | None = None) -> dict[str, Any]:
     if not path.exists():
+        inferred = inferred_result_from_copilot_output(copilot_output_path)
+        if inferred:
+            return inferred
+
         return {
             "decision": "defer",
-            "summary": (
-                "The Copilot repair lane did not produce a machine-readable result. "
-                "Leaving this Dependabot PR open for manual review."
-            ),
+            "summary": default_result_summary(),
             "validation": [],
         }
 
@@ -279,13 +317,6 @@ def scan_targets(
     targets: list[dict[str, Any]] = []
     for pr in prs:
         if not is_dependabot_pr(pr):
-            continue
-
-        labels = label_names(pr)
-        if "dependabot:auto-merge" in labels:
-            continue
-
-        if "dependabot:manual-review" not in labels and specific_pr is None:
             continue
 
         if not pr_has_failure(pr):
@@ -768,7 +799,9 @@ def comment_manual_review(original_pr_number: int, marker: str, summary: str) ->
 
 def cmd_finalize(args: argparse.Namespace) -> int:
     original_pr = fetch_pr(args.pr_number)
-    result = load_result(Path(args.result_path))
+    result_path = Path(args.result_path)
+    copilot_output_path = Path(args.copilot_output_path) if args.copilot_output_path else None
+    result = load_result(result_path, copilot_output_path=copilot_output_path)
     summary = (result.get("summary") or "No summary was produced.").strip()
     validation = [str(item).strip() for item in result.get("validation") or [] if str(item).strip()]
     marker = f"{MARKER_PREFIX}pr-{args.pr_number}:{args.head_sha} -->"
@@ -808,13 +841,20 @@ def cmd_finalize(args: argparse.Namespace) -> int:
         close_original_pr(args.pr_number, existing["number"], existing["url"], marker, summary)
         return 0
 
-    if result.get("decision") != "fixed":
-        comment_manual_review(args.pr_number, marker, summary)
-        return 0
-
     branch_head_commit = current_head_commit()
     has_uncommitted_changes = working_tree_has_changes()
     has_new_commit = branch_head_commit != args.baseline_sha
+
+    if result.get("decision") != "fixed":
+        if not result_path.exists() and (has_uncommitted_changes or has_new_commit):
+            summary = (
+                f"{summary}\n\n"
+                "The repair branch contains changes even though no structured result file was available, "
+                "so opening a superseding PR for human review."
+            )
+        else:
+            comment_manual_review(args.pr_number, marker, summary)
+            return 0
 
     if not has_uncommitted_changes and not has_new_commit:
         comment_manual_review(
@@ -880,7 +920,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    scan = subparsers.add_parser("scan", help="List open red/manual-review Dependabot PRs.")
+    scan = subparsers.add_parser("scan", help="List open red Dependabot PRs that need repair follow-up.")
     scan.add_argument("--limit", type=int, default=2)
     scan.add_argument("--pr-number", type=int)
     scan.add_argument("--force", action="store_true")
@@ -900,6 +940,7 @@ def build_parser() -> argparse.ArgumentParser:
     finalize.add_argument("--replacement-branch", required=True)
     finalize.add_argument("--baseline-sha", required=True)
     finalize.add_argument("--result-path", required=True)
+    finalize.add_argument("--copilot-output-path")
     finalize.set_defaults(func=cmd_finalize)
 
     return parser

--- a/scripts/dependabot_repair_agent.py
+++ b/scripts/dependabot_repair_agent.py
@@ -245,11 +245,13 @@ def inferred_result_from_copilot_output(path: Path | None) -> dict[str, Any] | N
         return None
 
     summary_match = re.search(r'"summary"\s*:\s*"((?:[^"\\]|\\.)*)"', text)
-    summary = (
-        json.loads(f'"{summary_match.group(1)}"')
-        if summary_match
-        else "Recovered the repair decision from Copilot output after the result file could not be written."
-    )
+    summary = "Recovered the repair decision from Copilot output after the result file could not be written."
+    if summary_match:
+        recovered_summary = summary_match.group(1)
+        try:
+            summary = json.loads(f'"{recovered_summary}"')
+        except json.JSONDecodeError:
+            summary = recovered_summary.strip() or summary
 
     validation_match = re.search(r'"validation"\s*:\s*(\[[\s\S]*?\])', text)
     validation: list[str] = []
@@ -281,7 +283,18 @@ def load_result(path: Path, *, copilot_output_path: Path | None = None) -> dict[
             "validation": [],
         }
 
-    return json.loads(path.read_text(encoding="utf-8"))
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        inferred = inferred_result_from_copilot_output(copilot_output_path)
+        if inferred:
+            return inferred
+
+        return {
+            "decision": "defer",
+            "summary": default_result_summary(),
+            "validation": [],
+        }
 
 
 def working_tree_has_changes() -> bool:
@@ -847,11 +860,18 @@ def cmd_finalize(args: argparse.Namespace) -> int:
 
     if result.get("decision") != "fixed":
         if not result_path.exists() and (has_uncommitted_changes or has_new_commit):
-            summary = (
-                f"{summary}\n\n"
-                "The repair branch contains changes even though no structured result file was available, "
-                "so opening a superseding PR for human review."
-            )
+            if summary == default_result_summary():
+                summary = (
+                    "The Copilot repair lane did not produce a machine-readable result, "
+                    "but the repair branch contains changes, so opening a superseding PR "
+                    "for human review."
+                )
+            else:
+                summary = (
+                    f"{summary}\n\n"
+                    "The repair branch contains changes even though no structured result file was available, "
+                    "so opening a superseding PR for human review."
+                )
         else:
             comment_manual_review(args.pr_number, marker, summary)
             return 0

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -4,11 +4,11 @@ Use this file to capture tasks discovered during development. Each entry should 
 
 ## Pending
 ### Execution Queue (Now / Next)
-- ID: TASK-050
-  Title: Security baseline phase 2 - high-priority remediation sprint
+- ID: TASK-120
+  Title: Dependabot repair-lane follow-up - precise labeling and resilient superseding PR creation
   Status: Pending
-  Rationale: Implement mitigations for top-ranked findings discovered in the security assessment.
-  Dependencies: TASK-048, TASK-049, TASK-043
+  Rationale: Follow up TASK-116 by making Dependabot labels reflect real PR state, ensuring red safe-lane PRs no longer stay mislabeled as auto-mergeable, and restoring a reliable repair path that can still produce repo-owned superseding PRs when a bounded fix is available.
+  Dependencies: TASK-116, TASK-061, TASK-041
 - ID: TASK-051
   Title: Security baseline phase 3 - verification, retest, and closure report
   Status: Pending
@@ -145,6 +145,11 @@ Use this file to capture tasks discovered during development. Each entry should 
   Dependencies: TASK-051
 
 ## Completed
+- ID: TASK-050
+  Title: Security baseline phase 2 - high-priority remediation sprint
+  Status: Done (2026-04-10)
+  Rationale: Completed the top-ranked security remediation slice by adding DB-backed abuse controls across public auth and agent-token entry points, moving human sessions to hashed-at-rest lookup semantics with explicit legacy invalidation, and enforcing current credential liveness during agent bearer-token use.
+  Dependencies: TASK-048, TASK-049, TASK-043
 - ID: TASK-116
   Title: Dependabot and CI automation - workflow hygiene, safe auto-merge, and bounded red-PR repair agent
   Status: Done (2026-04-09)

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,107 +1,100 @@
-# Current Task: TASK-050 Security Baseline Phase 2 - High-Priority Remediation Sprint
+# Current Task: TASK-120 Dependabot Repair-Lane Follow-Up - Precise Labels and Resilient Superseding PRs
 
 ## Task ID
-TASK-050
+TASK-120
 
 ## Status
 In progress
 
 ## Objective
-Implement the highest-priority security fixes identified by the completed
-`TASK-049` assessment so the project closes its most material exposure gaps
-before moving further into feature delivery.
+Restore trustworthy Dependabot maintenance behavior after the live post-TASK-116
+drift by making labels reflect actual PR state and by hardening the repair lane
+so failing Dependabot PRs can still produce reviewable repo-owned superseding
+PRs when a bounded repair path exists.
 
 ## Why This Task Matters
-- `TASK-049` produced a ranked remediation list instead of a vague audit.
-- The next security value is now in code changes, not more assessment.
-- This task is the bridge between the validated hardening baseline from
-  `TASK-048` / `TASK-116` and a stronger production-ready security posture.
+- `TASK-116` established the intended Dependabot operating model, but the latest
+  live PR batch exposed two gaps:
+  - red safe-lane PRs can remain mislabeled as auto-mergeable
+  - the repair lane can reach execution without producing a repo-owned
+    superseding PR
+- That breaks the maintenance contract the repo is trying to create:
+  maintainers should not have to manually triage mislabeled red Dependabot PRs
+  or wonder whether the repair lane actually attempted a fix.
+- The repo also now has a concrete red-failure mode on current Dependabot PRs:
+  lockfile drift causes `npm ci` to fail before real validation begins, so the
+  repair lane needs a practical bounded path for that class of failure.
 
 ## Initial Focus
-- implement abuse-control baseline on the public auth and token-exchange paths
-- harden session-token storage semantics
-- reduce revocation lag on agent bearer-token usage where feasible
-- preserve existing CI and preview validation standards while making these
-  changes
+- tighten Dependabot label transitions so red PRs do not remain in the
+  auto-merge lane
+- make the repair scanner resilient to stale/misleading labels when a Dependabot
+  PR is clearly red
+- restore reliable superseding-PR creation when the repair lane can apply a
+  bounded fix or when Copilot changes the branch but omits the expected
+  metadata file
+- align CI/install assumptions where necessary so current Dependabot PRs stop
+  failing for tooling drift before real checks run
 
 ## Expected Output
-- repo code changes that close the top three ranked findings from
-  `TASK-049`
-- any required Prisma migration(s) and compatibility handling for session-token
-  storage changes
-- regression coverage for the new abuse controls, session-token behavior, and
-  agent revocation semantics
-- documentation updates that capture any new runtime assumptions, follow-up
-  constraints, or verification notes needed for `TASK-051`
+- workflow and orchestration changes that keep Dependabot labels aligned with
+  actual PR readiness
+- repair-lane changes that increase the chance of creating a repo-owned
+  superseding PR for qualifying red Dependabot PRs
+- any supporting package/CI alignment needed to prevent lockfile-only false-red
+  failures on fresh Dependabot PRs
+- updated task tracking and operator-facing docs/journal notes for the revised
+  behavior
 
 ## Acceptance Criteria
-- Public auth and token-entry surfaces have a real abuse-control baseline for
-  the implemented perimeter:
-  - sign-in
-  - sign-up
-  - forgot-password request
-  - verification-email resend
-  - `POST /api/auth/agent/token`
-- Abuse-control behavior is fail-closed on clear overuse while preserving
-  stable, non-leaky user-facing responses and bounded logging metadata.
-- Failed sign-in and failed agent token-exchange attempts become observable
-  through structured telemetry and/or audit records with request correlation,
-  without storing raw secrets.
-- Human session tokens are no longer stored in plaintext at rest.
-- Session lookup, sign-out, and session revocation flows continue to work
-  correctly after the session-token storage change.
-- Legacy plaintext-backed sessions are handled explicitly by the implementation:
-  either migrated safely or invalidated/rotated with the chosen behavior
-  documented in this task and the journal.
-- Already-issued agent bearer tokens no longer remain valid solely because
-  their signature and expiry are still valid; bearer-token use must also honor
-  current credential liveness/revocation state.
-- Existing valid human auth flows and valid agent flows continue to work after
-  the remediation pass.
-- The task remains code-first and does not expand into a new broad security
-  assessment or unrelated hardening scope.
+- A Dependabot PR that is red on required checks does not remain labeled as
+  `dependabot:auto-merge`.
+- A Dependabot PR that is actually eligible for the safe green lane still keeps
+  the existing auto-merge behavior after required checks pass.
+- The repair-lane scanner can target qualifying red Dependabot PRs even if a
+  stale label state exists temporarily.
+- The repair lane can create a repo-owned superseding PR when a bounded
+  repair is available for the current failure mode, or when Copilot leaves
+  repair changes on the branch without writing the expected metadata file.
+- Superseding PRs remain human-merge-owned and continue to dispatch the required
+  reviewable CI surface.
+- The work stays focused on Dependabot/CI maintenance and does not widen into an
+  unrelated product feature pass.
 
 ## Definition Of Done
-1. The ranked remediation scope from `tasks/task-049-security-assessment-and-threat-model.md`
-   findings 1-3 is implemented in code.
-2. Automated coverage is added or updated for the changed behavior, including
-   denial-path assertions for abuse controls, session-token lookup/storage
-   semantics, and revoked/rotated agent bearer-token use.
-3. Required tracking docs are updated and consistent:
+1. The TASK-116 follow-up behavior is implemented in code and workflow config.
+2. Required tracking docs are updated and consistent:
    - `tasks/current.md`
+   - `tasks/backlog.md`
    - `journal.md`
-   - `README.md` and/or runbooks when runtime behavior or operator expectations
-     change
-4. Validation is completed with evidence captured:
+   - `README.md` when operator expectations or automation behavior change
+3. Validation is completed with evidence captured:
    - `npm run lint`
-   - `npm test`
-   - `npm run test:coverage`
    - `npm run build`
-   - `npm run test:e2e` when the local PostgreSQL-backed fixture path is
-     available; if it is not available, the blocker and fallback validation
-     path must be recorded explicitly
-5. Residual risk and any verification-only follow-up work are left clearly
-   bounded for `TASK-051` rather than staying implicit.
+   - targeted workflow/script validation for the Dependabot follow-up
+   - live PR/workflow validation on the follow-up branch once pushed
+4. A branch and PR are created for this task, Copilot review is monitored, and
+   actionable review feedback is handled before handoff.
+
 ## Dependencies
-- `TASK-048`
-- `TASK-049`
-- `TASK-043`
+- `TASK-116`
+- `TASK-061`
+- `TASK-041`
 
 ## Notes
-- Treat this as a code-first remediation task, not another assessment pass.
-- Use the findings and prioritization from
-  `tasks/task-049-security-assessment-and-threat-model.md`.
-- Follow-up verification and closure reporting remain in `TASK-051`.
-- Implementation decision record:
-  - `adr/task-050-security-remediation-adr.md`
-- Chosen migration behavior for plaintext legacy sessions:
-  - invalidate existing human sessions during rollout rather than preserve
-    dual-format session lookup compatibility indefinitely
-- Abuse-control baseline storage:
-  - PostgreSQL-backed fixed-window buckets keyed by hashed identifiers so the
-    controls remain authoritative across stateless app instances
+- Treat this as a bounded workflow-maintenance follow-up, not a new broad
+  Dependabot redesign.
+- Current live batch signal to address first:
+  - red safe-lane PRs can remain mislabeled as auto-mergeable
+  - red/manual-review PRs can reach the Copilot lane without producing a
+    superseding PR
+  - current failures are dominated by `npm ci` lockfile-sync errors rather than
+    surfaced app-compatibility regressions
+- Keep the final ownership model intact:
+  green safe lanes should disappear automatically, while repaired/manual lanes
+  come back as repo-owned review surfaces rather than raw bot PRs.
 
 ---
 
-Last Updated: 2026-04-10
+Last Updated: 2026-04-13
 Assigned To: User + Agent


### PR DESCRIPTION
## What changed
- reclassify failed safe-lane Dependabot PRs out of `dependabot:auto-merge` during workflow-run reconciliation instead of leaving stale green-lane labels behind
- move the repair agent prompt/log/result context under the repo `tmp/` tree so the Copilot sandbox can write the machine-readable result it is asked for
- broaden the repair scanner to any red Dependabot PR and recover structured decisions from `copilot-output.log` when the result file is still missing
- update task tracking, README, and journal entries for the TASK-120 follow-up

## Why
TASK-116 was live, but the current Dependabot batch exposed two real gaps:
- PR `#162` stayed labeled `dependabot:auto-merge` even while required checks were red
- the repair lane reached Copilot for PRs like `#163` / `#164`, but no superseding PR could be created because Copilot was told to write `result.json` into `$RUNNER_TEMP`, which its sandbox treated as outside the repository

## Impact
- safe Dependabot lanes still auto-merge when required checks are green
- failed safe-lane PRs are pushed back into manual review automatically
- stale labels no longer block the repair lane from seeing red Dependabot PRs
- Copilot repairs have a working in-repo result path, and finalize can still recover the repair decision from Copilot output if the file is absent

## Validation
- `python -m compileall scripts/dependabot_repair_agent.py`
- `python scripts/dependabot_repair_agent.py scan --limit 5` with `GITHUB_REPOSITORY=dorianagaesse/nexus_dash` (confirmed the scanner now includes red PR `#162`)
- inline Python validation for `load_result(..., copilot_output_path=...)` using recovered `fixed` output
- YAML parse check for `.github/workflows/dependabot-auto-triage.yml` and `.github/workflows/dependabot-repair-agent.yml`

## Local blocker
- `npm ci` fails on this workstation because local Node is `v20.17.0`, while current Prisma/tooling in this repo now requires Node `20.19+` / `22.12+`
