### PR TITLE
TASK-089 Generated avatar baseline with account regeneration

### DIFF
--- a/app/account/actions.ts
+++ b/app/account/actions.ts
@@ -13,6 +13,7 @@ import {
   respondToProjectInvitation,
 } from "@/lib/services/project-collaboration-service";
 import {
+  regenerateAccountAvatar,
   updateAccountEmail,
   updateAccountPassword,
   updateAccountUsername,
@@ -90,6 +91,27 @@ export async function updateAccountUsernameAction(formData: FormData): Promise<v
   }
 
   redirectWithStatus("username-updated");
+}
+
+export async function regenerateAccountAvatarAction(): Promise<void> {
+  const actorUserId = await requireVerifiedSessionUserIdFromServer();
+
+  let result: Awaited<ReturnType<typeof regenerateAccountAvatar>>;
+  try {
+    result = await regenerateAccountAvatar({
+      actorUserId,
+    });
+  } catch (error) {
+    logServerError("regenerateAccountAvatarAction", error);
+    redirectWithError("avatar-regenerate-failed");
+  }
+
+  if (!result.ok) {
+    redirectWithError(result.error);
+  }
+
+  revalidateAccountPaths();
+  redirectWithStatus("avatar-regenerated");
 }
 
 export async function updateAccountPasswordAction(formData: FormData): Promise<void> {

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -7,6 +7,7 @@ import { AutoDismissingAlert } from "@/components/auto-dismissing-alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import { requireSessionUserIdFromServer } from "@/lib/auth/server-guard";
 import { logServerError } from "@/lib/observability/logger";
 import {
@@ -24,6 +25,7 @@ import {
 import {
   acceptProjectInvitationAction,
   declineProjectInvitationAction,
+  regenerateAccountAvatarAction,
   updateAccountEmailAction,
   updateAccountPasswordAction,
   updateAccountUsernameAction,
@@ -34,6 +36,7 @@ type SearchParams = Record<string, string | string[] | undefined>;
 export const dynamic = "force-dynamic";
 
 const STATUS_MESSAGES: Record<string, string> = {
+  "avatar-regenerated": "Avatar regenerated.",
   "username-updated": "Username updated.",
   "username-updated-regenerated":
     "Username updated. Discriminator changed to keep your tag unique.",
@@ -46,6 +49,7 @@ const STATUS_MESSAGES: Record<string, string> = {
 const ERROR_MESSAGES: Record<string, string> = {
   unauthorized: "You must be signed in to manage account profile.",
   forbidden: "You cannot update another user profile.",
+  "avatar-regenerate-failed": "Could not regenerate avatar. Please retry.",
   "invalid-email": "Email address is invalid.",
   "email-in-use": "This email is already used by another account.",
   "invalid-username":
@@ -104,6 +108,8 @@ export default async function AccountProfilePage({
 
   const status = readQueryValue(resolvedSearchParams?.status);
   const error = readQueryValue(resolvedSearchParams?.error);
+  const avatarDisplayName =
+    profileResult.data.usernameTag || profileResult.data.username || "Account";
 
   return (
     <main className="container py-12">
@@ -215,88 +221,113 @@ export default async function AccountProfilePage({
           <CardHeader>
             <CardTitle className="text-xl">Identity</CardTitle>
             <CardDescription>
-              Update your public tag and account email from one place.
+              Manage your generated avatar, public tag, and account email from one
+              place.
             </CardDescription>
           </CardHeader>
-          <CardContent className="grid gap-6 md:grid-cols-2">
-            <form action={updateAccountUsernameAction} className="grid gap-4">
-              <div className="space-y-1">
-                <h2 className="text-base font-medium">Username</h2>
-                <p className="text-xs text-muted-foreground">
-                  {profileResult.data.usernameTag ? (
-                    <>
-                      Current tag: <code>{profileResult.data.usernameTag}</code>
-                    </>
-                  ) : (
-                    "No public tag assigned yet."
-                  )}
-                </p>
-              </div>
-              <div className="grid gap-2">
-                <label htmlFor="account-username" className="text-sm font-medium">
-                  Username
-                </label>
-                <div className="relative">
-                  <input
-                    id="account-username"
-                    name="username"
-                    type="text"
-                    defaultValue={profileResult.data.username}
-                    autoComplete="username"
-                    autoCapitalize="none"
-                    autoCorrect="off"
-                    spellCheck={false}
-                    required
-                    minLength={MIN_USERNAME_LENGTH}
-                    maxLength={MAX_USERNAME_LENGTH}
-                    pattern="[A-Za-z0-9._]+"
-                    className="h-10 w-full rounded-md border border-input bg-background px-3 pr-24 text-sm"
-                  />
-                  <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-sm text-muted-foreground select-none">
-                    #{profileResult.data.usernameDiscriminator ?? "pending"}
-                  </span>
-                </div>
-                <p className="text-xs text-muted-foreground">
-                  Use {MIN_USERNAME_LENGTH}-{MAX_USERNAME_LENGTH} letters, numbers,
-                  dots, or underscores. Uppercase input is normalized to lowercase.
-                </p>
-              </div>
-              <div>
-                <Button type="submit">Save username</Button>
-              </div>
-            </form>
-
-            <form action={updateAccountEmailAction} className="grid gap-4">
-              <div className="space-y-1">
-                <h2 className="text-base font-medium">Email</h2>
-                <p className="text-xs text-muted-foreground">
-                  {profileResult.data.isEmailVerified
-                    ? "Verified email on file."
-                    : "Email pending verification."}
-                </p>
-              </div>
-              <div className="grid gap-2">
-                <label htmlFor="account-email" className="text-sm font-medium">
-                  Email address
-                </label>
-                <input
-                  id="account-email"
-                  name="email"
-                  type="email"
-                  defaultValue={profileResult.data.email ?? ""}
-                  autoComplete="email"
-                  required
-                  className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+          <CardContent className="grid gap-6">
+            <div className="flex flex-col gap-4 rounded-xl border border-border/70 bg-muted/20 p-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-center gap-4">
+                <UserAvatar
+                  avatarSeed={profileResult.data.avatarSeed}
+                  displayName={avatarDisplayName}
+                  className="h-16 w-16 border-border/80"
                 />
-                <p className="text-xs text-muted-foreground">
-                  Changing email requires verifying the new address before workspace
-                  access resumes.
-                </p>
+                <div className="space-y-1">
+                  <p className="text-sm font-medium">Generated avatar</p>
+                  <p className="text-xs text-muted-foreground">
+                    NexusDash uses a deterministic pixel avatar seeded to your
+                    account. Regenerate it any time from here.
+                  </p>
+                </div>
               </div>
-              <div>
-                <Button type="submit">Update email</Button>
-              </div>
-            </form>
+              <form action={regenerateAccountAvatarAction}>
+                <Button type="submit" variant="outline">
+                  Regenerate avatar
+                </Button>
+              </form>
+            </div>
+
+            <div className="grid gap-6 md:grid-cols-2">
+              <form action={updateAccountUsernameAction} className="grid gap-4">
+                <div className="space-y-1">
+                  <h2 className="text-base font-medium">Username</h2>
+                  <p className="text-xs text-muted-foreground">
+                    {profileResult.data.usernameTag ? (
+                      <>
+                        Current tag: <code>{profileResult.data.usernameTag}</code>
+                      </>
+                    ) : (
+                      "No public tag assigned yet."
+                    )}
+                  </p>
+                </div>
+                <div className="grid gap-2">
+                  <label htmlFor="account-username" className="text-sm font-medium">
+                    Username
+                  </label>
+                  <div className="relative">
+                    <input
+                      id="account-username"
+                      name="username"
+                      type="text"
+                      defaultValue={profileResult.data.username}
+                      autoComplete="username"
+                      autoCapitalize="none"
+                      autoCorrect="off"
+                      spellCheck={false}
+                      required
+                      minLength={MIN_USERNAME_LENGTH}
+                      maxLength={MAX_USERNAME_LENGTH}
+                      pattern="[A-Za-z0-9._]+"
+                      className="h-10 w-full rounded-md border border-input bg-background px-3 pr-24 text-sm"
+                    />
+                    <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-sm text-muted-foreground select-none">
+                      #{profileResult.data.usernameDiscriminator ?? "pending"}
+                    </span>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    Use {MIN_USERNAME_LENGTH}-{MAX_USERNAME_LENGTH} letters, numbers,
+                    dots, or underscores. Uppercase input is normalized to lowercase.
+                  </p>
+                </div>
+                <div>
+                  <Button type="submit">Save username</Button>
+                </div>
+              </form>
+
+              <form action={updateAccountEmailAction} className="grid gap-4">
+                <div className="space-y-1">
+                  <h2 className="text-base font-medium">Email</h2>
+                  <p className="text-xs text-muted-foreground">
+                    {profileResult.data.isEmailVerified
+                      ? "Verified email on file."
+                      : "Email pending verification."}
+                  </p>
+                </div>
+                <div className="grid gap-2">
+                  <label htmlFor="account-email" className="text-sm font-medium">
+                    Email address
+                  </label>
+                  <input
+                    id="account-email"
+                    name="email"
+                    type="email"
+                    defaultValue={profileResult.data.email ?? ""}
+                    autoComplete="email"
+                    required
+                    className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Changing email requires verifying the new address before workspace
+                    access resumes.
+                  </p>
+                </div>
+                <div>
+                  <Button type="submit">Update email</Button>
+                </div>
+              </form>
+            </div>
           </CardContent>
         </Card>
 

--- a/app/account/settings/developers/page.tsx
+++ b/app/account/settings/developers/page.tsx
@@ -1,20 +1,27 @@
 import { headers } from "next/headers";
+import { notFound } from "next/navigation";
 
 import { requireSessionUserIdFromServer } from "@/lib/auth/server-guard";
 import { AgentOnboardingGuide } from "@/components/agent-onboarding/agent-onboarding-guide";
 import { AccountSettingsShell } from "@/components/account/account-settings-shell";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { resolveRequestOriginFromHeaders } from "@/lib/http/request-origin";
+import { getAccountIdentitySummary } from "@/lib/services/account-identity-service";
 
 export default async function AccountDeveloperSettingsPage() {
-  await requireSessionUserIdFromServer();
+  const actorUserId = await requireSessionUserIdFromServer();
+  const identity = await getAccountIdentitySummary(actorUserId);
   const requestOrigin = resolveRequestOriginFromHeaders(await headers());
+  if (!identity) {
+    notFound();
+  }
 
   return (
     <AccountSettingsShell
       activeTab="developers"
       title="Developer onboarding"
       description="Use hosted docs and project-scoped credentials to connect external agents to NexusDash."
+      identity={identity}
     >
       <Card className="border-border/60 bg-background/70">
         <CardHeader>

--- a/app/account/settings/page.tsx
+++ b/app/account/settings/page.tsx
@@ -5,6 +5,7 @@ import { AccountSettingsShell } from "@/components/account/account-settings-shel
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { requireSessionUserIdFromServer } from "@/lib/auth/server-guard";
+import { getAccountIdentitySummary } from "@/lib/services/account-identity-service";
 import {
   DEFAULT_GOOGLE_CALENDAR_ID,
   MAX_GOOGLE_CALENDAR_ID_LENGTH,
@@ -50,8 +51,11 @@ export default async function AccountSettingsPage({
   const actorUserId = await requireSessionUserIdFromServer();
   const resolvedSearchParams = await searchParams;
 
-  const settingsResult = await getGoogleCalendarTargetSettings(actorUserId);
-  if (!settingsResult.ok) {
+  const [settingsResult, identity] = await Promise.all([
+    getGoogleCalendarTargetSettings(actorUserId),
+    getAccountIdentitySummary(actorUserId),
+  ]);
+  if (!settingsResult.ok || !identity) {
     notFound();
   }
 
@@ -65,6 +69,7 @@ export default async function AccountSettingsPage({
       activeTab="calendar"
       title="Google Calendar target"
       description="Choose which Google Calendar receives events created from NexusDash."
+      identity={identity}
     >
       {status && STATUS_MESSAGES[status] ? (
         <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-700 dark:text-emerald-200">

--- a/app/api/projects/[projectId]/tasks/route.ts
+++ b/app/api/projects/[projectId]/tasks/route.ts
@@ -9,6 +9,7 @@ import { mapTaskAttachmentResponse } from "@/lib/services/project-attachment-ser
 import { listProjectKanbanTasks } from "@/lib/services/project-service";
 import { createTaskForProject } from "@/lib/services/project-task-service";
 import { requireAgentProjectScopes } from "@/lib/services/project-access-service";
+import { mapTaskPersonSummary } from "@/lib/task-person";
 import { formatTaskDeadlineDate } from "@/lib/task-deadline";
 
 const ATTACHMENT_FILES_FIELD = "attachmentFiles";
@@ -18,6 +19,7 @@ interface TaskCreateJsonRequestBody {
   title?: unknown;
   description?: unknown;
   deadlineDate?: unknown;
+  assigneeUserId?: unknown;
   labels?: unknown;
   relatedTaskIds?: unknown;
   attachmentLinks?: unknown;
@@ -119,6 +121,9 @@ export async function GET(request: NextRequest, props: { params: Promise<{ proje
       labelsJson: task.labelsJson,
       createdAt: task.createdAt,
       updatedAt: task.updatedAt,
+      assignee: mapTaskPersonSummary(task.assigneeUser),
+      createdBy: mapTaskPersonSummary(task.createdByUser),
+      updatedBy: mapTaskPersonSummary(task.updatedByUser),
       attachments: task.attachments.map((attachment: TaskAttachment) =>
         mapTaskAttachmentResponse(params.projectId, task.id, attachment)
       ),
@@ -144,6 +149,7 @@ export async function POST(request: NextRequest, props: { params: Promise<{ proj
   let title = "";
   let description = "";
   let deadlineDate = "";
+  let assigneeUserId: string | null = null;
   let labelsJsonRaw = "";
   let relatedTaskIdsJsonRaw = "";
   let attachmentLinksJsonRaw = "";
@@ -174,6 +180,17 @@ export async function POST(request: NextRequest, props: { params: Promise<{ proj
     }
     deadlineDate =
       typeof payload.deadlineDate === "string" ? payload.deadlineDate.trim() : "";
+    if (
+      payload.assigneeUserId !== undefined &&
+      payload.assigneeUserId !== null &&
+      typeof payload.assigneeUserId !== "string"
+    ) {
+      return NextResponse.json({ error: "assignee-invalid" }, { status: 400 });
+    }
+    assigneeUserId =
+      typeof payload.assigneeUserId === "string"
+        ? payload.assigneeUserId.trim() || null
+        : null;
     labelsJsonRaw = serializeJsonField(payload.labels);
     relatedTaskIdsJsonRaw = serializeJsonField(payload.relatedTaskIds);
     attachmentLinksJsonRaw = serializeJsonField(payload.attachmentLinks);
@@ -193,6 +210,7 @@ export async function POST(request: NextRequest, props: { params: Promise<{ proj
     title = readText(formData, "title");
     description = readText(formData, "description");
     deadlineDate = readText(formData, "deadlineDate");
+    assigneeUserId = readText(formData, "assigneeUserId") || null;
     labelsJsonRaw = readText(formData, "labels");
     relatedTaskIdsJsonRaw = readText(formData, "relatedTaskIds");
     attachmentLinksJsonRaw = readText(formData, "attachmentLinks");
@@ -212,6 +230,7 @@ export async function POST(request: NextRequest, props: { params: Promise<{ proj
     title,
     description,
     deadlineDate,
+    assigneeUserId,
     labelsJsonRaw,
     relatedTaskIdsJsonRaw,
     attachmentLinksJsonRaw,

--- a/app/projects/[projectId]/kanban-board-section.tsx
+++ b/app/projects/[projectId]/kanban-board-section.tsx
@@ -1,12 +1,19 @@
 import { Columns3 } from "lucide-react";
 
-import { KanbanBoard, type KanbanTask } from "@/components/kanban-board";
+import {
+  KanbanBoard,
+  type KanbanTask,
+} from "@/components/kanban-board";
 import {
   PROJECT_SECTION_CARD_CLASS,
   PROJECT_SECTION_HEADER_CLASS,
 } from "@/components/project-dashboard/project-section-chrome";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { listProjectKanbanTasks } from "@/lib/services/project-service";
+import {
+  listProjectCollaborators,
+  listProjectKanbanTasks,
+} from "@/lib/services/project-service";
+import { mapTaskPersonSummary } from "@/lib/task-person";
 import { mapRelatedTaskSummary } from "@/lib/task-related";
 import { ATTACHMENT_KIND_FILE } from "@/lib/task-attachment";
 import { formatTaskDeadlineDate } from "@/lib/task-deadline";
@@ -33,7 +40,10 @@ export async function KanbanBoardSection({
   canEdit,
   storageProvider,
 }: KanbanBoardSectionProps) {
-  const tasks = await listProjectKanbanTasks(projectId, actorUserId);
+  const [tasks, collaborators] = await Promise.all([
+    listProjectKanbanTasks(projectId, actorUserId),
+    listProjectCollaborators(projectId, actorUserId),
+  ]);
   const kanbanTasks: KanbanTask[] = [];
   const archivedDoneTasks: KanbanTask[] = [];
 
@@ -54,6 +64,11 @@ export async function KanbanBoardSection({
         content: entry.content,
         createdAt: entry.createdAt.toISOString(),
       })),
+      assignee: mapTaskPersonSummary(task.assigneeUser),
+      createdBy: mapTaskPersonSummary(task.createdByUser)!,
+      updatedBy: mapTaskPersonSummary(task.updatedByUser)!,
+      createdAt: task.createdAt.toISOString(),
+      updatedAt: task.updatedAt.toISOString(),
       archivedAt: task.archivedAt ? task.archivedAt.toISOString() : null,
       relatedTasks: [
         ...task.outgoingRelations.map((entry: OutgoingRelation) =>
@@ -93,6 +108,8 @@ export async function KanbanBoardSection({
       storageProvider={storageProvider}
       initialTasks={kanbanTasks}
       archivedDoneTasks={archivedDoneTasks}
+      collaborators={collaborators}
+      actorUserId={actorUserId}
     />
   );
 }

--- a/components/account-menu.tsx
+++ b/components/account-menu.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useState } from "react";
 import { CircleUserRound, LogOut, MailPlus, Settings } from "lucide-react";
 
+import { UserAvatar } from "@/components/ui/user-avatar";
 import { Button } from "@/components/ui/button";
 import { useDismissibleMenu } from "@/lib/hooks/use-dismissible-menu";
 
@@ -11,6 +12,7 @@ interface AccountMenuProps {
   isAuthenticated: boolean;
   displayName: string | null;
   usernameTag: string | null;
+  avatarSeed: string | null;
   pendingInvitationCount: number;
 }
 
@@ -18,6 +20,7 @@ export function AccountMenu({
   isAuthenticated,
   displayName,
   usernameTag,
+  avatarSeed,
   pendingInvitationCount,
 }: AccountMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
@@ -37,8 +40,17 @@ export function AccountMenu({
         aria-haspopup="menu"
         aria-expanded={isOpen}
         onClick={() => setIsOpen((previous) => !previous)}
+        className="relative overflow-hidden rounded-full p-0"
       >
-        <CircleUserRound className="h-5 w-5" />
+        {avatarSeed && displayName ? (
+          <UserAvatar
+            avatarSeed={avatarSeed}
+            displayName={displayName}
+            className="h-full w-full border-none"
+          />
+        ) : (
+          <CircleUserRound className="h-5 w-5" />
+        )}
         {pendingInvitationCount > 0 ? (
           <span
             aria-hidden="true"
@@ -50,12 +62,23 @@ export function AccountMenu({
         <div className="absolute right-0 z-30 mt-1 w-56 rounded-md border border-border/70 bg-background p-1 shadow-md">
           {displayName ? (
             <div className="border-b border-border/70 px-3 py-2">
-              <p className="truncate text-xs font-medium">Welcome {displayName}!</p>
-              {usernameTag ? (
-                <p className="truncate text-[11px] text-muted-foreground">
-                  {usernameTag}
-                </p>
-              ) : null}
+              <div className="flex items-center gap-3">
+                {avatarSeed ? (
+                  <UserAvatar
+                    avatarSeed={avatarSeed}
+                    displayName={displayName}
+                    className="h-10 w-10 border-border/80"
+                  />
+                ) : null}
+                <div className="min-w-0">
+                  <p className="truncate text-xs font-medium">Welcome {displayName}!</p>
+                  {usernameTag ? (
+                    <p className="truncate text-[11px] text-muted-foreground">
+                      {usernameTag}
+                    </p>
+                  ) : null}
+                </div>
+              </div>
             </div>
           ) : null}
           <Button type="button" variant="ghost" className="w-full justify-start" asChild>

--- a/components/account-menu.tsx
+++ b/components/account-menu.tsx
@@ -47,6 +47,7 @@ export function AccountMenu({
             avatarSeed={avatarSeed}
             displayName={displayName}
             className="h-full w-full border-none"
+            decorative
           />
         ) : (
           <CircleUserRound className="h-5 w-5" />

--- a/components/account/account-settings-shell.tsx
+++ b/components/account/account-settings-shell.tsx
@@ -2,15 +2,23 @@ import Link from "next/link";
 import { ArrowLeft, BookOpenText, CalendarDays } from "lucide-react";
 import type { ReactNode } from "react";
 
+import { UserAvatar } from "@/components/ui/user-avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 
 type AccountSettingsTab = "calendar" | "developers";
 
+interface AccountSettingsIdentity {
+  displayName: string;
+  usernameTag: string | null;
+  avatarSeed: string;
+}
+
 interface AccountSettingsShellProps {
   activeTab: AccountSettingsTab;
   title: string;
   description: string;
+  identity: AccountSettingsIdentity;
   children: ReactNode;
 }
 
@@ -18,6 +26,7 @@ export function AccountSettingsShell({
   activeTab,
   title,
   description,
+  identity,
   children,
 }: AccountSettingsShellProps) {
   return (
@@ -37,6 +46,24 @@ export function AccountSettingsShell({
         <div className="space-y-2">
           <h1 className="text-3xl font-semibold tracking-tight">{title}</h1>
           <p className="text-sm text-muted-foreground">{description}</p>
+        </div>
+
+        <div className="flex flex-col gap-3 rounded-xl border border-border/70 bg-muted/20 p-4 sm:flex-row sm:items-center">
+          <UserAvatar
+            avatarSeed={identity.avatarSeed}
+            displayName={identity.usernameTag ?? identity.displayName}
+            className="h-14 w-14 border-border/80"
+          />
+          <div className="space-y-1">
+            <p className="text-sm font-medium">{identity.displayName}</p>
+            {identity.usernameTag ? (
+              <p className="text-xs text-muted-foreground">{identity.usernameTag}</p>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Generated avatar active for this account.
+              </p>
+            )}
+          </div>
         </div>
 
         <div className="flex flex-wrap gap-2">

--- a/components/create-task-dialog.tsx
+++ b/components/create-task-dialog.tsx
@@ -7,10 +7,14 @@ import { useRouter } from "next/navigation";
 
 import { TaskDeadlineField } from "@/components/kanban/task-deadline-field";
 import { RelatedTaskSelector, type RelatedTaskOption } from "@/components/kanban/related-task-field";
-import type { TaskRelatedSummary } from "@/components/kanban-board-types";
+import type {
+  ProjectTaskCollaborator,
+  TaskRelatedSummary,
+} from "@/components/kanban-board-types";
 import { RichTextEditor } from "@/components/rich-text-editor";
 import { useToast } from "@/components/toast-provider";
 import { AttachmentLinkComposer } from "@/components/ui/attachment-link-composer";
+import { AssigneeSelect } from "@/components/ui/assignee-select";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { EmojiInputField } from "@/components/ui/emoji-field";
@@ -32,6 +36,7 @@ interface CreateTaskDialogProps {
   storageProvider: "local" | "r2";
   existingLabels: string[];
   availableTasks: RelatedTaskOption[];
+  availableAssignees: ProjectTaskCollaborator[];
 }
 
 interface PendingAttachmentLink {
@@ -48,6 +53,7 @@ export function CreateTaskDialog({
   storageProvider,
   existingLabels,
   availableTasks,
+  availableAssignees,
 }: CreateTaskDialogProps) {
   const isMountedRef = useRef(true);
   const router = useRouter();
@@ -55,6 +61,7 @@ export function CreateTaskDialog({
   const [isOpen, setIsOpen] = useState(false);
   const [description, setDescription] = useState("");
   const [deadlineDate, setDeadlineDate] = useState("");
+  const [assigneeUserId, setAssigneeUserId] = useState("");
   const [labels, setLabels] = useState<string[]>([]);
   const [labelInput, setLabelInput] = useState("");
   const [relatedTaskSearch, setRelatedTaskSearch] = useState("");
@@ -88,6 +95,7 @@ export function CreateTaskDialog({
   const resetDraft = () => {
     setDescription("");
     setDeadlineDate("");
+    setAssigneeUserId("");
     setLabels([]);
     setLabelInput("");
     setRelatedTaskSearch("");
@@ -120,6 +128,8 @@ export function CreateTaskDialog({
         return "One or more attachment links are invalid. Use http:// or https:// URLs.";
       case "deadline-invalid":
         return "Deadline must use a valid date.";
+      case "assignee-invalid":
+        return "Assignee must be a current collaborator on this project.";
       case "attachment-file-too-large":
         return attachmentFileSizeErrorMessage;
       case "attachment-file-type-invalid":
@@ -465,6 +475,22 @@ export function CreateTaskDialog({
                         disabled={isSubmitting}
                         helperText="Optional. Near deadlines are highlighted automatically on the board."
                       />
+
+                      <div className="grid gap-2">
+                        <label htmlFor="task-assignee" className="text-sm font-medium">
+                          Assignee
+                        </label>
+                        <AssigneeSelect
+                          id="task-assignee"
+                          name="assigneeUserId"
+                          value={assigneeUserId}
+                          onChange={setAssigneeUserId}
+                          options={availableAssignees}
+                        />
+                        <p className="text-xs text-muted-foreground">
+                          Optional. Leave unassigned until ownership is clear.
+                        </p>
+                      </div>
 
                       <div className="grid gap-2">
                         <label className="text-sm font-medium">Related tasks</label>

--- a/components/kanban-board-types.ts
+++ b/components/kanban-board-types.ts
@@ -17,6 +17,7 @@ export interface TaskCommentAuthor {
   id: string;
   displayName: string;
   usernameTag: string | null;
+  avatarSeed: string;
 }
 
 export interface TaskComment {

--- a/components/kanban-board-types.ts
+++ b/components/kanban-board-types.ts
@@ -1,5 +1,14 @@
 import type { TaskStatus } from "@/lib/task-status";
 
+export interface TaskPersonSummary {
+  id: string;
+  displayName: string;
+  usernameTag: string | null;
+  avatarSeed: string;
+}
+
+export type ProjectTaskCollaboratorRole = "owner" | "editor" | "viewer";
+
 export interface TaskBlockedFollowUp {
   id: string;
   content: string;
@@ -13,12 +22,7 @@ export interface TaskRelatedSummary {
   archivedAt: string | null;
 }
 
-export interface TaskCommentAuthor {
-  id: string;
-  displayName: string;
-  usernameTag: string | null;
-  avatarSeed: string;
-}
+export type TaskCommentAuthor = TaskPersonSummary;
 
 export interface TaskComment {
   id: string;
@@ -49,10 +53,19 @@ export interface KanbanTask {
   archivedAt: string | null;
   attachments: TaskAttachment[];
   relatedTasks: TaskRelatedSummary[];
+  assignee: TaskPersonSummary | null;
+  createdBy: TaskPersonSummary;
+  updatedBy: TaskPersonSummary;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface PendingAttachmentUpload {
   id: string;
   name: string;
   sizeBytes: number;
+}
+
+export interface ProjectTaskCollaborator extends TaskPersonSummary {
+  projectRole: ProjectTaskCollaboratorRole;
 }

--- a/components/kanban-board.tsx
+++ b/components/kanban-board.tsx
@@ -13,8 +13,10 @@ import type { DropResult } from "@hello-pangea/dnd";
 import type { RelatedTaskOption } from "@/components/kanban/related-task-field";
 import {
   type KanbanTask,
+  type ProjectTaskCollaborator,
   type TaskComment,
   type PendingAttachmentUpload,
+  type TaskPersonSummary,
   type TaskAttachment,
   type TaskRelatedSummary,
 } from "@/components/kanban-board-types";
@@ -58,21 +60,40 @@ export type { KanbanTask } from "@/components/kanban-board-types";
 interface KanbanBoardProps {
   canEdit: boolean;
   projectId: string;
+  actorUserId: string;
   storageProvider: "local" | "r2";
   initialTasks: KanbanTask[];
   archivedDoneTasks?: KanbanTask[];
+  collaborators: ProjectTaskCollaborator[];
 }
 
 function createLocalUploadId(): string {
   return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
 
+function stampTaskActivity(
+  task: KanbanTask,
+  actor: TaskPersonSummary | null
+): KanbanTask {
+  if (!actor) {
+    return task;
+  }
+
+  return {
+    ...task,
+    updatedBy: actor,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
 export function KanbanBoard({
   canEdit,
   projectId,
+  actorUserId,
   storageProvider,
   initialTasks,
   archivedDoneTasks: initialArchivedDoneTasks = [],
+  collaborators,
 }: KanbanBoardProps) {
   const initialColumns = useMemo(
     () => mapTasksToColumns(initialTasks),
@@ -106,6 +127,7 @@ export function KanbanBoard({
   const [editLabelInput, setEditLabelInput] = useState("");
   const [editDescription, setEditDescription] = useState("");
   const [editDeadlineDate, setEditDeadlineDate] = useState("");
+  const [editAssigneeUserId, setEditAssigneeUserId] = useState("");
   const [editRelatedTasks, setEditRelatedTasks] = useState<TaskRelatedSummary[]>([]);
   const [relatedTaskSearch, setRelatedTaskSearch] = useState("");
   const [newBlockedFollowUpEntry, setNewBlockedFollowUpEntry] = useState("");
@@ -137,6 +159,10 @@ export function KanbanBoard({
       : MAX_ATTACHMENT_FILE_SIZE_LABEL;
   const attachmentFileSizeErrorMessage = `Attachment files must be ${maxAttachmentFileSizeLabel} or smaller.`;
   const hasPendingAttachmentUploads = pendingAttachmentUploads.length > 0;
+  const currentActorSummary = useMemo<TaskPersonSummary | null>(
+    () => collaborators.find((collaborator) => collaborator.id === actorUserId) ?? null,
+    [actorUserId, collaborators]
+  );
 
   const resetTaskEditDraft = useCallback((task: KanbanTask) => {
     setTaskModalError(null);
@@ -145,6 +171,7 @@ export function KanbanBoard({
     setEditLabelInput("");
     setEditDescription(task.description ?? "");
     setEditDeadlineDate(task.deadlineDate ?? "");
+    setEditAssigneeUserId(task.assignee?.id ?? "");
     setEditRelatedTasks(task.relatedTasks);
     setRelatedTaskSearch("");
     setNewBlockedFollowUpEntry("");
@@ -344,6 +371,14 @@ export function KanbanBoard({
         }))
         .sort((left, right) => left.title.localeCompare(right.title)),
     [columns]
+  );
+
+  const availableAssignees = useMemo<ProjectTaskCollaborator[]>(
+    () =>
+      [...collaborators].sort((left, right) =>
+        left.displayName.localeCompare(right.displayName)
+      ),
+    [collaborators]
   );
 
   const addEditLabel = useCallback(
@@ -580,10 +615,17 @@ export function KanbanBoard({
         return;
       }
 
-      nextColumns[destinationStatus].splice(destination.index, 0, {
-        ...movedTask,
-        status: destinationStatus,
-      });
+      nextColumns[destinationStatus].splice(
+        destination.index,
+        0,
+        stampTaskActivity(
+          {
+            ...movedTask,
+            status: destinationStatus,
+          },
+          currentActorSummary
+        )
+      );
 
       setColumns(nextColumns);
       syncRelatedTaskSummary(movedTask.id, {
@@ -597,7 +639,7 @@ export function KanbanBoard({
         void persistColumns(nextColumns, previousColumns);
       });
     },
-    [canEdit, columns, persistColumns, syncRelatedTaskSummary]
+    [canEdit, columns, currentActorSummary, persistColumns, syncRelatedTaskSummary]
   );
 
   const closeTaskModal = useCallback(() => {
@@ -608,6 +650,7 @@ export function KanbanBoard({
     setAttachmentError(null);
     setTaskCommentsError(null);
     setEditRelatedTasks([]);
+    setEditAssigneeUserId("");
     setRelatedTaskSearch("");
     setPreviewAttachment(null);
     setTaskComments([]);
@@ -703,6 +746,7 @@ export function KanbanBoard({
               labels: editLabels,
               description: editDescription,
               deadlineDate: editDeadlineDate || null,
+              assigneeUserId: editAssigneeUserId || null,
               blockedFollowUpEntry: normalizedBlockedEntry,
               relatedTaskIds,
             }),
@@ -716,6 +760,8 @@ export function KanbanBoard({
           const message =
             payload?.error === "related-tasks-invalid"
               ? "Related tasks must stay active and belong to this project."
+              : payload?.error === "assignee-invalid"
+                ? "Assignee must be a current collaborator on this project."
               : payload?.error === "deadline-invalid"
                 ? "Deadline must use a valid date."
               : (payload?.error ?? "Failed to update task");
@@ -735,6 +781,11 @@ export function KanbanBoard({
             status: string;
             position: number;
             archivedAt: string | null;
+            assignee: TaskPersonSummary | null;
+            createdBy: TaskPersonSummary;
+            updatedBy: TaskPersonSummary;
+            createdAt: string;
+            updatedAt: string;
             relatedTasks: TaskRelatedSummary[];
             blockedFollowUps: {
               id: string;
@@ -758,6 +809,11 @@ export function KanbanBoard({
           description: payload.task.description,
           deadlineDate: payload.task.deadlineDate,
           commentCount: payload.task.commentCount,
+          assignee: payload.task.assignee,
+          createdBy: payload.task.createdBy,
+          updatedBy: payload.task.updatedBy,
+          createdAt: payload.task.createdAt,
+          updatedAt: payload.task.updatedAt,
           blockedFollowUps: payload.task.blockedFollowUps.map((entry) => ({
             ...entry,
             createdAt: entry.createdAt,
@@ -839,6 +895,7 @@ export function KanbanBoard({
     },
     [
       canEdit,
+      editAssigneeUserId,
       editDeadlineDate,
       editDescription,
       editLabels,
@@ -904,21 +961,30 @@ export function KanbanBoard({
         return;
       }
 
-      nextColumns[nextStatus].unshift({
-        ...movedTask,
-        status: nextStatus,
-      });
+      nextColumns[nextStatus].unshift(
+        stampTaskActivity(
+          {
+            ...movedTask,
+            status: nextStatus,
+            archivedAt: null,
+          },
+          currentActorSummary
+        )
+      );
 
       setColumns(nextColumns);
       setSelectedTask((previousTask) => {
         if (!previousTask || previousTask.id !== task.id) {
           return previousTask;
         }
-        return {
-          ...previousTask,
-          status: nextStatus,
-          archivedAt: null,
-        };
+        return stampTaskActivity(
+          {
+            ...previousTask,
+            status: nextStatus,
+            archivedAt: null,
+          },
+          currentActorSummary
+        );
       });
       syncRelatedTaskSummary(task.id, {
         title: task.title,
@@ -936,7 +1002,14 @@ export function KanbanBoard({
         message: `Task moved to ${nextStatus}.`,
       });
     },
-    [canEdit, columns, persistColumns, pushToast, syncRelatedTaskSummary]
+    [
+      canEdit,
+      columns,
+      currentActorSummary,
+      persistColumns,
+      pushToast,
+      syncRelatedTaskSummary,
+    ]
   );
 
   const confirmDeleteTask = useCallback(async () => {
@@ -1024,10 +1097,13 @@ export function KanbanBoard({
       const payload = (await response.json()) as { archivedAt: string };
 
       const taskToArchive = selectedTask;
-      const archivedTask = {
-        ...taskToArchive,
-        archivedAt: payload.archivedAt,
-      };
+      const archivedTask = stampTaskActivity(
+        {
+          ...taskToArchive,
+          archivedAt: payload.archivedAt,
+        },
+        currentActorSummary
+      );
 
       setColumns((previousColumns) => {
         const nextColumns = createEmptyColumns<KanbanTask>();
@@ -1061,7 +1137,16 @@ export function KanbanBoard({
     } finally {
       setIsArchivingTask(false);
     }
-  }, [canEdit, closeTaskModal, isArchivingTask, projectId, pushToast, selectedTask, syncRelatedTaskSummary]);
+  }, [
+    canEdit,
+    closeTaskModal,
+    currentActorSummary,
+    isArchivingTask,
+    projectId,
+    pushToast,
+    selectedTask,
+    syncRelatedTaskSummary,
+  ]);
 
   const handleUnarchiveTask = useCallback(async () => {
     if (!canEdit) {
@@ -1086,10 +1171,13 @@ export function KanbanBoard({
         throw new Error(await readApiError(response, "Could not unarchive task."));
       }
 
-      const taskToRestore = {
-        ...selectedTask,
-        archivedAt: null,
-      };
+      const taskToRestore = stampTaskActivity(
+        {
+          ...selectedTask,
+          archivedAt: null,
+        },
+        currentActorSummary
+      );
 
       setArchivedDoneTasks((previousTasks) =>
         previousTasks.filter((task) => task.id !== taskToRestore.id)
@@ -1123,7 +1211,16 @@ export function KanbanBoard({
     } finally {
       setIsArchivingTask(false);
     }
-  }, [canEdit, isArchivingTask, isSelectedTaskArchived, projectId, pushToast, selectedTask, syncRelatedTaskSummary]);
+  }, [
+    canEdit,
+    currentActorSummary,
+    isArchivingTask,
+    isSelectedTaskArchived,
+    projectId,
+    pushToast,
+    selectedTask,
+    syncRelatedTaskSummary,
+  ]);
 
   const handleAddBlockedFollowUpEntry = useCallback(async () => {
     if (!canEdit) {
@@ -1227,10 +1324,15 @@ export function KanbanBoard({
 
       setTaskComments((previousComments) => [...previousComments, payload.comment]);
       setNewTaskComment("");
-      applyTaskMutation(selectedTask.id, (task) => ({
-        ...task,
-        commentCount: task.commentCount + 1,
-      }));
+      applyTaskMutation(selectedTask.id, (task) =>
+        stampTaskActivity(
+          {
+            ...task,
+            commentCount: task.commentCount + 1,
+          },
+          currentActorSummary
+        )
+      );
       pushToast({
         variant: "success",
         message: "Comment added.",
@@ -1247,7 +1349,15 @@ export function KanbanBoard({
     } finally {
       setIsSubmittingTaskComment(false);
     }
-  }, [applyTaskMutation, canEdit, newTaskComment, projectId, pushToast, selectedTask]);
+  }, [
+    applyTaskMutation,
+    canEdit,
+    currentActorSummary,
+    newTaskComment,
+    projectId,
+    pushToast,
+    selectedTask,
+  ]);
 
   const handleAddLinkAttachment = useCallback(async () => {
     if (!canEdit) {
@@ -1282,10 +1392,15 @@ export function KanbanBoard({
       }
 
       const payload = (await response.json()) as { attachment: TaskAttachment };
-      applyTaskMutation(selectedTask.id, (task) => ({
-        ...task,
-        attachments: [payload.attachment, ...task.attachments],
-      }));
+      applyTaskMutation(selectedTask.id, (task) =>
+        stampTaskActivity(
+          {
+            ...task,
+            attachments: [payload.attachment, ...task.attachments],
+          },
+          currentActorSummary
+        )
+      );
       setLinkUrl("");
       setIsLinkComposerOpen(false);
       pushToast({
@@ -1304,7 +1419,15 @@ export function KanbanBoard({
     } finally {
       setIsSubmittingAttachment(false);
     }
-  }, [applyTaskMutation, canEdit, linkUrl, projectId, pushToast, selectedTask]);
+  }, [
+    applyTaskMutation,
+    canEdit,
+    currentActorSummary,
+    linkUrl,
+    projectId,
+    pushToast,
+    selectedTask,
+  ]);
 
   const handleAddFileAttachment = useCallback(
     async (selectedFile: File | null) => {
@@ -1372,10 +1495,15 @@ export function KanbanBoard({
           attachment = payload.attachment;
         }
 
-        applyTaskMutation(taskId, (task) => ({
-          ...task,
-          attachments: [attachment, ...task.attachments],
-        }));
+        applyTaskMutation(taskId, (task) =>
+          stampTaskActivity(
+            {
+              ...task,
+              attachments: [attachment, ...task.attachments],
+            },
+            currentActorSummary
+          )
+        );
         pushToast({
           variant: "success",
           message: "Attachment uploaded.",
@@ -1401,6 +1529,7 @@ export function KanbanBoard({
       applyTaskMutation,
       attachmentFileSizeErrorMessage,
       canEdit,
+      currentActorSummary,
       maxAttachmentFileSizeBytes,
       projectId,
       selectedTask,
@@ -1436,12 +1565,17 @@ export function KanbanBoard({
           );
         }
 
-        applyTaskMutation(selectedTask.id, (task) => ({
-          ...task,
-          attachments: task.attachments.filter(
-            (attachment) => attachment.id !== attachmentId
-          ),
-        }));
+        applyTaskMutation(selectedTask.id, (task) =>
+          stampTaskActivity(
+            {
+              ...task,
+              attachments: task.attachments.filter(
+                (attachment) => attachment.id !== attachmentId
+              ),
+            },
+            currentActorSummary
+          )
+        );
         pushToast({
           variant: "success",
           message: "Attachment deleted.",
@@ -1459,7 +1593,7 @@ export function KanbanBoard({
         setIsSubmittingAttachment(false);
       }
     },
-    [applyTaskMutation, canEdit, projectId, pushToast, selectedTask]
+    [applyTaskMutation, canEdit, currentActorSummary, projectId, pushToast, selectedTask]
   );
 
   const totalTaskCount = useMemo(
@@ -1503,6 +1637,7 @@ export function KanbanBoard({
             storageProvider={storageProvider}
             existingLabels={allKnownLabels}
             availableTasks={createDialogAvailableTasks}
+            availableAssignees={availableAssignees}
           />
         ) : null}
         onToggleExpanded={() => setIsExpanded((previous) => !previous)}
@@ -1538,6 +1673,7 @@ export function KanbanBoard({
         editLabelSuggestions={editLabelSuggestions}
         editDescription={editDescription}
         editDeadlineDate={editDeadlineDate}
+        editAssigneeUserId={editAssigneeUserId}
         editRelatedTasks={editRelatedTasks}
         relatedTaskSearch={relatedTaskSearch}
         newBlockedFollowUpEntry={newBlockedFollowUpEntry}
@@ -1567,9 +1703,11 @@ export function KanbanBoard({
         onRemoveEditLabel={removeEditLabel}
         onEditDescriptionChange={setEditDescription}
         onEditDeadlineDateChange={setEditDeadlineDate}
+        onEditAssigneeUserIdChange={setEditAssigneeUserId}
         onRelatedTaskSearchChange={setRelatedTaskSearch}
         onAddRelatedTask={addRelatedTask}
         onRemoveRelatedTask={removeRelatedTask}
+        availableAssignees={availableAssignees}
         availableRelatedTaskOptions={availableRelatedTaskOptions}
         onOpenRelatedTask={openRelatedTask}
         onNewBlockedFollowUpEntryChange={setNewBlockedFollowUpEntry}

--- a/components/kanban/kanban-columns-grid.tsx
+++ b/components/kanban/kanban-columns-grid.tsx
@@ -9,6 +9,7 @@ import { Archive, Clock3, GripVertical, Link2, MessageSquare, Paperclip, Triangl
 import type { KanbanTask } from "@/components/kanban-board-types";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import {
   buildDragStyle,
   getDescriptionPreview,
@@ -275,6 +276,18 @@ function KanbanColumn({
                         <p className="break-words text-xs text-muted-foreground">
                           {getDescriptionPreview(task.description)}
                         </p>
+                      ) : null}
+
+                      {task.assignee ? (
+                        <div className="mt-3 flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-2 py-1 text-xs text-muted-foreground">
+                          <UserAvatar
+                            avatarSeed={task.assignee.avatarSeed}
+                            displayName={task.assignee.displayName}
+                            className="h-5 w-5 border-border/70"
+                            decorative
+                          />
+                          <span className="truncate">{task.assignee.displayName}</span>
+                        </div>
                       ) : null}
 
                       {task.labels.length > 0 ? (

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -41,6 +41,7 @@ import { AttachmentLinkComposer } from "@/components/ui/attachment-link-composer
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { EmojiInputField, EmojiTextareaField } from "@/components/ui/emoji-field";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import { useDismissibleMenu } from "@/lib/hooks/use-dismissible-menu";
 import {
   ATTACHMENT_KIND_FILE,
@@ -676,20 +677,30 @@ function TaskReadOnlyContent({
                   key={comment.id}
                   className="rounded-xl border border-border/50 bg-background/80 px-3 py-2.5"
                 >
-                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                    <p className="text-sm font-medium">{comment.author.displayName}</p>
-                    {getCommentIdentityMeta(comment.author) ? (
-                      <p className="text-[11px] text-muted-foreground">
-                        {getCommentIdentityMeta(comment.author)}
+                  <div className="flex items-start gap-3">
+                    <UserAvatar
+                      avatarSeed={comment.author.avatarSeed}
+                      displayName={comment.author.displayName}
+                      className="mt-0.5 h-9 w-9 border-border/70"
+                      decorative
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                        <p className="text-sm font-medium">{comment.author.displayName}</p>
+                        {getCommentIdentityMeta(comment.author) ? (
+                          <p className="text-[11px] text-muted-foreground">
+                            {getCommentIdentityMeta(comment.author)}
+                          </p>
+                        ) : null}
+                        <p className="text-[11px] text-muted-foreground">
+                          {formatTaskCommentTimestamp(comment.createdAt)}
+                        </p>
+                      </div>
+                      <p className="mt-1.5 whitespace-pre-wrap break-words text-sm text-foreground">
+                        {comment.content}
                       </p>
-                    ) : null}
-                    <p className="text-[11px] text-muted-foreground">
-                      {formatTaskCommentTimestamp(comment.createdAt)}
-                    </p>
+                    </div>
                   </div>
-                  <p className="mt-1.5 whitespace-pre-wrap break-words text-sm text-foreground">
-                    {comment.content}
-                  </p>
                 </article>
               ))}
             </div>

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -21,6 +21,8 @@ import {
   type KanbanTask,
   type TaskComment,
   type PendingAttachmentUpload,
+  type ProjectTaskCollaborator,
+  type TaskPersonSummary,
   type TaskAttachment,
 } from "@/components/kanban-board-types";
 import {
@@ -37,6 +39,7 @@ import { AttachmentPreviewModal } from "@/components/attachment-preview-modal";
 import { RichTextContent } from "@/components/rich-text-content";
 import { RichTextEditor } from "@/components/rich-text-editor";
 import { Badge } from "@/components/ui/badge";
+import { AssigneeSelect } from "@/components/ui/assignee-select";
 import { AttachmentLinkComposer } from "@/components/ui/attachment-link-composer";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
@@ -69,6 +72,7 @@ interface TaskDetailModalProps {
   editLabelSuggestions: string[];
   editDescription: string;
   editDeadlineDate: string;
+  editAssigneeUserId: string;
   editRelatedTasks: KanbanTask["relatedTasks"];
   relatedTaskSearch: string;
   newBlockedFollowUpEntry: string;
@@ -98,9 +102,11 @@ interface TaskDetailModalProps {
   onRemoveEditLabel: (label: string) => void;
   onEditDescriptionChange: (value: string) => void;
   onEditDeadlineDateChange: (value: string) => void;
+  onEditAssigneeUserIdChange: (value: string) => void;
   onRelatedTaskSearchChange: (value: string) => void;
   onAddRelatedTask: (taskId: string) => void;
   onRemoveRelatedTask: (taskId: string) => void;
+  availableAssignees: ProjectTaskCollaborator[];
   availableRelatedTaskOptions: RelatedTaskOption[];
   onOpenRelatedTask: (taskId: string) => void;
   onNewBlockedFollowUpEntryChange: (value: string) => void;
@@ -131,6 +137,7 @@ export function TaskDetailModal({
   editLabelSuggestions,
   editDescription,
   editDeadlineDate,
+  editAssigneeUserId,
   editRelatedTasks,
   relatedTaskSearch,
   newBlockedFollowUpEntry,
@@ -160,9 +167,11 @@ export function TaskDetailModal({
   onRemoveEditLabel,
   onEditDescriptionChange,
   onEditDeadlineDateChange,
+  onEditAssigneeUserIdChange,
   onRelatedTaskSearchChange,
   onAddRelatedTask,
   onRemoveRelatedTask,
+  availableAssignees,
   availableRelatedTaskOptions,
   onOpenRelatedTask,
   onNewBlockedFollowUpEntryChange,
@@ -204,7 +213,7 @@ export function TaskDetailModal({
             onMouseDown={(event) => event.stopPropagation()}
           >
             <CardHeader className="flex shrink-0 flex-col gap-3 space-y-0 sm:flex-row sm:items-start sm:justify-between">
-              <div className="min-w-0 space-y-2">
+              <div className="min-w-0 flex-1 space-y-2">
                 <Badge
                   variant="outline"
                   className={
@@ -216,18 +225,21 @@ export function TaskDetailModal({
                   {isArchivedTask ? "Archived" : selectedTask.status}
                 </Badge>
                 {!isEditing ? (
-                  <CardTitle
-                    className="text-xl leading-tight"
-                    onDoubleClick={() => {
-                      if (!canEdit) {
-                        return;
-                      }
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                    <CardTitle
+                      className="min-w-0 flex-1 text-xl leading-tight"
+                      onDoubleClick={() => {
+                        if (!canEdit) {
+                          return;
+                        }
 
-                      onActivateEditMode();
-                    }}
-                  >
-                    {selectedTask.title}
-                  </CardTitle>
+                        onActivateEditMode();
+                      }}
+                    >
+                      {selectedTask.title}
+                    </CardTitle>
+                    <TaskAssigneeBadge assignee={selectedTask.assignee} />
+                  </div>
                 ) : (
                   <EmojiInputField
                     aria-label="Task title"
@@ -287,6 +299,7 @@ export function TaskDetailModal({
                   editLabelSuggestions={editLabelSuggestions}
                   editDescription={editDescription}
                   editDeadlineDate={editDeadlineDate}
+                  editAssigneeUserId={editAssigneeUserId}
                   editRelatedTasks={editRelatedTasks}
                   relatedTaskSearch={relatedTaskSearch}
                   newBlockedFollowUpEntry={newBlockedFollowUpEntry}
@@ -304,9 +317,11 @@ export function TaskDetailModal({
                   onRemoveEditLabel={onRemoveEditLabel}
                   onEditDescriptionChange={onEditDescriptionChange}
                   onEditDeadlineDateChange={onEditDeadlineDateChange}
+                  onEditAssigneeUserIdChange={onEditAssigneeUserIdChange}
                   onRelatedTaskSearchChange={onRelatedTaskSearchChange}
                   onAddRelatedTask={onAddRelatedTask}
                   onRemoveRelatedTask={onRemoveRelatedTask}
+                  availableAssignees={availableAssignees}
                   availableRelatedTaskOptions={availableRelatedTaskOptions}
                   onNewBlockedFollowUpEntryChange={onNewBlockedFollowUpEntryChange}
                   onAddBlockedFollowUpEntry={onAddBlockedFollowUpEntry}
@@ -403,6 +418,95 @@ function TaskDeadlineBadge({
       {relativeLabel ? (
         <span className="hidden sm:inline">- {relativeLabel}</span>
       ) : null}
+    </div>
+  );
+}
+
+function formatTaskActivityDate(value: string): string {
+  return new Date(value).toLocaleDateString();
+}
+
+function buildTaskPersonHoverLabel(person: TaskPersonSummary): string {
+  return person.usernameTag ?? person.displayName;
+}
+
+function TaskAssigneeBadge({ assignee }: { assignee: TaskPersonSummary | null }) {
+  return (
+    <div className="flex flex-col gap-1 sm:items-end">
+      <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+        Assignee
+      </p>
+      <div
+        className="inline-flex max-w-full items-center gap-2 rounded-full border border-border/60 bg-background/85 px-2.5 py-1.5"
+        title={assignee ? buildTaskPersonHoverLabel(assignee) : "Unassigned"}
+      >
+        {assignee ? (
+          <>
+            <UserAvatar
+              avatarSeed={assignee.avatarSeed}
+              displayName={assignee.displayName}
+              className="h-7 w-7 border-border/70"
+              decorative
+            />
+            <span className="max-w-[160px] truncate text-sm font-medium text-foreground">
+              {assignee.displayName}
+            </span>
+          </>
+        ) : (
+          <>
+            <span className="inline-flex h-7 w-7 shrink-0 rounded-full border border-dashed border-border/70 bg-muted/30" />
+            <span className="text-sm text-muted-foreground">Unassigned</span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TaskActivityInline({
+  label,
+  person,
+  fallback,
+  timestamp,
+}: {
+  label: string;
+  person: TaskPersonSummary | null;
+  fallback: string;
+  timestamp: string;
+}) {
+  if (!person) {
+    return (
+      <div className="grid gap-1 rounded-xl border border-border/50 bg-background/75 px-2.5 py-2">
+        <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+          {label}
+        </p>
+        <p className="text-xs text-muted-foreground">{fallback}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="grid min-w-0 gap-1 rounded-xl border border-border/50 bg-background/75 px-2.5 py-2"
+      title={`${label}: ${buildTaskPersonHoverLabel(person)}`}
+    >
+      <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+        {label}
+      </p>
+      <div className="flex min-w-0 items-center gap-1.5">
+        <UserAvatar
+          avatarSeed={person.avatarSeed}
+          displayName={person.displayName}
+          className="h-5 w-5 border-border/70"
+          decorative
+        />
+        <span className="max-w-[96px] truncate text-xs font-medium text-foreground">
+          {person.displayName}
+        </span>
+      </div>
+      <span className="text-[11px] text-muted-foreground">
+        {formatTaskActivityDate(timestamp)}
+      </span>
     </div>
   );
 }
@@ -675,13 +779,13 @@ function TaskReadOnlyContent({
               {taskComments.map((comment) => (
                 <article
                   key={comment.id}
-                  className="rounded-xl border border-border/50 bg-background/80 px-3 py-2.5"
+                  className="rounded-xl border border-border/50 bg-background/80 px-3 py-2"
                 >
-                  <div className="flex items-start gap-3">
+                  <div className="flex items-start gap-2.5">
                     <UserAvatar
                       avatarSeed={comment.author.avatarSeed}
                       displayName={comment.author.displayName}
-                      className="mt-0.5 h-9 w-9 border-border/70"
+                      className="mt-0.5 h-8 w-8 border-border/70"
                       decorative
                     />
                     <div className="min-w-0 flex-1">
@@ -696,7 +800,7 @@ function TaskReadOnlyContent({
                           {formatTaskCommentTimestamp(comment.createdAt)}
                         </p>
                       </div>
-                      <p className="mt-1.5 whitespace-pre-wrap break-words text-sm text-foreground">
+                      <p className="mt-1 whitespace-pre-wrap break-words text-sm text-foreground">
                         {comment.content}
                       </p>
                     </div>
@@ -730,7 +834,21 @@ function TaskReadOnlyContent({
                 className="h-11 min-h-11 resize-none rounded-xl border border-border/50 bg-background/80 px-3 py-2 text-sm leading-5 transition-colors focus-visible:outline-none focus-visible:border-ring/60"
                 disabled={isSubmittingTaskComment}
               />
-              <div className="flex justify-end">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                <div className="flex flex-wrap items-center gap-2">
+                  <TaskActivityInline
+                    label="Created by"
+                    person={selectedTask.createdBy}
+                    fallback="Unknown creator"
+                    timestamp={selectedTask.createdAt}
+                  />
+                  <TaskActivityInline
+                    label="Last updated by"
+                    person={selectedTask.updatedBy}
+                    fallback="Unknown collaborator"
+                    timestamp={selectedTask.updatedAt}
+                  />
+                </div>
                 <Button
                   type="button"
                   size="sm"
@@ -742,7 +860,22 @@ function TaskReadOnlyContent({
                 </Button>
               </div>
             </div>
-          ) : null}
+          ) : (
+            <div className="flex flex-wrap items-center gap-2">
+              <TaskActivityInline
+                label="Created by"
+                person={selectedTask.createdBy}
+                fallback="Unknown creator"
+                timestamp={selectedTask.createdAt}
+              />
+              <TaskActivityInline
+                label="Last updated by"
+                person={selectedTask.updatedBy}
+                fallback="Unknown collaborator"
+                timestamp={selectedTask.updatedAt}
+              />
+            </div>
+          )}
         </div>
       </section>
       {hasAttachments ? (
@@ -821,6 +954,7 @@ interface TaskEditContentProps {
   editLabelSuggestions: string[];
   editDescription: string;
   editDeadlineDate: string;
+  editAssigneeUserId: string;
   editRelatedTasks: KanbanTask["relatedTasks"];
   relatedTaskSearch: string;
   newBlockedFollowUpEntry: string;
@@ -838,9 +972,11 @@ interface TaskEditContentProps {
   onRemoveEditLabel: (label: string) => void;
   onEditDescriptionChange: (value: string) => void;
   onEditDeadlineDateChange: (value: string) => void;
+  onEditAssigneeUserIdChange: (value: string) => void;
   onRelatedTaskSearchChange: (value: string) => void;
   onAddRelatedTask: (taskId: string) => void;
   onRemoveRelatedTask: (taskId: string) => void;
+  availableAssignees: ProjectTaskCollaborator[];
   availableRelatedTaskOptions: RelatedTaskOption[];
   onNewBlockedFollowUpEntryChange: (value: string) => void;
   onAddBlockedFollowUpEntry: () => void | Promise<void>;
@@ -861,6 +997,7 @@ function TaskEditContent({
   editLabelSuggestions,
   editDescription,
   editDeadlineDate,
+  editAssigneeUserId,
   editRelatedTasks,
   relatedTaskSearch,
   newBlockedFollowUpEntry,
@@ -878,9 +1015,11 @@ function TaskEditContent({
   onRemoveEditLabel,
   onEditDescriptionChange,
   onEditDeadlineDateChange,
+  onEditAssigneeUserIdChange,
   onRelatedTaskSearchChange,
   onAddRelatedTask,
   onRemoveRelatedTask,
+  availableAssignees,
   availableRelatedTaskOptions,
   onNewBlockedFollowUpEntryChange,
   onAddBlockedFollowUpEntry,
@@ -975,6 +1114,19 @@ function TaskEditContent({
           onChange={onEditDeadlineDateChange}
           disabled={isUpdatingTask}
         />
+
+        <div className="grid gap-2">
+          <label htmlFor="task-edit-assignee" className="text-sm font-medium">
+            Assignee
+          </label>
+          <AssigneeSelect
+            id="task-edit-assignee"
+            value={editAssigneeUserId}
+            onChange={onEditAssigneeUserIdChange}
+            disabled={isUpdatingTask}
+            options={availableAssignees}
+          />
+        </div>
 
         {selectedTask.status === "Blocked" ? (
           <div className="grid gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2">

--- a/components/project-dashboard/project-dashboard-owner-access-panel.tsx
+++ b/components/project-dashboard/project-dashboard-owner-access-panel.tsx
@@ -5,6 +5,7 @@ import { Check, Copy } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { UserAvatar } from "@/components/ui/user-avatar";
 
 import {
   formatIdentity,
@@ -108,21 +109,29 @@ export function ProjectDashboardOwnerAccessPanel({
                   key={member.membershipId}
                   className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-border/60 bg-card p-3"
                 >
-                  <div className="space-y-1">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <p className="text-sm font-medium">{member.displayName}</p>
-                      <Badge
-                        variant={member.isOwner ? "secondary" : "outline"}
-                        className="capitalize"
-                      >
-                        {member.role}
-                      </Badge>
+                  <div className="flex items-center gap-3">
+                    <UserAvatar
+                      avatarSeed={member.avatarSeed}
+                      displayName={member.displayName}
+                      className="h-10 w-10 border-border/70"
+                      decorative
+                    />
+                    <div className="space-y-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="text-sm font-medium">{member.displayName}</p>
+                        <Badge
+                          variant={member.isOwner ? "secondary" : "outline"}
+                          className="capitalize"
+                        >
+                          {member.role}
+                        </Badge>
+                      </div>
+                      {getSecondaryIdentity(member.displayName, formatIdentity(member)) ? (
+                        <p className="text-xs text-muted-foreground">
+                          {getSecondaryIdentity(member.displayName, formatIdentity(member))}
+                        </p>
+                      ) : null}
                     </div>
-                    {getSecondaryIdentity(member.displayName, formatIdentity(member)) ? (
-                      <p className="text-xs text-muted-foreground">
-                        {getSecondaryIdentity(member.displayName, formatIdentity(member))}
-                      </p>
-                    ) : null}
                   </div>
 
                   {member.isOwner ? null : (
@@ -165,6 +174,7 @@ export function ProjectDashboardOwnerAccessPanel({
                       displayName: invitation.invitedUserDisplayName,
                       usernameTag: invitation.invitedUserUsernameTag,
                       email: invitation.invitedEmail,
+                      avatarSeed: invitation.invitedUserId ?? invitation.invitedEmail,
                     })
                   : invitation.invitedEmail;
                 const secondaryIdentity = getSecondaryIdentity(

--- a/components/project-dashboard/project-dashboard-owner-actions.shared.ts
+++ b/components/project-dashboard/project-dashboard-owner-actions.shared.ts
@@ -16,6 +16,7 @@ export interface CollaboratorIdentitySummary {
   displayName: string;
   usernameTag: string | null;
   email: string | null;
+  avatarSeed: string;
 }
 
 export interface ProjectMemberSummary extends CollaboratorIdentitySummary {

--- a/components/top-right-controls.tsx
+++ b/components/top-right-controls.tsx
@@ -47,6 +47,7 @@ export async function TopRightControls() {
         isAuthenticated={Boolean(actorUserId)}
         displayName={accountIdentity?.displayName ?? null}
         usernameTag={accountIdentity?.usernameTag ?? null}
+        avatarSeed={accountIdentity?.avatarSeed ?? null}
         pendingInvitationCount={pendingInvitationCount}
       />
       <ThemeToggle />

--- a/components/ui/assignee-select.tsx
+++ b/components/ui/assignee-select.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import { createPortal } from "react-dom";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Check, ChevronDown } from "lucide-react";
+
+import type {
+  ProjectTaskCollaborator,
+  ProjectTaskCollaboratorRole,
+} from "@/components/kanban-board-types";
+import { UserAvatar } from "@/components/ui/user-avatar";
+import { cn } from "@/lib/utils";
+
+interface AssigneeSelectProps {
+  id?: string;
+  name?: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: ProjectTaskCollaborator[];
+  disabled?: boolean;
+  className?: string;
+  unassignedLabel?: string;
+}
+
+function formatProjectRole(role: ProjectTaskCollaboratorRole): string {
+  switch (role) {
+    case "owner":
+      return "Owner";
+    case "editor":
+      return "Editor";
+    case "viewer":
+      return "Viewer";
+    default:
+      return role;
+  }
+}
+
+function buildAssigneeHoverLabel(assignee: ProjectTaskCollaborator): string {
+  return assignee.usernameTag ?? assignee.displayName;
+}
+
+export function AssigneeSelect({
+  id,
+  name,
+  value,
+  onChange,
+  options,
+  disabled = false,
+  className,
+  unassignedLabel = "Unassigned",
+}: AssigneeSelectProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [dropdownPosition, setDropdownPosition] = useState<{
+    top: number;
+    left: number;
+    width: number;
+    maxHeight: number;
+  } | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
+
+  const selectedAssignee = useMemo(
+    () => options.find((option) => option.id === value) ?? null,
+    [options, value]
+  );
+
+  useEffect(() => {
+    if (!isOpen) {
+      setDropdownPosition(null);
+      return;
+    }
+
+    const updateDropdownPosition = () => {
+      const trigger = triggerRef.current;
+      if (!trigger) {
+        return;
+      }
+
+      const rect = trigger.getBoundingClientRect();
+      const viewportPadding = 12;
+      const estimatedHeight = Math.min(56 * (options.length + 1), 280);
+      const availableBelow = window.innerHeight - rect.bottom - viewportPadding;
+      const availableAbove = rect.top - viewportPadding;
+      const shouldOpenAbove =
+        availableBelow < estimatedHeight && availableAbove > availableBelow;
+      const maxHeight = Math.max(
+        140,
+        shouldOpenAbove ? availableAbove - 6 : availableBelow - 6
+      );
+
+      setDropdownPosition({
+        top: shouldOpenAbove
+          ? Math.max(viewportPadding, rect.top - Math.min(estimatedHeight, maxHeight) - 6)
+          : rect.bottom + 6,
+        left: rect.left,
+        width: Math.max(rect.width, 260),
+        maxHeight,
+      });
+    };
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node | null;
+      if (!target) {
+        return;
+      }
+
+      if (triggerRef.current?.contains(target) || dropdownRef.current?.contains(target)) {
+        return;
+      }
+
+      setIsOpen(false);
+    };
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+
+    updateDropdownPosition();
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleEscape);
+    window.addEventListener("resize", updateDropdownPosition);
+    window.addEventListener("scroll", updateDropdownPosition, true);
+
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleEscape);
+      window.removeEventListener("resize", updateDropdownPosition);
+      window.removeEventListener("scroll", updateDropdownPosition, true);
+    };
+  }, [isOpen, options.length]);
+
+  return (
+    <div className="relative">
+      {name ? <input type="hidden" name={name} value={value} /> : null}
+      <button
+        ref={triggerRef}
+        id={id}
+        type="button"
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        className={cn(
+          "flex min-h-10 w-full items-center justify-between gap-3 rounded-md border border-input bg-background px-3 py-2 text-left transition-colors",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+          "disabled:cursor-not-allowed disabled:opacity-60",
+          className
+        )}
+        onClick={() => {
+          if (disabled) {
+            return;
+          }
+
+          setIsOpen((previous) => !previous);
+        }}
+        title={selectedAssignee ? buildAssigneeHoverLabel(selectedAssignee) : undefined}
+      >
+        {selectedAssignee ? (
+          <div className="flex min-w-0 items-center gap-3">
+            <UserAvatar
+              avatarSeed={selectedAssignee.avatarSeed}
+              displayName={selectedAssignee.displayName}
+              className="h-8 w-8 border-border/70"
+              decorative
+            />
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium text-foreground">
+                {selectedAssignee.displayName}
+              </p>
+              <p className="truncate text-xs text-muted-foreground">
+                {formatProjectRole(selectedAssignee.projectRole)}
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="flex min-w-0 items-center gap-3">
+            <span className="inline-flex h-8 w-8 shrink-0 rounded-full border border-dashed border-border/70 bg-muted/30" />
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium text-foreground">{unassignedLabel}</p>
+              <p className="truncate text-xs text-muted-foreground">No owner yet</p>
+            </div>
+          </div>
+        )}
+        <ChevronDown
+          className={cn(
+            "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
+            isOpen && "rotate-180"
+          )}
+        />
+      </button>
+
+      {isOpen && dropdownPosition && typeof document !== "undefined"
+        ? createPortal(
+            <div
+              ref={dropdownRef}
+              role="listbox"
+              className="z-[140] overflow-hidden rounded-xl border border-border/70 bg-popover p-1 shadow-lg"
+              style={{
+                position: "fixed",
+                top: dropdownPosition.top,
+                left: dropdownPosition.left,
+                width: dropdownPosition.width,
+                maxHeight: dropdownPosition.maxHeight,
+              }}
+            >
+              <div className="scrollbar-hidden space-y-1 overflow-y-auto p-0.5">
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={!selectedAssignee}
+                  className="flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-left transition hover:bg-muted"
+                  onClick={() => {
+                    onChange("");
+                    setIsOpen(false);
+                  }}
+                >
+                  <div className="flex min-w-0 items-center gap-3">
+                    <span className="inline-flex h-9 w-9 shrink-0 rounded-full border border-dashed border-border/70 bg-muted/30" />
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium text-foreground">
+                        {unassignedLabel}
+                      </p>
+                      <p className="truncate text-xs text-muted-foreground">
+                        Leave without an assignee
+                      </p>
+                    </div>
+                  </div>
+                  {!selectedAssignee ? <Check className="h-4 w-4 text-foreground" /> : null}
+                </button>
+
+                {options.map((assignee) => {
+                  const isSelected = assignee.id === selectedAssignee?.id;
+
+                  return (
+                    <button
+                      key={assignee.id}
+                      type="button"
+                      role="option"
+                      aria-selected={isSelected}
+                      title={buildAssigneeHoverLabel(assignee)}
+                      className="flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-left transition hover:bg-muted"
+                      onClick={() => {
+                        onChange(assignee.id);
+                        setIsOpen(false);
+                      }}
+                    >
+                      <div className="flex min-w-0 items-center gap-3">
+                        <UserAvatar
+                          avatarSeed={assignee.avatarSeed}
+                          displayName={assignee.displayName}
+                          className="h-9 w-9 border-border/70"
+                          decorative
+                        />
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-medium text-foreground">
+                            {assignee.displayName}
+                          </p>
+                          <p className="truncate text-xs text-muted-foreground">
+                            {formatProjectRole(assignee.projectRole)}
+                          </p>
+                        </div>
+                      </div>
+                      {isSelected ? <Check className="h-4 w-4 text-foreground" /> : null}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>,
+            document.body
+          )
+        : null}
+    </div>
+  );
+}

--- a/components/ui/user-avatar.tsx
+++ b/components/ui/user-avatar.tsx
@@ -8,6 +8,7 @@ interface UserAvatarProps {
   displayName: string;
   className?: string;
   imageClassName?: string;
+  decorative?: boolean;
 }
 
 export function UserAvatar({
@@ -15,9 +16,11 @@ export function UserAvatar({
   displayName,
   className,
   imageClassName,
+  decorative = false,
 }: UserAvatarProps) {
   return (
     <span
+      aria-hidden={decorative}
       className={cn(
         "inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full border border-border/60 bg-muted",
         className
@@ -25,7 +28,7 @@ export function UserAvatar({
     >
       <Image
         src={buildGeneratedAvatarDataUri(avatarSeed)}
-        alt={`${displayName} avatar`}
+        alt={decorative ? "" : `${displayName} avatar`}
         width={64}
         height={64}
         unoptimized

--- a/components/ui/user-avatar.tsx
+++ b/components/ui/user-avatar.tsx
@@ -1,0 +1,36 @@
+import Image from "next/image";
+
+import { buildGeneratedAvatarDataUri } from "@/lib/avatar";
+import { cn } from "@/lib/utils";
+
+interface UserAvatarProps {
+  avatarSeed: string;
+  displayName: string;
+  className?: string;
+  imageClassName?: string;
+}
+
+export function UserAvatar({
+  avatarSeed,
+  displayName,
+  className,
+  imageClassName,
+}: UserAvatarProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full border border-border/60 bg-muted",
+        className
+      )}
+    >
+      <Image
+        src={buildGeneratedAvatarDataUri(avatarSeed)}
+        alt={`${displayName} avatar`}
+        width={64}
+        height={64}
+        unoptimized
+        className={cn("h-full w-full object-cover", imageClassName)}
+      />
+    </span>
+  );
+}

--- a/journal.md
+++ b/journal.md
@@ -14,6 +14,21 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ### 2026-04-21
 - Type: Execution
+- Summary: TASK-101 implemented first-class task ownership and provenance end to end so tasks now persist creator, updater, and optional assignee metadata and surface avatar-backed attribution across task cards, task detail, create/edit flows, comments, and task-related attachment activity.
+- Evidence: Added task ownership fields plus migration `prisma/migrations/20260421131500_task101_task_ownership_and_provenance/migration.sql`; updated `prisma/schema.prisma`, `lib/services/project-task-service.ts`, `lib/services/project-service.ts`, `lib/services/project-task-comment-service.ts`, `lib/services/project-attachment-service.ts`, `app/api/projects/[projectId]/tasks/route.ts`, `app/projects/[projectId]/kanban-board-section.tsx`, `components/kanban-board.tsx`, `components/kanban/task-detail-modal.tsx`, `components/kanban/kanban-columns-grid.tsx`, `components/create-task-dialog.tsx`, `components/kanban-board-types.ts`, `lib/agent-onboarding.ts`, and related API/service tests.
+
+### 2026-04-21
+- Type: Validation
+- Summary: TASK-101 local validation passed for lint, targeted regressions, full Vitest suite, coverage, and production build after regenerating Prisma client artifacts with a Node `20.19.0` runtime compatible with the current Prisma `7.7` toolchain.
+- Evidence: `npm run lint`; `npx vitest run tests/lib/project-attachment-service.test.ts tests/api/task-create.route.test.ts tests/api/task-comments.route.test.ts tests/api/task-update.route.test.ts tests/api/tasks-reorder.route.test.ts tests/api/agent-project-routes.test.ts tests/lib/project-service.test.ts`; `$env:DATABASE_URL='postgresql://localhost:5432/postgres'; $env:DIRECT_URL='postgresql://localhost:5432/postgres'; npx -y -p node@20.19.0 node .\\node_modules\\vitest\\vitest.mjs run`; same env with `--coverage`; `npx -y -p node@20.19.0 node .\\node_modules\\prisma\\build\\index.js generate`; `$env:DATABASE_URL='postgresql://localhost:5432/postgres'; $env:DIRECT_URL='postgresql://localhost:5433/postgres'; $env:GOOGLE_TOKEN_ENCRYPTION_KEY='0123456789abcdef0123456789abcdef'; $env:AGENT_TOKEN_SIGNING_SECRET='0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'; npm run build`.
+
+### 2026-04-21
+- Type: Blocker
+- Summary: TASK-101 local Playwright validation is blocked before browser interaction because Playwright boots against the shared `.env` database, and that database has not yet had the TASK-101 ownership/provenance migration applied.
+- Evidence: `$env:DATABASE_URL='postgresql://localhost:5432/postgres'; $env:DIRECT_URL='postgresql://localhost:5433/postgres'; $env:GOOGLE_TOKEN_ENCRYPTION_KEY='0123456789abcdef0123456789abcdef'; npx -y -p node@20.19.0 node .\\node_modules\\playwright\\cli.js test` failed during seed user creation in `tests/e2e/helpers/auth-helpers.ts` / `tests/e2e/password-recovery.spec.ts` with `PrismaClientKnownRequestError` before UI flow execution; the controlled preview deployment workflow applies migrations and is the safe place to complete browser verification.
+
+### 2026-04-21
+- Type: Execution
 - Summary: TASK-089 follow-up extended the generated-avatar rollout by lowering pixel density, rendering avatars in task comments, and adding avatars to the project settings contributors list while keeping the same shared avatar primitive and collaborator/comment identity contracts.
 - Evidence: Updated `lib/avatar.ts`, `lib/services/project-task-comment-service.ts`, `components/kanban/task-detail-modal.tsx`, `lib/services/project-collaboration-service.ts`, `components/project-dashboard/project-dashboard-owner-access-panel.tsx`, `components/project-dashboard/project-dashboard-owner-actions.shared.ts`, `lib/agent-onboarding.ts`, `tasks/current.md`, and related tests in `tests/api/task-comments.route.test.ts` plus `tests/components/project-dashboard-owner-access-panel.test.tsx`.
 

--- a/journal.md
+++ b/journal.md
@@ -12,6 +12,21 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ## Recent Entries (Most Relevant)
 
+### 2026-04-21
+- Type: Validation
+- Summary: TASK-089 local validation passed for lint, full Vitest suite, coverage, Prisma client regeneration, and production build after running the repo toolchain on Node `20.19.0`, which matches the current Prisma/Next baseline better than the workstation default Node `20.17.0`.
+- Evidence: `npm run lint`; `$env:DATABASE_URL='postgresql://user:pass@127.0.0.1:5432/postgres?sslmode=require'; $env:DIRECT_URL='postgresql://user:pass@127.0.0.1:5433/postgres?sslmode=require'; $env:RESEND_API_KEY='test-resend-key'; $env:GOOGLE_TOKEN_ENCRYPTION_KEY='0123456789abcdef0123456789abcdef'; $env:AGENT_TOKEN_SIGNING_SECRET='0123456789abcdef0123456789abcdef'; npx -y -p node@20.19.0 node .\\node_modules\\vitest\\vitest.mjs run`; same env with `--coverage`; same env with `npx -y -p node@20.19.0 node .\\node_modules\\next\\dist\\bin\\next build`; `npx -y -p node@20.19.0 node .\\node_modules\\prisma\\build\\index.js generate`.
+
+### 2026-04-21
+- Type: Blocker
+- Summary: TASK-089 browser-based Playwright validation remains blocked in this workstation session because the local PostgreSQL fixture service expected by the authenticated app flow is unreachable, so the app cannot boot into a usable browser test target.
+- Evidence: `Test-NetConnection -ComputerName 127.0.0.1 -Port 5432` returned `TcpTestSucceeded : False`; `playwright.config.ts` expects a local app server backed by the project database.
+
+### 2026-04-21
+- Type: Execution
+- Summary: TASK-089 implemented the generated avatar baseline end to end with persisted avatar seeds, deterministic pixel-avatar rendering, account-page regeneration, and first-party rollout across the top-right account affordance plus account/settings identity surfaces.
+- Evidence: Added `avatarSeed` to `User` in `prisma/schema.prisma` plus migration `prisma/migrations/20260421103000_task089_generated_avatar_baseline/migration.sql`; added `lib/avatar.ts` and `components/ui/user-avatar.tsx`; updated account identity/profile flows in `lib/services/account-identity-service.ts`, `lib/services/account-profile-service.ts`, and `app/account/actions.ts`; updated UI consumers in `app/account/page.tsx`, `components/account-menu.tsx`, `components/top-right-controls.tsx`, `components/account/account-settings-shell.tsx`, `app/account/settings/page.tsx`, and `app/account/settings/developers/page.tsx`; added avatar coverage in `tests/lib/avatar.test.ts` and refreshed affected account/menu tests.
+
 ### 2026-04-19
 - Type: Governance
 - Summary: TASK-099 shipped to PR `#180`, initial Copilot review completed with two actionable comments, both were applied in follow-up commit `94b534a` and the review threads were replied to and resolved before handoff.

--- a/journal.md
+++ b/journal.md
@@ -13,6 +13,11 @@ Use it for important implementation milestones, blockers, validation runs, and r
 ## Recent Entries (Most Relevant)
 
 ### 2026-04-21
+- Type: Execution
+- Summary: TASK-089 follow-up extended the generated-avatar rollout by lowering pixel density, rendering avatars in task comments, and adding avatars to the project settings contributors list while keeping the same shared avatar primitive and collaborator/comment identity contracts.
+- Evidence: Updated `lib/avatar.ts`, `lib/services/project-task-comment-service.ts`, `components/kanban/task-detail-modal.tsx`, `lib/services/project-collaboration-service.ts`, `components/project-dashboard/project-dashboard-owner-access-panel.tsx`, `components/project-dashboard/project-dashboard-owner-actions.shared.ts`, `lib/agent-onboarding.ts`, `tasks/current.md`, and related tests in `tests/api/task-comments.route.test.ts` plus `tests/components/project-dashboard-owner-access-panel.test.tsx`.
+
+### 2026-04-21
 - Type: Validation
 - Summary: TASK-089 local validation passed for lint, full Vitest suite, coverage, Prisma client regeneration, and production build after running the repo toolchain on Node `20.19.0`, which matches the current Prisma/Next baseline better than the workstation default Node `20.17.0`.
 - Evidence: `npm run lint`; `$env:DATABASE_URL='postgresql://user:pass@127.0.0.1:5432/postgres?sslmode=require'; $env:DIRECT_URL='postgresql://user:pass@127.0.0.1:5433/postgres?sslmode=require'; $env:RESEND_API_KEY='test-resend-key'; $env:GOOGLE_TOKEN_ENCRYPTION_KEY='0123456789abcdef0123456789abcdef'; $env:AGENT_TOKEN_SIGNING_SECRET='0123456789abcdef0123456789abcdef'; npx -y -p node@20.19.0 node .\\node_modules\\vitest\\vitest.mjs run`; same env with `--coverage`; same env with `npx -y -p node@20.19.0 node .\\node_modules\\next\\dist\\bin\\next build`; `npx -y -p node@20.19.0 node .\\node_modules\\prisma\\build\\index.js generate`.

--- a/lib/agent-onboarding.ts
+++ b/lib/agent-onboarding.ts
@@ -390,7 +390,7 @@ export function buildAgentTaskCreateExample(): string {
     'curl -X POST "$NEXUSDASH_BASE_URL/api/projects/$NEXUSDASH_PROJECT_ID/tasks" \\',
     `  -H "Authorization: Bearer $${AGENT_BEARER_TOKEN_ENV_NAME}" \\`,
     '  -H "Content-Type: application/json" \\',
-    "  -d '{\"title\":\"Draft release notes\",\"description\":\"<p>Summarize this week''s changes.</p>\",\"deadlineDate\":\"2026-04-24\",\"labels\":[\"release\",\"docs\"],\"attachmentLinks\":[{\"name\":\"Spec\",\"url\":\"https://example.com/spec\"}]}'",
+    "  -d '{\"title\":\"Draft release notes\",\"description\":\"<p>Summarize this week''s changes.</p>\",\"deadlineDate\":\"2026-04-24\",\"assigneeUserId\":\"user_456\",\"labels\":[\"release\",\"docs\"],\"attachmentLinks\":[{\"name\":\"Spec\",\"url\":\"https://example.com/spec\"}]}'",
   ].join("\n");
 }
 
@@ -408,7 +408,7 @@ export function buildAgentTaskUpdateExample(): string {
     'curl -X PATCH "$NEXUSDASH_BASE_URL/api/projects/$NEXUSDASH_PROJECT_ID/tasks/$TASK_ID" \\',
     `  -H "Authorization: Bearer $${AGENT_BEARER_TOKEN_ENV_NAME}" \\`,
     '  -H "Content-Type: application/json" \\',
-    '  -d \'{"title":"Draft release notes","description":"<p>Add release highlights.</p>","deadlineDate":"2026-04-25","labels":["release","ready"],"relatedTaskIds":["task_456"]}\'',
+    '  -d \'{"title":"Draft release notes","description":"<p>Add release highlights.</p>","deadlineDate":"2026-04-25","assigneeUserId":"user_456","labels":["release","ready"],"relatedTaskIds":["task_456"]}\'',
   ].join("\n");
 }
 
@@ -939,6 +939,9 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
             "labelsJson",
             "createdAt",
             "updatedAt",
+            "assignee",
+            "createdBy",
+            "updatedBy",
             "attachments",
             "relatedTasks",
             "blockedFollowUps",
@@ -961,6 +964,18 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
             labelsJson: { type: ["string", "null"] },
             createdAt: { type: "string", format: "date-time" },
             updatedAt: { type: "string", format: "date-time" },
+            assignee: {
+              anyOf: [
+                { $ref: "#/components/schemas/TaskCommentAuthor" },
+                { type: "null" },
+              ],
+            },
+            createdBy: {
+              $ref: "#/components/schemas/TaskCommentAuthor",
+            },
+            updatedBy: {
+              $ref: "#/components/schemas/TaskCommentAuthor",
+            },
             attachments: {
               type: "array",
               items: {
@@ -1000,6 +1015,7 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
             title: { type: "string" },
             description: { type: "string" },
             deadlineDate: { type: "string", format: "date" },
+            assigneeUserId: { type: ["string", "null"] },
             labels: {
               type: "array",
               items: {
@@ -1042,6 +1058,7 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
               type: ["string", "null"],
               format: "date",
             },
+            assigneeUserId: { type: ["string", "null"] },
             blockedFollowUpEntry: { type: "string" },
             relatedTaskIds: {
               type: "array",
@@ -1067,6 +1084,11 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
                 "status",
                 "position",
                 "archivedAt",
+                "assignee",
+                "createdBy",
+                "updatedBy",
+                "createdAt",
+                "updatedAt",
                 "relatedTasks",
                 "blockedFollowUps",
               ],
@@ -1085,6 +1107,20 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
                 },
                 position: { type: "integer" },
                 archivedAt: { type: ["string", "null"], format: "date-time" },
+                assignee: {
+                  anyOf: [
+                    { $ref: "#/components/schemas/TaskCommentAuthor" },
+                    { type: "null" },
+                  ],
+                },
+                createdBy: {
+                  $ref: "#/components/schemas/TaskCommentAuthor",
+                },
+                updatedBy: {
+                  $ref: "#/components/schemas/TaskCommentAuthor",
+                },
+                createdAt: { type: "string", format: "date-time" },
+                updatedAt: { type: "string", format: "date-time" },
                 relatedTasks: {
                   type: "array",
                   items: {

--- a/lib/agent-onboarding.ts
+++ b/lib/agent-onboarding.ts
@@ -1103,11 +1103,12 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
         },
         TaskCommentAuthor: {
           type: "object",
-          required: ["id", "displayName", "usernameTag"],
+          required: ["id", "displayName", "usernameTag", "avatarSeed"],
           properties: {
             id: { type: "string" },
             displayName: { type: "string" },
             usernameTag: { type: ["string", "null"] },
+            avatarSeed: { type: "string" },
           },
         },
         TaskCommentRecord: {

--- a/lib/avatar.ts
+++ b/lib/avatar.ts
@@ -3,6 +3,7 @@ const GRID_SIZE = 5;
 const GRID_INSET = 7;
 const CELL_SIZE = 10;
 const CELL_GAP = 0;
+const GRID_CENTER_INDEX = Math.floor(GRID_SIZE / 2);
 const PIXEL_COLORS = ["#F5F7FA", "#D5DBE3", "#5D6470"] as const;
 const BACKGROUND_COLORS = [
   "#E76F51",
@@ -83,52 +84,67 @@ function getNeighborCoordinates(row: number, column: number) {
   return neighbors;
 }
 
+function getDistanceFromCenter(row: number, column: number): number {
+  return Math.abs(row - GRID_CENTER_INDEX) + Math.abs(column - GRID_CENTER_INDEX);
+}
+
+function isEdgeCell(row: number, column: number): boolean {
+  return row === 0 || column === 0 || row === GRID_SIZE - 1 || column === GRID_SIZE - 1;
+}
+
+function buildFrontier(grid: boolean[][], filledCells: Array<{ row: number; column: number }>) {
+  const uniqueCandidates = new Map<string, { row: number; column: number }>();
+
+  for (const { row, column } of filledCells) {
+    for (const neighbor of getNeighborCoordinates(row, column)) {
+      if (grid[neighbor.row]![neighbor.column]) {
+        continue;
+      }
+
+      uniqueCandidates.set(`${neighbor.row}:${neighbor.column}`, neighbor);
+    }
+  }
+
+  return Array.from(uniqueCandidates.values());
+}
+
+function pickNextCell(
+  random: () => number,
+  candidates: Array<{ row: number; column: number }>
+) {
+  const scoredCandidates = candidates
+    .map((candidate) => {
+      const centerDistance = getDistanceFromCenter(candidate.row, candidate.column);
+      const edgePenalty = isEdgeCell(candidate.row, candidate.column) ? 1.25 : 0;
+
+      return {
+        candidate,
+        score: 5 - centerDistance - edgePenalty + random() * 0.35,
+      };
+    })
+    .sort((left, right) => right.score - left.score);
+
+  return scoredCandidates[0]?.candidate ?? null;
+}
+
 function buildPixelMask(random: () => number): boolean[][] {
   const grid = createEmptyGrid();
   const filledCells: Array<{ row: number; column: number }> = [];
-  const targetPixelCount = 6 + Math.floor(random() * 3);
+  const targetPixelCount = 9 + Math.floor(random() * 3);
 
-  const startRow = Math.floor(random() * GRID_SIZE);
-  const startColumn = Math.floor(random() * GRID_SIZE);
+  const startRow = GRID_CENTER_INDEX;
+  const startColumn = GRID_CENTER_INDEX;
 
   grid[startRow]![startColumn] = true;
   filledCells.push({ row: startRow, column: startColumn });
 
   while (filledCells.length < targetPixelCount) {
-    const anchor = filledCells[Math.floor(random() * filledCells.length)];
-    if (!anchor) {
+    const frontier = buildFrontier(grid, filledCells);
+    if (frontier.length === 0) {
       break;
     }
 
-    const availableNeighbors = getNeighborCoordinates(anchor.row, anchor.column).filter(
-      ({ row, column }) => !grid[row]![column]
-    );
-
-    if (availableNeighbors.length === 0) {
-      const fallbackNeighbors = filledCells.flatMap(({ row, column }) =>
-        getNeighborCoordinates(row, column).filter(
-          (neighbor) => !grid[neighbor.row]![neighbor.column]
-        )
-      );
-
-      if (fallbackNeighbors.length === 0) {
-        break;
-      }
-
-      const fallback =
-        fallbackNeighbors[Math.floor(random() * fallbackNeighbors.length)];
-
-      if (!fallback) {
-        break;
-      }
-
-      grid[fallback.row]![fallback.column] = true;
-      filledCells.push(fallback);
-      continue;
-    }
-
-    const nextCell =
-      availableNeighbors[Math.floor(random() * availableNeighbors.length)];
+    const nextCell = pickNextCell(random, frontier);
 
     if (!nextCell) {
       break;

--- a/lib/avatar.ts
+++ b/lib/avatar.ts
@@ -60,7 +60,7 @@ function buildAvatarSvg(seed: string): string {
 
   for (let row = 0; row < GRID_SIZE; row += 1) {
     for (let column = 0; column < GRID_SIZE; column += 1) {
-      const shouldDrawPixel = random() >= 0.42;
+      const shouldDrawPixel = random() >= 0.71;
       if (!shouldDrawPixel) {
         continue;
       }

--- a/lib/avatar.ts
+++ b/lib/avatar.ts
@@ -92,6 +92,16 @@ function isEdgeCell(row: number, column: number): boolean {
   return row === 0 || column === 0 || row === GRID_SIZE - 1 || column === GRID_SIZE - 1;
 }
 
+function countFilledNeighbors(
+  grid: boolean[][],
+  row: number,
+  column: number
+): number {
+  return getNeighborCoordinates(row, column).reduce((count, neighbor) => {
+    return count + (grid[neighbor.row]![neighbor.column] ? 1 : 0);
+  }, 0);
+}
+
 function buildFrontier(grid: boolean[][], filledCells: Array<{ row: number; column: number }>) {
   const uniqueCandidates = new Map<string, { row: number; column: number }>();
 
@@ -110,21 +120,43 @@ function buildFrontier(grid: boolean[][], filledCells: Array<{ row: number; colu
 
 function pickNextCell(
   random: () => number,
+  grid: boolean[][],
   candidates: Array<{ row: number; column: number }>
 ) {
-  const scoredCandidates = candidates
-    .map((candidate) => {
-      const centerDistance = getDistanceFromCenter(candidate.row, candidate.column);
-      const edgePenalty = isEdgeCell(candidate.row, candidate.column) ? 1.25 : 0;
+  const weightedCandidates = candidates.map((candidate) => {
+    const centerDistance = getDistanceFromCenter(candidate.row, candidate.column);
+    const filledNeighborCount = countFilledNeighbors(
+      grid,
+      candidate.row,
+      candidate.column
+    );
+    const edgePenalty = isEdgeCell(candidate.row, candidate.column) ? 0.85 : 0;
+    const weight = Math.max(
+      0.2,
+      4.2 - centerDistance * 0.8 + filledNeighborCount * 0.3 - edgePenalty
+    );
 
-      return {
-        candidate,
-        score: 5 - centerDistance - edgePenalty + random() * 0.35,
-      };
-    })
-    .sort((left, right) => right.score - left.score);
+    return {
+      candidate,
+      weight,
+    };
+  });
 
-  return scoredCandidates[0]?.candidate ?? null;
+  const totalWeight = weightedCandidates.reduce((sum, entry) => sum + entry.weight, 0);
+  if (totalWeight <= 0) {
+    return weightedCandidates[0]?.candidate ?? null;
+  }
+
+  let remainingWeight = random() * totalWeight;
+
+  for (const entry of weightedCandidates) {
+    remainingWeight -= entry.weight;
+    if (remainingWeight <= 0) {
+      return entry.candidate;
+    }
+  }
+
+  return weightedCandidates[weightedCandidates.length - 1]?.candidate ?? null;
 }
 
 function buildPixelMask(random: () => number): boolean[][] {
@@ -144,7 +176,7 @@ function buildPixelMask(random: () => number): boolean[][] {
       break;
     }
 
-    const nextCell = pickNextCell(random, frontier);
+    const nextCell = pickNextCell(random, grid, frontier);
 
     if (!nextCell) {
       break;

--- a/lib/avatar.ts
+++ b/lib/avatar.ts
@@ -1,8 +1,8 @@
 const AVATAR_SIZE = 64;
 const GRID_SIZE = 5;
-const GRID_INSET = 8;
-const CELL_SIZE = 8;
-const CELL_GAP = 2;
+const GRID_INSET = 7;
+const CELL_SIZE = 10;
+const CELL_GAP = 0;
 const PIXEL_COLORS = ["#F5F7FA", "#D5DBE3", "#5D6470"] as const;
 const BACKGROUND_COLORS = [
   "#E76F51",
@@ -50,6 +50,97 @@ function createMulberry32(seed: number) {
   };
 }
 
+function createEmptyGrid(): boolean[][] {
+  return Array.from({ length: GRID_SIZE }, () => Array.from({ length: GRID_SIZE }, () => false));
+}
+
+function getNeighborCoordinates(row: number, column: number) {
+  const neighbors: Array<{ row: number; column: number }> = [];
+
+  for (let rowOffset = -1; rowOffset <= 1; rowOffset += 1) {
+    for (let columnOffset = -1; columnOffset <= 1; columnOffset += 1) {
+      if (rowOffset === 0 && columnOffset === 0) {
+        continue;
+      }
+
+      const nextRow = row + rowOffset;
+      const nextColumn = column + columnOffset;
+      const isWithinBounds =
+        nextRow >= 0 &&
+        nextRow < GRID_SIZE &&
+        nextColumn >= 0 &&
+        nextColumn < GRID_SIZE;
+
+      if (isWithinBounds) {
+        neighbors.push({
+          row: nextRow,
+          column: nextColumn,
+        });
+      }
+    }
+  }
+
+  return neighbors;
+}
+
+function buildPixelMask(random: () => number): boolean[][] {
+  const grid = createEmptyGrid();
+  const filledCells: Array<{ row: number; column: number }> = [];
+  const targetPixelCount = 6 + Math.floor(random() * 3);
+
+  const startRow = Math.floor(random() * GRID_SIZE);
+  const startColumn = Math.floor(random() * GRID_SIZE);
+
+  grid[startRow]![startColumn] = true;
+  filledCells.push({ row: startRow, column: startColumn });
+
+  while (filledCells.length < targetPixelCount) {
+    const anchor = filledCells[Math.floor(random() * filledCells.length)];
+    if (!anchor) {
+      break;
+    }
+
+    const availableNeighbors = getNeighborCoordinates(anchor.row, anchor.column).filter(
+      ({ row, column }) => !grid[row]![column]
+    );
+
+    if (availableNeighbors.length === 0) {
+      const fallbackNeighbors = filledCells.flatMap(({ row, column }) =>
+        getNeighborCoordinates(row, column).filter(
+          (neighbor) => !grid[neighbor.row]![neighbor.column]
+        )
+      );
+
+      if (fallbackNeighbors.length === 0) {
+        break;
+      }
+
+      const fallback =
+        fallbackNeighbors[Math.floor(random() * fallbackNeighbors.length)];
+
+      if (!fallback) {
+        break;
+      }
+
+      grid[fallback.row]![fallback.column] = true;
+      filledCells.push(fallback);
+      continue;
+    }
+
+    const nextCell =
+      availableNeighbors[Math.floor(random() * availableNeighbors.length)];
+
+    if (!nextCell) {
+      break;
+    }
+
+    grid[nextCell.row]![nextCell.column] = true;
+    filledCells.push(nextCell);
+  }
+
+  return grid;
+}
+
 function buildAvatarSvg(seed: string): string {
   const normalizedSeed = normalizeSeed(seed);
   const random = createMulberry32(hashSeed(normalizedSeed));
@@ -57,11 +148,11 @@ function buildAvatarSvg(seed: string): string {
     BACKGROUND_COLORS[Math.floor(random() * BACKGROUND_COLORS.length)] ??
     BACKGROUND_COLORS[0];
   const pixels: string[] = [];
+  const pixelMask = buildPixelMask(random);
 
   for (let row = 0; row < GRID_SIZE; row += 1) {
     for (let column = 0; column < GRID_SIZE; column += 1) {
-      const shouldDrawPixel = random() >= 0.71;
-      if (!shouldDrawPixel) {
+      if (!pixelMask[row]![column]) {
         continue;
       }
 

--- a/lib/avatar.ts
+++ b/lib/avatar.ts
@@ -1,8 +1,8 @@
 const AVATAR_SIZE = 64;
-const GRID_SIZE = 7;
-const GRID_INSET = 11;
-const CELL_SIZE = 6;
-const CELL_GAP = 1;
+const GRID_SIZE = 5;
+const GRID_INSET = 8;
+const CELL_SIZE = 8;
+const CELL_GAP = 2;
 const PIXEL_COLORS = ["#F5F7FA", "#D5DBE3", "#5D6470"] as const;
 const BACKGROUND_COLORS = [
   "#E76F51",

--- a/lib/avatar.ts
+++ b/lib/avatar.ts
@@ -77,7 +77,7 @@ function buildAvatarSvg(seed: string): string {
     }
   }
 
-  const title = escapeSvgAttribute(`Generated avatar ${normalizedSeed}`);
+  const title = escapeSvgAttribute("Generated avatar");
 
   return [
     `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${AVATAR_SIZE} ${AVATAR_SIZE}" role="img" aria-labelledby="avatar-title">`,

--- a/lib/avatar.ts
+++ b/lib/avatar.ts
@@ -1,0 +1,109 @@
+const AVATAR_SIZE = 64;
+const GRID_SIZE = 7;
+const GRID_INSET = 11;
+const CELL_SIZE = 6;
+const CELL_GAP = 1;
+const PIXEL_COLORS = ["#F5F7FA", "#D5DBE3", "#5D6470"] as const;
+const BACKGROUND_COLORS = [
+  "#E76F51",
+  "#F4A261",
+  "#E9C46A",
+  "#2A9D8F",
+  "#4D908E",
+  "#577590",
+  "#90BE6D",
+  "#F28482",
+  "#84A59D",
+  "#6D597A",
+] as const;
+
+function normalizeSeed(seed: string): string {
+  return seed.trim().toLowerCase();
+}
+
+function escapeSvgAttribute(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function hashSeed(seed: string): number {
+  let hash = 0x811c9dc5;
+  for (const character of seed) {
+    hash ^= character.charCodeAt(0);
+    hash = Math.imul(hash, 0x01000193);
+  }
+
+  return hash >>> 0;
+}
+
+function createMulberry32(seed: number) {
+  let state = seed >>> 0;
+
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let next = Math.imul(state ^ (state >>> 15), state | 1);
+    next ^= next + Math.imul(next ^ (next >>> 7), next | 61);
+    return ((next ^ (next >>> 14)) >>> 0) / 4_294_967_296;
+  };
+}
+
+function buildAvatarSvg(seed: string): string {
+  const normalizedSeed = normalizeSeed(seed);
+  const random = createMulberry32(hashSeed(normalizedSeed));
+  const backgroundColor =
+    BACKGROUND_COLORS[Math.floor(random() * BACKGROUND_COLORS.length)] ??
+    BACKGROUND_COLORS[0];
+  const pixels: string[] = [];
+
+  for (let row = 0; row < GRID_SIZE; row += 1) {
+    for (let column = 0; column < GRID_SIZE; column += 1) {
+      const shouldDrawPixel = random() >= 0.42;
+      if (!shouldDrawPixel) {
+        continue;
+      }
+
+      const colorIndex = Math.floor(random() * PIXEL_COLORS.length);
+      const color = PIXEL_COLORS[colorIndex] ?? PIXEL_COLORS[0];
+      const x = GRID_INSET + column * (CELL_SIZE + CELL_GAP);
+      const y = GRID_INSET + row * (CELL_SIZE + CELL_GAP);
+      const radius = Math.max(1, Math.round(random() * 2));
+
+      pixels.push(
+        `<rect x="${x}" y="${y}" width="${CELL_SIZE}" height="${CELL_SIZE}" rx="${radius}" fill="${color}" />`
+      );
+    }
+  }
+
+  const title = escapeSvgAttribute(`Generated avatar ${normalizedSeed}`);
+
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${AVATAR_SIZE} ${AVATAR_SIZE}" role="img" aria-labelledby="avatar-title">`,
+    `<title id="avatar-title">${title}</title>`,
+    `<defs><clipPath id="avatar-clip"><circle cx="${AVATAR_SIZE / 2}" cy="${AVATAR_SIZE / 2}" r="${AVATAR_SIZE / 2}" /></clipPath></defs>`,
+    `<g clip-path="url(#avatar-clip)">`,
+    `<rect width="${AVATAR_SIZE}" height="${AVATAR_SIZE}" fill="${backgroundColor}" />`,
+    pixels.join(""),
+    `</g>`,
+    `</svg>`,
+  ].join("");
+}
+
+export function resolveAvatarSeed(
+  avatarSeed: string | null | undefined,
+  fallbackKey: string
+): string {
+  const normalizedSeed = typeof avatarSeed === "string" ? avatarSeed.trim() : "";
+  return normalizedSeed || fallbackKey.trim();
+}
+
+export function buildGeneratedAvatarDataUri(seed: string): string {
+  const svg = buildAvatarSvg(seed);
+  return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`;
+}
+
+export function generateAvatarSeed(): string {
+  return crypto.randomUUID().replace(/-/g, "");
+}

--- a/lib/services/account-identity-service.ts
+++ b/lib/services/account-identity-service.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/prisma";
+import { resolveAvatarSeed } from "@/lib/avatar";
 import { validateUsernameDiscriminator } from "@/lib/services/account-security-policy";
 
 interface AccountIdentitySummary {
@@ -6,6 +7,7 @@ interface AccountIdentitySummary {
   username: string | null;
   usernameDiscriminator: string | null;
   usernameTag: string | null;
+  avatarSeed: string;
 }
 
 function normalizeActorUserId(actorUserId: string | null | undefined): string {
@@ -50,10 +52,12 @@ export async function getAccountIdentitySummary(
   const user = await prisma.user.findUnique({
     where: { id: normalizedActorUserId },
     select: {
+      id: true,
       name: true,
       email: true,
       username: true,
       usernameDiscriminator: true,
+      avatarSeed: true,
     },
   });
 
@@ -79,5 +83,6 @@ export async function getAccountIdentitySummary(
     username: user.username ?? null,
     usernameDiscriminator,
     usernameTag,
+    avatarSeed: resolveAvatarSeed(user.avatarSeed, user.id),
   };
 }

--- a/lib/services/account-profile-service.ts
+++ b/lib/services/account-profile-service.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/prisma";
+import { generateAvatarSeed, resolveAvatarSeed } from "@/lib/avatar";
 import {
   generateUsernameDiscriminator,
   normalizeEmail,
@@ -164,6 +165,7 @@ export async function getAccountProfile(
     username: string;
     usernameDiscriminator: string | null;
     usernameTag: string | null;
+    avatarSeed: string;
   }>
 > {
   const normalizedActorUserId = normalizeUserId(actorUserId);
@@ -174,10 +176,12 @@ export async function getAccountProfile(
   const user = await prisma.user.findUnique({
     where: { id: normalizedActorUserId },
     select: {
+      id: true,
       email: true,
       emailVerified: true,
       username: true,
       usernameDiscriminator: true,
+      avatarSeed: true,
     },
   });
 
@@ -197,7 +201,54 @@ export async function getAccountProfile(
     username: user.username ?? "",
     usernameDiscriminator,
     usernameTag: buildUsernameTag(user.username, usernameDiscriminator),
+    avatarSeed: resolveAvatarSeed(user.avatarSeed, user.id),
   });
+}
+
+export async function regenerateAccountAvatar(
+  input: {
+    actorUserId: string;
+    subjectUserId?: string;
+  }
+): Promise<
+  AccountProfileResult<{
+    avatarSeed: string;
+  }>
+> {
+  const authError = isUnauthorizedOrForbidden(input.actorUserId, input.subjectUserId);
+  if (authError) {
+    return authError;
+  }
+
+  const actorUserId = normalizeUserId(input.actorUserId);
+  const avatarSeed = generateAvatarSeed();
+
+  try {
+    const updatedUser = await prisma.user.update({
+      where: { id: actorUserId },
+      data: {
+        avatarSeed,
+      },
+      select: {
+        avatarSeed: true,
+      },
+    });
+
+    return createSuccess(200, {
+      avatarSeed: updatedUser.avatarSeed ?? avatarSeed,
+    });
+  } catch (error) {
+    if (
+      !!error &&
+      typeof error === "object" &&
+      "code" in error &&
+      (error as { code?: string }).code === "P2025"
+    ) {
+      return createError(401, "unauthorized");
+    }
+
+    throw error;
+  }
 }
 
 export async function updateAccountEmail(

--- a/lib/services/project-attachment-service.ts
+++ b/lib/services/project-attachment-service.ts
@@ -210,6 +210,22 @@ export function mapTaskAttachmentResponse(
   };
 }
 
+async function touchTaskActivity(
+  db: DbClient,
+  taskId: string,
+  actorUserId: string
+) {
+  await db.task.update({
+    where: { id: taskId },
+    data: {
+      updatedByUserId: actorUserId,
+    },
+    select: {
+      id: true,
+    },
+  });
+}
+
 export function mapContextAttachmentResponse(
   projectId: string,
   cardId: string,
@@ -423,6 +439,8 @@ export async function createTaskAttachmentFromForm(input: {
           },
         });
 
+        await touchTaskActivity(db, input.taskId, actorUserId);
+
         return {
           ok: true,
           data: mapTaskAttachmentResponse(input.projectId, input.taskId, attachment),
@@ -494,6 +512,8 @@ export async function createTaskAttachmentFromForm(input: {
           sizeBytes: true,
         },
       });
+
+      await touchTaskActivity(db, input.taskId, actorUserId);
 
       return {
         ok: true,
@@ -886,6 +906,8 @@ export async function finalizeTaskAttachmentDirectUpload(input: {
           sizeBytes: true,
         },
       });
+
+      await touchTaskActivity(db, input.taskId, actorUserId);
 
       return {
         ok: true,
@@ -1354,6 +1376,8 @@ export async function deleteTaskAttachmentForProject(input: {
       await db.taskAttachment.delete({
         where: { id: attachment.id },
       });
+
+      await touchTaskActivity(db, input.taskId, actorUserId);
 
       if (attachment.kind === ATTACHMENT_KIND_FILE && attachment.storageKey) {
         await deleteAttachmentFile(attachment.storageKey).catch((error) => {

--- a/lib/services/project-collaboration-service.ts
+++ b/lib/services/project-collaboration-service.ts
@@ -1,5 +1,6 @@
 import { Prisma, ProjectMembershipRole } from "@prisma/client";
 
+import { resolveAvatarSeed } from "@/lib/avatar";
 import { normalizeReturnToPath } from "@/lib/navigation/return-to";
 import { prisma } from "@/lib/prisma";
 import {
@@ -39,6 +40,7 @@ export interface CollaboratorIdentitySummary {
   displayName: string;
   usernameTag: string | null;
   email: string | null;
+  avatarSeed: string;
 }
 
 export interface ProjectMemberSummary extends CollaboratorIdentitySummary {
@@ -260,12 +262,14 @@ function buildIdentitySummary(input: {
   username: string | null;
   usernameDiscriminator: string | null;
   email: string | null;
+  avatarSeed?: string | null;
 }): CollaboratorIdentitySummary {
   return {
     id: input.id,
     displayName: buildDisplayName(input),
     usernameTag: buildUsernameTag(input.username, input.usernameDiscriminator),
     email: input.email,
+    avatarSeed: resolveAvatarSeed(input.avatarSeed, input.id),
   };
 }
 
@@ -400,6 +404,7 @@ async function getVerifiedUsersByEmail(
       name: true,
       username: true,
       usernameDiscriminator: true,
+      avatarSeed: true,
     },
   });
 
@@ -641,6 +646,7 @@ export async function searchInvitableUsersForProject(input: {
         name: true,
         username: true,
         usernameDiscriminator: true,
+        avatarSeed: true,
       },
       take: INVITABLE_USER_SEARCH_LIMIT,
       orderBy: [{ username: "asc" }, { name: "asc" }, { email: "asc" }],
@@ -721,6 +727,7 @@ export async function inviteUserToProject(input: {
           name: true,
           username: true,
           usernameDiscriminator: true,
+          avatarSeed: true,
         },
       }),
       db.projectMembership.findFirst({
@@ -860,6 +867,7 @@ export async function getProjectSharingSummary(input: {
                 name: true,
                 username: true,
                 usernameDiscriminator: true,
+                avatarSeed: true,
               },
             },
           },
@@ -1115,6 +1123,7 @@ export async function listPendingProjectInvitationsForUser(
           name: true,
           username: true,
           usernameDiscriminator: true,
+          avatarSeed: true,
         },
       }),
       listPendingInvitationMetadataRows(db),
@@ -1447,6 +1456,7 @@ export async function getProjectInvitationRecipientView(input: {
       name: true,
       username: true,
       usernameDiscriminator: true,
+      avatarSeed: true,
     },
   });
 

--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -10,6 +10,10 @@ import {
 } from "@/lib/services/project-access-service";
 import { withActorRlsContext } from "@/lib/services/rls-context";
 import type { DbClient } from "@/lib/services/rls-context";
+import {
+  mapTaskPersonSummary,
+  type TaskPersonSummary,
+} from "@/lib/task-person";
 
 const ARCHIVE_AFTER_DAYS = 7;
 const ARCHIVE_AFTER_MS = ARCHIVE_AFTER_DAYS * 24 * 60 * 60 * 1000;
@@ -45,6 +49,36 @@ type ProjectKanbanTaskRecord = Prisma.TaskGetPayload<{
             archivedAt: true;
           };
         };
+      };
+    };
+    createdByUser: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+        username: true;
+        usernameDiscriminator: true;
+        avatarSeed: true;
+      };
+    };
+    updatedByUser: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+        username: true;
+        usernameDiscriminator: true;
+        avatarSeed: true;
+      };
+    };
+    assigneeUser: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+        username: true;
+        usernameDiscriminator: true;
+        avatarSeed: true;
       };
     };
   };
@@ -98,6 +132,10 @@ interface ProjectWithCountsRecord {
   };
 }
 
+export interface ProjectCollaboratorIdentitySummary extends TaskPersonSummary {
+  projectRole: ProjectMembershipRole;
+}
+
 interface ProjectUpsertInput {
   actorUserId: string;
   name: string;
@@ -133,6 +171,21 @@ function normalizeProjectDescription(
 
   const normalizedDescription = description.trim();
   return normalizedDescription.length > 0 ? normalizedDescription : null;
+}
+
+function buildProjectCollaboratorIdentitySummary(input: {
+  id: string;
+  name: string | null;
+  email: string | null;
+  username: string | null;
+  usernameDiscriminator: string | null;
+  avatarSeed: string | null;
+  projectRole: ProjectMembershipRole;
+}): ProjectCollaboratorIdentitySummary {
+  return {
+    ...mapTaskPersonSummary(input)!,
+    projectRole: input.projectRole,
+  };
 }
 
 async function ensureSyntheticTestUserExists(actorUserId: string, db: DbClient = prisma) {
@@ -534,8 +587,112 @@ export async function listProjectKanbanTasks(
             },
           },
         },
+        createdByUser: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            username: true,
+            usernameDiscriminator: true,
+            avatarSeed: true,
+          },
+        },
+        updatedByUser: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            username: true,
+            usernameDiscriminator: true,
+            avatarSeed: true,
+          },
+        },
+        assigneeUser: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            username: true,
+            usernameDiscriminator: true,
+            avatarSeed: true,
+          },
+        },
       },
     });
+  });
+}
+
+export async function listProjectCollaborators(
+  projectId: string,
+  actorUserId: string
+): Promise<ProjectCollaboratorIdentitySummary[]> {
+  const normalizedActorUserId = normalizeActorUserId(actorUserId);
+  if (!normalizedActorUserId) {
+    return [];
+  }
+
+  return withActorRlsContext(normalizedActorUserId, async (db) => {
+    const project = await db.project.findFirst({
+      where: {
+        id: projectId,
+        ...buildProjectPrincipalWhere(normalizedActorUserId),
+      },
+      select: {
+        owner: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            username: true,
+            usernameDiscriminator: true,
+            avatarSeed: true,
+          },
+        },
+        memberships: {
+          orderBy: [{ createdAt: "asc" }],
+          select: {
+            role: true,
+            user: {
+              select: {
+                id: true,
+                name: true,
+                email: true,
+                username: true,
+                usernameDiscriminator: true,
+                avatarSeed: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!project) {
+      return [];
+    }
+
+    const collaboratorById = new Map<string, ProjectCollaboratorIdentitySummary>();
+    const ownerSummary = buildProjectCollaboratorIdentitySummary({
+      ...project.owner,
+      projectRole: "owner",
+    });
+    collaboratorById.set(ownerSummary.id, ownerSummary);
+
+    for (const membership of project.memberships) {
+      if (collaboratorById.has(membership.user.id)) {
+        continue;
+      }
+
+      collaboratorById.set(
+        membership.user.id,
+        buildProjectCollaboratorIdentitySummary({
+          ...membership.user,
+          projectRole: membership.role,
+        })
+      );
+    }
+
+    return Array.from(collaboratorById.values());
   });
 }
 

--- a/lib/services/project-task-comment-service.ts
+++ b/lib/services/project-task-comment-service.ts
@@ -1,12 +1,14 @@
-import { resolveAvatarSeed } from "@/lib/avatar";
 import { logServerError } from "@/lib/observability/logger";
 import {
   requireAgentProjectScopes,
   requireProjectRole,
   type AgentProjectAccessContext,
 } from "@/lib/services/project-access-service";
-import { withActorRlsContext } from "@/lib/services/rls-context";
-import { validateUsernameDiscriminator } from "@/lib/services/account-security-policy";
+import { type DbClient, withActorRlsContext } from "@/lib/services/rls-context";
+import {
+  mapTaskPersonSummary,
+  type TaskPersonSummary,
+} from "@/lib/task-person";
 
 const MAX_TASK_COMMENT_LENGTH = 4000;
 
@@ -23,12 +25,7 @@ interface ServiceSuccessResult<T> {
 
 type ServiceResult<T> = ServiceSuccessResult<T> | ServiceErrorResult;
 
-export interface TaskCommentAuthorSummary {
-  id: string;
-  displayName: string;
-  usernameTag: string | null;
-  avatarSeed: string;
-}
+export type TaskCommentAuthorSummary = TaskPersonSummary;
 
 export interface TaskCommentSummary {
   id: string;
@@ -49,29 +46,6 @@ function normalizeActorUserId(actorUserId: string | null | undefined): string {
   return actorUserId.trim();
 }
 
-function getEmailLocalPart(email: string | null | undefined): string | null {
-  if (!email || !email.includes("@")) {
-    return null;
-  }
-
-  return email.split("@", 1)[0] ?? null;
-}
-
-function buildUsernameTag(
-  username: string | null | undefined,
-  usernameDiscriminator: string | null | undefined
-): string | null {
-  if (
-    !username ||
-    !usernameDiscriminator ||
-    !validateUsernameDiscriminator(usernameDiscriminator)
-  ) {
-    return null;
-  }
-
-  return `${username}#${usernameDiscriminator}`;
-}
-
 function mapTaskComment(input: {
   id: string;
   content: string;
@@ -85,27 +59,28 @@ function mapTaskComment(input: {
     avatarSeed: string | null;
   };
 }): TaskCommentSummary {
-  const usernameTag = buildUsernameTag(
-    input.author.username,
-    input.author.usernameDiscriminator
-  );
-  const displayName =
-    input.author.username ??
-    input.author.name ??
-    getEmailLocalPart(input.author.email) ??
-    "Account";
-
   return {
     id: input.id,
     content: input.content,
     createdAt: input.createdAt,
-    author: {
-      id: input.author.id,
-      displayName,
-      usernameTag,
-      avatarSeed: resolveAvatarSeed(input.author.avatarSeed, input.author.id),
-    },
+    author: mapTaskPersonSummary(input.author)!,
   };
+}
+
+async function touchTaskActivity(
+  db: DbClient,
+  taskId: string,
+  actorUserId: string
+) {
+  await db.task.update({
+    where: { id: taskId },
+    data: {
+      updatedByUserId: actorUserId,
+    },
+    select: {
+      id: true,
+    },
+  });
 }
 
 export async function listTaskCommentsForProject(input: {
@@ -262,6 +237,8 @@ export async function createTaskCommentForProject(input: {
           },
         },
       });
+
+      await touchTaskActivity(db, input.taskId, actorUserId);
 
       return {
         ok: true,

--- a/lib/services/project-task-comment-service.ts
+++ b/lib/services/project-task-comment-service.ts
@@ -1,3 +1,4 @@
+import { resolveAvatarSeed } from "@/lib/avatar";
 import { logServerError } from "@/lib/observability/logger";
 import {
   requireAgentProjectScopes,
@@ -26,6 +27,7 @@ export interface TaskCommentAuthorSummary {
   id: string;
   displayName: string;
   usernameTag: string | null;
+  avatarSeed: string;
 }
 
 export interface TaskCommentSummary {
@@ -80,6 +82,7 @@ function mapTaskComment(input: {
     email: string | null;
     username: string | null;
     usernameDiscriminator: string | null;
+    avatarSeed: string | null;
   };
 }): TaskCommentSummary {
   const usernameTag = buildUsernameTag(
@@ -100,6 +103,7 @@ function mapTaskComment(input: {
       id: input.author.id,
       displayName,
       usernameTag,
+      avatarSeed: resolveAvatarSeed(input.author.avatarSeed, input.author.id),
     },
   };
 }
@@ -164,6 +168,7 @@ export async function listTaskCommentsForProject(input: {
               email: true,
               username: true,
               usernameDiscriminator: true,
+              avatarSeed: true,
             },
           },
         },
@@ -252,6 +257,7 @@ export async function createTaskCommentForProject(input: {
               email: true,
               username: true,
               usernameDiscriminator: true,
+              avatarSeed: true,
             },
           },
         },

--- a/lib/services/project-task-service.ts
+++ b/lib/services/project-task-service.ts
@@ -28,6 +28,11 @@ import {
   requireProjectRole,
   type AgentProjectAccessContext,
 } from "@/lib/services/project-access-service";
+import {
+  mapTaskPersonSummary,
+  taskPersonSummarySelect,
+  type TaskPersonSummary,
+} from "@/lib/task-person";
 import { type DbClient, withActorRlsContext } from "@/lib/services/rls-context";
 
 const MIN_TITLE_LENGTH = 2;
@@ -62,6 +67,7 @@ export interface UpdateTaskPayload {
   deadlineDate?: string | null;
   blockedFollowUpEntry?: string;
   relatedTaskIds?: string[];
+  assigneeUserId?: string | null;
 }
 
 interface CreateTaskForProjectInput {
@@ -70,6 +76,7 @@ interface CreateTaskForProjectInput {
   title: string;
   description: string;
   deadlineDate: string;
+  assigneeUserId: string | null;
   labelsJsonRaw: string;
   relatedTaskIdsJsonRaw: string;
   attachmentLinksJsonRaw: string;
@@ -89,6 +96,11 @@ interface UpdatedTaskPayload {
   status: string;
   position: number;
   archivedAt: Date | null;
+  assignee: TaskPersonSummary | null;
+  createdBy: TaskPersonSummary;
+  updatedBy: TaskPersonSummary;
+  createdAt: Date;
+  updatedAt: Date;
   relatedTasks: RelatedTaskSummary[];
   blockedFollowUps: {
     id: string;
@@ -256,6 +268,46 @@ async function validateRelatedTaskIds(input: {
   };
 }
 
+async function validateAssigneeUserId(input: {
+  db: DbClient;
+  projectId: string;
+  assigneeUserId: string | null;
+}): Promise<ServiceResult<{ assigneeUserId: string | null }>> {
+  const assigneeUserId = normalizeText(input.assigneeUserId);
+  if (!assigneeUserId) {
+    return {
+      ok: true,
+      data: {
+        assigneeUserId: null,
+      },
+    };
+  }
+
+  const collaborator = await input.db.project.findFirst({
+    where: {
+      id: input.projectId,
+      OR: [
+        { ownerId: assigneeUserId },
+        { memberships: { some: { userId: assigneeUserId } } },
+      ],
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  if (!collaborator) {
+    return createError(400, "assignee-invalid");
+  }
+
+  return {
+    ok: true,
+    data: {
+      assigneeUserId,
+    },
+  };
+}
+
 async function replaceTaskRelations(input: {
   db: DbClient;
   projectId: string;
@@ -399,6 +451,15 @@ export async function createTaskForProject(
         return relatedTaskValidation;
       }
 
+      const assigneeValidation = await validateAssigneeUserId({
+        db,
+        projectId: input.projectId,
+        assigneeUserId: input.assigneeUserId,
+      });
+      if (!assigneeValidation.ok) {
+        return assigneeValidation;
+      }
+
       const maxPosition = await db.task.aggregate({
         where: {
           projectId: input.projectId,
@@ -425,6 +486,9 @@ export async function createTaskForProject(
           labelsJson: serializedLabels,
           status,
           position: nextPosition,
+          createdByUserId: actorUserId,
+          updatedByUserId: actorUserId,
+          assigneeUserId: assigneeValidation.data.assigneeUserId,
         },
         select: { id: true },
       });
@@ -551,6 +615,7 @@ export async function reorderProjectTasks(
                 status: column.status,
                 position: index,
                 archivedAt: null,
+                updatedByUserId: normalizedActorUserId,
                 completedAt:
                   column.status === "Done"
                     ? movedToDone
@@ -604,6 +669,10 @@ export async function updateTaskForProject(
   }
   const blockedFollowUpEntry = normalizeText(payload.blockedFollowUpEntry);
   const relatedTaskIds = normalizeRelatedTaskIds(payload.relatedTaskIds ?? []);
+  const assigneeProvided = Object.prototype.hasOwnProperty.call(payload, "assigneeUserId");
+  const assigneeUserId = assigneeProvided
+    ? normalizeText(payload.assigneeUserId)
+    : null;
   const agentScopeAccess = requireAgentProjectScopes({
     agentAccess,
     projectId,
@@ -636,6 +705,7 @@ export async function updateTaskForProject(
           projectId: true,
           status: true,
           position: true,
+          assigneeUserId: true,
           outgoingRelations: {
             select: {
               rightTaskId: true,
@@ -667,6 +737,22 @@ export async function updateTaskForProject(
         return relatedTaskValidation;
       }
 
+      const assigneeValidation = assigneeProvided
+        ? await validateAssigneeUserId({
+            db,
+            projectId,
+            assigneeUserId: assigneeUserId || null,
+          })
+        : {
+            ok: true as const,
+            data: {
+              assigneeUserId: existingTask.assigneeUserId,
+            },
+          };
+      if (!assigneeValidation.ok) {
+        return assigneeValidation;
+      }
+
       const updateWithClient = async (tx: typeof db) => {
         await tx.task.update({
           where: { id: taskId },
@@ -675,6 +761,8 @@ export async function updateTaskForProject(
             label: normalizedLabels[0] ?? null,
             labelsJson: serializedLabels,
             description,
+            updatedByUserId: normalizedActorUserId,
+            assigneeUserId: assigneeValidation.data.assigneeUserId,
             ...(deadlineInput.data.provided
               ? { deadlineAt: deadlineInput.data.deadlineAt }
               : {}),
@@ -715,6 +803,17 @@ export async function updateTaskForProject(
             status: true,
             position: true,
             archivedAt: true,
+            createdAt: true,
+            updatedAt: true,
+            createdByUser: {
+              select: taskPersonSummarySelect,
+            },
+            updatedByUser: {
+              select: taskPersonSummarySelect,
+            },
+            assigneeUser: {
+              select: taskPersonSummarySelect,
+            },
             outgoingRelations: {
               select: {
                 rightTask: {
@@ -762,6 +861,13 @@ export async function updateTaskForProject(
             status: updatedTask.status,
             position: updatedTask.position,
             archivedAt: updatedTask.archivedAt,
+            assignee: updatedTask.assigneeUser
+              ? mapTaskPersonSummary(updatedTask.assigneeUser)
+              : null,
+            createdBy: mapTaskPersonSummary(updatedTask.createdByUser)!,
+            updatedBy: mapTaskPersonSummary(updatedTask.updatedByUser)!,
+            createdAt: updatedTask.createdAt,
+            updatedAt: updatedTask.updatedAt,
             relatedTasks: mergeRelatedTaskSummaries(updatedTask),
             blockedFollowUps: updatedTask.blockedFollowUps,
           },
@@ -837,6 +943,7 @@ export async function archiveTaskForProject(
         where: { id: taskId },
         data: {
           archivedAt: new Date(),
+          updatedByUserId: normalizedActorUserId,
         },
         select: {
           archivedAt: true,
@@ -929,6 +1036,7 @@ export async function unarchiveTaskForProject(
         where: { id: taskId },
         data: {
           archivedAt: null,
+          updatedByUserId: normalizedActorUserId,
         },
         select: {
           id: true,

--- a/lib/task-person.ts
+++ b/lib/task-person.ts
@@ -1,0 +1,69 @@
+import { resolveAvatarSeed } from "@/lib/avatar";
+import { validateUsernameDiscriminator } from "@/lib/services/account-security-policy";
+
+export interface TaskPersonSummary {
+  id: string;
+  displayName: string;
+  usernameTag: string | null;
+  avatarSeed: string;
+}
+
+export interface TaskPersonRecord {
+  id: string;
+  name: string | null;
+  email: string | null;
+  username: string | null;
+  usernameDiscriminator: string | null;
+  avatarSeed: string | null;
+}
+
+export const taskPersonSummarySelect = {
+  id: true,
+  name: true,
+  email: true,
+  username: true,
+  usernameDiscriminator: true,
+  avatarSeed: true,
+} as const;
+
+function buildUsernameTag(
+  username: string | null | undefined,
+  usernameDiscriminator: string | null | undefined
+): string | null {
+  if (
+    !username ||
+    !usernameDiscriminator ||
+    !validateUsernameDiscriminator(usernameDiscriminator)
+  ) {
+    return null;
+  }
+
+  return `${username}#${usernameDiscriminator}`;
+}
+
+function getEmailLocalPart(email: string | null | undefined): string | null {
+  if (!email || !email.includes("@")) {
+    return null;
+  }
+
+  return email.split("@", 1)[0] ?? null;
+}
+
+export function mapTaskPersonSummary(
+  input: TaskPersonRecord | null
+): TaskPersonSummary | null {
+  if (!input) {
+    return null;
+  }
+
+  return {
+    id: input.id,
+    displayName:
+      input.username ??
+      input.name ??
+      getEmailLocalPart(input.email) ??
+      "Account",
+    usernameTag: buildUsernameTag(input.username, input.usernameDiscriminator),
+    avatarSeed: resolveAvatarSeed(input.avatarSeed, input.id),
+  };
+}

--- a/prisma/migrations/20260421103000_task089_generated_avatar_baseline/migration.sql
+++ b/prisma/migrations/20260421103000_task089_generated_avatar_baseline/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "User"
+ADD COLUMN "avatarSeed" VARCHAR(64);

--- a/prisma/migrations/20260421131500_task101_task_ownership_and_provenance/migration.sql
+++ b/prisma/migrations/20260421131500_task101_task_ownership_and_provenance/migration.sql
@@ -1,0 +1,32 @@
+ALTER TABLE "Task"
+ADD COLUMN "createdByUserId" TEXT,
+ADD COLUMN "updatedByUserId" TEXT,
+ADD COLUMN "assigneeUserId" TEXT;
+
+UPDATE "Task" AS task
+SET
+  "createdByUserId" = project."ownerId",
+  "updatedByUserId" = project."ownerId"
+FROM "Project" AS project
+WHERE project.id = task."projectId";
+
+ALTER TABLE "Task"
+ALTER COLUMN "createdByUserId" SET NOT NULL,
+ALTER COLUMN "updatedByUserId" SET NOT NULL;
+
+CREATE INDEX "Task_createdByUserId_idx" ON "Task"("createdByUserId");
+CREATE INDEX "Task_updatedByUserId_idx" ON "Task"("updatedByUserId");
+CREATE INDEX "Task_assigneeUserId_idx" ON "Task"("assigneeUserId");
+CREATE INDEX "Task_projectId_assigneeUserId_idx" ON "Task"("projectId", "assigneeUserId");
+
+ALTER TABLE "Task"
+ADD CONSTRAINT "Task_createdByUserId_fkey"
+FOREIGN KEY ("createdByUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "Task"
+ADD CONSTRAINT "Task_updatedByUserId_fkey"
+FOREIGN KEY ("updatedByUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "Task"
+ADD CONSTRAINT "Task_assigneeUserId_fkey"
+FOREIGN KEY ("assigneeUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,9 @@ model User {
   projectInvitationsSent     ProjectInvitation[]       @relation("ProjectInvitationInviter")
   taskAttachments            TaskAttachment[]          @relation("TaskAttachmentUploader")
   taskComments               TaskComment[]             @relation("TaskCommentAuthor")
+  tasksCreated              Task[]                    @relation("TaskCreatedBy")
+  tasksUpdated              Task[]                    @relation("TaskUpdatedBy")
+  tasksAssigned             Task[]                    @relation("TaskAssignee")
   resourceAttachments        ResourceAttachment[]      @relation("ResourceAttachmentUploader")
   googleCalendarCredential   GoogleCalendarCredential?
   emailVerificationTokens    EmailVerificationToken[]
@@ -196,7 +199,13 @@ model Task {
   label             String?
   labelsJson        String?
   projectId         String
+  createdByUserId   String
+  updatedByUserId   String
+  assigneeUserId    String?
   project           Project               @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  createdByUser     User                  @relation("TaskCreatedBy", fields: [createdByUserId], references: [id])
+  updatedByUser     User                  @relation("TaskUpdatedBy", fields: [updatedByUserId], references: [id])
+  assigneeUser      User?                 @relation("TaskAssignee", fields: [assigneeUserId], references: [id], onDelete: SetNull)
   attachments       TaskAttachment[]
   comments          TaskComment[]
   blockedFollowUps  TaskBlockedFollowUp[]
@@ -207,6 +216,10 @@ model Task {
 
   @@index([projectId])
   @@index([projectId, deadlineAt])
+  @@index([createdByUserId])
+  @@index([updatedByUserId])
+  @@index([assigneeUserId])
+  @@index([projectId, assigneeUserId])
 }
 
 model TaskComment {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,7 @@ model User {
   passwordHash          String?
   username              String?   @db.VarChar(20)
   usernameDiscriminator String?   @db.VarChar(4)
+  avatarSeed            String?   @db.VarChar(64)
   emailVerified         DateTime?
   image                 String?
   createdAt             DateTime  @default(now())

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -9,11 +9,6 @@ Use this file to capture tasks discovered during development. Each entry should 
   Status: Pending
   Rationale: Add task-level ownership metadata so collaborators can see who created a task, who is currently responsible for it, and who last touched it, with room for future filtering, accountability, and notification workflows without relying on external chat context.
   Dependencies: TASK-058, TASK-076, TASK-079
-- ID: TASK-099
-  Title: Task comments - project-scoped discussion thread on tasks
-  Status: Pending
-  Rationale: Let users comment directly on tasks so execution context, quick discussion, clarifications, and follow-up decisions stay attached to the work item instead of being lost in external chat or generic context cards; implementation should stay future-friendly for chronology, author attribution, and mention/notification follow-ups.
-  Dependencies: TASK-076, TASK-079
 - ID: TASK-107
   Title: Task epic links - parent epic relationship and grouped execution context
   Status: Pending
@@ -39,8 +34,28 @@ Use this file to capture tasks discovered during development. Each entry should 
 - ID: TASK-104
   Title: Invite email delivery - app-managed sending for project collaboration invites
   Status: Pending
-  Rationale: After copy-link invite delivery is in place, add first-party email sending for collaboration invites so owners can trigger invite delivery directly from the app, with explicit sender identity, provider configuration, and deliverability/error-handling decisions rather than coupling those concerns into TASK-103 by default.
-  Dependencies: TASK-103, TASK-083
+  Rationale: After copy-link invite delivery is in place, add first-party email sending for collaboration invites so owners can trigger invite delivery directly from the app, building on the reusable outbound-email foundation instead of coupling provider/deliverability concerns into TASK-103 by default.
+  Dependencies: TASK-103, TASK-083, TASK-125
+- ID: TASK-123
+  Title: Notification center - unified in-app inbox for invitations, mentions, and future activity
+  Status: Pending
+  Rationale: Introduce a dedicated notification center so invitation events, future task-comment mentions, and other product activity can land in one durable in-app inbox instead of being split across isolated surfaces, giving NexusDash a reusable foundation for unread state, chronological triage, and future notification categories.
+  Dependencies: TASK-058, TASK-103
+- ID: TASK-124
+  Title: Comment mentions - project-member @tagging with notification-center delivery
+  Status: Pending
+  Rationale: Let collaborators tag project members directly in task comments with `@` mentions, including member autocomplete, highlighted mention rendering, and notification creation routed into the in-app notification center so task discussion can pull the right people in without external chat.
+  Dependencies: TASK-058, TASK-099, TASK-123
+- ID: TASK-125
+  Title: Outbound email foundation - reusable app-owned email delivery for invites and future notifications
+  Status: Pending
+  Rationale: Establish NexusDash-owned outbound email infrastructure so future invite delivery, notification emails, and other transactional sends can come from the product itself with explicit provider, sender identity, template, observability, and failure-handling decisions instead of being implemented piecemeal.
+  Dependencies: TASK-083
+- ID: TASK-126
+  Title: Comment reactions - lightweight emoji response system on task threads
+  Status: Pending
+  Rationale: Add lightweight reactions on task comments so collaborators can acknowledge, support, or quickly respond without posting extra text, preserving comment readability while giving task discussions faster signal.
+  Dependencies: TASK-099
 - ID: TASK-109
   Title: Todo list feature - lightweight checklist capture alongside project execution
   Status: Pending
@@ -120,6 +135,11 @@ Use this file to capture tasks discovered during development. Each entry should 
   Dependencies: TASK-051
 
 ## Completed
+- ID: TASK-099
+  Title: Task comments - project-scoped discussion thread on tasks
+  Status: Done (2026-04-20, merged via PR #180)
+  Rationale: Added project-scoped task discussion threads with append-only, chronological, author-attributed comments in task detail, lightweight board-level comment visibility, API/service coverage, and merged the rollout through PR `#180`.
+  Dependencies: TASK-076, TASK-079
 - ID: TASK-117
   Title: Deadline feature - due dates, urgency visibility, and reminder-ready planning hooks
   Status: Done (2026-04-19, merged via PR #178)

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -4,11 +4,6 @@ Use this file to capture tasks discovered during development. Each entry should 
 
 ## Pending
 ### Execution Queue (Now / Next)
-- ID: TASK-101
-  Title: Task ownership and provenance - created-by visibility, assignee model, and task activity attribution
-  Status: Pending
-  Rationale: Add task-level ownership metadata so collaborators can see who created a task, who is currently responsible for it, and who last touched it, with room for future filtering, accountability, and notification workflows without relying on external chat context.
-  Dependencies: TASK-058, TASK-076, TASK-079
 - ID: TASK-107
   Title: Task epic links - parent epic relationship and grouped execution context
   Status: Pending
@@ -135,6 +130,11 @@ Use this file to capture tasks discovered during development. Each entry should 
   Dependencies: TASK-051
 
 ## Completed
+- ID: TASK-101
+  Title: Task ownership and provenance - created-by visibility, assignee model, and task activity attribution
+  Status: Done (2026-04-21, merged via PR #193 into PR #192)
+  Rationale: Added task-level ownership/provenance across schema, services, APIs, and Kanban surfaces so collaborators can see who created a task, who is assigned, and who last updated it, with avatar-backed UI and durable attribution for future filtering and notification workflows.
+  Dependencies: TASK-058, TASK-076, TASK-079
 - ID: TASK-099
   Title: Task comments - project-scoped discussion thread on tasks
   Status: Done (2026-04-20, merged via PR #180)

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -75,6 +75,8 @@ surfaces without waiting for a full profile-photo management feature.
 - Apply the new avatar baseline to the first consumer surfaces:
   - top-right account icon/menu
   - account/settings identity surfaces
+  - task comments
+  - project settings contributors tab
 - Add targeted regression coverage for avatar resolution and the first UI
   consumer surfaces.
 - Update tracking docs in the same task PR.
@@ -84,7 +86,6 @@ surfaces without waiting for a full profile-photo management feature.
 - Rendering provider-supplied `user.image` through the shared avatar path.
 - Project-page collaborator presence rollout; that belongs to `TASK-119`.
 - Task-surface avatar rollout for:
-  - comments
   - assignee
   - created-by / modified-by
   Those are expected follow-ons for `TASK-101`.
@@ -94,11 +95,12 @@ surfaces without waiting for a full profile-photo management feature.
 ## Desired Follow-On Consumers
 These are not all part of `TASK-089`, but this task should make them easy:
 - After `TASK-089` + `TASK-101`, avatars should be usable in:
-  - task comments
   - assignee display
   - created-by / modified-by metadata
   - top-right account icon
   - settings/account identity surfaces
+  - task comments
+  - project settings contributors
 - Later, `TASK-119` should reuse the same avatar foundation for:
   - project-page collaborator presence and member rows
 
@@ -131,8 +133,11 @@ These are not all part of `TASK-089`, but this task should make them easy:
 - `components/top-right-controls.tsx`
 - `app/account/page.tsx`
 - `app/account/settings/**` if settings-shell identity chrome is updated
+- `components/kanban/task-detail-modal.tsx`
+- `components/project-dashboard/project-dashboard-owner-access-panel.tsx`
 - `lib/services/account-identity-service.ts`
 - `lib/services/account-profile-service.ts`
+- `lib/services/project-task-comment-service.ts`
 - `lib/services/project-collaboration-service.ts` if shared identity types are
   expanded for future reuse
 - a new shared avatar helper under `lib/**`
@@ -146,6 +151,8 @@ These are not all part of `TASK-089`, but this task should make them easy:
 - top-right account/menu avatar rendering
 - account/settings identity surfaces updated to use the generated avatar
   baseline
+- task comments and project-settings contributor rows updated to use the shared
+  avatar baseline
 - aligned tests and documentation updates
 - a dedicated task branch and PR that follow the repository shipping workflow
 
@@ -155,6 +162,8 @@ These are not all part of `TASK-089`, but this task should make them easy:
   the updated result on account-owned surfaces.
 - The top-right signed-in account affordance uses the new avatar system.
 - Account/settings identity surfaces use the new avatar system.
+- Task comments use the new avatar system.
+- Project settings contributor rows use the new avatar system.
 - The avatar baseline is implemented in a reusable way that can support
   `TASK-101` and `TASK-119` without redesigning the primitive.
 - Required tracking docs are updated consistently in the same PR.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,212 +1,185 @@
-# Current Task: TASK-099 Task Comments - Project-Scoped Discussion Thread On Tasks
+# Current Task: TASK-089 Automatic Avatar Creation - Generated Identity Avatar Baseline
 
 ## Task ID
-TASK-099
+TASK-089
 
 ## Status
-Active on `feature/task-099-task-comments` as of `2026-04-19`; implementation
-is complete, PR `#180` is open, Copilot feedback has been applied/resolved, and
-preview deployment plus PR checks have passed for the latest branch head.
+Implemented locally on branch `feature/task-089-generated-avatar-baseline`;
+local validation is complete and the task is ready for the repository review /
+PR path.
 
 ## Objective
-Add first-class task comments so execution-specific discussion, clarifications,
-and follow-up decisions stay attached to the task itself, with clear chronology
-and author attribution, without broadening this task into realtime messaging,
-mentions, or a full notification system.
+Introduce a deterministic generated-avatar baseline with persisted seed and
+user-triggered regeneration so NexusDash can render a consistent visual
+identity across account-owned surfaces now and unblock later collaboration
+surfaces without waiting for a full profile-photo management feature.
 
 ## Why This Task Matters
-- The current task model already captures execution structure well
-  (`description`, labels, deadlines, attachments, blocked follow-ups, related
-  tasks), but it has no durable place for discussion tied to the work item.
-- Important decisions and clarifications are currently easy to lose in external
-  chat or generic context cards, which weakens task-level continuity.
-- `TASK-076`, `TASK-079`, `TASK-095`, and `TASK-117` established the current
-  service boundary, safer task interactions, relationship model, and richer
-  task metadata. Comments should extend those patterns rather than introduce a
-  parallel collaboration model.
-- Agent-facing task APIs are now a supported product surface, so any new
-  task-scoped discussion resource should stay coherent across services, routes,
-  and hosted agent/OpenAPI documentation.
+- The data model already supports optional user images, but only social-auth
+  users reliably get one today. Credentials users still appear as text-only
+  identities across the product.
+- Upcoming collaboration and task-provenance work benefits from a reusable
+  avatar foundation instead of inventing ad hoc text badges for every new
+  person-oriented surface.
+- `TASK-101` needs a clean visual identity affordance for assignee,
+  created-by, and modified-by metadata. Shipping a baseline avatar system first
+  reduces rework and gives those future surfaces a stronger default UX.
+- `TASK-119` is intended to expose collaborator presence on project pages, and
+  that feature should build on a shared avatar primitive rather than defining a
+  second identity presentation model.
 
-## Current Understanding
-- Task persistence lives in `prisma/schema.prisma`, with project/task authz
-  enforced in `lib/services/**` and RLS actor propagation handled through
-  `lib/services/rls-context.ts`.
-- Task creation/update/delete flows are handled in
-  `lib/services/project-task-service.ts`, while dashboard task reads come from
-  `lib/services/project-service.ts`.
-- The project page currently builds Kanban task data in
-  `app/projects/[projectId]/kanban-board-section.tsx`, then hands the live
-  client interaction model to `components/kanban-board.tsx`.
-- The task modal in `components/kanban/task-detail-modal.tsx` is the existing
-  task detail/read-edit surface and is the natural home for an inline
-  discussion thread.
-- Current board payloads already include attachments, blocked follow-ups,
-  related tasks, and deadlines for scan/read workflows; comments differ because
-  they can grow without bound and should not force the dashboard to eagerly
-  hydrate every thread body.
-- Account identity display patterns already exist:
-  `lib/services/account-identity-service.ts` provides `displayName` and
-  `usernameTag`, and project-collaboration surfaces already show user identity
-  in a compact consistent way.
-- RLS currently protects task-scoped tables such as `Task`,
-  `TaskBlockedFollowUp`, `TaskAttachment`, and `TaskRelation`; a new
-  task-comment table must receive equivalent policy treatment in the migration
-  layer.
-- Agent docs and OpenAPI are generated from `lib/agent-onboarding.ts` and the
-  `/api/docs/agent/v1/openapi.json` route, so comment endpoints or task payload
-  changes need to be reflected there deliberately.
+## Current Baseline Confirmed In Repo
+- `User.image` already exists in `prisma/schema.prisma`.
+- Social auth ingestion already preserves provider-supplied avatar URLs in
+  `lib/services/social-auth-service.ts`.
+- Human-readable identity summaries already exist via:
+  - `lib/services/account-identity-service.ts`
+  - `lib/services/account-profile-service.ts`
+  - `lib/services/project-collaboration-service.ts`
+  - `lib/services/project-task-comment-service.ts`
+- The top-right signed-in affordance currently shows text identity only through
+  `components/account-menu.tsx` and `components/top-right-controls.tsx`.
+- The account page (`app/account/page.tsx`) already exposes identity/settings
+  surfaces, but it does not yet render avatar state or avatar-specific copy.
 
 ## Working Product Assumptions
-- V1 comments are task-scoped only. This task does not add comments to projects,
-  context cards, calendar events, or attachments.
-- V1 comments are append-only:
-  - supported operations: list comments, create comment
-  - out of scope for v1: edit comment, delete comment, reactions, threading,
-    resolution state
-- Comment content should be plain text in v1 with preserved line breaks, not a
-  second rich-text editor. This keeps the interaction lightweight and lowers
-  implementation risk while remaining future-friendly for mention parsing.
-- Comment author attribution should use the same identity hierarchy already used
-  elsewhere in the product:
-  - `usernameTag` when available
-  - otherwise the existing display-name fallback path
-- Read access should align with task visibility (`task:read` / project access),
-  and write access should align with task mutation permissions (`task:write` /
-  editor-or-owner role semantics).
-- The Kanban/dashboard payload should expose only lightweight comment metadata
-  for scan-time visibility, with the full comment thread fetched lazily when the
-  task modal opens.
-- Comment chronology should read oldest-to-newest in the thread so the modal
-  behaves like a natural conversation log rather than a reverse-ordered audit
-  table.
-- Mention parsing, notifications, digests, realtime push, and unread state are
-  intentionally deferred, but schema and route design should not block those
-  follow-ups later.
+- `TASK-089` ships a generated avatar baseline, not a full avatar-management
+  system.
+- The generated avatar is the active account avatar for this milestone, even if
+  provider-supplied `user.image` exists today.
+- The visual should be deterministic from a stable persisted seed until the
+  user explicitly regenerates it.
+- The generated avatar must not depend on external avatar services.
+- The generated avatar must stay privacy-safe and cheap to compute:
+  - no external fetch
+  - no separate object storage pipeline
+  - no requirement for uploaded image assets
+- A user must be able to regenerate the avatar from the account page without
+  needing admin involvement or direct database changes.
+- The baseline should be reusable by future task/collaboration work, but this
+  task should not broaden into task ownership/provenance or project presence
+  rollout by itself.
 
 ## Scope
-- Add first-class task comment persistence through Prisma schema and migration
-  updates.
-- Add task-comment RLS policy coverage and indexes consistent with the current
-  `TASK-085` protected-table model.
-- Introduce service-layer task-comment reads/writes under
-  `lib/services/**`, keeping transport adapters thin.
-- Add dedicated task-comment API endpoints for at least:
-  - list thread for one task
-  - create comment on one task
-- Extend the Kanban/dashboard task shape with lightweight comment visibility,
-  such as `commentCount`.
-- Add a task-detail modal discussion surface that:
-  - loads the thread lazily
-  - renders author + timestamp + content
-  - lets authorized users add a comment inline
-- Add a compact board/task indicator so comments are discoverable without
-  opening every task blindly.
-- Keep project-role enforcement, agent scope enforcement, and RLS actor-context
-  behavior intact for all new reads and writes.
-- Align agent-facing task docs/OpenAPI and onboarding guidance if task comments
-  become part of the supported agent surface.
-- Add or update regression coverage and tracking docs in the same task PR.
+- Add a reusable avatar rendering primitive for NexusDash identity surfaces.
+- Add deterministic generated-avatar helpers, including:
+  - stable seed handling
+  - color/style derivation
+  - pixel-pattern generation
+- Persist a generated-avatar seed on the user record so the avatar remains
+  stable until explicit regeneration.
+- Extend account-level identity data flow so the signed-in shell and account
+  surfaces can render resolved avatar state.
+- Add account-level avatar regeneration through the existing account-management
+  flow.
+- Apply the new avatar baseline to the first consumer surfaces:
+  - top-right account icon/menu
+  - account/settings identity surfaces
+- Add targeted regression coverage for avatar resolution and the first UI
+  consumer surfaces.
+- Update tracking docs in the same task PR.
 
 ## Out Of Scope
-- Comment editing, deletion, reactions, emoji reactions, or nested reply
-  threads.
-- Rich-text comment authoring.
-- File or link attachments scoped directly to comments.
-- Mention parsing, mention notifications, email notifications, push
-  notifications, or digest delivery.
-- Realtime collaboration or live comment streaming across sessions.
-- Comment search, filtering, moderation, or per-user unread state.
-- Broad redesign of the Kanban/dashboard beyond the comment affordances needed
-  for this task.
+- User-uploaded avatar management or avatar file storage.
+- Rendering provider-supplied `user.image` through the shared avatar path.
+- Project-page collaborator presence rollout; that belongs to `TASK-119`.
+- Task-surface avatar rollout for:
+  - comments
+  - assignee
+  - created-by / modified-by
+  Those are expected follow-ons for `TASK-101`.
+- Notification, activity-feed, or presence semantics.
+- Reworking auth or social-account linking behavior.
 
-## Expected Implementation Touchpoints
-- `prisma/schema.prisma`
-- `prisma/migrations/**`
-- `lib/services/project-task-comment-service.ts` (new)
-- `lib/services/project-service.ts`
-- `app/api/projects/[projectId]/tasks/[taskId]/comments/route.ts` (new)
-- `app/api/projects/[projectId]/tasks/route.ts`
-- `app/projects/[projectId]/kanban-board-section.tsx`
-- `components/kanban-board-types.ts`
-- `components/kanban-board.tsx`
-- `components/kanban/kanban-columns-grid.tsx`
-- `components/kanban/task-detail-modal.tsx`
-- `lib/agent-onboarding.ts`
-- `/api/docs/agent/v1/openapi.json` generation path
+## Desired Follow-On Consumers
+These are not all part of `TASK-089`, but this task should make them easy:
+- After `TASK-089` + `TASK-101`, avatars should be usable in:
+  - task comments
+  - assignee display
+  - created-by / modified-by metadata
+  - top-right account icon
+  - settings/account identity surfaces
+- Later, `TASK-119` should reuse the same avatar foundation for:
+  - project-page collaborator presence and member rows
+
+## Design Constraints
+### 1. Determinism
+- A given user should receive the same generated avatar every time.
+- The seed should prefer a stable principal identifier and not rely only on
+  mutable presentation text.
+
+### 2. Fallback Quality
+- The generated fallback should feel intentional rather than like a generic
+  placeholder.
+- If initials are used, they should complement the visual treatment rather than
+  becoming the entire design.
+
+### 3. Reusability
+- The avatar primitive should support future compact and expanded contexts:
+  - menu trigger
+  - inline person metadata
+  - collaborator rows
+  - task provenance chips
+
+### 4. Safe Incremental Rollout
+- First ship the avatar baseline in account-owned surfaces that already exist.
+- Avoid coupling this task to collaboration-presence or task-provenance schema
+  changes.
+
+## Likely Implementation Touchpoints
+- `components/account-menu.tsx`
+- `components/top-right-controls.tsx`
+- `app/account/page.tsx`
+- `app/account/settings/**` if settings-shell identity chrome is updated
+- `lib/services/account-identity-service.ts`
+- `lib/services/account-profile-service.ts`
+- `lib/services/project-collaboration-service.ts` if shared identity types are
+  expanded for future reuse
+- a new shared avatar helper under `lib/**`
+- a new shared avatar UI component under `components/**`
 - relevant `tests/**`
 
-## Resolved Implementation Decisions
-1. Comments ship as a dedicated task-scoped resource:
-   - do not overload `Task.description`
-   - do not repurpose `TaskBlockedFollowUp`
-2. Full threads load lazily per selected task:
-   - dashboard/board payload stays lightweight
-   - board payload should expose only compact comment metadata such as
-     `commentCount`
-3. V1 comment authoring is append-only plain text:
-   - no edit/delete lifecycle in this task
-   - preserve line breaks and timestamps for a clean chronological thread
-
 ## Expected Output
-- an active `tasks/current.md` brief for `TASK-099`
-- task comment persistence and RLS-aware service/API support
-- task modal thread read/write UX with author attribution
-- compact comment visibility on Kanban task surfaces
+- an active `tasks/current.md` brief for `TASK-089`
+- a reusable avatar component + deterministic generated-avatar helpers
+- persisted avatar seed + account-page regeneration flow
+- top-right account/menu avatar rendering
+- account/settings identity surfaces updated to use the generated avatar
+  baseline
 - aligned tests and documentation updates
-- a dedicated task branch and PR that follow the repository shipping workflow,
-  including initial Copilot review triage before handoff
-
-## Implementation Status
-- Completed locally:
-  - Prisma schema + migration for `TaskComment`
-  - task-comment service + API route (`GET`/`POST`)
-  - lightweight `commentCount` support in task payloads
-  - task-detail modal thread loading + inline comment composer
-  - board/task comment visibility affordances
-  - agent onboarding/OpenAPI updates
-  - regression coverage for task comments and updated task payload contracts
-- Shipping steps in progress:
-  - final merge decision on PR `#180`
+- a dedicated task branch and PR that follow the repository shipping workflow
 
 ## Acceptance Criteria
-- Tasks support a persisted comment thread with at least create and list
-  behavior.
-- Every comment stores stable task linkage, project scoping, author identity,
-  and chronology metadata required for future follow-ups.
-- Comment reads and writes remain service-authorized and project-scoped under
-  the current `TASK-076` / `TASK-085` boundary model.
-- The task modal renders a chronological discussion thread with clear author and
-  timestamp context.
-- Authorized collaborators can add comments from the task detail surface without
-  degrading existing task edit, attachment, related-task, and deadline flows.
-- The Kanban/task surface exposes lightweight visibility that a task has
-  comments, preferably including a count.
-- Agent-facing documentation is updated if comment endpoints or task payload
-  contracts are added.
+- Users render a deterministic generated avatar from a stable persisted seed.
+- Users can regenerate their avatar from the account page and immediately see
+  the updated result on account-owned surfaces.
+- The top-right signed-in account affordance uses the new avatar system.
+- Account/settings identity surfaces use the new avatar system.
+- The avatar baseline is implemented in a reusable way that can support
+  `TASK-101` and `TASK-119` without redesigning the primitive.
 - Required tracking docs are updated consistently in the same PR.
 
 ## Definition Of Done
-1. `TASK-099` is the active task in `tasks/current.md`.
-2. Task comments are implemented end to end across schema, migration/RLS,
-   services, routes, and the primary task UI surface.
+1. `TASK-089` is the active task in `tasks/current.md`.
+2. The avatar baseline is implemented end to end across helpers and the first
+   account-owned UI surfaces.
 3. Validation is green for the relevant scope:
    - `npm run lint`
    - `npm test`
    - `npm run test:coverage`
    - `npm run build`
-   - `npm run test:e2e` if the final UI changes warrant E2E coverage or touch a
-     currently covered critical flow
+   - `npm run test:e2e` if the final UI changes materially affect an existing
+     covered authenticated flow and local prerequisites are available
 4. Tracking docs are updated consistently (`tasks/current.md`, `journal.md`,
    `adr/decisions.md` if the final design introduces an architecture-level
-   decision).
-5. The task ships through a dedicated PR whose title includes `TASK-099`, with
+   identity-rendering decision).
+5. The task ships through a dedicated PR whose title includes `TASK-089`, with
    Copilot's initial review state monitored and any valid feedback handled
    before handoff.
 
 ## Dependencies
-- `TASK-076`
-- `TASK-079`
+- `TASK-047`
+- `TASK-082`
 
 ## Evidence Plan
 - Repo source of truth:
@@ -214,25 +187,24 @@ mentions, or a full notification system.
   - `project.md`
   - `README.md`
   - `prisma/schema.prisma`
-  - `lib/services/project-task-service.ts`
-  - `lib/services/project-service.ts`
-  - `components/kanban-board.tsx`
-  - `components/kanban/task-detail-modal.tsx`
-  - `components/kanban/kanban-columns-grid.tsx`
+  - `lib/services/social-auth-service.ts`
   - `lib/services/account-identity-service.ts`
-  - `lib/agent-onboarding.ts`
+  - `lib/services/account-profile-service.ts`
+  - `components/account-menu.tsx`
+  - `components/top-right-controls.tsx`
+  - `app/account/page.tsx`
 - Validation source of truth:
   - local lint/unit/coverage/build runs
   - PR checks: `check-name`, `Quality Core`, `E2E Smoke`, and
     `Container Image`
 
 ## Outcome Target
-- NexusDash gains a durable task-level discussion thread so execution context
-  stays attached to the work item instead of escaping into unrelated channels.
-- The resulting implementation should make future mentions/notifications
-  additive rather than forcing a comment-model rewrite.
+- NexusDash gains a consistent visual identity baseline for every user, even
+  without uploaded photos.
+- The resulting avatar system should make `TASK-101` and `TASK-119` additive
+  consumer rollouts rather than forcing a second identity-UI rewrite.
 
 ---
 
-Last Updated: 2026-04-19
+Last Updated: 2026-04-21
 Assigned To: Agent

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,217 +1,139 @@
-# Current Task: TASK-089 Automatic Avatar Creation - Generated Identity Avatar Baseline
+# Current Task: TASK-101 Task Ownership And Provenance
 
 ## Task ID
-TASK-089
+TASK-101
 
 ## Status
-Implemented locally on branch `feature/task-089-generated-avatar-baseline`;
-local validation is complete and the task is ready for the repository review /
-PR path.
+Implementation complete on branch
+`feature/task-101-task-ownership-and-provenance`, stacked on top of `TASK-089`
+so the avatar baseline can be reused immediately across task ownership
+surfaces. Local validation is green aside from Playwright being blocked by the
+shared database schema not yet reflecting this branch migration; PR/review and
+preview deployment are the remaining release steps.
 
 ## Objective
-Introduce a deterministic generated-avatar baseline with persisted seed and
-user-triggered regeneration so NexusDash can render a consistent visual
-identity across account-owned surfaces now and unblock later collaboration
-surfaces without waiting for a full profile-photo management feature.
+Add first-class task ownership metadata so every task can show who created it,
+who is currently assigned to it, and who last touched it, with the data model,
+API contracts, and UI all aligned around the same provenance source of truth.
 
 ## Why This Task Matters
-- The data model already supports optional user images, but only social-auth
-  users reliably get one today. Credentials users still appear as text-only
-  identities across the product.
-- Upcoming collaboration and task-provenance work benefits from a reusable
-  avatar foundation instead of inventing ad hoc text badges for every new
-  person-oriented surface.
-- `TASK-101` needs a clean visual identity affordance for assignee,
-  created-by, and modified-by metadata. Shipping a baseline avatar system first
-  reduces rework and gives those future surfaces a stronger default UX.
-- `TASK-119` is intended to expose collaborator presence on project pages, and
-  that feature should build on a shared avatar primitive rather than defining a
-  second identity presentation model.
+- Collaboration is already live, but task ownership is still implicit and
+  depends on outside context instead of product-visible metadata.
+- `TASK-089` established a shared avatar foundation; `TASK-101` is the first
+  feature that needs to apply that foundation to real work attribution.
+- Assignee and provenance data are prerequisites for later filtering,
+  accountability, notification, and richer project-presence work.
+- Shipping this cleanly now reduces the risk of inventing multiple incompatible
+  identity models across task comments, assignee chips, and future activity
+  surfaces.
 
 ## Current Baseline Confirmed In Repo
-- `User.image` already exists in `prisma/schema.prisma`.
-- Social auth ingestion already preserves provider-supplied avatar URLs in
-  `lib/services/social-auth-service.ts`.
-- Human-readable identity summaries already exist via:
-  - `lib/services/account-identity-service.ts`
-  - `lib/services/account-profile-service.ts`
-  - `lib/services/project-collaboration-service.ts`
-  - `lib/services/project-task-comment-service.ts`
-- The top-right signed-in affordance currently shows text identity only through
-  `components/account-menu.tsx` and `components/top-right-controls.tsx`.
-- The account page (`app/account/page.tsx`) already exposes identity/settings
-  surfaces, but it does not yet render avatar state or avatar-specific copy.
+- `Task` currently has no creator, updater, or assignee relationship fields in
+  `prisma/schema.prisma`.
+- Kanban task reads come from `listProjectKanbanTasks` and the task routes, so
+  provenance data needs to be added at the service/API layer rather than only
+  in the UI.
+- Task comments already resolve avatar-backed author identities after
+  `TASK-089`.
+- The board already has a stable task detail modal, task create dialog, and
+  task edit flow, which are the right surfaces to introduce ownership and
+  provenance.
 
 ## Working Product Assumptions
-- `TASK-089` ships a generated avatar baseline, not a full avatar-management
-  system.
-- The generated avatar is the active account avatar for this milestone, even if
-  provider-supplied `user.image` exists today.
-- The visual should be deterministic from a stable persisted seed until the
-  user explicitly regenerates it.
-- The generated avatar must not depend on external avatar services.
-- The generated avatar must stay privacy-safe and cheap to compute:
-  - no external fetch
-  - no separate object storage pipeline
-  - no requirement for uploaded image assets
-- A user must be able to regenerate the avatar from the account page without
-  needing admin involvement or direct database changes.
-- The baseline should be reusable by future task/collaboration work, but this
-  task should not broaden into task ownership/provenance or project presence
-  rollout by itself.
+- A task must always retain a creator and last-updater once the migration is
+  applied.
+- Assignee is optional and should support explicit clearing back to an
+  unassigned state.
+- Valid assignees are current project collaborators, including the owner.
+- "Last touched" should reflect task mutations that materially change the task
+  record or task activity, including comment and attachment writes.
+- Existing tasks need a practical backfill path; project owner is the baseline
+  provenance fallback for legacy rows.
 
 ## Scope
-- Add a reusable avatar rendering primitive for NexusDash identity surfaces.
-- Add deterministic generated-avatar helpers, including:
-  - stable seed handling
-  - color/style derivation
-  - pixel-pattern generation
-- Persist a generated-avatar seed on the user record so the avatar remains
-  stable until explicit regeneration.
-- Extend account-level identity data flow so the signed-in shell and account
-  surfaces can render resolved avatar state.
-- Add account-level avatar regeneration through the existing account-management
-  flow.
-- Apply the new avatar baseline to the first consumer surfaces:
-  - top-right account icon/menu
-  - account/settings identity surfaces
-  - task comments
-  - project settings contributors tab
-- Add targeted regression coverage for avatar resolution and the first UI
-  consumer surfaces.
-- Update tracking docs in the same task PR.
+- Extend the task schema with:
+  - creator relationship
+  - updater relationship
+  - optional assignee relationship
+- Backfill provenance for existing tasks through a migration.
+- Validate assignee changes against current project collaborators.
+- Update task create, update, reorder, archive, unarchive, comment, and
+  attachment flows so provenance stays accurate.
+- Expose provenance and assignee metadata through task list/update API
+  responses.
+- Add assignee selection to task create/edit flows.
+- Render avatar-backed ownership UI on the main task surfaces:
+  - board card assignee display
+  - task detail assignee display
+  - task detail created-by / modified-by display
+- Update agent/OpenAPI documentation where task payloads change.
+- Add targeted regression coverage for the new task contracts and provenance
+  behavior.
+- Update tracking docs in the same task branch.
 
 ## Out Of Scope
-- User-uploaded avatar management or avatar file storage.
-- Rendering provider-supplied `user.image` through the shared avatar path.
-- Project-page collaborator presence rollout; that belongs to `TASK-119`.
-- Task-surface avatar rollout for:
-  - assignee
-  - created-by / modified-by
-  Those are expected follow-ons for `TASK-101`.
-- Notification, activity-feed, or presence semantics.
-- Reworking auth or social-account linking behavior.
-
-## Desired Follow-On Consumers
-These are not all part of `TASK-089`, but this task should make them easy:
-- After `TASK-089` + `TASK-101`, avatars should be usable in:
-  - assignee display
-  - created-by / modified-by metadata
-  - top-right account icon
-  - settings/account identity surfaces
-  - task comments
-  - project settings contributors
-- Later, `TASK-119` should reuse the same avatar foundation for:
-  - project-page collaborator presence and member rows
-
-## Design Constraints
-### 1. Determinism
-- A given user should receive the same generated avatar every time.
-- The seed should prefer a stable principal identifier and not rely only on
-  mutable presentation text.
-
-### 2. Fallback Quality
-- The generated fallback should feel intentional rather than like a generic
-  placeholder.
-- If initials are used, they should complement the visual treatment rather than
-  becoming the entire design.
-
-### 3. Reusability
-- The avatar primitive should support future compact and expanded contexts:
-  - menu trigger
-  - inline person metadata
-  - collaborator rows
-  - task provenance chips
-
-### 4. Safe Incremental Rollout
-- First ship the avatar baseline in account-owned surfaces that already exist.
-- Avoid coupling this task to collaboration-presence or task-provenance schema
-  changes.
-
-## Likely Implementation Touchpoints
-- `components/account-menu.tsx`
-- `components/top-right-controls.tsx`
-- `app/account/page.tsx`
-- `app/account/settings/**` if settings-shell identity chrome is updated
-- `components/kanban/task-detail-modal.tsx`
-- `components/project-dashboard/project-dashboard-owner-access-panel.tsx`
-- `lib/services/account-identity-service.ts`
-- `lib/services/account-profile-service.ts`
-- `lib/services/project-task-comment-service.ts`
-- `lib/services/project-collaboration-service.ts` if shared identity types are
-  expanded for future reuse
-- a new shared avatar helper under `lib/**`
-- a new shared avatar UI component under `components/**`
-- relevant `tests/**`
-
-## Expected Output
-- an active `tasks/current.md` brief for `TASK-089`
-- a reusable avatar component + deterministic generated-avatar helpers
-- persisted avatar seed + account-page regeneration flow
-- top-right account/menu avatar rendering
-- account/settings identity surfaces updated to use the generated avatar
-  baseline
-- task comments and project-settings contributor rows updated to use the shared
-  avatar baseline
-- aligned tests and documentation updates
-- a dedicated task branch and PR that follow the repository shipping workflow
+- User-uploaded avatars or alternative avatar rendering systems.
+- Project-page collaborator rollups; that remains later work (`TASK-119`).
+- Notification delivery, reminders, or ownership-based inbox features.
+- Complex assignee filtering/search UX on the board.
+- Historic provenance reconstruction beyond a sensible legacy backfill.
 
 ## Acceptance Criteria
-- Users render a deterministic generated avatar from a stable persisted seed.
-- Users can regenerate their avatar from the account page and immediately see
-  the updated result on account-owned surfaces.
-- The top-right signed-in account affordance uses the new avatar system.
-- Account/settings identity surfaces use the new avatar system.
-- Task comments use the new avatar system.
-- Project settings contributor rows use the new avatar system.
-- The avatar baseline is implemented in a reusable way that can support
-  `TASK-101` and `TASK-119` without redesigning the primitive.
+- New tasks persist creator and updater metadata automatically.
+- Tasks can store an optional assignee and reject non-collaborator assignees.
+- Task update flows keep updater metadata current.
+- Comment and attachment task activity updates the task attribution trail.
+- The kanban board can render assignee identity with the avatar baseline.
+- The task detail modal shows assignee, created-by, and modified-by metadata.
+- Task create/edit flows allow selecting or clearing an assignee.
+- Task API and agent docs stay aligned with the new payload shape.
 - Required tracking docs are updated consistently in the same PR.
 
 ## Definition Of Done
-1. `TASK-089` is the active task in `tasks/current.md`.
-2. The avatar baseline is implemented end to end across helpers and the first
-   account-owned UI surfaces.
-3. Validation is green for the relevant scope:
+1. `TASK-101` is the active brief in `tasks/current.md`.
+2. Schema, services, routes, and UI all support task assignee + provenance end
+   to end.
+3. Relevant validation is green:
    - `npm run lint`
    - `npm test`
    - `npm run test:coverage`
    - `npm run build`
-   - `npm run test:e2e` if the final UI changes materially affect an existing
-     covered authenticated flow and local prerequisites are available
+   - preview validation once the branch is published
 4. Tracking docs are updated consistently (`tasks/current.md`, `journal.md`,
-   `adr/decisions.md` if the final design introduces an architecture-level
-   identity-rendering decision).
-5. The task ships through a dedicated PR whose title includes `TASK-089`, with
-   Copilot's initial review state monitored and any valid feedback handled
-   before handoff.
+   and `adr/decisions.md` only if an architecture-level decision is introduced).
+5. The task ships through its own dedicated PR with the normal review and
+   preview workflow handled before handoff.
 
 ## Dependencies
-- `TASK-047`
-- `TASK-082`
+- `TASK-058`
+- `TASK-076`
+- `TASK-079`
+- `TASK-089`
 
 ## Evidence Plan
 - Repo source of truth:
   - `agent.md`
-  - `project.md`
-  - `README.md`
+  - `tasks/backlog.md`
   - `prisma/schema.prisma`
-  - `lib/services/social-auth-service.ts`
-  - `lib/services/account-identity-service.ts`
-  - `lib/services/account-profile-service.ts`
-  - `components/account-menu.tsx`
-  - `components/top-right-controls.tsx`
-  - `app/account/page.tsx`
+  - `lib/services/project-service.ts`
+  - `lib/services/project-task-service.ts`
+  - `lib/services/project-task-comment-service.ts`
+  - `lib/services/project-attachment-service.ts`
+  - `app/api/projects/[projectId]/tasks/**`
+  - `app/projects/[projectId]/kanban-board-section.tsx`
+  - `components/kanban-board.tsx`
+  - `components/kanban/task-detail-modal.tsx`
+  - `components/create-task-dialog.tsx`
 - Validation source of truth:
-  - local lint/unit/coverage/build runs
-  - PR checks: `check-name`, `Quality Core`, `E2E Smoke`, and
-    `Container Image`
+  - local lint/unit/build runs
+  - PR review comments and CI checks
+  - preview deployment verification
 
 ## Outcome Target
-- NexusDash gains a consistent visual identity baseline for every user, even
-  without uploaded photos.
-- The resulting avatar system should make `TASK-101` and `TASK-119` additive
-  consumer rollouts rather than forcing a second identity-UI rewrite.
+- NexusDash gains explicit task ownership and provenance instead of relying on
+  chat context or naming conventions.
+- The avatar baseline from `TASK-089` becomes visible where ownership actually
+  matters: assignee, creator, and last modifier.
 
 ---
 

--- a/tests/api/agent-project-routes.test.ts
+++ b/tests/api/agent-project-routes.test.ts
@@ -52,6 +52,23 @@ vi.mock("@/lib/services/context-card-service", () => ({
   createContextCardForProject: contextCardServiceMock.createContextCardForProject,
 }));
 
+vi.mock("@/lib/services/project-attachment-service", () => ({
+  mapTaskAttachmentResponse: vi.fn((projectId: string, taskId: string, attachment: Record<string, unknown>) => ({
+    ...attachment,
+    downloadUrl:
+      attachment.kind === "file"
+        ? `/api/projects/${projectId}/tasks/${taskId}/attachments/${attachment.id}/download`
+        : null,
+  })),
+  mapContextAttachmentResponse: vi.fn((projectId: string, cardId: string, attachment: Record<string, unknown>) => ({
+    ...attachment,
+    downloadUrl:
+      attachment.kind === "file"
+        ? `/api/projects/${projectId}/context-cards/${cardId}/attachments/${attachment.id}/download`
+        : null,
+  })),
+}));
+
 import { GET as getProject } from "@/app/api/projects/[projectId]/route";
 import { GET as getTasks } from "@/app/api/projects/[projectId]/tasks/route";
 import { GET as getContextCards } from "@/app/api/projects/[projectId]/context-cards/route";
@@ -176,6 +193,30 @@ describe("agent project routes", () => {
         labelsJson: '["docs"]',
         createdAt: "2026-04-03T09:00:00.000Z",
         updatedAt: "2026-04-03T10:00:00.000Z",
+        createdByUser: {
+          id: "user-1",
+          name: "Alice Example",
+          email: "alice@example.com",
+          username: "alice",
+          usernameDiscriminator: "1234",
+          avatarSeed: null,
+        },
+        updatedByUser: {
+          id: "user-2",
+          name: null,
+          email: "bob@example.com",
+          username: "bob",
+          usernameDiscriminator: "4321",
+          avatarSeed: "seed-bob",
+        },
+        assigneeUser: {
+          id: "user-3",
+          name: "Casey Example",
+          email: "casey@example.com",
+          username: null,
+          usernameDiscriminator: null,
+          avatarSeed: null,
+        },
         attachments: [
           {
             id: "att-1",
@@ -215,6 +256,24 @@ describe("agent project routes", () => {
           labelsJson: '["docs"]',
           createdAt: "2026-04-03T09:00:00.000Z",
           updatedAt: "2026-04-03T10:00:00.000Z",
+          createdBy: {
+            id: "user-1",
+            displayName: "alice",
+            usernameTag: "alice#1234",
+            avatarSeed: "user-1",
+          },
+          updatedBy: {
+            id: "user-2",
+            displayName: "bob",
+            usernameTag: "bob#4321",
+            avatarSeed: "seed-bob",
+          },
+          assignee: {
+            id: "user-3",
+            displayName: "Casey Example",
+            usernameTag: null,
+            avatarSeed: "user-3",
+          },
           attachments: [
             {
               id: "att-1",

--- a/tests/api/task-comments.route.test.ts
+++ b/tests/api/task-comments.route.test.ts
@@ -70,6 +70,7 @@ describe("task comments route", () => {
           email: "alice@example.com",
           username: "alice",
           usernameDiscriminator: "1234",
+          avatarSeed: null,
         },
       },
       {
@@ -82,6 +83,7 @@ describe("task comments route", () => {
           email: "bob@example.com",
           username: null,
           usernameDiscriminator: null,
+          avatarSeed: "seed-222",
         },
       },
     ]);
@@ -102,6 +104,7 @@ describe("task comments route", () => {
             id: "user-1",
             displayName: "alice",
             usernameTag: "alice#1234",
+            avatarSeed: "user-1",
           },
         },
         {
@@ -112,6 +115,7 @@ describe("task comments route", () => {
             id: "user-2",
             displayName: "bob",
             usernameTag: null,
+            avatarSeed: "seed-222",
           },
         },
       ],
@@ -132,6 +136,7 @@ describe("task comments route", () => {
             email: true,
             username: true,
             usernameDiscriminator: true,
+            avatarSeed: true,
           },
         },
       },
@@ -187,6 +192,7 @@ describe("task comments route", () => {
         email: "reviewer@example.com",
         username: "reviewer",
         usernameDiscriminator: "0007",
+        avatarSeed: null,
       },
     });
 
@@ -211,6 +217,7 @@ describe("task comments route", () => {
           id: "test-user",
           displayName: "reviewer",
           usernameTag: "reviewer#0007",
+          avatarSeed: "test-user",
         },
       },
     });
@@ -231,6 +238,7 @@ describe("task comments route", () => {
             email: true,
             username: true,
             usernameDiscriminator: true,
+            avatarSeed: true,
           },
         },
       },

--- a/tests/api/task-comments.route.test.ts
+++ b/tests/api/task-comments.route.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const prismaMock = vi.hoisted(() => ({
+  $transaction: vi.fn(),
   project: {
     findFirst: vi.fn(),
   },
   task: {
     findUnique: vi.fn(),
+    update: vi.fn(),
   },
   taskComment: {
     findMany: vi.fn(),
@@ -39,6 +41,7 @@ async function readJson(response: Response): Promise<Record<string, unknown>> {
 describe("task comments route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    prismaMock.$transaction.mockImplementation(async (callback) => callback(prismaMock));
     apiGuardMock.requireApiPrincipal.mockResolvedValue({
       ok: true,
       principal: {
@@ -241,6 +244,15 @@ describe("task comments route", () => {
             avatarSeed: true,
           },
         },
+      },
+    });
+    expect(prismaMock.task.update).toHaveBeenCalledWith({
+      where: { id: "task-1" },
+      data: {
+        updatedByUserId: "test-user",
+      },
+      select: {
+        id: true,
       },
     });
   });

--- a/tests/api/task-create.route.test.ts
+++ b/tests/api/task-create.route.test.ts
@@ -18,6 +18,24 @@ vi.mock("@/lib/services/project-task-service", () => ({
   createTaskForProject: projectTaskServiceMock.createTaskForProject,
 }));
 
+vi.mock("@/lib/services/project-attachment-service", () => ({
+  mapTaskAttachmentResponse: vi.fn((projectId: string, taskId: string, attachment: Record<string, unknown>) => ({
+    ...attachment,
+    downloadUrl:
+      attachment.kind === "file"
+        ? `/api/projects/${projectId}/tasks/${taskId}/attachments/${attachment.id}/download`
+        : null,
+  })),
+}));
+
+vi.mock("@/lib/services/project-service", () => ({
+  listProjectKanbanTasks: vi.fn(),
+}));
+
+vi.mock("@/lib/services/project-access-service", () => ({
+  requireAgentProjectScopes: vi.fn(() => ({ ok: true })),
+}));
+
 import { POST } from "@/app/api/projects/[projectId]/tasks/route";
 
 async function readJson(response: Response): Promise<Record<string, unknown>> {
@@ -65,6 +83,7 @@ describe("POST /api/projects/:projectId/tasks", () => {
     formData.set("title", "  New Task  ");
     formData.set("description", "  Description  ");
     formData.set("deadlineDate", "2026-04-24");
+    formData.set("assigneeUserId", "user-2");
     formData.set("labels", '["backend"]');
     formData.set("relatedTaskIds", '["task-a","task-b"]');
     formData.set(
@@ -94,6 +113,7 @@ describe("POST /api/projects/:projectId/tasks", () => {
     expect(call.title).toBe("New Task");
     expect(call.description).toBe("Description");
     expect(call.deadlineDate).toBe("2026-04-24");
+    expect(call.assigneeUserId).toBe("user-2");
     expect(call.labelsJsonRaw).toBe('["backend"]');
     expect(call.relatedTaskIdsJsonRaw).toBe('["task-a","task-b"]');
     expect(call.attachmentLinksJsonRaw).toBe(
@@ -119,6 +139,7 @@ describe("POST /api/projects/:projectId/tasks", () => {
         title: "  Draft API smoke test  ",
         description: "  <p>Validate the agent route.</p>  ",
         deadlineDate: "2026-04-25",
+        assigneeUserId: "user-2",
         labels: ["agent", "qa"],
         relatedTaskIds: ["task-a"],
         attachmentLinks: [{ name: "Spec", url: "https://example.com/spec" }],
@@ -137,6 +158,7 @@ describe("POST /api/projects/:projectId/tasks", () => {
       title: "Draft API smoke test",
       description: "<p>Validate the agent route.</p>",
       deadlineDate: "2026-04-25",
+      assigneeUserId: "user-2",
       labelsJsonRaw: '["agent","qa"]',
       relatedTaskIdsJsonRaw: '["task-a"]',
       attachmentLinksJsonRaw:
@@ -165,6 +187,29 @@ describe("POST /api/projects/:projectId/tasks", () => {
     expect(response.status).toBe(400);
     await expect(readJson(response)).resolves.toEqual({
       error: "deadline-invalid",
+    });
+    expect(projectTaskServiceMock.createTaskForProject).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 when json assigneeUserId is not a string", async () => {
+    const request = new Request("http://localhost/api/projects/p1/tasks", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        title: "Draft API smoke test",
+        assigneeUserId: 123,
+      }),
+    });
+
+    const response = await POST(request as never, {
+      params: { projectId: "p1" },
+    });
+
+    expect(response.status).toBe(400);
+    await expect(readJson(response)).resolves.toEqual({
+      error: "assignee-invalid",
     });
     expect(projectTaskServiceMock.createTaskForProject).not.toHaveBeenCalled();
   });

--- a/tests/api/task-update.route.test.ts
+++ b/tests/api/task-update.route.test.ts
@@ -139,6 +139,7 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       status: "Blocked",
       position: 0,
       archivedAt: null,
+      assigneeUserId: "user-2",
       outgoingRelations: [],
       incomingRelations: [],
     });
@@ -156,6 +157,32 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       status: "Blocked",
       position: 0,
       archivedAt: null,
+      createdAt: new Date("2026-04-20T08:00:00.000Z"),
+      updatedAt: new Date("2026-04-21T09:00:00.000Z"),
+      createdByUser: {
+        id: "user-1",
+        name: "Alice Example",
+        email: "alice@example.com",
+        username: "alice",
+        usernameDiscriminator: "1234",
+        avatarSeed: null,
+      },
+      updatedByUser: {
+        id: "test-user",
+        name: "Reviewer",
+        email: "reviewer@example.com",
+        username: "reviewer",
+        usernameDiscriminator: "0007",
+        avatarSeed: "seed-reviewer",
+      },
+      assigneeUser: {
+        id: "user-2",
+        name: "Bob Example",
+        email: "bob@example.com",
+        username: null,
+        usernameDiscriminator: null,
+        avatarSeed: null,
+      },
       outgoingRelations: [
         {
           rightTask: {
@@ -201,6 +228,26 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
         status: "Blocked",
         position: 0,
         archivedAt: null,
+        assignee: {
+          id: "user-2",
+          displayName: "Bob Example",
+          usernameTag: null,
+          avatarSeed: "user-2",
+        },
+        createdBy: {
+          id: "user-1",
+          displayName: "alice",
+          usernameTag: "alice#1234",
+          avatarSeed: "user-1",
+        },
+        updatedBy: {
+          id: "test-user",
+          displayName: "reviewer",
+          usernameTag: "reviewer#0007",
+          avatarSeed: "seed-reviewer",
+        },
+        createdAt: "2026-04-20T08:00:00.000Z",
+        updatedAt: "2026-04-21T09:00:00.000Z",
         relatedTasks: [
           {
             id: "t2",
@@ -222,6 +269,7 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       labelsJson: JSON.stringify(["Critical", "backend"]),
       description: "<p>Hello</p>",
       deadlineAt: new Date("2026-04-24T00:00:00.000Z"),
+      updatedByUserId: "test-user",
     });
 
     expect(prismaMock.taskBlockedFollowUp.create).toHaveBeenCalledTimes(1);
@@ -256,6 +304,7 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       status: "In Progress",
       position: 2,
       archivedAt: null,
+      assigneeUserId: null,
       outgoingRelations: [],
       incomingRelations: [],
     });
@@ -273,6 +322,25 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       status: "In Progress",
       position: 2,
       archivedAt: null,
+      createdAt: new Date("2026-04-18T08:00:00.000Z"),
+      updatedAt: new Date("2026-04-18T09:00:00.000Z"),
+      createdByUser: {
+        id: "user-1",
+        name: "Alice Example",
+        email: "alice@example.com",
+        username: "alice",
+        usernameDiscriminator: "1234",
+        avatarSeed: null,
+      },
+      updatedByUser: {
+        id: "test-user",
+        name: "Reviewer",
+        email: "reviewer@example.com",
+        username: "reviewer",
+        usernameDiscriminator: "0007",
+        avatarSeed: null,
+      },
+      assigneeUser: null,
       outgoingRelations: [],
       incomingRelations: [],
       blockedFollowUps: [],
@@ -303,6 +371,7 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       status: "In Progress",
       position: 2,
       archivedAt: null,
+      assigneeUserId: null,
       outgoingRelations: [
         {
           rightTaskId: "archived-task",
@@ -339,6 +408,7 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       status: "In Progress",
       position: 2,
       archivedAt: null,
+      assigneeUserId: null,
       outgoingRelations: [
         {
           rightTaskId: "archived-task",
@@ -361,6 +431,25 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       status: "In Progress",
       position: 2,
       archivedAt: null,
+      createdAt: new Date("2026-04-10T08:00:00.000Z"),
+      updatedAt: new Date("2026-04-18T09:00:00.000Z"),
+      createdByUser: {
+        id: "user-1",
+        name: "Alice Example",
+        email: "alice@example.com",
+        username: "alice",
+        usernameDiscriminator: "1234",
+        avatarSeed: null,
+      },
+      updatedByUser: {
+        id: "test-user",
+        name: "Reviewer",
+        email: "reviewer@example.com",
+        username: "reviewer",
+        usernameDiscriminator: "0007",
+        avatarSeed: null,
+      },
+      assigneeUser: null,
       outgoingRelations: [
         {
           rightTask: {
@@ -402,6 +491,21 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
         status: "In Progress",
         position: 2,
         archivedAt: null,
+        assignee: null,
+        createdBy: {
+          id: "user-1",
+          displayName: "alice",
+          usernameTag: "alice#1234",
+          avatarSeed: "user-1",
+        },
+        updatedBy: {
+          id: "test-user",
+          displayName: "reviewer",
+          usernameTag: "reviewer#0007",
+          avatarSeed: "test-user",
+        },
+        createdAt: "2026-04-10T08:00:00.000Z",
+        updatedAt: "2026-04-18T09:00:00.000Z",
         relatedTasks: [
           {
             id: "archived-task",
@@ -574,6 +678,7 @@ describe("POST /api/projects/:projectId/tasks/:taskId/archive", () => {
       where: { id: "t1" },
       data: {
         archivedAt: expect.any(Date),
+        updatedByUserId: "test-user",
       },
       select: {
         archivedAt: true,
@@ -665,6 +770,7 @@ describe("DELETE /api/projects/:projectId/tasks/:taskId/archive", () => {
       where: { id: "t1" },
       data: {
         archivedAt: null,
+        updatedByUserId: "test-user",
       },
       select: {
         id: true,

--- a/tests/api/tasks-reorder.route.test.ts
+++ b/tests/api/tasks-reorder.route.test.ts
@@ -162,6 +162,7 @@ describe("POST /api/projects/:projectId/tasks/reorder", () => {
     expect(firstUpdate.data.status).toBe("Done");
     expect(firstUpdate.data.position).toBe(0);
     expect(firstUpdate.data.archivedAt).toBeNull();
+    expect(firstUpdate.data.updatedByUserId).toBe("test-user");
     expect(firstUpdate.data.completedAt).toBeInstanceOf(Date);
 
     const secondUpdate = prismaMock.task.update.mock.calls[1][0];
@@ -169,6 +170,7 @@ describe("POST /api/projects/:projectId/tasks/reorder", () => {
     expect(secondUpdate.data.status).toBe("Done");
     expect(secondUpdate.data.position).toBe(1);
     expect(secondUpdate.data.archivedAt).toBeNull();
+    expect(secondUpdate.data.updatedByUserId).toBe("test-user");
     expect(secondUpdate.data.completedAt).toBe(existingDoneDate);
   });
 

--- a/tests/app/account-actions.test.ts
+++ b/tests/app/account-actions.test.ts
@@ -5,6 +5,7 @@ const authGuardMock = vi.hoisted(() => ({
 }));
 
 const accountProfileServiceMock = vi.hoisted(() => ({
+  regenerateAccountAvatar: vi.fn(),
   updateAccountEmail: vi.fn(),
   updateAccountPassword: vi.fn(),
   updateAccountUsername: vi.fn(),
@@ -55,6 +56,7 @@ vi.mock("@/lib/observability/logger", () => ({
 }));
 
 vi.mock("@/lib/services/account-profile-service", () => ({
+  regenerateAccountAvatar: accountProfileServiceMock.regenerateAccountAvatar,
   updateAccountEmail: accountProfileServiceMock.updateAccountEmail,
   updateAccountPassword: accountProfileServiceMock.updateAccountPassword,
   updateAccountUsername: accountProfileServiceMock.updateAccountUsername,
@@ -76,6 +78,7 @@ vi.mock("@/lib/services/session-service", () => ({
 import {
   acceptProjectInvitationAction,
   declineProjectInvitationAction,
+  regenerateAccountAvatarAction,
   updateAccountEmailAction,
 } from "@/app/account/actions";
 
@@ -83,6 +86,13 @@ describe("account actions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     authGuardMock.requireVerifiedSessionUserIdFromServer.mockResolvedValue("user-1");
+    accountProfileServiceMock.regenerateAccountAvatar.mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: {
+        avatarSeed: "seed-123",
+      },
+    });
     accountProfileServiceMock.updateAccountEmail.mockResolvedValue({
       ok: true,
       status: 200,
@@ -127,6 +137,19 @@ describe("account actions", () => {
       "NEXT_REDIRECT:/account?error=invalid-email"
     );
     expect(emailVerificationServiceMock.issueEmailVerificationForUser).not.toHaveBeenCalled();
+  });
+
+  test("regenerates avatar and redirects with success status", async () => {
+    await expect(regenerateAccountAvatarAction()).rejects.toThrow(
+      "NEXT_REDIRECT:/account?status=avatar-regenerated"
+    );
+
+    expect(accountProfileServiceMock.regenerateAccountAvatar).toHaveBeenCalledWith({
+      actorUserId: "user-1",
+    });
+    expect(revalidatePathMock).toHaveBeenCalledWith("/account");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/account/settings");
+    expect(revalidatePathMock).toHaveBeenCalledWith("/projects");
   });
 
   test("redirects to verify-email with sent status when email changes successfully", async () => {

--- a/tests/app/agent-onboarding-pages.test.ts
+++ b/tests/app/agent-onboarding-pages.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 const headersMock = vi.hoisted(() => vi.fn());
 const requireSessionUserIdFromServerMock = vi.hoisted(() => vi.fn());
 const resolveRequestOriginFromHeadersMock = vi.hoisted(() => vi.fn());
+const getAccountIdentitySummaryMock = vi.hoisted(() => vi.fn());
 
 vi.mock("next/headers", () => ({
   headers: headersMock,
@@ -18,6 +19,10 @@ vi.mock("@/lib/http/request-origin", () => ({
   resolveRequestOriginFromHeaders: resolveRequestOriginFromHeadersMock,
 }));
 
+vi.mock("@/lib/services/account-identity-service", () => ({
+  getAccountIdentitySummary: getAccountIdentitySummaryMock,
+}));
+
 import AccountDeveloperSettingsPage from "@/app/account/settings/developers/page";
 import AgentApiDocsPage from "@/app/docs/agent/v1/page";
 
@@ -28,6 +33,13 @@ describe("agent onboarding pages", () => {
     vi.clearAllMocks();
     headersMock.mockReturnValue(new Headers());
     requireSessionUserIdFromServerMock.mockResolvedValue("user-1");
+    getAccountIdentitySummaryMock.mockResolvedValue({
+      displayName: "test.user",
+      username: "test.user",
+      usernameDiscriminator: "1234",
+      usernameTag: "test.user#1234",
+      avatarSeed: "seed-123",
+    });
   });
 
   test("renders hosted docs with concrete SSR URLs", async () => {

--- a/tests/components/account-menu.test.ts
+++ b/tests/components/account-menu.test.ts
@@ -43,6 +43,7 @@ describe("account-menu", () => {
     expect(result).toContain("aria-label=\"Account menu\"");
     expect(result).toContain("aria-expanded=\"false\"");
     expect(result).toContain("data:image/svg+xml");
+    expect(result).toContain("alt=\"\"");
   });
 
   test("renders invitation indicator when pending invitations exist", () => {

--- a/tests/components/account-menu.test.ts
+++ b/tests/components/account-menu.test.ts
@@ -21,6 +21,7 @@ describe("account-menu", () => {
         isAuthenticated: false,
         displayName: null,
         usernameTag: null,
+        avatarSeed: null,
         pendingInvitationCount: 0,
       })
     );
@@ -34,12 +35,14 @@ describe("account-menu", () => {
         isAuthenticated: true,
         displayName: "test.user",
         usernameTag: "test.user#1234",
+        avatarSeed: "seed-123",
         pendingInvitationCount: 0,
       })
     );
 
     expect(result).toContain("aria-label=\"Account menu\"");
     expect(result).toContain("aria-expanded=\"false\"");
+    expect(result).toContain("data:image/svg+xml");
   });
 
   test("renders invitation indicator when pending invitations exist", () => {
@@ -48,6 +51,7 @@ describe("account-menu", () => {
         isAuthenticated: true,
         displayName: "test.user",
         usernameTag: "test.user#1234",
+        avatarSeed: "seed-123",
         pendingInvitationCount: 3,
       })
     );

--- a/tests/components/project-dashboard-owner-access-panel.test.tsx
+++ b/tests/components/project-dashboard-owner-access-panel.test.tsx
@@ -21,6 +21,7 @@ describe("project-dashboard-owner-access-panel", () => {
               displayName: "dorianagaesse#3762",
               usernameTag: "dorianagaesse#3762",
               email: "dorian@example.com",
+              avatarSeed: "seed-owner",
               role: "owner",
               joinedAt: "2026-03-25T10:00:00.000Z",
               isOwner: true,
@@ -40,6 +41,7 @@ describe("project-dashboard-owner-access-panel", () => {
     expect(result.match(/dorianagaesse#3762/g)?.length).toBe(1);
     expect(result).not.toContain("Project owner");
     expect(result).toContain("Only you are on this project right now.");
+    expect(result).toContain("data:image/svg+xml");
   });
 
   test("renders the inline copy control for pending email invitations", () => {

--- a/tests/lib/account-identity-service.test.ts
+++ b/tests/lib/account-identity-service.test.ts
@@ -33,10 +33,12 @@ describe("account-identity-service", () => {
 
   test("returns username tag when username identity is present", async () => {
     prismaMock.user.findUnique.mockResolvedValueOnce({
+      id: "user-1",
       name: "Test User",
       email: "user@example.com",
       username: "test.user",
       usernameDiscriminator: "1234",
+      avatarSeed: "seed-123",
     });
 
     const result = await getAccountIdentitySummary("user-1");
@@ -46,15 +48,18 @@ describe("account-identity-service", () => {
       username: "test.user",
       usernameDiscriminator: "1234",
       usernameTag: "test.user#1234",
+      avatarSeed: "seed-123",
     });
   });
 
   test("hides invalid legacy discriminator from account identity summary", async () => {
     prismaMock.user.findUnique.mockResolvedValueOnce({
+      id: "user-1",
       name: "Test User",
       email: "user@example.com",
       username: "test.user",
       usernameDiscriminator: "ab12cd",
+      avatarSeed: null,
     });
 
     const result = await getAccountIdentitySummary("user-1");
@@ -64,15 +69,18 @@ describe("account-identity-service", () => {
       username: "test.user",
       usernameDiscriminator: null,
       usernameTag: null,
+      avatarSeed: "user-1",
     });
   });
 
   test("falls back to name/email when username identity is not present", async () => {
     prismaMock.user.findUnique.mockResolvedValueOnce({
+      id: "user-1",
       name: null,
       email: "user@example.com",
       username: null,
       usernameDiscriminator: null,
+      avatarSeed: null,
     });
 
     const result = await getAccountIdentitySummary("user-1");
@@ -82,15 +90,18 @@ describe("account-identity-service", () => {
       username: null,
       usernameDiscriminator: null,
       usernameTag: null,
+      avatarSeed: "user-1",
     });
   });
 
   test("falls back to Account when email has no local-part separator", async () => {
     prismaMock.user.findUnique.mockResolvedValueOnce({
+      id: "user-1",
       name: null,
       email: "invalid-email-format",
       username: null,
       usernameDiscriminator: null,
+      avatarSeed: null,
     });
 
     const result = await getAccountIdentitySummary("user-1");
@@ -100,6 +111,7 @@ describe("account-identity-service", () => {
       username: null,
       usernameDiscriminator: null,
       usernameTag: null,
+      avatarSeed: "user-1",
     });
   });
 });

--- a/tests/lib/account-profile-service.test.ts
+++ b/tests/lib/account-profile-service.test.ts
@@ -16,6 +16,10 @@ const sessionServiceMock = vi.hoisted(() => ({
   deleteAllOtherSessionsForUser: vi.fn(),
 }));
 
+const avatarMock = vi.hoisted(() => ({
+  generateAvatarSeed: vi.fn(),
+}));
+
 const cryptoMock = vi.hoisted(() => ({
   randomInt: vi.fn(),
 }));
@@ -37,8 +41,17 @@ vi.mock("@/lib/services/session-service", () => ({
   deleteAllOtherSessionsForUser: sessionServiceMock.deleteAllOtherSessionsForUser,
 }));
 
+vi.mock("@/lib/avatar", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/avatar")>("@/lib/avatar");
+  return {
+    ...actual,
+    generateAvatarSeed: avatarMock.generateAvatarSeed,
+  };
+});
+
 import {
   getAccountProfile,
+  regenerateAccountAvatar,
   updateAccountEmail,
   updateAccountPassword,
   updateAccountUsername,
@@ -48,6 +61,7 @@ describe("account-profile-service", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     cryptoMock.randomInt.mockReturnValue(1);
+    avatarMock.generateAvatarSeed.mockReturnValue("seed-generated");
   });
 
   test("returns unauthorized profile result for missing actor", async () => {
@@ -63,10 +77,12 @@ describe("account-profile-service", () => {
 
   test("returns profile summary for authenticated user", async () => {
     prismaMock.user.findUnique.mockResolvedValueOnce({
+      id: "user-1",
       email: "user@example.com",
       emailVerified: new Date("2026-02-27T00:00:00.000Z"),
       username: "test.user",
       usernameDiscriminator: "1234",
+      avatarSeed: "seed-123",
     });
 
     const result = await getAccountProfile("user-1");
@@ -80,16 +96,19 @@ describe("account-profile-service", () => {
         username: "test.user",
         usernameDiscriminator: "1234",
         usernameTag: "test.user#1234",
+        avatarSeed: "seed-123",
       },
     });
   });
 
   test("sanitizes legacy non-numeric discriminator in profile summary", async () => {
     prismaMock.user.findUnique.mockResolvedValueOnce({
+      id: "user-1",
       email: "user@example.com",
       emailVerified: new Date("2026-02-27T00:00:00.000Z"),
       username: "test.user",
       usernameDiscriminator: "abc123",
+      avatarSeed: null,
     });
 
     const result = await getAccountProfile("user-1");
@@ -103,16 +122,19 @@ describe("account-profile-service", () => {
         username: "test.user",
         usernameDiscriminator: null,
         usernameTag: null,
+        avatarSeed: "user-1",
       },
     });
   });
 
   test("returns profile with nullable identity fields for legacy users", async () => {
     prismaMock.user.findUnique.mockResolvedValueOnce({
+      id: "user-1",
       email: "legacy@example.com",
       emailVerified: null,
       username: null,
       usernameDiscriminator: null,
+      avatarSeed: null,
     });
 
     const result = await getAccountProfile("user-1");
@@ -126,6 +148,34 @@ describe("account-profile-service", () => {
         username: "",
         usernameDiscriminator: null,
         usernameTag: null,
+        avatarSeed: "user-1",
+      },
+    });
+  });
+
+  test("regenerates avatar seed for authenticated user", async () => {
+    prismaMock.user.update.mockResolvedValueOnce({
+      avatarSeed: "seed-generated",
+    });
+
+    const result = await regenerateAccountAvatar({
+      actorUserId: "user-1",
+    });
+
+    expect(prismaMock.user.update).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      data: {
+        avatarSeed: "seed-generated",
+      },
+      select: {
+        avatarSeed: true,
+      },
+    });
+    expect(result).toEqual({
+      ok: true,
+      status: 200,
+      data: {
+        avatarSeed: "seed-generated",
       },
     });
   });

--- a/tests/lib/avatar.test.ts
+++ b/tests/lib/avatar.test.ts
@@ -31,6 +31,15 @@ describe("avatar helpers", () => {
     expect(svg).not.toContain("seed-123");
   });
 
+  test("always includes the center pixel block in the generated pattern", () => {
+    const encodedUri = buildGeneratedAvatarDataUri("seed-123");
+    const svg = decodeURIComponent(
+      encodedUri.replace("data:image/svg+xml;charset=UTF-8,", "")
+    );
+
+    expect(svg).toContain('<rect x="27" y="27" width="10" height="10"');
+  });
+
   test("resolves avatar seed from stored seed or stable fallback key", () => {
     expect(resolveAvatarSeed(" custom-seed ", "user-1")).toBe("custom-seed");
     expect(resolveAvatarSeed(null, "user-1")).toBe("user-1");

--- a/tests/lib/avatar.test.ts
+++ b/tests/lib/avatar.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  buildGeneratedAvatarDataUri,
+  resolveAvatarSeed,
+} from "@/lib/avatar";
+
+describe("avatar helpers", () => {
+  test("builds deterministic avatar data URIs from the same seed", () => {
+    const first = buildGeneratedAvatarDataUri("seed-123");
+    const second = buildGeneratedAvatarDataUri("seed-123");
+
+    expect(first).toBe(second);
+    expect(first).toContain("data:image/svg+xml");
+  });
+
+  test("builds different avatar data URIs for different seeds", () => {
+    const first = buildGeneratedAvatarDataUri("seed-123");
+    const second = buildGeneratedAvatarDataUri("seed-456");
+
+    expect(first).not.toBe(second);
+  });
+
+  test("resolves avatar seed from stored seed or stable fallback key", () => {
+    expect(resolveAvatarSeed(" custom-seed ", "user-1")).toBe("custom-seed");
+    expect(resolveAvatarSeed(null, "user-1")).toBe("user-1");
+  });
+});

--- a/tests/lib/avatar.test.ts
+++ b/tests/lib/avatar.test.ts
@@ -21,6 +21,16 @@ describe("avatar helpers", () => {
     expect(first).not.toBe(second);
   });
 
+  test("does not embed the raw seed in the generated svg metadata", () => {
+    const encodedUri = buildGeneratedAvatarDataUri("seed-123");
+    const svg = decodeURIComponent(
+      encodedUri.replace("data:image/svg+xml;charset=UTF-8,", "")
+    );
+
+    expect(svg).toContain("Generated avatar");
+    expect(svg).not.toContain("seed-123");
+  });
+
   test("resolves avatar seed from stored seed or stable fallback key", () => {
     expect(resolveAvatarSeed(" custom-seed ", "user-1")).toBe("custom-seed");
     expect(resolveAvatarSeed(null, "user-1")).toBe("user-1");

--- a/tests/lib/project-attachment-service.test.ts
+++ b/tests/lib/project-attachment-service.test.ts
@@ -4,11 +4,13 @@ import { RESOURCE_TYPE_CONTEXT_CARD } from "@/lib/resource-type";
 import { AttachmentStorageUnavailableError } from "@/lib/storage/errors";
 
 const prismaMock = vi.hoisted(() => ({
+  $transaction: vi.fn(),
   project: {
     findFirst: vi.fn(),
   },
   task: {
     findUnique: vi.fn(),
+    update: vi.fn(),
   },
   resource: {
     findUnique: vi.fn(),
@@ -67,6 +69,7 @@ describe("project-attachment-service", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    prismaMock.$transaction.mockImplementation(async (callback) => callback(prismaMock));
     prismaMock.project.findFirst.mockResolvedValue({ ownerId: actorUserId, memberships: [] });
   });
 
@@ -256,6 +259,10 @@ describe("project-attachment-service", () => {
       mimeType: "application/pdf",
       sizeBytes: 2048,
     });
+    prismaMock.task.update.mockResolvedValueOnce({
+      id: "task-1",
+    });
+    attachmentStorageMock.deleteAttachmentFile.mockResolvedValue(undefined);
 
     const result = await finalizeTaskAttachmentDirectUpload({
       actorUserId,
@@ -281,6 +288,11 @@ describe("project-attachment-service", () => {
       },
     });
     expect(prismaMock.taskAttachment.create).toHaveBeenCalledTimes(1);
+    expect(prismaMock.task.update).toHaveBeenCalledWith({
+      where: { id: "task-1" },
+      data: { updatedByUserId: actorUserId },
+      select: { id: true },
+    });
     expect(attachmentStorageMock.deleteAttachmentFile).not.toHaveBeenCalled();
   });
 

--- a/tests/lib/project-service.test.ts
+++ b/tests/lib/project-service.test.ts
@@ -41,6 +41,7 @@ import {
   createProject,
   getProjectDashboardById,
   getProjectSummaryById,
+  listProjectCollaborators,
   listProjectsWithCounts,
   listProjectContextResources,
   listProjectKanbanTasks,
@@ -280,6 +281,129 @@ describe("project-service", () => {
                 title: true,
                 status: true,
                 archivedAt: true,
+              },
+            },
+          },
+        },
+        createdByUser: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            username: true,
+            usernameDiscriminator: true,
+            avatarSeed: true,
+          },
+        },
+        updatedByUser: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            username: true,
+            usernameDiscriminator: true,
+            avatarSeed: true,
+          },
+        },
+        assigneeUser: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            username: true,
+            usernameDiscriminator: true,
+            avatarSeed: true,
+          },
+        },
+      },
+    });
+  });
+
+  test("lists project collaborators with owner included once", async () => {
+    prismaMock.project.findFirst.mockResolvedValueOnce({
+      owner: {
+        id: "user-1",
+        name: "Owner",
+        email: "owner@example.com",
+        username: "owner",
+        usernameDiscriminator: "1111",
+        avatarSeed: null,
+      },
+      memberships: [
+        {
+          role: "owner",
+          user: {
+            id: "user-1",
+            name: "Owner Duplicate",
+            email: "owner@example.com",
+            username: "owner",
+            usernameDiscriminator: "1111",
+            avatarSeed: null,
+          },
+        },
+        {
+          role: "editor",
+          user: {
+            id: "user-2",
+            name: "Editor",
+            email: "editor@example.com",
+            username: null,
+            usernameDiscriminator: null,
+            avatarSeed: "seed-editor",
+          },
+        },
+      ],
+    });
+
+    const result = await listProjectCollaborators("project-1", actorUserId);
+
+    expect(result).toEqual([
+      {
+        id: "user-1",
+        displayName: "owner",
+        usernameTag: "owner#1111",
+        avatarSeed: "user-1",
+        projectRole: "owner",
+      },
+      {
+        id: "user-2",
+        displayName: "Editor",
+        usernameTag: null,
+        avatarSeed: "seed-editor",
+        projectRole: "editor",
+      },
+    ]);
+    expect(prismaMock.project.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: "project-1",
+        OR: [
+          { ownerId: actorUserId },
+          { memberships: { some: { userId: actorUserId } } },
+        ],
+      },
+      select: {
+        owner: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            username: true,
+            usernameDiscriminator: true,
+            avatarSeed: true,
+          },
+        },
+        memberships: {
+          orderBy: [{ createdAt: "asc" }],
+          select: {
+            role: true,
+            user: {
+              select: {
+                id: true,
+                name: true,
+                email: true,
+                username: true,
+                usernameDiscriminator: true,
+                avatarSeed: true,
               },
             },
           },


### PR DESCRIPTION
## Summary
- add a reusable generated avatar primitive based on a persisted `avatarSeed`
- add account-side avatar regeneration and wire the generated avatar through the top-right account menu plus account/settings identity surfaces
- update tests and task/journal tracking docs for the shipped TASK-089 scope

## Why
TASK-089 establishes the avatar foundation needed before broader avatar rollout on task and collaboration surfaces. This implementation keeps the first milestone intentionally narrow and ships a deterministic generated avatar that users can regenerate themselves from the account page.

## User Impact
- signed-in users now see a generated avatar in the account menu and account/settings surfaces
- avatars remain stable across sessions/devices until regenerated
- users can regenerate their avatar from `/account`

## Validation
- `npm run lint`
- `npx -y -p node@20.19.0 node .\\node_modules\\vitest\\vitest.mjs run`
- `npx -y -p node@20.19.0 node .\\node_modules\\vitest\\vitest.mjs run --coverage`
- `npx -y -p node@20.19.0 node .\\node_modules\\next\\dist\\bin\\next build`
- `npx -y -p node@20.19.0 node .\\node_modules\\prisma\\build\\index.js generate`

## Notes
- local Playwright validation is still blocked in this workstation session because the PostgreSQL fixture service expected at `127.0.0.1:5432` is unreachable
- follow-on avatar consumers remain intentionally deferred to TASK-101 and TASK-119
