### PR TITLE
[codex] assess convex migration fit

### DIFF
--- a/adr/decisions.md
+++ b/adr/decisions.md
@@ -16,6 +16,13 @@ Keep UI-only or task-only notes in `journal.md`.
 
 ## Active Decisions
 
+## 2026-04-15 - Keep PostgreSQL/Prisma baseline; do not pursue Convex migration now
+- Status: Accepted
+- Context: `TASK-105` re-evaluated Convex against the current NexusDash architecture after the repo had already adopted Prisma-owned PostgreSQL migrations, production RLS, DB-backed human sessions, project-scoped agent access, and a service-layer authorization model, while future backlog work made realtime collaboration worth reassessing explicitly.
+- Decision: Keep `Prisma + PostgreSQL` as the system of record and do not migrate NexusDash to Convex at this stage; revisit only if the product becomes strongly realtime-first and the team is willing to replace Prisma migrations, PostgreSQL RLS, and the current auth/session architecture as part of a broader backend rewrite.
+- Consequences: The repo preserves its existing relational and security guarantees while avoiding a broad platform rewrite whose main payoff would currently be limited mostly to future realtime collaboration work; near-term live-update needs should be explored on the current stack before reopening the migration question.
+- Links: `adr/task-105-convex-migration-assessment.md`, `tasks/current.md`, `tasks/backlog.md`
+
 ## 2026-04-10 - Close TASK-050 security gaps with DB-backed abuse controls, hashed sessions, and request-time agent credential liveness
 - Status: Accepted
 - Context: `TASK-049` ranked perimeter abuse control, plaintext human sessions at rest, and agent bearer revocation lag as the top remaining security findings, and the repo already operates as a stateless Next.js/PostgreSQL system.

--- a/adr/task-105-convex-migration-assessment.md
+++ b/adr/task-105-convex-migration-assessment.md
@@ -1,0 +1,472 @@
+# TASK-105 Convex Migration Assessment - Fit, Tradeoffs, And Migration Risk Review
+
+Date: 2026-04-15
+Status: Assessment complete
+
+## 1) Recommendation
+
+Do **not** migrate NexusDash from the current `Prisma + PostgreSQL +
+Supabase-hosted Postgres` baseline to Convex at this stage.
+
+Keep the current stack as the system of record, and revisit Convex only if the
+product roadmap becomes decisively realtime-first and collaborative enough that
+we are willing to replace:
+
+- Prisma-owned schema and migration control
+- PostgreSQL Row-Level Security as defense in depth
+- the current DB-backed human session model
+- the current service/query model built around relational data and SQL-backed
+  enforcement
+
+## 2) Executive Summary
+
+Convex is attractive for NexusDash in one important area: the product has
+pending work around live multi-user updates, and Convex's automatic realtime
+query model would likely make that class of feature easier to build and reason
+about than the current request/refresh-oriented architecture.
+
+That said, the **current NexusDash backend is not merely "CRUD on a database."**
+It is already shaped around relational PostgreSQL semantics, repository-owned
+migrations, database-enforced RLS, DB-backed session persistence, invitation
+and membership constraints, and a mix of service-layer guards plus DB-level
+policy enforcement. A move to Convex would be a broad platform rewrite, not an
+incremental swap of one persistence adapter for another.
+
+The repo's strongest existing reasons to stay put are:
+
+- the app already depends on real PostgreSQL RLS in production
+- schema evolution is already owned in-repo through Prisma and SQL migrations
+- auth and collaboration flows are tightly coupled to relational constraints
+  and database-backed session state
+- the current codebase already isolated persistence behind `lib/services/**`,
+  which lowers future portability risk without discarding the current stack now
+
+The main reason to revisit Convex later is **if NexusDash becomes primarily a
+live collaborative workspace**, where automatic subscriptions, presence-style
+updates, and low-friction reactive backend queries become more strategically
+important than Postgres-native enforcement and SQL-led control.
+
+## 3) Current Repo Reality
+
+The implemented repository state matters more than theoretical platform pros.
+Today NexusDash has all of the following:
+
+### 3.1 Current Data And Runtime Baseline
+- PostgreSQL is the canonical datastore and Supabase-managed Postgres is the
+  default hosted target.
+- Prisma schema and repository-owned migrations are the schema source of truth.
+- The repo currently has 21 PostgreSQL migration directories under
+  `prisma/migrations`.
+- Runtime and migration DB credentials are split via `DATABASE_URL` and
+  `DIRECT_URL`.
+
+Evidence:
+- `adr/task-056-data-platform-adr.md`
+- `README.md`
+- `prisma/schema.prisma`
+- `docs/runbooks/database-connection-hardening.md`
+
+### 3.2 Authorization And Isolation Are Already Dual-Layered
+- Service-layer authorization exists across project-scoped operations.
+- PostgreSQL RLS is enabled and forced on core user/project-scoped tables.
+- RLS context is propagated through `withActorRlsContext()` via
+  `set_config('app.user_id', ...)`.
+- Later collaboration features built on top of that policy surface rather than
+  replacing it.
+
+Evidence:
+- `lib/services/rls-context.ts`
+- `tasks/task-085-postgresql-rls-staged-rollout.md`
+- `prisma/migrations/20260305173000_task085_rls_phase1_enable_policies/migration.sql`
+- `prisma/migrations/20260309113000_task085_rls_phase2_force/migration.sql`
+
+### 3.3 The Domain Model Is Relational And Constraint-Oriented
+- `Project`, `ProjectMembership`, and `ProjectInvitation` define collaboration.
+- `Task`, `TaskRelation`, `TaskBlockedFollowUp`, and attachments form a graph
+  with project-scoped ownership rules.
+- `ApiCredential`, scope grants, and audit events add an agent-auth layer.
+- Auth/session entities remain relational and DB-backed.
+- Google Calendar credentials are user-scoped and tied to current auth
+  semantics.
+
+Evidence:
+- `prisma/schema.prisma`
+- `lib/services/project-access-service.ts`
+- `lib/services/project-collaboration-service.ts`
+- `lib/services/project-agent-access-service.ts`
+- `lib/services/session-service.ts`
+
+### 3.4 The Repo Is Not Realtime-First Yet
+- The current product largely serves data through page loads, server actions,
+  route handlers, and client refreshes.
+- `TASK-118` explicitly tracks realtime collaboration updates as future work.
+- This means realtime is a meaningful gap, but not the current architectural
+  center of gravity.
+
+Evidence:
+- `tasks/backlog.md`
+- `project.md`
+
+## 4) Where Convex Would Help This Project
+
+These are the places where Convex is a real improvement opportunity, not a
+fantasy benefit list.
+
+### 4.1 Realtime Collaboration And Freshness
+
+Convex's strongest fit for NexusDash is live data propagation.
+
+Official docs say Convex is "automatically realtime," with query dependencies
+tracked so subscribed clients update automatically. Queries are also cached and
+subscribable, while mutations run as transactions.
+
+Why that matters here:
+- `TASK-118` exists because the app currently has stale-state and
+  manual-refresh friction during multi-user work.
+- task boards, context cards, and project collaboration surfaces are natural
+  subscription targets
+- presence-adjacent UX becomes easier when live updates are native rather than
+  bolted on later
+
+For a future where shared project work is actively concurrent, Convex would
+give NexusDash a more opinionated and lower-friction live data model than the
+current request-oriented stack.
+
+### 4.2 Simpler Reactive Read Model
+
+Convex pushes backend reads into query functions that are immediately consumable
+from its client libraries. That would likely reduce some of the bespoke loading
+and invalidation decisions the current app carries in its route/component split.
+
+Potential benefit areas:
+- project dashboard live refresh
+- task reorder and mutation feedback coherence across clients
+- collaboration banners, invite counts, and live project summaries
+
+### 4.3 Built-In Scheduling For Future Workflow Automation
+
+Convex has first-class scheduled functions. That could become helpful for:
+- reminders and deadline-driven follow-up
+- future automation around roadmap/timeline features
+- background maintenance that is currently deferred in `TASK-063`
+
+### 4.4 Possible Backend Consolidation For Greenfield-Style Features
+
+If NexusDash were earlier in its lifecycle, Convex could plausibly consolidate:
+- database access
+- reactive subscriptions
+- scheduled backend jobs
+- file storage primitives for some asset flows
+
+That is a genuine platform advantage in greenfield collaborative apps.
+
+## 5) Where The Current Stack Fits Better
+
+These are the reasons the migration does **not** make sense now.
+
+### 5.1 PostgreSQL RLS Is Already Carrying Real Security Weight
+
+This repo already implemented and promoted PostgreSQL RLS in a staged rollout,
+including forced RLS on project-scoped tables. That is not incidental
+infrastructure; it is a core safety property.
+
+Convex can absolutely enforce authorization in application code, but it does
+not give NexusDash a drop-in equivalent to PostgreSQL RLS policy enforcement.
+Migrating would mean:
+- deleting the current DB-level defense-in-depth layer
+- re-implementing all access guarantees in function code alone
+- re-validating every protected path without the current SQL policy backstop
+
+For this app, that is a security and verification cost, not just a refactor.
+
+### 5.2 The Existing Data Model Is More Relational Than Convex-Ideal
+
+Convex supports schemas, IDs, indexes, and document references, so this is not
+about "Convex cannot model relationships." It can.
+
+The issue is fit and cost:
+- project ownership, memberships, and invitations are relational and policy-rich
+- task relations are a graph-like cross-reference feature
+- attachments and audit records carry ownership and lifecycle constraints
+- auth/session and invite flows depend on uniqueness, expiry, replacement, and
+  role semantics that map very naturally to SQL tables + migrations
+
+NexusDash is not a simple feed/chat app where a document model is obviously
+superior. It is a structured workspace with cross-entity constraints.
+
+### 5.3 Prisma And Migration History Are Existing Assets
+
+The repo deliberately chose repository-owned Prisma migrations to avoid tight
+platform coupling. That choice has already paid off:
+- schema history is readable and reviewable in Git
+- RLS, grants, and policy SQL are explicit
+- deployment flow already understands runtime vs migration credentials
+
+A move to Convex would strand that investment. The migration cost is not just
+data copy; it is losing the current schema-management contract.
+
+### 5.4 Auth And Next.js Runtime Fit Are Better On The Current Stack
+
+NexusDash currently uses:
+- DB-backed human sessions
+- email verification and password reset lifecycle
+- owner-managed project agent credentials with short-lived bearer tokens
+- Google OAuth for calendar integration
+
+Convex Auth is currently documented as beta, and its own docs note that
+authentication support for Next.js server components, API routes, middleware,
+and SSR is under active development.
+
+That is a poor fit for a repo that already relies heavily on Next.js App Router
+server behavior plus established auth flows. Even if Convex auth eventually
+becomes a strong fit, it is not the safest way to replace the current
+well-defined human session + agent token architecture now.
+
+### 5.5 The Current External-Service Shape Already Works
+
+The app already integrates:
+- Google Calendar APIs
+- transactional email delivery
+- Cloudflare R2-backed attachment storage
+- route/action-level transport contracts
+
+Convex actions can call external APIs, but moving these flows would still
+require a broad re-architecture. There is no strong sign that the current pain
+point is "our external API integration model is fundamentally broken."
+
+### 5.6 The Biggest Current Convex Benefit Can Be Pursued More Cheaply
+
+The strongest reason to adopt Convex is realtime. But the repo does not need a
+full platform migration to improve realtime behavior.
+
+Cheaper next steps exist:
+- implement `TASK-118` on the current stack first
+- evaluate targeted live-update options while keeping PostgreSQL as the system
+  of record
+- measure whether realtime is becoming central enough to justify replacing RLS,
+  Prisma migrations, and the auth/session model
+
+That path preserves learning without paying migration cost too early.
+
+## 6) Detailed Comparison For NexusDash
+
+### 6.1 Data Model And Query Shape
+- Current stack advantage:
+  - relational tables, SQL constraints, Prisma relations, and explicit
+    migration review all align with the current domain.
+- Convex advantage:
+  - reactive query model and document references are ergonomic for live UI.
+- Assessment:
+  - slight to moderate advantage to the current stack for this repo today.
+
+### 6.2 Authorization And Tenant Isolation
+- Current stack advantage:
+  - service-layer authorization plus PostgreSQL RLS.
+- Convex advantage:
+  - centralized function-level authorization is straightforward in concept.
+- Assessment:
+  - strong advantage to the current stack because NexusDash already depends on
+    DB-level defense in depth and has invested in proving it.
+
+### 6.3 Realtime And Live Collaboration
+- Current stack advantage:
+  - none structural beyond future extensibility.
+- Convex advantage:
+  - automatic subscriptions, cache coherence, consistent snapshots, and a
+    collaboration-friendly default.
+- Assessment:
+  - strong advantage to Convex for future live collaboration work.
+
+### 6.4 Background Jobs And Automation
+- Current stack advantage:
+  - already compatible with scheduled/deploy workflows and standard cron-style
+    patterns.
+- Convex advantage:
+  - built-in scheduled functions are attractive for reminders and future job
+    flows.
+- Assessment:
+  - moderate advantage to Convex, but not enough to outweigh the migration
+    cost by itself.
+
+### 6.5 Auth
+- Current stack advantage:
+  - working DB-backed sessions, established invite and verification flows,
+    clear agent-token contract.
+- Convex advantage:
+  - potential long-term consolidation if the app were re-architected around its
+    model.
+- Assessment:
+  - strong advantage to the current stack on current repo maturity and safety.
+
+### 6.6 Storage And Attachments
+- Current stack advantage:
+  - existing `StorageProvider` abstraction with local + R2 flows and direct
+    upload handling.
+- Convex advantage:
+  - built-in file storage exists, which could simplify some greenfield cases.
+- Assessment:
+  - neutral to slight current-stack advantage because the repo already solved
+    this problem in a portable way.
+
+### 6.7 Ops, Tooling, And Data Portability
+- Current stack advantage:
+  - plain PostgreSQL, Prisma migrations, SQL visibility, familiar export/debug
+    model, and no new platform rewrite.
+- Convex advantage:
+  - managed backend ergonomics and built-in patterns.
+- Assessment:
+  - moderate advantage to the current stack for an already-shipping codebase.
+
+## 7) Migration Scope If We Chose Convex Anyway
+
+This would be a substantial rewrite, not a backend swap.
+
+### 7.1 Data Layer Rewrite
+- Re-express Prisma schema entities as Convex tables and document references.
+- Rebuild indexes and relation traversal patterns.
+- Replace existing Prisma queries and includes across service modules.
+
+### 7.2 Security Model Rewrite
+- Retire PostgreSQL RLS policies and SQL helpers.
+- Re-implement access rules in Convex functions.
+- Re-verify all project, membership, invitation, attachment, and calendar
+  boundaries.
+
+### 7.3 Auth Rewrite Or Hybrid Complexity
+- Either replace the current DB-backed session model and surrounding auth
+  flows, or keep auth elsewhere and introduce a split-brain auth/data model.
+- Revisit the agent access design, token exchange, audit trail, and request
+  usage semantics.
+
+### 7.4 Integration Rewrite
+- Re-thread Google Calendar, email, and attachment flows through Convex or keep
+  a hybrid backend surface.
+- Revisit API route/server action boundaries and their callers.
+
+### 7.5 Data Migration
+- Export users, projects, memberships, invitations, tasks, task relations,
+  attachments, audit events, and calendar credential references.
+- Define ordering, backfill, and rollback rules for production cutover.
+- Reconcile attachment metadata and external object storage lineage.
+
+### 7.6 Test And CI Rewrite
+- Update unit/service tests that mock Prisma or rely on current route/service
+  contracts.
+- Rebuild any environment assumptions tied to PostgreSQL fixtures.
+- Revalidate deployment, preview, and rollback workflows.
+
+## 8) Major Migration Risks
+
+### 8.1 Security Regression Risk
+Removing the current PostgreSQL RLS layer would reduce defense in depth unless
+function-level authorization is reimplemented perfectly and verified thoroughly.
+
+### 8.2 Auth Boundary Drift
+The app's human-session and agent-token model is mature enough that replacing
+or hybridizing it could create subtle inconsistencies.
+
+### 8.3 Domain Semantics Rewrite Risk
+Invitation replacement, role transitions, scoped agent access, archived-task
+semantics, and related-task constraints are all places where small mistakes
+would be user-visible.
+
+### 8.4 Platform Split Risk
+A partial migration would likely leave the repo with:
+- one system for auth or external integrations
+- another for core data and subscriptions
+
+That is operationally worse than the current design unless the realtime payoff
+is overwhelming.
+
+### 8.5 Opportunity Cost
+The team could spend several tasks re-platforming instead of delivering:
+- realtime updates directly
+- roadmap/epic/todo/deadline features
+- collaboration UX improvements
+
+## 9) Better Near-Term Options Than A Full Migration
+
+1. Keep PostgreSQL/Prisma as the system of record and execute `TASK-118`
+   directly on the current stack.
+2. Preserve the current service-layer portability boundary so future platform
+   experiments remain possible.
+3. Reassess only after realtime collaboration proves central enough to justify
+   replacing the current data-security contract.
+4. If we want Convex learning now, prototype it in an isolated non-critical
+   feature or throwaway branch rather than as a production migration target.
+
+## 10) Revisit Conditions
+
+Reopen the Convex question if all or most of the following become true:
+
+- live multi-user updates become a primary product differentiator, not a
+  backlog nicety
+- presence, collaborative editing, or low-latency shared state become frequent
+  across the workspace
+- the team is willing to move away from PostgreSQL RLS as a core enforcement
+  layer
+- the current Prisma migration and SQL-policy model becomes a delivery burden
+  rather than an asset
+- Convex auth and Next.js integration mature enough to cleanly replace the
+  current browser-session and agent-token architecture
+
+## 11) Final Conclusion
+
+Convex is a **plausible future fit for a more aggressively collaborative,
+realtime-first NexusDash**, but it is **not the right move for the current
+codebase**.
+
+The platform would solve one of the repo's meaningful future needs well:
+realtime synchronization. But today the project gains more from preserving:
+
+- its mature PostgreSQL authorization posture
+- its Prisma-owned schema control
+- its DB-backed session/auth model
+- its already-working external integration boundaries
+
+The recommendation is therefore:
+
+- keep the current PostgreSQL/Prisma/Supabase baseline
+- treat realtime as the core problem to solve, not "switch databases" as the
+  default answer
+- revisit Convex only if the product shifts hard toward always-live
+  collaboration and the team is ready for a deliberate backend rewrite
+
+## 12) Repo Evidence
+
+- `project.md`
+- `README.md`
+- `prisma/schema.prisma`
+- `prisma/migrations/**`
+- `lib/services/rls-context.ts`
+- `lib/services/project-access-service.ts`
+- `lib/services/project-service.ts`
+- `lib/services/project-task-service.ts`
+- `lib/services/project-collaboration-service.ts`
+- `lib/services/project-agent-access-service.ts`
+- `lib/services/session-service.ts`
+- `lib/services/calendar-service.ts`
+- `lib/auth/api-guard.ts`
+- `adr/decisions.md`
+- `adr/task-056-data-platform-adr.md`
+- `adr/task-020-modern-auth-authorization-adr.md`
+- `tasks/task-085-postgresql-rls-staged-rollout.md`
+
+## 13) External Sources Consulted
+
+Official Convex documentation, accessed 2026-04-15:
+- Functions: https://docs.convex.dev/functions
+- Realtime: https://docs.convex.dev/realtime
+- Schemas: https://docs.convex.dev/database/schemas
+- Convex Auth: https://docs.convex.dev/auth/convex-auth
+- Scheduled Functions: https://docs.convex.dev/scheduling/scheduled-functions
+- File Storage: https://docs.convex.dev/file-storage
+- Data Import & Export: https://docs.convex.dev/database/import-export
+- Backup & Restore: https://docs.convex.dev/database/backup-restore
+
+Official Supabase documentation, accessed 2026-04-15:
+- Auth: https://supabase.com/docs/guides/auth
+- Row Level Security: https://supabase.com/docs/guides/database/postgres/row-level-security
+- Postgres Changes / Realtime: https://supabase.com/docs/guides/realtime/postgres-changes
+- Prisma: https://supabase.com/docs/guides/database/prisma
+- Branching: https://supabase.com/docs/guides/deployment/branching

--- a/adr/task-105-convex-migration-assessment.md
+++ b/adr/task-105-convex-migration-assessment.md
@@ -1,7 +1,7 @@
 # TASK-105 Convex Migration Assessment - Fit, Tradeoffs, And Migration Risk Review
 
 Date: 2026-04-15
-Status: Assessment complete
+Status: Accepted
 
 ## 1) Recommendation
 

--- a/journal.md
+++ b/journal.md
@@ -17,6 +17,11 @@ Use it for important implementation milestones, blockers, validation runs, and r
 - Summary: Started `TASK-105` on a dedicated `docs/task-105-convex-assessment` branch, moved it to the top of the execution queue, replaced `tasks/current.md`, and drafted the initial Convex migration assessment plus architecture decision update.
 - Evidence: Reviewed `project.md`, `README.md`, `prisma/schema.prisma`, `prisma/migrations/**`, `lib/services/rls-context.ts`, `lib/services/project-access-service.ts`, `lib/services/project-service.ts`, `lib/services/project-task-service.ts`, `lib/services/project-collaboration-service.ts`, `lib/services/project-agent-access-service.ts`, `lib/services/session-service.ts`, `lib/services/calendar-service.ts`, and `lib/auth/api-guard.ts`; consulted official docs at `https://docs.convex.dev/functions`, `https://docs.convex.dev/realtime`, `https://docs.convex.dev/database/schemas`, `https://docs.convex.dev/auth/convex-auth`, `https://docs.convex.dev/scheduling/scheduled-functions`, `https://docs.convex.dev/file-storage`, `https://docs.convex.dev/database/import-export`, `https://docs.convex.dev/database/backup-restore`, `https://supabase.com/docs/guides/auth`, `https://supabase.com/docs/guides/database/postgres/row-level-security`, `https://supabase.com/docs/guides/realtime/postgres-changes`, `https://supabase.com/docs/guides/database/prisma`, and `https://supabase.com/docs/guides/deployment/branching`.
 
+### 2026-04-15
+- Type: Validation
+- Summary: Opened PR `#176`, let CI complete, waited for Copilot's initial review, and applied the one valid documentation follow-up by aligning the task ADR status with the repository ADR template.
+- Evidence: PR `#176`; checks `check-name`, `Quality Core (lint, test, coverage, build)`, `E2E Smoke (Playwright)`, and `Container Image (build + metadata artifact)` passed; Copilot review `pullrequestreview-4116748451` left inline comment `3089308118`, addressed by changing `adr/task-105-convex-migration-assessment.md` to `Status: Accepted`.
+
 ### 2026-04-14
 - Type: Validation
 - Summary: TASK-091 mobile QA passed across the priority small-screen flows on `390x844` and `360x800`, confirming no horizontal overflow on home, projects, workspace, and the task/context modal paths while keeping modal primary actions reachable inside the viewport.

--- a/journal.md
+++ b/journal.md
@@ -12,6 +12,11 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ## Recent Entries (Most Relevant)
 
+### 2026-04-15
+- Type: Planning
+- Summary: Started `TASK-105` on a dedicated `docs/task-105-convex-assessment` branch, moved it to the top of the execution queue, replaced `tasks/current.md`, and drafted the initial Convex migration assessment plus architecture decision update.
+- Evidence: Reviewed `project.md`, `README.md`, `prisma/schema.prisma`, `prisma/migrations/**`, `lib/services/rls-context.ts`, `lib/services/project-access-service.ts`, `lib/services/project-service.ts`, `lib/services/project-task-service.ts`, `lib/services/project-collaboration-service.ts`, `lib/services/project-agent-access-service.ts`, `lib/services/session-service.ts`, `lib/services/calendar-service.ts`, and `lib/auth/api-guard.ts`; consulted official docs at `https://docs.convex.dev/functions`, `https://docs.convex.dev/realtime`, `https://docs.convex.dev/database/schemas`, `https://docs.convex.dev/auth/convex-auth`, `https://docs.convex.dev/scheduling/scheduled-functions`, `https://docs.convex.dev/file-storage`, `https://docs.convex.dev/database/import-export`, `https://docs.convex.dev/database/backup-restore`, `https://supabase.com/docs/guides/auth`, `https://supabase.com/docs/guides/database/postgres/row-level-security`, `https://supabase.com/docs/guides/realtime/postgres-changes`, `https://supabase.com/docs/guides/database/prisma`, and `https://supabase.com/docs/guides/deployment/branching`.
+
 ### 2026-04-14
 - Type: Validation
 - Summary: TASK-091 mobile QA passed across the priority small-screen flows on `390x844` and `360x800`, confirming no horizontal overflow on home, projects, workspace, and the task/context modal paths while keeping modal primary actions reachable inside the viewport.

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -4,6 +4,11 @@ Use this file to capture tasks discovered during development. Each entry should 
 
 ## Pending
 ### Execution Queue (Now / Next)
+- ID: TASK-105
+  Title: Convex migration assessment - fit, tradeoffs, and migration risk review
+  Status: In Progress
+  Rationale: Reassess the current PostgreSQL/Prisma baseline against Convex so we have an explicit, written pros/cons view before any future platform pivot, including real constraints around relational data, RLS-style isolation, existing migrations, auth boundaries, and operational complexity rather than evaluating the option abstractly.
+  Dependencies: TASK-056, TASK-057, TASK-085
 - ID: TASK-122
   Title: Dependabot repair cadence - scheduled full-backlog drain with bounded parallelism
   Status: In Progress
@@ -21,11 +26,6 @@ Use this file to capture tasks discovered during development. Each entry should 
   Dependencies: TASK-091, TASK-079, TASK-096
 
 ### Deferred (Intentional)
-- ID: TASK-105
-  Title: Convex migration assessment - fit, tradeoffs, and migration risk review
-  Status: Pending
-  Rationale: Reassess the current PostgreSQL/Prisma baseline against Convex so we have an explicit, written pros/cons view before any future platform pivot, including real constraints around relational data, RLS-style isolation, existing migrations, auth boundaries, and operational complexity rather than evaluating the option abstractly.
-  Dependencies: TASK-056, TASK-057, TASK-085
 - ID: TASK-106
   Title: Project roadmap feature - milestone/timeline visibility for better execution sight
   Status: Pending

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,7 +4,7 @@
 TASK-105
 
 ## Status
-In Progress
+Completed on 2026-04-15 (PR `#176`)
 
 ## Objective
 Produce a grounded, repo-specific assessment of whether NexusDash should move
@@ -118,6 +118,16 @@ explicit migration risks, benefits, and revisit conditions.
 - Minimum validation for this task:
   - review the written assessment for internal consistency against repo code
   - ensure the PR body clearly summarizes the recommendation and evidence base
+
+## Outcome
+- The recommendation is to keep the current `Prisma + PostgreSQL +
+  Supabase-hosted Postgres` baseline and not migrate to Convex now.
+- Convex is considered worth revisiting only if NexusDash becomes strongly
+  realtime-first and collaborative enough to justify replacing Prisma-owned
+  migrations, PostgreSQL RLS, and the current auth/session model.
+- The durable output for this task lives in
+  `adr/task-105-convex-migration-assessment.md`, with the concise resulting
+  decision captured in `adr/decisions.md`.
 
 ---
 

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,72 +1,125 @@
-# Current Task: TASK-122 Dependabot Repair Cadence - Scheduled Full-Backlog Drain
+# Current Task: TASK-105 Convex Migration Assessment - Fit, Tradeoffs, And Migration Risk Review
 
 ## Task ID
-TASK-122
+TASK-105
 
 ## Status
 In Progress
 
 ## Objective
-Update the Dependabot repair lane so the weekly scheduled run attempts every
-eligible red Dependabot PR instead of stopping at a small fixed batch size,
-while keeping manual targeted controls and bounded execution characteristics for
-operators.
+Produce a grounded, repo-specific assessment of whether NexusDash should move
+from its current `Prisma + PostgreSQL + Supabase-hosted Postgres` baseline to
+Convex, then turn that assessment into a clear written recommendation with
+explicit migration risks, benefits, and revisit conditions.
 
 ## Why This Task Matters
-- The current Monday schedule still behaves like “repair only the first N red
-  PRs,” which can leave a backlog behind even when the repair lane itself is
-  functioning correctly.
-- The intended operating model is stronger: every scheduled run should attempt
-  the full eligible red Dependabot backlog, while maintainers still retain
-  precise manual controls for debugging or single-PR reruns.
-- Now that TASK-120 has proven the repair lane end to end, the safety mechanism
-  should shift from a weekly item cap to explicit matrix parallelism.
+- `TASK-056`, `TASK-057`, and `TASK-085` deliberately established the current
+  data/runtime baseline around PostgreSQL, Prisma-owned migrations, and
+  database-level RLS.
+- The backlog now includes collaboration and realtime-oriented follow-ups,
+  especially `TASK-118`, which makes Convex a reasonable technology to
+  reassess instead of dismissing abstractly.
+- A platform pivot is expensive. This task exists to replace hand-wavy
+  "Convex might be better" thinking with a written decision-quality artifact
+  tied to the actual NexusDash architecture.
 
-## Implementation Plan
-- Make scheduled runs call the scanner without a numeric item cap so every
-  eligible red Dependabot PR enters the matrix.
-- Keep `workflow_dispatch` support for `max_prs`, `pr_number`, and `force_rerun`
-  so maintainers can still run small, targeted repairs manually.
-- Add explicit matrix `max-parallel` control so “repair all” does not become
-  uncontrolled concurrency.
-- Validate the new scan behavior locally, then open and monitor a PR until the
-  Copilot review appears and handle any actionable feedback.
+## Scope
+- Audit the implemented repository architecture relevant to a data-platform
+  change:
+  - data model shape
+  - Prisma usage and migration ownership
+  - PostgreSQL RLS dependence
+  - auth/session boundaries
+  - agent access model
+  - attachment/storage strategy
+  - calendar and external API integration patterns
+- Review current official Convex and Supabase documentation.
+- Compare the current stack against Convex specifically for this repo, not for
+  generic greenfield apps.
+- Produce a durable assessment document in `adr/`.
+- Open a dedicated PR for the investigation and monitor Copilot review to first
+  completion, addressing valid feedback in-thread.
+
+## Out Of Scope
+- Migrating any runtime code or schema to Convex.
+- Replacing Prisma, Postgres, Auth.js-compatible sessions, or RLS in this task.
+- Building a proof-of-concept dual-write or hybrid Convex/Postgres data layer.
+- Inventing performance claims without evidence from the current repo or
+  official product documentation.
+
+## Investigation Questions
+1. Where would Convex materially improve NexusDash compared to the current
+   stack?
+2. Which current architecture choices make a Convex migration expensive or
+   risky?
+3. Would a migration simplify the hardest current problems, or mostly replace
+   one set of tradeoffs with another?
+4. If the answer is "not now," under what future product conditions should the
+   decision be revisited?
 
 ## Expected Output
-- a workflow/script change that makes the Monday repair run attempt the full
-  eligible red Dependabot backlog
-- preserved manual controls for bounded or single-PR runs
-- controlled parallel repair execution instead of a weekly item cap
-- a PR with review/validation evidence for the new operating model
+- a precise `tasks/current.md` brief for `TASK-105`
+- a durable assessment document in `adr/` with:
+  - current architecture snapshot
+  - Convex fit analysis
+  - pros and cons
+  - migration scope and risk review
+  - recommendation and revisit conditions
+- tracking updates in `tasks/backlog.md`, `journal.md`, and `adr/decisions.md`
+  as appropriate
+- a dedicated PR with Copilot review triaged before handoff
 
 ## Acceptance Criteria
-- Scheduled runs no longer enforce a small fixed `max_prs` cap and instead scan
-  the full eligible red Dependabot set.
-- Manual dispatch retains `max_prs`, `pr_number`, and `force_rerun` controls.
-- Repair execution uses explicit bounded parallelism rather than a silent scan
-  cap as the primary safety control.
-- The implementation is validated and reviewed through a dedicated PR.
+- The assessment is based on the implemented repository state rather than only
+  backlog labels or generic platform marketing.
+- Official current documentation for both Convex and Supabase is incorporated
+  into the comparison.
+- The output states a clear recommendation, not just a list of features.
+- Migration risks cover at minimum data model, authorization/RLS, auth/session
+  model, storage, background work, testing/CI, and operational impact.
+- A PR is opened for the investigation, Copilot completes its initial review
+  state, and any valid review feedback is handled.
 
 ## Definition Of Done
-1. `TASK-122` is tracked in `tasks/current.md` and `tasks/backlog.md`.
-2. The repair workflow and script implement the new scheduled/manual split.
-3. The change is validated with targeted local checks.
-4. A PR is opened and monitored through Copilot review, with any valid review
-   follow-up addressed.
+1. `TASK-105` is the active task in `tasks/current.md` and is at the top of the
+   execution queue in `tasks/backlog.md`.
+2. A durable written assessment exists in `adr/` and is specific enough to
+   guide future platform decisions.
+3. Tracking docs are updated consistently with the assessment result.
+4. A dedicated PR exists for this task, Copilot has finished its initial review
+   pass, and all valid comments have been addressed or answered with rationale.
 
 ## Dependencies
-- `TASK-120`
-- `TASK-116`
-- repository GitHub Actions / Copilot automation secrets
+- `TASK-056`
+- `TASK-057`
+- `TASK-085`
+- official current Convex documentation
+- official current Supabase documentation
 
-## Notes
-- Recommended operating model for this task:
-  - scheduled Mondays drain all eligible red Dependabot PRs
-  - manual runs stay bounded and targetable for diagnosis or controlled reruns
-- Preferred safety control:
-  - matrix `max-parallel`, not a hidden weekly item cap
+## Evidence Plan
+- Repo source of truth:
+  - `project.md`
+  - `README.md`
+  - `prisma/schema.prisma`
+  - `prisma/migrations/**`
+  - `lib/services/**`
+  - `lib/auth/**`
+  - `adr/decisions.md`
+  - `adr/task-056-data-platform-adr.md`
+  - `adr/task-020-modern-auth-authorization-adr.md`
+  - `tasks/task-085-postgresql-rls-staged-rollout.md`
+- External source of truth:
+  - official Convex docs
+  - official Supabase docs
+
+## Validation
+- This is a documentation/investigation task, so code validation commands are
+  optional unless a follow-up edit expands scope beyond docs.
+- Minimum validation for this task:
+  - review the written assessment for internal consistency against repo code
+  - ensure the PR body clearly summarizes the recommendation and evidence base
 
 ---
 
-Last Updated: 2026-04-13
-Assigned To: User + Agent
+Last Updated: 2026-04-15
+Assigned To: Agent


### PR DESCRIPTION
## What changed

This PR turns `TASK-105` into a concrete repo-level investigation instead of a deferred backlog note.

It:
- replaces `tasks/current.md` with a precise `TASK-105` brief
- moves `TASK-105` to the top of the execution queue in `tasks/backlog.md`
- adds a durable assessment in `adr/task-105-convex-migration-assessment.md`
- records the resulting architecture decision in `adr/decisions.md`
- logs the investigation start in `journal.md`

## Why it changed

The repo has enough architecture now that a Convex discussion should be grounded in reality, not generic platform comparisons.

The assessment reviews the current NexusDash baseline against Convex using:
- implemented repo architecture
- current PostgreSQL / Prisma / RLS decisions already shipped here
- official current Convex docs
- official current Supabase docs

The recommendation in the report is to keep the current `Prisma + PostgreSQL + Supabase-hosted Postgres` baseline for now and revisit Convex only if the product becomes strongly realtime-first and collaborative enough to justify replacing Prisma migrations, PostgreSQL RLS, and the current auth/session model.

## User / developer impact

This gives the project a written answer to:
- what Convex would genuinely improve here
- what it would cost to migrate from the current architecture
- why the current stack is still the better fit today
- which future conditions should trigger a new reassessment

## Validation

This is a docs-only investigation task.

Validation performed:
- direct repo architecture review across the current data, auth, RLS, service, and integration layers
- consistency review of the written recommendation against current repo state
- official-doc review for Convex and Supabase source material

No code/test/build commands were required for this task because no runtime behavior changed.