### PR TITLE
Fix calendar datepicker modal overflow

### DIFF
--- a/components/calendar-date-time-field.tsx
+++ b/components/calendar-date-time-field.tsx
@@ -25,6 +25,10 @@ import { cn } from "@/lib/utils";
 const PICKER_WIDTH = 320;
 const PICKER_GUTTER = 12;
 const PICKER_OFFSET = 4;
+const ESTIMATED_PICKER_HEIGHT = {
+  dateOnly: 320,
+  withTime: 396,
+} as const;
 
 export interface CalendarDateTimeFieldProps {
   id: string;
@@ -78,12 +82,15 @@ export function CalendarDateTimeField({
     const triggerRect = triggerRef.current.getBoundingClientRect();
     const viewportWidth = window.innerWidth;
     const viewportHeight = window.innerHeight;
-    const width = Math.min(PICKER_WIDTH, viewportWidth - PICKER_GUTTER * 2);
+    const maxAvailableWidth = Math.max(0, viewportWidth - PICKER_GUTTER * 2);
+    const width = Math.min(PICKER_WIDTH, maxAvailableWidth);
     const left = Math.min(
       Math.max(PICKER_GUTTER, triggerRect.left),
-      viewportWidth - width - PICKER_GUTTER
+      Math.max(PICKER_GUTTER, viewportWidth - width - PICKER_GUTTER)
     );
-    const estimatedPopoverHeight = includeTime ? 396 : 320;
+    const estimatedPopoverHeight = includeTime
+      ? ESTIMATED_PICKER_HEIGHT.withTime
+      : ESTIMATED_PICKER_HEIGHT.dateOnly;
     const spaceBelow = viewportHeight - triggerRect.bottom - PICKER_GUTTER;
     const spaceAbove = triggerRect.top - PICKER_GUTTER;
     const shouldOpenAbove = spaceBelow < estimatedPopoverHeight && spaceAbove > spaceBelow;
@@ -137,13 +144,13 @@ export function CalendarDateTimeField({
     document.addEventListener("mousedown", handlePointerDown);
     document.addEventListener("keydown", handleEscape);
     window.addEventListener("resize", updatePopoverPosition);
-    document.addEventListener("scroll", updatePopoverPosition, true);
+    window.addEventListener("scroll", updatePopoverPosition, true);
 
     return () => {
       document.removeEventListener("mousedown", handlePointerDown);
       document.removeEventListener("keydown", handleEscape);
       window.removeEventListener("resize", updatePopoverPosition);
-      document.removeEventListener("scroll", updatePopoverPosition, true);
+      window.removeEventListener("scroll", updatePopoverPosition, true);
     };
   }, [isOpen, updatePopoverPosition]);
 

--- a/components/calendar-date-time-field.tsx
+++ b/components/calendar-date-time-field.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   CalendarDays,
   ChevronLeft,
@@ -21,6 +22,10 @@ import {
 } from "@/components/project-calendar-panel-utils";
 import { cn } from "@/lib/utils";
 
+const PICKER_WIDTH = 320;
+const PICKER_GUTTER = 12;
+const PICKER_OFFSET = 4;
+
 export interface CalendarDateTimeFieldProps {
   id: string;
   value: string;
@@ -36,8 +41,17 @@ export function CalendarDateTimeField({
   includeTime,
   disabled,
 }: CalendarDateTimeFieldProps) {
+  const [isBrowserReady, setIsBrowserReady] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+  const [popoverPosition, setPopoverPosition] = useState<{
+    left: number;
+    width: number;
+    top?: number;
+    bottom?: number;
+  } | null>(null);
 
   const parsedValue = useMemo(
     () => (includeTime ? parseDateTimeInputValue(value) : parseDateInputValue(value)),
@@ -53,12 +67,48 @@ export function CalendarDateTimeField({
   const calendarDays = useMemo(() => buildCalendarGrid(visibleMonth), [visibleMonth]);
 
   useEffect(() => {
+    setIsBrowserReady(true);
+  }, []);
+
+  const updatePopoverPosition = useCallback(() => {
+    if (!triggerRef.current || typeof window === "undefined") {
+      return;
+    }
+
+    const triggerRect = triggerRef.current.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+    const width = Math.min(PICKER_WIDTH, viewportWidth - PICKER_GUTTER * 2);
+    const left = Math.min(
+      Math.max(PICKER_GUTTER, triggerRect.left),
+      viewportWidth - width - PICKER_GUTTER
+    );
+    const estimatedPopoverHeight = includeTime ? 396 : 320;
+    const spaceBelow = viewportHeight - triggerRect.bottom - PICKER_GUTTER;
+    const spaceAbove = triggerRect.top - PICKER_GUTTER;
+    const shouldOpenAbove = spaceBelow < estimatedPopoverHeight && spaceAbove > spaceBelow;
+
+    setPopoverPosition({
+      left,
+      width,
+      ...(shouldOpenAbove
+        ? {
+            bottom: viewportHeight - triggerRect.top + PICKER_OFFSET,
+          }
+        : {
+            top: triggerRect.bottom + PICKER_OFFSET,
+          }),
+    });
+  }, [includeTime]);
+
+  useEffect(() => {
     if (!isOpen) {
       return;
     }
 
     setVisibleMonth(toMonthStart(selectedDate));
-  }, [isOpen, selectedDate]);
+    updatePopoverPosition();
+  }, [isOpen, selectedDate, updatePopoverPosition]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -66,13 +116,16 @@ export function CalendarDateTimeField({
     }
 
     const handlePointerDown = (event: MouseEvent) => {
-      if (!wrapperRef.current) {
+      const eventTarget = event.target as Node;
+
+      if (
+        wrapperRef.current?.contains(eventTarget) ||
+        popoverRef.current?.contains(eventTarget)
+      ) {
         return;
       }
 
-      if (!wrapperRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
-      }
+      setIsOpen(false);
     };
 
     const handleEscape = (event: KeyboardEvent) => {
@@ -83,12 +136,16 @@ export function CalendarDateTimeField({
 
     document.addEventListener("mousedown", handlePointerDown);
     document.addEventListener("keydown", handleEscape);
+    window.addEventListener("resize", updatePopoverPosition);
+    document.addEventListener("scroll", updatePopoverPosition, true);
 
     return () => {
       document.removeEventListener("mousedown", handlePointerDown);
       document.removeEventListener("keydown", handleEscape);
+      window.removeEventListener("resize", updatePopoverPosition);
+      document.removeEventListener("scroll", updatePopoverPosition, true);
     };
-  }, [isOpen]);
+  }, [isOpen, updatePopoverPosition]);
 
   const selectedHour = parsedValue?.getHours() ?? new Date().getHours();
   const selectedMinute = parsedValue?.getMinutes() ?? 0;
@@ -133,10 +190,131 @@ export function CalendarDateTimeField({
     year: "numeric",
   });
 
+  const pickerPopover =
+    isOpen && isBrowserReady && popoverPosition
+      ? createPortal(
+          <div
+            ref={popoverRef}
+            data-calendar-popover="true"
+            className="fixed z-[120] max-h-[calc(100vh-24px)] overflow-y-auto rounded-md border border-border/70 bg-popover p-3 shadow-xl"
+            style={popoverPosition}
+          >
+            <div className="mb-2 flex items-center justify-between">
+              <p className="text-sm font-medium capitalize text-popover-foreground">{monthLabel}</p>
+              <div className="flex items-center gap-1">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={() =>
+                    setVisibleMonth(
+                      (previous) => new Date(previous.getFullYear(), previous.getMonth() - 1, 1)
+                    )
+                  }
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={() =>
+                    setVisibleMonth(
+                      (previous) => new Date(previous.getFullYear(), previous.getMonth() + 1, 1)
+                    )
+                  }
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+
+            <div className="mb-1 grid grid-cols-7 gap-1">
+              {["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"].map((weekday) => (
+                <span
+                  key={weekday}
+                  className="text-center text-[11px] font-medium text-muted-foreground"
+                >
+                  {weekday}
+                </span>
+              ))}
+            </div>
+
+            <div className="grid grid-cols-7 gap-1">
+              {calendarDays.map((date) => {
+                const isCurrentMonth = date.getMonth() === visibleMonth.getMonth();
+                const isSelected = isSameDate(date, selectedDate);
+                return (
+                  <button
+                    key={`${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`}
+                    type="button"
+                    className={cn(
+                      "h-8 rounded text-sm transition",
+                      isSelected
+                        ? "bg-primary text-primary-foreground"
+                        : "text-foreground hover:bg-muted",
+                      isCurrentMonth ? "" : "text-muted-foreground/70"
+                    )}
+                    onClick={() => applyDate(date)}
+                  >
+                    {date.getDate()}
+                  </button>
+                );
+              })}
+            </div>
+
+            {includeTime ? (
+              <div className="mt-3 flex items-center gap-2 rounded-md border border-border/60 bg-background px-2 py-1.5">
+                <Clock3 className="h-4 w-4 text-muted-foreground" />
+                <select
+                  className="h-8 flex-1 rounded border border-input bg-background px-2 text-sm"
+                  value={`${selectedHour}`.padStart(2, "0")}
+                  onChange={(event) => updateHour(event.target.value)}
+                >
+                  {Array.from({ length: 24 }, (_, hour) => {
+                    const hourValue = `${hour}`.padStart(2, "0");
+                    return (
+                      <option key={hourValue} value={hourValue}>
+                        {hourValue}
+                      </option>
+                    );
+                  })}
+                </select>
+                <span className="text-sm text-muted-foreground">:</span>
+                <select
+                  className="h-8 flex-1 rounded border border-input bg-background px-2 text-sm"
+                  value={`${selectedMinute}`.padStart(2, "0")}
+                  onChange={(event) => updateMinute(event.target.value)}
+                >
+                  {["00", "15", "30", "45"].map((minuteValue) => (
+                    <option key={minuteValue} value={minuteValue}>
+                      {minuteValue}
+                    </option>
+                  ))}
+                </select>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  className="h-8 px-2"
+                  onClick={() => setIsOpen(false)}
+                >
+                  Done
+                </Button>
+              </div>
+            ) : null}
+          </div>,
+          document.body
+        )
+      : null;
+
   return (
     <div ref={wrapperRef} className="relative">
       <button
         id={id}
+        ref={triggerRef}
         type="button"
         className="flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 text-left text-sm transition hover:bg-muted/40"
         disabled={disabled}
@@ -145,117 +323,7 @@ export function CalendarDateTimeField({
         <span className="truncate">{formatPickerFieldValue(value, includeTime)}</span>
         <CalendarDays className="h-4 w-4 text-muted-foreground" />
       </button>
-
-      {isOpen ? (
-        <div className="absolute left-0 z-[80] mt-1 w-[320px] rounded-md border border-border/70 bg-popover p-3 shadow-xl">
-          <div className="mb-2 flex items-center justify-between">
-            <p className="text-sm font-medium capitalize text-popover-foreground">{monthLabel}</p>
-            <div className="flex items-center gap-1">
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7"
-                onClick={() =>
-                  setVisibleMonth(
-                    (previous) => new Date(previous.getFullYear(), previous.getMonth() - 1, 1)
-                  )
-                }
-              >
-                <ChevronLeft className="h-4 w-4" />
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7"
-                onClick={() =>
-                  setVisibleMonth(
-                    (previous) => new Date(previous.getFullYear(), previous.getMonth() + 1, 1)
-                  )
-                }
-              >
-                <ChevronRight className="h-4 w-4" />
-              </Button>
-            </div>
-          </div>
-
-          <div className="mb-1 grid grid-cols-7 gap-1">
-            {["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"].map((weekday) => (
-              <span
-                key={weekday}
-                className="text-center text-[11px] font-medium text-muted-foreground"
-              >
-                {weekday}
-              </span>
-            ))}
-          </div>
-
-          <div className="grid grid-cols-7 gap-1">
-            {calendarDays.map((date) => {
-              const isCurrentMonth = date.getMonth() === visibleMonth.getMonth();
-              const isSelected = isSameDate(date, selectedDate);
-              return (
-                <button
-                  key={`${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`}
-                  type="button"
-                  className={cn(
-                    "h-8 rounded text-sm transition",
-                    isSelected
-                      ? "bg-primary text-primary-foreground"
-                      : "text-foreground hover:bg-muted",
-                    isCurrentMonth ? "" : "text-muted-foreground/70"
-                  )}
-                  onClick={() => applyDate(date)}
-                >
-                  {date.getDate()}
-                </button>
-              );
-            })}
-          </div>
-
-          {includeTime ? (
-            <div className="mt-3 flex items-center gap-2 rounded-md border border-border/60 bg-background px-2 py-1.5">
-              <Clock3 className="h-4 w-4 text-muted-foreground" />
-              <select
-                className="h-8 flex-1 rounded border border-input bg-background px-2 text-sm"
-                value={`${selectedHour}`.padStart(2, "0")}
-                onChange={(event) => updateHour(event.target.value)}
-              >
-                {Array.from({ length: 24 }, (_, hour) => {
-                  const hourValue = `${hour}`.padStart(2, "0");
-                  return (
-                    <option key={hourValue} value={hourValue}>
-                      {hourValue}
-                    </option>
-                  );
-                })}
-              </select>
-              <span className="text-sm text-muted-foreground">:</span>
-              <select
-                className="h-8 flex-1 rounded border border-input bg-background px-2 text-sm"
-                value={`${selectedMinute}`.padStart(2, "0")}
-                onChange={(event) => updateMinute(event.target.value)}
-              >
-                {["00", "15", "30", "45"].map((minuteValue) => (
-                  <option key={minuteValue} value={minuteValue}>
-                    {minuteValue}
-                  </option>
-                ))}
-              </select>
-              <Button
-                type="button"
-                variant="secondary"
-                size="sm"
-                className="h-8 px-2"
-                onClick={() => setIsOpen(false)}
-              >
-                Done
-              </Button>
-            </div>
-          ) : null}
-        </div>
-      ) : null}
+      {pickerPopover}
     </div>
   );
 }

--- a/journal.md
+++ b/journal.md
@@ -12,6 +12,16 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ## Recent Entries (Most Relevant)
 
+### 2026-04-17
+- Type: Execution
+- Summary: Fixed the shared calendar datepicker so its popup renders through a body portal instead of inside scrollable modal content, preventing Google Calendar event dialogs from growing inner scrollbars when the picker opens.
+- Evidence: Updated `components/calendar-date-time-field.tsx` to portal the picker surface, track trigger position on resize/scroll, and preserve outside-click dismissal across the portaled popup.
+
+### 2026-04-17
+- Type: Validation
+- Summary: Datepicker overflow follow-up validated with lint, a focused picker regression test, and a production build on the repo's Node `20.19.0` toolchain.
+- Evidence: `npm run lint`; `npx -y -p node@20.19.0 node .\\node_modules\\vitest\\vitest.mjs run tests/components/calendar-date-time-field.test.ts`; `$env:DATABASE_URL='postgresql://user:pass@localhost:5432/postgres'; $env:DIRECT_URL='postgresql://user:pass@localhost:5432/postgres'; $env:VERCEL_ENV='preview'; $env:RESEND_API_KEY='test-resend-key'; $env:GOOGLE_TOKEN_ENCRYPTION_KEY='0123456789abcdef0123456789abcdef'; $env:AGENT_TOKEN_SIGNING_SECRET='0123456789abcdef0123456789abcdef'; npx -y -p node@20.19.0 node .\\node_modules\\next\\dist\\bin\\next build`.
+
 ### 2026-04-15
 - Type: Planning
 - Summary: Started `TASK-105` on a dedicated `docs/task-105-convex-assessment` branch, moved it to the top of the execution queue, replaced `tasks/current.md`, and drafted the initial Convex migration assessment plus architecture decision update.

--- a/tests/components/calendar-date-time-field.test.ts
+++ b/tests/components/calendar-date-time-field.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { CalendarDateTimeField } from "@/components/calendar-date-time-field";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function createTestRenderer() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  return {
+    container,
+    root,
+  };
+}
+
+async function renderWithRoot(root: Root, ui: React.ReactElement) {
+  await act(async () => {
+    root.render(ui);
+  });
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("calendar-date-time-field", () => {
+  test("renders the picker popover through a body portal", async () => {
+    const { container, root } = createTestRenderer();
+
+    await renderWithRoot(
+      root,
+      React.createElement(CalendarDateTimeField, {
+        id: "calendar-date",
+        value: "2026-04-17",
+        onChange: vi.fn(),
+        includeTime: false,
+        disabled: false,
+      })
+    );
+
+    const trigger = container.querySelector<HTMLButtonElement>("#calendar-date");
+    expect(trigger).not.toBeNull();
+
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.querySelector("[data-calendar-popover='true']")).toBeNull();
+    expect(document.body.querySelector("[data-calendar-popover='true']")).not.toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  test("closes the portaled popover on outside click", async () => {
+    const { container, root } = createTestRenderer();
+
+    await renderWithRoot(
+      root,
+      React.createElement(CalendarDateTimeField, {
+        id: "calendar-date",
+        value: "2026-04-17",
+        onChange: vi.fn(),
+        includeTime: false,
+        disabled: false,
+      })
+    );
+
+    const trigger = container.querySelector<HTMLButtonElement>("#calendar-date");
+    expect(trigger).not.toBeNull();
+
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(document.body.querySelector("[data-calendar-popover='true']")).not.toBeNull();
+
+    await act(async () => {
+      document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    });
+
+    expect(document.body.querySelector("[data-calendar-popover='true']")).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/tests/components/calendar-date-time-field.test.ts
+++ b/tests/components/calendar-date-time-field.test.ts
@@ -94,4 +94,66 @@ describe("calendar-date-time-field", () => {
       root.unmount();
     });
   });
+
+  test("repositions the portaled popover when the viewport changes", async () => {
+    const { container, root } = createTestRenderer();
+    let triggerLeft = 100;
+
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      writable: true,
+      value: 900,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      writable: true,
+      value: 800,
+    });
+
+    await renderWithRoot(
+      root,
+      React.createElement(CalendarDateTimeField, {
+        id: "calendar-date",
+        value: "2026-04-17",
+        onChange: vi.fn(),
+        includeTime: false,
+        disabled: false,
+      })
+    );
+
+    const trigger = container.querySelector<HTMLButtonElement>("#calendar-date");
+    expect(trigger).not.toBeNull();
+
+    vi.spyOn(trigger as HTMLButtonElement, "getBoundingClientRect").mockImplementation(() => ({
+      x: triggerLeft,
+      y: 200,
+      left: triggerLeft,
+      top: 200,
+      right: triggerLeft + 240,
+      bottom: 240,
+      width: 240,
+      height: 40,
+      toJSON: () => ({}),
+    }));
+
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const popover = document.body.querySelector<HTMLElement>("[data-calendar-popover='true']");
+    expect(popover).not.toBeNull();
+    expect(popover?.style.left).toBe("100px");
+
+    triggerLeft = 180;
+
+    await act(async () => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(popover?.style.left).toBe("180px");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- portal the shared calendar picker popover to document.body so it no longer expands scrollable modal content
- keep the popover aligned to its trigger on resize and nested scroll containers while preserving outside-click dismissal
- add a focused regression test for the portaled picker behavior and record the fix in the journal

## Validation
- npm run lint
- npx -y -p node@20.19.0 node .\\node_modules\\vitest\\vitest.mjs run tests/components/calendar-date-time-field.test.ts
- npx -y -p node@20.19.0 node .\\node_modules\\next\\dist\\bin\\next build