### PR TITLE
TASK-101 Task ownership and provenance

### DIFF
--- a/app/api/projects/[projectId]/tasks/route.ts
+++ b/app/api/projects/[projectId]/tasks/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
+import { resolveAvatarSeed } from "@/lib/avatar";
 import {
   getAgentProjectAccessContext,
   requireApiPrincipal,
@@ -9,6 +10,7 @@ import { mapTaskAttachmentResponse } from "@/lib/services/project-attachment-ser
 import { listProjectKanbanTasks } from "@/lib/services/project-service";
 import { createTaskForProject } from "@/lib/services/project-task-service";
 import { requireAgentProjectScopes } from "@/lib/services/project-access-service";
+import { validateUsernameDiscriminator } from "@/lib/services/account-security-policy";
 import { formatTaskDeadlineDate } from "@/lib/task-deadline";
 
 const ATTACHMENT_FILES_FIELD = "attachmentFiles";
@@ -18,6 +20,7 @@ interface TaskCreateJsonRequestBody {
   title?: unknown;
   description?: unknown;
   deadlineDate?: unknown;
+  assigneeUserId?: unknown;
   labels?: unknown;
   relatedTaskIds?: unknown;
   attachmentLinks?: unknown;
@@ -77,6 +80,35 @@ function mapRelatedTasks(task: {
   ].sort((left, right) => left.title.localeCompare(right.title));
 }
 
+function mapTaskPerson(person: {
+  id: string;
+  name: string | null;
+  email: string | null;
+  username: string | null;
+  usernameDiscriminator: string | null;
+  avatarSeed: string | null;
+} | null) {
+  if (!person) {
+    return null;
+  }
+
+  return {
+    id: person.id,
+    displayName:
+      person.username ??
+      person.name ??
+      person.email?.split("@", 1)[0] ??
+      "Account",
+    usernameTag:
+      person.username &&
+      person.usernameDiscriminator &&
+      validateUsernameDiscriminator(person.usernameDiscriminator)
+        ? `${person.username}#${person.usernameDiscriminator}`
+        : null,
+    avatarSeed: resolveAvatarSeed(person.avatarSeed, person.id),
+  };
+}
+
 export async function GET(request: NextRequest, props: { params: Promise<{ projectId: string }> }) {
   const params = await props.params;
   const principalResult = await requireApiPrincipal(request);
@@ -119,6 +151,9 @@ export async function GET(request: NextRequest, props: { params: Promise<{ proje
       labelsJson: task.labelsJson,
       createdAt: task.createdAt,
       updatedAt: task.updatedAt,
+      assignee: mapTaskPerson(task.assigneeUser),
+      createdBy: mapTaskPerson(task.createdByUser),
+      updatedBy: mapTaskPerson(task.updatedByUser),
       attachments: task.attachments.map((attachment: TaskAttachment) =>
         mapTaskAttachmentResponse(params.projectId, task.id, attachment)
       ),
@@ -144,6 +179,7 @@ export async function POST(request: NextRequest, props: { params: Promise<{ proj
   let title = "";
   let description = "";
   let deadlineDate = "";
+  let assigneeUserId: string | null = null;
   let labelsJsonRaw = "";
   let relatedTaskIdsJsonRaw = "";
   let attachmentLinksJsonRaw = "";
@@ -174,6 +210,17 @@ export async function POST(request: NextRequest, props: { params: Promise<{ proj
     }
     deadlineDate =
       typeof payload.deadlineDate === "string" ? payload.deadlineDate.trim() : "";
+    if (
+      payload.assigneeUserId !== undefined &&
+      payload.assigneeUserId !== null &&
+      typeof payload.assigneeUserId !== "string"
+    ) {
+      return NextResponse.json({ error: "assignee-invalid" }, { status: 400 });
+    }
+    assigneeUserId =
+      typeof payload.assigneeUserId === "string"
+        ? payload.assigneeUserId.trim() || null
+        : null;
     labelsJsonRaw = serializeJsonField(payload.labels);
     relatedTaskIdsJsonRaw = serializeJsonField(payload.relatedTaskIds);
     attachmentLinksJsonRaw = serializeJsonField(payload.attachmentLinks);
@@ -193,6 +240,7 @@ export async function POST(request: NextRequest, props: { params: Promise<{ proj
     title = readText(formData, "title");
     description = readText(formData, "description");
     deadlineDate = readText(formData, "deadlineDate");
+    assigneeUserId = readText(formData, "assigneeUserId") || null;
     labelsJsonRaw = readText(formData, "labels");
     relatedTaskIdsJsonRaw = readText(formData, "relatedTaskIds");
     attachmentLinksJsonRaw = readText(formData, "attachmentLinks");
@@ -212,6 +260,7 @@ export async function POST(request: NextRequest, props: { params: Promise<{ proj
     title,
     description,
     deadlineDate,
+    assigneeUserId,
     labelsJsonRaw,
     relatedTaskIdsJsonRaw,
     attachmentLinksJsonRaw,

--- a/app/api/projects/[projectId]/tasks/route.ts
+++ b/app/api/projects/[projectId]/tasks/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { resolveAvatarSeed } from "@/lib/avatar";
 import {
   getAgentProjectAccessContext,
   requireApiPrincipal,
@@ -10,7 +9,7 @@ import { mapTaskAttachmentResponse } from "@/lib/services/project-attachment-ser
 import { listProjectKanbanTasks } from "@/lib/services/project-service";
 import { createTaskForProject } from "@/lib/services/project-task-service";
 import { requireAgentProjectScopes } from "@/lib/services/project-access-service";
-import { validateUsernameDiscriminator } from "@/lib/services/account-security-policy";
+import { mapTaskPersonSummary } from "@/lib/task-person";
 import { formatTaskDeadlineDate } from "@/lib/task-deadline";
 
 const ATTACHMENT_FILES_FIELD = "attachmentFiles";
@@ -80,35 +79,6 @@ function mapRelatedTasks(task: {
   ].sort((left, right) => left.title.localeCompare(right.title));
 }
 
-function mapTaskPerson(person: {
-  id: string;
-  name: string | null;
-  email: string | null;
-  username: string | null;
-  usernameDiscriminator: string | null;
-  avatarSeed: string | null;
-} | null) {
-  if (!person) {
-    return null;
-  }
-
-  return {
-    id: person.id,
-    displayName:
-      person.username ??
-      person.name ??
-      person.email?.split("@", 1)[0] ??
-      "Account",
-    usernameTag:
-      person.username &&
-      person.usernameDiscriminator &&
-      validateUsernameDiscriminator(person.usernameDiscriminator)
-        ? `${person.username}#${person.usernameDiscriminator}`
-        : null,
-    avatarSeed: resolveAvatarSeed(person.avatarSeed, person.id),
-  };
-}
-
 export async function GET(request: NextRequest, props: { params: Promise<{ projectId: string }> }) {
   const params = await props.params;
   const principalResult = await requireApiPrincipal(request);
@@ -151,9 +121,9 @@ export async function GET(request: NextRequest, props: { params: Promise<{ proje
       labelsJson: task.labelsJson,
       createdAt: task.createdAt,
       updatedAt: task.updatedAt,
-      assignee: mapTaskPerson(task.assigneeUser),
-      createdBy: mapTaskPerson(task.createdByUser),
-      updatedBy: mapTaskPerson(task.updatedByUser),
+      assignee: mapTaskPersonSummary(task.assigneeUser),
+      createdBy: mapTaskPersonSummary(task.createdByUser),
+      updatedBy: mapTaskPersonSummary(task.updatedByUser),
       attachments: task.attachments.map((attachment: TaskAttachment) =>
         mapTaskAttachmentResponse(params.projectId, task.id, attachment)
       ),

--- a/app/projects/[projectId]/kanban-board-section.tsx
+++ b/app/projects/[projectId]/kanban-board-section.tsx
@@ -4,9 +4,6 @@ import {
   KanbanBoard,
   type KanbanTask,
 } from "@/components/kanban-board";
-import type {
-  ProjectTaskCollaborator,
-} from "@/components/kanban-board-types";
 import {
   PROJECT_SECTION_CARD_CLASS,
   PROJECT_SECTION_HEADER_CLASS,
@@ -111,7 +108,7 @@ export async function KanbanBoardSection({
       storageProvider={storageProvider}
       initialTasks={kanbanTasks}
       archivedDoneTasks={archivedDoneTasks}
-      collaborators={collaborators as ProjectTaskCollaborator[]}
+      collaborators={collaborators}
       actorUserId={actorUserId}
     />
   );

--- a/app/projects/[projectId]/kanban-board-section.tsx
+++ b/app/projects/[projectId]/kanban-board-section.tsx
@@ -1,12 +1,24 @@
 import { Columns3 } from "lucide-react";
 
-import { KanbanBoard, type KanbanTask } from "@/components/kanban-board";
+import {
+  KanbanBoard,
+  type KanbanTask,
+} from "@/components/kanban-board";
+import type {
+  ProjectTaskCollaborator,
+  TaskPersonSummary,
+} from "@/components/kanban-board-types";
 import {
   PROJECT_SECTION_CARD_CLASS,
   PROJECT_SECTION_HEADER_CLASS,
 } from "@/components/project-dashboard/project-section-chrome";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { listProjectKanbanTasks } from "@/lib/services/project-service";
+import { resolveAvatarSeed } from "@/lib/avatar";
+import { validateUsernameDiscriminator } from "@/lib/services/account-security-policy";
+import {
+  listProjectCollaborators,
+  listProjectKanbanTasks,
+} from "@/lib/services/project-service";
 import { mapRelatedTaskSummary } from "@/lib/task-related";
 import { ATTACHMENT_KIND_FILE } from "@/lib/task-attachment";
 import { formatTaskDeadlineDate } from "@/lib/task-deadline";
@@ -27,13 +39,45 @@ interface KanbanBoardSectionProps {
   storageProvider: "local" | "r2";
 }
 
+function mapTaskPersonSummary(person: {
+  id: string;
+  name: string | null;
+  email: string | null;
+  username: string | null;
+  usernameDiscriminator: string | null;
+  avatarSeed: string | null;
+} | null): TaskPersonSummary | null {
+  if (!person) {
+    return null;
+  }
+
+  return {
+    id: person.id,
+    displayName:
+      person.username ??
+      person.name ??
+      person.email?.split("@", 1)[0] ??
+      "Account",
+    usernameTag:
+      person.username &&
+      person.usernameDiscriminator &&
+      validateUsernameDiscriminator(person.usernameDiscriminator)
+        ? `${person.username}#${person.usernameDiscriminator}`
+        : null,
+    avatarSeed: resolveAvatarSeed(person.avatarSeed, person.id),
+  };
+}
+
 export async function KanbanBoardSection({
   projectId,
   actorUserId,
   canEdit,
   storageProvider,
 }: KanbanBoardSectionProps) {
-  const tasks = await listProjectKanbanTasks(projectId, actorUserId);
+  const [tasks, collaborators] = await Promise.all([
+    listProjectKanbanTasks(projectId, actorUserId),
+    listProjectCollaborators(projectId, actorUserId),
+  ]);
   const kanbanTasks: KanbanTask[] = [];
   const archivedDoneTasks: KanbanTask[] = [];
 
@@ -54,6 +98,11 @@ export async function KanbanBoardSection({
         content: entry.content,
         createdAt: entry.createdAt.toISOString(),
       })),
+      assignee: mapTaskPersonSummary(task.assigneeUser),
+      createdBy: mapTaskPersonSummary(task.createdByUser)!,
+      updatedBy: mapTaskPersonSummary(task.updatedByUser)!,
+      createdAt: task.createdAt.toISOString(),
+      updatedAt: task.updatedAt.toISOString(),
       archivedAt: task.archivedAt ? task.archivedAt.toISOString() : null,
       relatedTasks: [
         ...task.outgoingRelations.map((entry: OutgoingRelation) =>
@@ -93,6 +142,8 @@ export async function KanbanBoardSection({
       storageProvider={storageProvider}
       initialTasks={kanbanTasks}
       archivedDoneTasks={archivedDoneTasks}
+      collaborators={collaborators as ProjectTaskCollaborator[]}
+      actorUserId={actorUserId}
     />
   );
 }

--- a/app/projects/[projectId]/kanban-board-section.tsx
+++ b/app/projects/[projectId]/kanban-board-section.tsx
@@ -6,19 +6,17 @@ import {
 } from "@/components/kanban-board";
 import type {
   ProjectTaskCollaborator,
-  TaskPersonSummary,
 } from "@/components/kanban-board-types";
 import {
   PROJECT_SECTION_CARD_CLASS,
   PROJECT_SECTION_HEADER_CLASS,
 } from "@/components/project-dashboard/project-section-chrome";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { resolveAvatarSeed } from "@/lib/avatar";
-import { validateUsernameDiscriminator } from "@/lib/services/account-security-policy";
 import {
   listProjectCollaborators,
   listProjectKanbanTasks,
 } from "@/lib/services/project-service";
+import { mapTaskPersonSummary } from "@/lib/task-person";
 import { mapRelatedTaskSummary } from "@/lib/task-related";
 import { ATTACHMENT_KIND_FILE } from "@/lib/task-attachment";
 import { formatTaskDeadlineDate } from "@/lib/task-deadline";
@@ -37,35 +35,6 @@ interface KanbanBoardSectionProps {
   actorUserId: string;
   canEdit: boolean;
   storageProvider: "local" | "r2";
-}
-
-function mapTaskPersonSummary(person: {
-  id: string;
-  name: string | null;
-  email: string | null;
-  username: string | null;
-  usernameDiscriminator: string | null;
-  avatarSeed: string | null;
-} | null): TaskPersonSummary | null {
-  if (!person) {
-    return null;
-  }
-
-  return {
-    id: person.id,
-    displayName:
-      person.username ??
-      person.name ??
-      person.email?.split("@", 1)[0] ??
-      "Account",
-    usernameTag:
-      person.username &&
-      person.usernameDiscriminator &&
-      validateUsernameDiscriminator(person.usernameDiscriminator)
-        ? `${person.username}#${person.usernameDiscriminator}`
-        : null,
-    avatarSeed: resolveAvatarSeed(person.avatarSeed, person.id),
-  };
 }
 
 export async function KanbanBoardSection({

--- a/components/create-task-dialog.tsx
+++ b/components/create-task-dialog.tsx
@@ -14,6 +14,7 @@ import type {
 import { RichTextEditor } from "@/components/rich-text-editor";
 import { useToast } from "@/components/toast-provider";
 import { AttachmentLinkComposer } from "@/components/ui/attachment-link-composer";
+import { AssigneeSelect } from "@/components/ui/assignee-select";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { EmojiInputField } from "@/components/ui/emoji-field";
@@ -479,23 +480,13 @@ export function CreateTaskDialog({
                         <label htmlFor="task-assignee" className="text-sm font-medium">
                           Assignee
                         </label>
-                        <select
+                        <AssigneeSelect
                           id="task-assignee"
                           name="assigneeUserId"
                           value={assigneeUserId}
-                          onChange={(event) => setAssigneeUserId(event.target.value)}
-                          className="h-10 rounded-md border border-input bg-background px-3 text-sm"
-                        >
-                          <option value="">Unassigned</option>
-                          {availableAssignees.map((assignee) => (
-                            <option key={assignee.id} value={assignee.id}>
-                              {assignee.usernameTag &&
-                              assignee.usernameTag !== assignee.displayName
-                                ? `${assignee.displayName} (${assignee.usernameTag})`
-                                : assignee.displayName}
-                            </option>
-                          ))}
-                        </select>
+                          onChange={setAssigneeUserId}
+                          options={availableAssignees}
+                        />
                         <p className="text-xs text-muted-foreground">
                           Optional. Leave unassigned until ownership is clear.
                         </p>

--- a/components/create-task-dialog.tsx
+++ b/components/create-task-dialog.tsx
@@ -7,7 +7,10 @@ import { useRouter } from "next/navigation";
 
 import { TaskDeadlineField } from "@/components/kanban/task-deadline-field";
 import { RelatedTaskSelector, type RelatedTaskOption } from "@/components/kanban/related-task-field";
-import type { TaskRelatedSummary } from "@/components/kanban-board-types";
+import type {
+  ProjectTaskCollaborator,
+  TaskRelatedSummary,
+} from "@/components/kanban-board-types";
 import { RichTextEditor } from "@/components/rich-text-editor";
 import { useToast } from "@/components/toast-provider";
 import { AttachmentLinkComposer } from "@/components/ui/attachment-link-composer";
@@ -32,6 +35,7 @@ interface CreateTaskDialogProps {
   storageProvider: "local" | "r2";
   existingLabels: string[];
   availableTasks: RelatedTaskOption[];
+  availableAssignees: ProjectTaskCollaborator[];
 }
 
 interface PendingAttachmentLink {
@@ -48,6 +52,7 @@ export function CreateTaskDialog({
   storageProvider,
   existingLabels,
   availableTasks,
+  availableAssignees,
 }: CreateTaskDialogProps) {
   const isMountedRef = useRef(true);
   const router = useRouter();
@@ -55,6 +60,7 @@ export function CreateTaskDialog({
   const [isOpen, setIsOpen] = useState(false);
   const [description, setDescription] = useState("");
   const [deadlineDate, setDeadlineDate] = useState("");
+  const [assigneeUserId, setAssigneeUserId] = useState("");
   const [labels, setLabels] = useState<string[]>([]);
   const [labelInput, setLabelInput] = useState("");
   const [relatedTaskSearch, setRelatedTaskSearch] = useState("");
@@ -88,6 +94,7 @@ export function CreateTaskDialog({
   const resetDraft = () => {
     setDescription("");
     setDeadlineDate("");
+    setAssigneeUserId("");
     setLabels([]);
     setLabelInput("");
     setRelatedTaskSearch("");
@@ -120,6 +127,8 @@ export function CreateTaskDialog({
         return "One or more attachment links are invalid. Use http:// or https:// URLs.";
       case "deadline-invalid":
         return "Deadline must use a valid date.";
+      case "assignee-invalid":
+        return "Assignee must be a current collaborator on this project.";
       case "attachment-file-too-large":
         return attachmentFileSizeErrorMessage;
       case "attachment-file-type-invalid":
@@ -465,6 +474,32 @@ export function CreateTaskDialog({
                         disabled={isSubmitting}
                         helperText="Optional. Near deadlines are highlighted automatically on the board."
                       />
+
+                      <div className="grid gap-2">
+                        <label htmlFor="task-assignee" className="text-sm font-medium">
+                          Assignee
+                        </label>
+                        <select
+                          id="task-assignee"
+                          name="assigneeUserId"
+                          value={assigneeUserId}
+                          onChange={(event) => setAssigneeUserId(event.target.value)}
+                          className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+                        >
+                          <option value="">Unassigned</option>
+                          {availableAssignees.map((assignee) => (
+                            <option key={assignee.id} value={assignee.id}>
+                              {assignee.usernameTag &&
+                              assignee.usernameTag !== assignee.displayName
+                                ? `${assignee.displayName} (${assignee.usernameTag})`
+                                : assignee.displayName}
+                            </option>
+                          ))}
+                        </select>
+                        <p className="text-xs text-muted-foreground">
+                          Optional. Leave unassigned until ownership is clear.
+                        </p>
+                      </div>
 
                       <div className="grid gap-2">
                         <label className="text-sm font-medium">Related tasks</label>

--- a/components/kanban-board-types.ts
+++ b/components/kanban-board-types.ts
@@ -1,5 +1,12 @@
 import type { TaskStatus } from "@/lib/task-status";
 
+export interface TaskPersonSummary {
+  id: string;
+  displayName: string;
+  usernameTag: string | null;
+  avatarSeed: string;
+}
+
 export interface TaskBlockedFollowUp {
   id: string;
   content: string;
@@ -13,12 +20,7 @@ export interface TaskRelatedSummary {
   archivedAt: string | null;
 }
 
-export interface TaskCommentAuthor {
-  id: string;
-  displayName: string;
-  usernameTag: string | null;
-  avatarSeed: string;
-}
+export type TaskCommentAuthor = TaskPersonSummary;
 
 export interface TaskComment {
   id: string;
@@ -49,6 +51,11 @@ export interface KanbanTask {
   archivedAt: string | null;
   attachments: TaskAttachment[];
   relatedTasks: TaskRelatedSummary[];
+  assignee: TaskPersonSummary | null;
+  createdBy: TaskPersonSummary;
+  updatedBy: TaskPersonSummary;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface PendingAttachmentUpload {
@@ -56,3 +63,5 @@ export interface PendingAttachmentUpload {
   name: string;
   sizeBytes: number;
 }
+
+export type ProjectTaskCollaborator = TaskPersonSummary;

--- a/components/kanban-board-types.ts
+++ b/components/kanban-board-types.ts
@@ -7,6 +7,8 @@ export interface TaskPersonSummary {
   avatarSeed: string;
 }
 
+export type ProjectTaskCollaboratorRole = "owner" | "editor" | "viewer";
+
 export interface TaskBlockedFollowUp {
   id: string;
   content: string;
@@ -64,4 +66,6 @@ export interface PendingAttachmentUpload {
   sizeBytes: number;
 }
 
-export type ProjectTaskCollaborator = TaskPersonSummary;
+export interface ProjectTaskCollaborator extends TaskPersonSummary {
+  projectRole: ProjectTaskCollaboratorRole;
+}

--- a/components/kanban-board.tsx
+++ b/components/kanban-board.tsx
@@ -13,8 +13,10 @@ import type { DropResult } from "@hello-pangea/dnd";
 import type { RelatedTaskOption } from "@/components/kanban/related-task-field";
 import {
   type KanbanTask,
+  type ProjectTaskCollaborator,
   type TaskComment,
   type PendingAttachmentUpload,
+  type TaskPersonSummary,
   type TaskAttachment,
   type TaskRelatedSummary,
 } from "@/components/kanban-board-types";
@@ -58,21 +60,40 @@ export type { KanbanTask } from "@/components/kanban-board-types";
 interface KanbanBoardProps {
   canEdit: boolean;
   projectId: string;
+  actorUserId: string;
   storageProvider: "local" | "r2";
   initialTasks: KanbanTask[];
   archivedDoneTasks?: KanbanTask[];
+  collaborators: ProjectTaskCollaborator[];
 }
 
 function createLocalUploadId(): string {
   return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
 
+function stampTaskActivity(
+  task: KanbanTask,
+  actor: TaskPersonSummary | null
+): KanbanTask {
+  if (!actor) {
+    return task;
+  }
+
+  return {
+    ...task,
+    updatedBy: actor,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
 export function KanbanBoard({
   canEdit,
   projectId,
+  actorUserId,
   storageProvider,
   initialTasks,
   archivedDoneTasks: initialArchivedDoneTasks = [],
+  collaborators,
 }: KanbanBoardProps) {
   const initialColumns = useMemo(
     () => mapTasksToColumns(initialTasks),
@@ -106,6 +127,7 @@ export function KanbanBoard({
   const [editLabelInput, setEditLabelInput] = useState("");
   const [editDescription, setEditDescription] = useState("");
   const [editDeadlineDate, setEditDeadlineDate] = useState("");
+  const [editAssigneeUserId, setEditAssigneeUserId] = useState("");
   const [editRelatedTasks, setEditRelatedTasks] = useState<TaskRelatedSummary[]>([]);
   const [relatedTaskSearch, setRelatedTaskSearch] = useState("");
   const [newBlockedFollowUpEntry, setNewBlockedFollowUpEntry] = useState("");
@@ -137,6 +159,10 @@ export function KanbanBoard({
       : MAX_ATTACHMENT_FILE_SIZE_LABEL;
   const attachmentFileSizeErrorMessage = `Attachment files must be ${maxAttachmentFileSizeLabel} or smaller.`;
   const hasPendingAttachmentUploads = pendingAttachmentUploads.length > 0;
+  const currentActorSummary = useMemo<TaskPersonSummary | null>(
+    () => collaborators.find((collaborator) => collaborator.id === actorUserId) ?? null,
+    [actorUserId, collaborators]
+  );
 
   const resetTaskEditDraft = useCallback((task: KanbanTask) => {
     setTaskModalError(null);
@@ -145,6 +171,7 @@ export function KanbanBoard({
     setEditLabelInput("");
     setEditDescription(task.description ?? "");
     setEditDeadlineDate(task.deadlineDate ?? "");
+    setEditAssigneeUserId(task.assignee?.id ?? "");
     setEditRelatedTasks(task.relatedTasks);
     setRelatedTaskSearch("");
     setNewBlockedFollowUpEntry("");
@@ -344,6 +371,14 @@ export function KanbanBoard({
         }))
         .sort((left, right) => left.title.localeCompare(right.title)),
     [columns]
+  );
+
+  const availableAssignees = useMemo<ProjectTaskCollaborator[]>(
+    () =>
+      [...collaborators].sort((left, right) =>
+        left.displayName.localeCompare(right.displayName)
+      ),
+    [collaborators]
   );
 
   const addEditLabel = useCallback(
@@ -580,10 +615,17 @@ export function KanbanBoard({
         return;
       }
 
-      nextColumns[destinationStatus].splice(destination.index, 0, {
-        ...movedTask,
-        status: destinationStatus,
-      });
+      nextColumns[destinationStatus].splice(
+        destination.index,
+        0,
+        stampTaskActivity(
+          {
+            ...movedTask,
+            status: destinationStatus,
+          },
+          currentActorSummary
+        )
+      );
 
       setColumns(nextColumns);
       syncRelatedTaskSummary(movedTask.id, {
@@ -597,7 +639,7 @@ export function KanbanBoard({
         void persistColumns(nextColumns, previousColumns);
       });
     },
-    [canEdit, columns, persistColumns, syncRelatedTaskSummary]
+    [canEdit, columns, currentActorSummary, persistColumns, syncRelatedTaskSummary]
   );
 
   const closeTaskModal = useCallback(() => {
@@ -608,6 +650,7 @@ export function KanbanBoard({
     setAttachmentError(null);
     setTaskCommentsError(null);
     setEditRelatedTasks([]);
+    setEditAssigneeUserId("");
     setRelatedTaskSearch("");
     setPreviewAttachment(null);
     setTaskComments([]);
@@ -703,6 +746,7 @@ export function KanbanBoard({
               labels: editLabels,
               description: editDescription,
               deadlineDate: editDeadlineDate || null,
+              assigneeUserId: editAssigneeUserId || null,
               blockedFollowUpEntry: normalizedBlockedEntry,
               relatedTaskIds,
             }),
@@ -716,6 +760,8 @@ export function KanbanBoard({
           const message =
             payload?.error === "related-tasks-invalid"
               ? "Related tasks must stay active and belong to this project."
+              : payload?.error === "assignee-invalid"
+                ? "Assignee must be a current collaborator on this project."
               : payload?.error === "deadline-invalid"
                 ? "Deadline must use a valid date."
               : (payload?.error ?? "Failed to update task");
@@ -735,6 +781,11 @@ export function KanbanBoard({
             status: string;
             position: number;
             archivedAt: string | null;
+            assignee: TaskPersonSummary | null;
+            createdBy: TaskPersonSummary;
+            updatedBy: TaskPersonSummary;
+            createdAt: string;
+            updatedAt: string;
             relatedTasks: TaskRelatedSummary[];
             blockedFollowUps: {
               id: string;
@@ -758,6 +809,11 @@ export function KanbanBoard({
           description: payload.task.description,
           deadlineDate: payload.task.deadlineDate,
           commentCount: payload.task.commentCount,
+          assignee: payload.task.assignee,
+          createdBy: payload.task.createdBy,
+          updatedBy: payload.task.updatedBy,
+          createdAt: payload.task.createdAt,
+          updatedAt: payload.task.updatedAt,
           blockedFollowUps: payload.task.blockedFollowUps.map((entry) => ({
             ...entry,
             createdAt: entry.createdAt,
@@ -839,6 +895,7 @@ export function KanbanBoard({
     },
     [
       canEdit,
+      editAssigneeUserId,
       editDeadlineDate,
       editDescription,
       editLabels,
@@ -904,21 +961,30 @@ export function KanbanBoard({
         return;
       }
 
-      nextColumns[nextStatus].unshift({
-        ...movedTask,
-        status: nextStatus,
-      });
+      nextColumns[nextStatus].unshift(
+        stampTaskActivity(
+          {
+            ...movedTask,
+            status: nextStatus,
+            archivedAt: null,
+          },
+          currentActorSummary
+        )
+      );
 
       setColumns(nextColumns);
       setSelectedTask((previousTask) => {
         if (!previousTask || previousTask.id !== task.id) {
           return previousTask;
         }
-        return {
-          ...previousTask,
-          status: nextStatus,
-          archivedAt: null,
-        };
+        return stampTaskActivity(
+          {
+            ...previousTask,
+            status: nextStatus,
+            archivedAt: null,
+          },
+          currentActorSummary
+        );
       });
       syncRelatedTaskSummary(task.id, {
         title: task.title,
@@ -936,7 +1002,14 @@ export function KanbanBoard({
         message: `Task moved to ${nextStatus}.`,
       });
     },
-    [canEdit, columns, persistColumns, pushToast, syncRelatedTaskSummary]
+    [
+      canEdit,
+      columns,
+      currentActorSummary,
+      persistColumns,
+      pushToast,
+      syncRelatedTaskSummary,
+    ]
   );
 
   const confirmDeleteTask = useCallback(async () => {
@@ -1024,10 +1097,13 @@ export function KanbanBoard({
       const payload = (await response.json()) as { archivedAt: string };
 
       const taskToArchive = selectedTask;
-      const archivedTask = {
-        ...taskToArchive,
-        archivedAt: payload.archivedAt,
-      };
+      const archivedTask = stampTaskActivity(
+        {
+          ...taskToArchive,
+          archivedAt: payload.archivedAt,
+        },
+        currentActorSummary
+      );
 
       setColumns((previousColumns) => {
         const nextColumns = createEmptyColumns<KanbanTask>();
@@ -1061,7 +1137,16 @@ export function KanbanBoard({
     } finally {
       setIsArchivingTask(false);
     }
-  }, [canEdit, closeTaskModal, isArchivingTask, projectId, pushToast, selectedTask, syncRelatedTaskSummary]);
+  }, [
+    canEdit,
+    closeTaskModal,
+    currentActorSummary,
+    isArchivingTask,
+    projectId,
+    pushToast,
+    selectedTask,
+    syncRelatedTaskSummary,
+  ]);
 
   const handleUnarchiveTask = useCallback(async () => {
     if (!canEdit) {
@@ -1086,10 +1171,13 @@ export function KanbanBoard({
         throw new Error(await readApiError(response, "Could not unarchive task."));
       }
 
-      const taskToRestore = {
-        ...selectedTask,
-        archivedAt: null,
-      };
+      const taskToRestore = stampTaskActivity(
+        {
+          ...selectedTask,
+          archivedAt: null,
+        },
+        currentActorSummary
+      );
 
       setArchivedDoneTasks((previousTasks) =>
         previousTasks.filter((task) => task.id !== taskToRestore.id)
@@ -1123,7 +1211,16 @@ export function KanbanBoard({
     } finally {
       setIsArchivingTask(false);
     }
-  }, [canEdit, isArchivingTask, isSelectedTaskArchived, projectId, pushToast, selectedTask, syncRelatedTaskSummary]);
+  }, [
+    canEdit,
+    currentActorSummary,
+    isArchivingTask,
+    isSelectedTaskArchived,
+    projectId,
+    pushToast,
+    selectedTask,
+    syncRelatedTaskSummary,
+  ]);
 
   const handleAddBlockedFollowUpEntry = useCallback(async () => {
     if (!canEdit) {
@@ -1227,10 +1324,15 @@ export function KanbanBoard({
 
       setTaskComments((previousComments) => [...previousComments, payload.comment]);
       setNewTaskComment("");
-      applyTaskMutation(selectedTask.id, (task) => ({
-        ...task,
-        commentCount: task.commentCount + 1,
-      }));
+      applyTaskMutation(selectedTask.id, (task) =>
+        stampTaskActivity(
+          {
+            ...task,
+            commentCount: task.commentCount + 1,
+          },
+          currentActorSummary
+        )
+      );
       pushToast({
         variant: "success",
         message: "Comment added.",
@@ -1247,7 +1349,15 @@ export function KanbanBoard({
     } finally {
       setIsSubmittingTaskComment(false);
     }
-  }, [applyTaskMutation, canEdit, newTaskComment, projectId, pushToast, selectedTask]);
+  }, [
+    applyTaskMutation,
+    canEdit,
+    currentActorSummary,
+    newTaskComment,
+    projectId,
+    pushToast,
+    selectedTask,
+  ]);
 
   const handleAddLinkAttachment = useCallback(async () => {
     if (!canEdit) {
@@ -1282,10 +1392,15 @@ export function KanbanBoard({
       }
 
       const payload = (await response.json()) as { attachment: TaskAttachment };
-      applyTaskMutation(selectedTask.id, (task) => ({
-        ...task,
-        attachments: [payload.attachment, ...task.attachments],
-      }));
+      applyTaskMutation(selectedTask.id, (task) =>
+        stampTaskActivity(
+          {
+            ...task,
+            attachments: [payload.attachment, ...task.attachments],
+          },
+          currentActorSummary
+        )
+      );
       setLinkUrl("");
       setIsLinkComposerOpen(false);
       pushToast({
@@ -1304,7 +1419,15 @@ export function KanbanBoard({
     } finally {
       setIsSubmittingAttachment(false);
     }
-  }, [applyTaskMutation, canEdit, linkUrl, projectId, pushToast, selectedTask]);
+  }, [
+    applyTaskMutation,
+    canEdit,
+    currentActorSummary,
+    linkUrl,
+    projectId,
+    pushToast,
+    selectedTask,
+  ]);
 
   const handleAddFileAttachment = useCallback(
     async (selectedFile: File | null) => {
@@ -1372,10 +1495,15 @@ export function KanbanBoard({
           attachment = payload.attachment;
         }
 
-        applyTaskMutation(taskId, (task) => ({
-          ...task,
-          attachments: [attachment, ...task.attachments],
-        }));
+        applyTaskMutation(taskId, (task) =>
+          stampTaskActivity(
+            {
+              ...task,
+              attachments: [attachment, ...task.attachments],
+            },
+            currentActorSummary
+          )
+        );
         pushToast({
           variant: "success",
           message: "Attachment uploaded.",
@@ -1401,6 +1529,7 @@ export function KanbanBoard({
       applyTaskMutation,
       attachmentFileSizeErrorMessage,
       canEdit,
+      currentActorSummary,
       maxAttachmentFileSizeBytes,
       projectId,
       selectedTask,
@@ -1436,12 +1565,17 @@ export function KanbanBoard({
           );
         }
 
-        applyTaskMutation(selectedTask.id, (task) => ({
-          ...task,
-          attachments: task.attachments.filter(
-            (attachment) => attachment.id !== attachmentId
-          ),
-        }));
+        applyTaskMutation(selectedTask.id, (task) =>
+          stampTaskActivity(
+            {
+              ...task,
+              attachments: task.attachments.filter(
+                (attachment) => attachment.id !== attachmentId
+              ),
+            },
+            currentActorSummary
+          )
+        );
         pushToast({
           variant: "success",
           message: "Attachment deleted.",
@@ -1459,7 +1593,7 @@ export function KanbanBoard({
         setIsSubmittingAttachment(false);
       }
     },
-    [applyTaskMutation, canEdit, projectId, pushToast, selectedTask]
+    [applyTaskMutation, canEdit, currentActorSummary, projectId, pushToast, selectedTask]
   );
 
   const totalTaskCount = useMemo(
@@ -1503,6 +1637,7 @@ export function KanbanBoard({
             storageProvider={storageProvider}
             existingLabels={allKnownLabels}
             availableTasks={createDialogAvailableTasks}
+            availableAssignees={availableAssignees}
           />
         ) : null}
         onToggleExpanded={() => setIsExpanded((previous) => !previous)}
@@ -1538,6 +1673,7 @@ export function KanbanBoard({
         editLabelSuggestions={editLabelSuggestions}
         editDescription={editDescription}
         editDeadlineDate={editDeadlineDate}
+        editAssigneeUserId={editAssigneeUserId}
         editRelatedTasks={editRelatedTasks}
         relatedTaskSearch={relatedTaskSearch}
         newBlockedFollowUpEntry={newBlockedFollowUpEntry}
@@ -1567,9 +1703,11 @@ export function KanbanBoard({
         onRemoveEditLabel={removeEditLabel}
         onEditDescriptionChange={setEditDescription}
         onEditDeadlineDateChange={setEditDeadlineDate}
+        onEditAssigneeUserIdChange={setEditAssigneeUserId}
         onRelatedTaskSearchChange={setRelatedTaskSearch}
         onAddRelatedTask={addRelatedTask}
         onRemoveRelatedTask={removeRelatedTask}
+        availableAssignees={availableAssignees}
         availableRelatedTaskOptions={availableRelatedTaskOptions}
         onOpenRelatedTask={openRelatedTask}
         onNewBlockedFollowUpEntryChange={setNewBlockedFollowUpEntry}

--- a/components/kanban/kanban-columns-grid.tsx
+++ b/components/kanban/kanban-columns-grid.tsx
@@ -9,6 +9,7 @@ import { Archive, Clock3, GripVertical, Link2, MessageSquare, Paperclip, Triangl
 import type { KanbanTask } from "@/components/kanban-board-types";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import {
   buildDragStyle,
   getDescriptionPreview,
@@ -275,6 +276,18 @@ function KanbanColumn({
                         <p className="break-words text-xs text-muted-foreground">
                           {getDescriptionPreview(task.description)}
                         </p>
+                      ) : null}
+
+                      {task.assignee ? (
+                        <div className="mt-3 flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-2 py-1 text-xs text-muted-foreground">
+                          <UserAvatar
+                            avatarSeed={task.assignee.avatarSeed}
+                            displayName={task.assignee.displayName}
+                            className="h-5 w-5 border-border/70"
+                            decorative
+                          />
+                          <span className="truncate">{task.assignee.displayName}</span>
+                        </div>
                       ) : null}
 
                       {task.labels.length > 0 ? (

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -39,6 +39,7 @@ import { AttachmentPreviewModal } from "@/components/attachment-preview-modal";
 import { RichTextContent } from "@/components/rich-text-content";
 import { RichTextEditor } from "@/components/rich-text-editor";
 import { Badge } from "@/components/ui/badge";
+import { AssigneeSelect } from "@/components/ui/assignee-select";
 import { AttachmentLinkComposer } from "@/components/ui/attachment-link-composer";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
@@ -212,7 +213,7 @@ export function TaskDetailModal({
             onMouseDown={(event) => event.stopPropagation()}
           >
             <CardHeader className="flex shrink-0 flex-col gap-3 space-y-0 sm:flex-row sm:items-start sm:justify-between">
-              <div className="min-w-0 space-y-2">
+              <div className="min-w-0 flex-1 space-y-2">
                 <Badge
                   variant="outline"
                   className={
@@ -224,18 +225,21 @@ export function TaskDetailModal({
                   {isArchivedTask ? "Archived" : selectedTask.status}
                 </Badge>
                 {!isEditing ? (
-                  <CardTitle
-                    className="text-xl leading-tight"
-                    onDoubleClick={() => {
-                      if (!canEdit) {
-                        return;
-                      }
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                    <CardTitle
+                      className="min-w-0 flex-1 text-xl leading-tight"
+                      onDoubleClick={() => {
+                        if (!canEdit) {
+                          return;
+                        }
 
-                      onActivateEditMode();
-                    }}
-                  >
-                    {selectedTask.title}
-                  </CardTitle>
+                        onActivateEditMode();
+                      }}
+                    >
+                      {selectedTask.title}
+                    </CardTitle>
+                    <TaskAssigneeBadge assignee={selectedTask.assignee} />
+                  </div>
                 ) : (
                   <EmojiInputField
                     aria-label="Task title"
@@ -422,15 +426,39 @@ function formatTaskActivityTimestamp(value: string): string {
   return new Date(value).toLocaleString();
 }
 
-function getTaskPersonMeta(person: TaskPersonSummary): string | null {
-  if (!person.usernameTag || person.usernameTag === person.displayName) {
-    return null;
-  }
-
-  return person.usernameTag;
+function buildTaskPersonHoverLabel(person: TaskPersonSummary): string {
+  return person.usernameTag ?? person.displayName;
 }
 
-function TaskIdentityRow({
+function TaskAssigneeBadge({ assignee }: { assignee: TaskPersonSummary | null }) {
+  return (
+    <div
+      className="inline-flex max-w-full items-center gap-2 rounded-full border border-border/60 bg-background/85 px-2.5 py-1.5"
+      title={assignee ? buildTaskPersonHoverLabel(assignee) : "Unassigned"}
+    >
+      {assignee ? (
+        <>
+          <UserAvatar
+            avatarSeed={assignee.avatarSeed}
+            displayName={assignee.displayName}
+            className="h-7 w-7 border-border/70"
+            decorative
+          />
+          <span className="max-w-[160px] truncate text-sm font-medium text-foreground">
+            {assignee.displayName}
+          </span>
+        </>
+      ) : (
+        <>
+          <span className="inline-flex h-7 w-7 shrink-0 rounded-full border border-dashed border-border/70 bg-muted/30" />
+          <span className="text-sm text-muted-foreground">Unassigned</span>
+        </>
+      )}
+    </div>
+  );
+}
+
+function TaskActivityInline({
   label,
   person,
   fallback,
@@ -439,42 +467,34 @@ function TaskIdentityRow({
   label: string;
   person: TaskPersonSummary | null;
   fallback: string;
-  timestamp?: string;
+  timestamp: string;
 }) {
+  if (!person) {
+    return (
+      <div className="inline-flex items-center gap-2 rounded-full border border-border/50 bg-background/75 px-2.5 py-1 text-xs text-muted-foreground">
+        <span>{label}</span>
+        <span>{fallback}</span>
+      </div>
+    );
+  }
+
   return (
-    <div className="grid gap-2 rounded-xl border border-border/60 bg-background/70 px-3 py-2.5">
-      <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
-        {label}
-      </p>
-      {person ? (
-        <div className="flex items-center gap-3">
-          <UserAvatar
-            avatarSeed={person.avatarSeed}
-            displayName={person.displayName}
-            className="h-9 w-9 border-border/70"
-            decorative
-          />
-          <div className="min-w-0">
-            <p className="truncate text-sm font-medium text-foreground">
-              {person.displayName}
-            </p>
-            <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-              {getTaskPersonMeta(person) ? (
-                <p className="text-[11px] text-muted-foreground">
-                  {getTaskPersonMeta(person)}
-                </p>
-              ) : null}
-              {timestamp ? (
-                <p className="text-[11px] text-muted-foreground">
-                  {formatTaskActivityTimestamp(timestamp)}
-                </p>
-              ) : null}
-            </div>
-          </div>
-        </div>
-      ) : (
-        <p className="text-sm text-muted-foreground">{fallback}</p>
-      )}
+    <div
+      className="inline-flex min-w-0 items-center gap-2 rounded-full border border-border/50 bg-background/75 px-2.5 py-1"
+      title={`${label}: ${buildTaskPersonHoverLabel(person)}`}
+    >
+      <UserAvatar
+        avatarSeed={person.avatarSeed}
+        displayName={person.displayName}
+        className="h-6 w-6 border-border/70"
+        decorative
+      />
+      <span className="max-w-[110px] truncate text-xs font-medium text-foreground">
+        {person.displayName}
+      </span>
+      <span className="text-[11px] text-muted-foreground">
+        {formatTaskActivityTimestamp(timestamp)}
+      </span>
     </div>
   );
 }
@@ -716,25 +736,6 @@ function TaskReadOnlyContent({
           )}
         </div>
       ) : null}
-      <section className="grid gap-2 sm:grid-cols-3">
-        <TaskIdentityRow
-          label="Assignee"
-          person={selectedTask.assignee}
-          fallback="Unassigned"
-        />
-        <TaskIdentityRow
-          label="Created by"
-          person={selectedTask.createdBy}
-          fallback="Unknown creator"
-          timestamp={selectedTask.createdAt}
-        />
-        <TaskIdentityRow
-          label="Last updated by"
-          person={selectedTask.updatedBy}
-          fallback="Unknown collaborator"
-          timestamp={selectedTask.updatedAt}
-        />
-      </section>
       <RichTextContent
         html={selectedTask.description}
         emptyContentHtml="<p>No description provided.</p>"
@@ -766,13 +767,13 @@ function TaskReadOnlyContent({
               {taskComments.map((comment) => (
                 <article
                   key={comment.id}
-                  className="rounded-xl border border-border/50 bg-background/80 px-3 py-2.5"
+                  className="rounded-xl border border-border/50 bg-background/80 px-3 py-2"
                 >
-                  <div className="flex items-start gap-3">
+                  <div className="flex items-start gap-2.5">
                     <UserAvatar
                       avatarSeed={comment.author.avatarSeed}
                       displayName={comment.author.displayName}
-                      className="mt-0.5 h-9 w-9 border-border/70"
+                      className="mt-0.5 h-8 w-8 border-border/70"
                       decorative
                     />
                     <div className="min-w-0 flex-1">
@@ -787,7 +788,7 @@ function TaskReadOnlyContent({
                           {formatTaskCommentTimestamp(comment.createdAt)}
                         </p>
                       </div>
-                      <p className="mt-1.5 whitespace-pre-wrap break-words text-sm text-foreground">
+                      <p className="mt-1 whitespace-pre-wrap break-words text-sm text-foreground">
                         {comment.content}
                       </p>
                     </div>
@@ -821,7 +822,21 @@ function TaskReadOnlyContent({
                 className="h-11 min-h-11 resize-none rounded-xl border border-border/50 bg-background/80 px-3 py-2 text-sm leading-5 transition-colors focus-visible:outline-none focus-visible:border-ring/60"
                 disabled={isSubmittingTaskComment}
               />
-              <div className="flex justify-end">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                <div className="flex flex-wrap items-center gap-2">
+                  <TaskActivityInline
+                    label="Created by"
+                    person={selectedTask.createdBy}
+                    fallback="Unknown creator"
+                    timestamp={selectedTask.createdAt}
+                  />
+                  <TaskActivityInline
+                    label="Last updated by"
+                    person={selectedTask.updatedBy}
+                    fallback="Unknown collaborator"
+                    timestamp={selectedTask.updatedAt}
+                  />
+                </div>
                 <Button
                   type="button"
                   size="sm"
@@ -833,7 +848,22 @@ function TaskReadOnlyContent({
                 </Button>
               </div>
             </div>
-          ) : null}
+          ) : (
+            <div className="flex flex-wrap items-center gap-2">
+              <TaskActivityInline
+                label="Created by"
+                person={selectedTask.createdBy}
+                fallback="Unknown creator"
+                timestamp={selectedTask.createdAt}
+              />
+              <TaskActivityInline
+                label="Last updated by"
+                person={selectedTask.updatedBy}
+                fallback="Unknown collaborator"
+                timestamp={selectedTask.updatedAt}
+              />
+            </div>
+          )}
         </div>
       </section>
       {hasAttachments ? (
@@ -1077,23 +1107,13 @@ function TaskEditContent({
           <label htmlFor="task-edit-assignee" className="text-sm font-medium">
             Assignee
           </label>
-          <select
+          <AssigneeSelect
             id="task-edit-assignee"
             value={editAssigneeUserId}
-            onChange={(event) => onEditAssigneeUserIdChange(event.target.value)}
+            onChange={onEditAssigneeUserIdChange}
             disabled={isUpdatingTask}
-            className="h-10 rounded-md border border-input bg-background px-3 text-sm"
-          >
-            <option value="">Unassigned</option>
-            {availableAssignees.map((assignee) => (
-              <option key={assignee.id} value={assignee.id}>
-                {assignee.usernameTag &&
-                assignee.usernameTag !== assignee.displayName
-                  ? `${assignee.displayName} (${assignee.usernameTag})`
-                  : assignee.displayName}
-              </option>
-            ))}
-          </select>
+            options={availableAssignees}
+          />
         </div>
 
         {selectedTask.status === "Blocked" ? (

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -422,8 +422,8 @@ function TaskDeadlineBadge({
   );
 }
 
-function formatTaskActivityTimestamp(value: string): string {
-  return new Date(value).toLocaleString();
+function formatTaskActivityDate(value: string): string {
+  return new Date(value).toLocaleDateString();
 }
 
 function buildTaskPersonHoverLabel(person: TaskPersonSummary): string {
@@ -432,28 +432,33 @@ function buildTaskPersonHoverLabel(person: TaskPersonSummary): string {
 
 function TaskAssigneeBadge({ assignee }: { assignee: TaskPersonSummary | null }) {
   return (
-    <div
-      className="inline-flex max-w-full items-center gap-2 rounded-full border border-border/60 bg-background/85 px-2.5 py-1.5"
-      title={assignee ? buildTaskPersonHoverLabel(assignee) : "Unassigned"}
-    >
-      {assignee ? (
-        <>
-          <UserAvatar
-            avatarSeed={assignee.avatarSeed}
-            displayName={assignee.displayName}
-            className="h-7 w-7 border-border/70"
-            decorative
-          />
-          <span className="max-w-[160px] truncate text-sm font-medium text-foreground">
-            {assignee.displayName}
-          </span>
-        </>
-      ) : (
-        <>
-          <span className="inline-flex h-7 w-7 shrink-0 rounded-full border border-dashed border-border/70 bg-muted/30" />
-          <span className="text-sm text-muted-foreground">Unassigned</span>
-        </>
-      )}
+    <div className="flex flex-col gap-1 sm:items-end">
+      <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+        Assignee
+      </p>
+      <div
+        className="inline-flex max-w-full items-center gap-2 rounded-full border border-border/60 bg-background/85 px-2.5 py-1.5"
+        title={assignee ? buildTaskPersonHoverLabel(assignee) : "Unassigned"}
+      >
+        {assignee ? (
+          <>
+            <UserAvatar
+              avatarSeed={assignee.avatarSeed}
+              displayName={assignee.displayName}
+              className="h-7 w-7 border-border/70"
+              decorative
+            />
+            <span className="max-w-[160px] truncate text-sm font-medium text-foreground">
+              {assignee.displayName}
+            </span>
+          </>
+        ) : (
+          <>
+            <span className="inline-flex h-7 w-7 shrink-0 rounded-full border border-dashed border-border/70 bg-muted/30" />
+            <span className="text-sm text-muted-foreground">Unassigned</span>
+          </>
+        )}
+      </div>
     </div>
   );
 }
@@ -471,29 +476,36 @@ function TaskActivityInline({
 }) {
   if (!person) {
     return (
-      <div className="inline-flex items-center gap-2 rounded-full border border-border/50 bg-background/75 px-2.5 py-1 text-xs text-muted-foreground">
-        <span>{label}</span>
-        <span>{fallback}</span>
+      <div className="grid gap-1 rounded-xl border border-border/50 bg-background/75 px-2.5 py-2">
+        <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+          {label}
+        </p>
+        <p className="text-xs text-muted-foreground">{fallback}</p>
       </div>
     );
   }
 
   return (
     <div
-      className="inline-flex min-w-0 items-center gap-2 rounded-full border border-border/50 bg-background/75 px-2.5 py-1"
+      className="grid min-w-0 gap-1 rounded-xl border border-border/50 bg-background/75 px-2.5 py-2"
       title={`${label}: ${buildTaskPersonHoverLabel(person)}`}
     >
-      <UserAvatar
-        avatarSeed={person.avatarSeed}
-        displayName={person.displayName}
-        className="h-6 w-6 border-border/70"
-        decorative
-      />
-      <span className="max-w-[110px] truncate text-xs font-medium text-foreground">
-        {person.displayName}
-      </span>
+      <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+        {label}
+      </p>
+      <div className="flex min-w-0 items-center gap-1.5">
+        <UserAvatar
+          avatarSeed={person.avatarSeed}
+          displayName={person.displayName}
+          className="h-5 w-5 border-border/70"
+          decorative
+        />
+        <span className="max-w-[96px] truncate text-xs font-medium text-foreground">
+          {person.displayName}
+        </span>
+      </div>
       <span className="text-[11px] text-muted-foreground">
-        {formatTaskActivityTimestamp(timestamp)}
+        {formatTaskActivityDate(timestamp)}
       </span>
     </div>
   );

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -21,6 +21,8 @@ import {
   type KanbanTask,
   type TaskComment,
   type PendingAttachmentUpload,
+  type ProjectTaskCollaborator,
+  type TaskPersonSummary,
   type TaskAttachment,
 } from "@/components/kanban-board-types";
 import {
@@ -69,6 +71,7 @@ interface TaskDetailModalProps {
   editLabelSuggestions: string[];
   editDescription: string;
   editDeadlineDate: string;
+  editAssigneeUserId: string;
   editRelatedTasks: KanbanTask["relatedTasks"];
   relatedTaskSearch: string;
   newBlockedFollowUpEntry: string;
@@ -98,9 +101,11 @@ interface TaskDetailModalProps {
   onRemoveEditLabel: (label: string) => void;
   onEditDescriptionChange: (value: string) => void;
   onEditDeadlineDateChange: (value: string) => void;
+  onEditAssigneeUserIdChange: (value: string) => void;
   onRelatedTaskSearchChange: (value: string) => void;
   onAddRelatedTask: (taskId: string) => void;
   onRemoveRelatedTask: (taskId: string) => void;
+  availableAssignees: ProjectTaskCollaborator[];
   availableRelatedTaskOptions: RelatedTaskOption[];
   onOpenRelatedTask: (taskId: string) => void;
   onNewBlockedFollowUpEntryChange: (value: string) => void;
@@ -131,6 +136,7 @@ export function TaskDetailModal({
   editLabelSuggestions,
   editDescription,
   editDeadlineDate,
+  editAssigneeUserId,
   editRelatedTasks,
   relatedTaskSearch,
   newBlockedFollowUpEntry,
@@ -160,9 +166,11 @@ export function TaskDetailModal({
   onRemoveEditLabel,
   onEditDescriptionChange,
   onEditDeadlineDateChange,
+  onEditAssigneeUserIdChange,
   onRelatedTaskSearchChange,
   onAddRelatedTask,
   onRemoveRelatedTask,
+  availableAssignees,
   availableRelatedTaskOptions,
   onOpenRelatedTask,
   onNewBlockedFollowUpEntryChange,
@@ -287,6 +295,7 @@ export function TaskDetailModal({
                   editLabelSuggestions={editLabelSuggestions}
                   editDescription={editDescription}
                   editDeadlineDate={editDeadlineDate}
+                  editAssigneeUserId={editAssigneeUserId}
                   editRelatedTasks={editRelatedTasks}
                   relatedTaskSearch={relatedTaskSearch}
                   newBlockedFollowUpEntry={newBlockedFollowUpEntry}
@@ -304,9 +313,11 @@ export function TaskDetailModal({
                   onRemoveEditLabel={onRemoveEditLabel}
                   onEditDescriptionChange={onEditDescriptionChange}
                   onEditDeadlineDateChange={onEditDeadlineDateChange}
+                  onEditAssigneeUserIdChange={onEditAssigneeUserIdChange}
                   onRelatedTaskSearchChange={onRelatedTaskSearchChange}
                   onAddRelatedTask={onAddRelatedTask}
                   onRemoveRelatedTask={onRemoveRelatedTask}
+                  availableAssignees={availableAssignees}
                   availableRelatedTaskOptions={availableRelatedTaskOptions}
                   onNewBlockedFollowUpEntryChange={onNewBlockedFollowUpEntryChange}
                   onAddBlockedFollowUpEntry={onAddBlockedFollowUpEntry}
@@ -403,6 +414,67 @@ function TaskDeadlineBadge({
       {relativeLabel ? (
         <span className="hidden sm:inline">- {relativeLabel}</span>
       ) : null}
+    </div>
+  );
+}
+
+function formatTaskActivityTimestamp(value: string): string {
+  return new Date(value).toLocaleString();
+}
+
+function getTaskPersonMeta(person: TaskPersonSummary): string | null {
+  if (!person.usernameTag || person.usernameTag === person.displayName) {
+    return null;
+  }
+
+  return person.usernameTag;
+}
+
+function TaskIdentityRow({
+  label,
+  person,
+  fallback,
+  timestamp,
+}: {
+  label: string;
+  person: TaskPersonSummary | null;
+  fallback: string;
+  timestamp?: string;
+}) {
+  return (
+    <div className="grid gap-2 rounded-xl border border-border/60 bg-background/70 px-3 py-2.5">
+      <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+        {label}
+      </p>
+      {person ? (
+        <div className="flex items-center gap-3">
+          <UserAvatar
+            avatarSeed={person.avatarSeed}
+            displayName={person.displayName}
+            className="h-9 w-9 border-border/70"
+            decorative
+          />
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium text-foreground">
+              {person.displayName}
+            </p>
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+              {getTaskPersonMeta(person) ? (
+                <p className="text-[11px] text-muted-foreground">
+                  {getTaskPersonMeta(person)}
+                </p>
+              ) : null}
+              {timestamp ? (
+                <p className="text-[11px] text-muted-foreground">
+                  {formatTaskActivityTimestamp(timestamp)}
+                </p>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">{fallback}</p>
+      )}
     </div>
   );
 }
@@ -644,6 +716,25 @@ function TaskReadOnlyContent({
           )}
         </div>
       ) : null}
+      <section className="grid gap-2 sm:grid-cols-3">
+        <TaskIdentityRow
+          label="Assignee"
+          person={selectedTask.assignee}
+          fallback="Unassigned"
+        />
+        <TaskIdentityRow
+          label="Created by"
+          person={selectedTask.createdBy}
+          fallback="Unknown creator"
+          timestamp={selectedTask.createdAt}
+        />
+        <TaskIdentityRow
+          label="Last updated by"
+          person={selectedTask.updatedBy}
+          fallback="Unknown collaborator"
+          timestamp={selectedTask.updatedAt}
+        />
+      </section>
       <RichTextContent
         html={selectedTask.description}
         emptyContentHtml="<p>No description provided.</p>"
@@ -821,6 +912,7 @@ interface TaskEditContentProps {
   editLabelSuggestions: string[];
   editDescription: string;
   editDeadlineDate: string;
+  editAssigneeUserId: string;
   editRelatedTasks: KanbanTask["relatedTasks"];
   relatedTaskSearch: string;
   newBlockedFollowUpEntry: string;
@@ -838,9 +930,11 @@ interface TaskEditContentProps {
   onRemoveEditLabel: (label: string) => void;
   onEditDescriptionChange: (value: string) => void;
   onEditDeadlineDateChange: (value: string) => void;
+  onEditAssigneeUserIdChange: (value: string) => void;
   onRelatedTaskSearchChange: (value: string) => void;
   onAddRelatedTask: (taskId: string) => void;
   onRemoveRelatedTask: (taskId: string) => void;
+  availableAssignees: ProjectTaskCollaborator[];
   availableRelatedTaskOptions: RelatedTaskOption[];
   onNewBlockedFollowUpEntryChange: (value: string) => void;
   onAddBlockedFollowUpEntry: () => void | Promise<void>;
@@ -861,6 +955,7 @@ function TaskEditContent({
   editLabelSuggestions,
   editDescription,
   editDeadlineDate,
+  editAssigneeUserId,
   editRelatedTasks,
   relatedTaskSearch,
   newBlockedFollowUpEntry,
@@ -878,9 +973,11 @@ function TaskEditContent({
   onRemoveEditLabel,
   onEditDescriptionChange,
   onEditDeadlineDateChange,
+  onEditAssigneeUserIdChange,
   onRelatedTaskSearchChange,
   onAddRelatedTask,
   onRemoveRelatedTask,
+  availableAssignees,
   availableRelatedTaskOptions,
   onNewBlockedFollowUpEntryChange,
   onAddBlockedFollowUpEntry,
@@ -975,6 +1072,29 @@ function TaskEditContent({
           onChange={onEditDeadlineDateChange}
           disabled={isUpdatingTask}
         />
+
+        <div className="grid gap-2">
+          <label htmlFor="task-edit-assignee" className="text-sm font-medium">
+            Assignee
+          </label>
+          <select
+            id="task-edit-assignee"
+            value={editAssigneeUserId}
+            onChange={(event) => onEditAssigneeUserIdChange(event.target.value)}
+            disabled={isUpdatingTask}
+            className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+          >
+            <option value="">Unassigned</option>
+            {availableAssignees.map((assignee) => (
+              <option key={assignee.id} value={assignee.id}>
+                {assignee.usernameTag &&
+                assignee.usernameTag !== assignee.displayName
+                  ? `${assignee.displayName} (${assignee.usernameTag})`
+                  : assignee.displayName}
+              </option>
+            ))}
+          </select>
+        </div>
 
         {selectedTask.status === "Blocked" ? (
           <div className="grid gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2">

--- a/components/ui/assignee-select.tsx
+++ b/components/ui/assignee-select.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import { createPortal } from "react-dom";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Check, ChevronDown } from "lucide-react";
+
+import type {
+  ProjectTaskCollaborator,
+  ProjectTaskCollaboratorRole,
+} from "@/components/kanban-board-types";
+import { UserAvatar } from "@/components/ui/user-avatar";
+import { cn } from "@/lib/utils";
+
+interface AssigneeSelectProps {
+  id?: string;
+  name?: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: ProjectTaskCollaborator[];
+  disabled?: boolean;
+  className?: string;
+  unassignedLabel?: string;
+}
+
+function formatProjectRole(role: ProjectTaskCollaboratorRole): string {
+  switch (role) {
+    case "owner":
+      return "Owner";
+    case "editor":
+      return "Editor";
+    case "viewer":
+      return "Viewer";
+    default:
+      return role;
+  }
+}
+
+function buildAssigneeHoverLabel(assignee: ProjectTaskCollaborator): string {
+  return assignee.usernameTag ?? assignee.displayName;
+}
+
+export function AssigneeSelect({
+  id,
+  name,
+  value,
+  onChange,
+  options,
+  disabled = false,
+  className,
+  unassignedLabel = "Unassigned",
+}: AssigneeSelectProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [dropdownPosition, setDropdownPosition] = useState<{
+    top: number;
+    left: number;
+    width: number;
+    maxHeight: number;
+  } | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
+
+  const selectedAssignee = useMemo(
+    () => options.find((option) => option.id === value) ?? null,
+    [options, value]
+  );
+
+  useEffect(() => {
+    if (!isOpen) {
+      setDropdownPosition(null);
+      return;
+    }
+
+    const updateDropdownPosition = () => {
+      const trigger = triggerRef.current;
+      if (!trigger) {
+        return;
+      }
+
+      const rect = trigger.getBoundingClientRect();
+      const viewportPadding = 12;
+      const estimatedHeight = Math.min(56 * (options.length + 1), 280);
+      const availableBelow = window.innerHeight - rect.bottom - viewportPadding;
+      const availableAbove = rect.top - viewportPadding;
+      const shouldOpenAbove =
+        availableBelow < estimatedHeight && availableAbove > availableBelow;
+      const maxHeight = Math.max(
+        140,
+        shouldOpenAbove ? availableAbove - 6 : availableBelow - 6
+      );
+
+      setDropdownPosition({
+        top: shouldOpenAbove
+          ? Math.max(viewportPadding, rect.top - Math.min(estimatedHeight, maxHeight) - 6)
+          : rect.bottom + 6,
+        left: rect.left,
+        width: Math.max(rect.width, 260),
+        maxHeight,
+      });
+    };
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node | null;
+      if (!target) {
+        return;
+      }
+
+      if (triggerRef.current?.contains(target) || dropdownRef.current?.contains(target)) {
+        return;
+      }
+
+      setIsOpen(false);
+    };
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+
+    updateDropdownPosition();
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleEscape);
+    window.addEventListener("resize", updateDropdownPosition);
+    window.addEventListener("scroll", updateDropdownPosition, true);
+
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleEscape);
+      window.removeEventListener("resize", updateDropdownPosition);
+      window.removeEventListener("scroll", updateDropdownPosition, true);
+    };
+  }, [isOpen, options.length]);
+
+  return (
+    <div className="relative">
+      {name ? <input type="hidden" name={name} value={value} /> : null}
+      <button
+        ref={triggerRef}
+        id={id}
+        type="button"
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        className={cn(
+          "flex min-h-10 w-full items-center justify-between gap-3 rounded-md border border-input bg-background px-3 py-2 text-left transition-colors",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+          "disabled:cursor-not-allowed disabled:opacity-60",
+          className
+        )}
+        onClick={() => {
+          if (disabled) {
+            return;
+          }
+
+          setIsOpen((previous) => !previous);
+        }}
+        title={selectedAssignee ? buildAssigneeHoverLabel(selectedAssignee) : undefined}
+      >
+        {selectedAssignee ? (
+          <div className="flex min-w-0 items-center gap-3">
+            <UserAvatar
+              avatarSeed={selectedAssignee.avatarSeed}
+              displayName={selectedAssignee.displayName}
+              className="h-8 w-8 border-border/70"
+              decorative
+            />
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium text-foreground">
+                {selectedAssignee.displayName}
+              </p>
+              <p className="truncate text-xs text-muted-foreground">
+                {formatProjectRole(selectedAssignee.projectRole)}
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="flex min-w-0 items-center gap-3">
+            <span className="inline-flex h-8 w-8 shrink-0 rounded-full border border-dashed border-border/70 bg-muted/30" />
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium text-foreground">{unassignedLabel}</p>
+              <p className="truncate text-xs text-muted-foreground">No owner yet</p>
+            </div>
+          </div>
+        )}
+        <ChevronDown
+          className={cn(
+            "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
+            isOpen && "rotate-180"
+          )}
+        />
+      </button>
+
+      {isOpen && dropdownPosition && typeof document !== "undefined"
+        ? createPortal(
+            <div
+              ref={dropdownRef}
+              role="listbox"
+              className="z-[140] overflow-hidden rounded-xl border border-border/70 bg-popover p-1 shadow-lg"
+              style={{
+                position: "fixed",
+                top: dropdownPosition.top,
+                left: dropdownPosition.left,
+                width: dropdownPosition.width,
+                maxHeight: dropdownPosition.maxHeight,
+              }}
+            >
+              <div className="scrollbar-hidden space-y-1 overflow-y-auto p-0.5">
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={!selectedAssignee}
+                  className="flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-left transition hover:bg-muted"
+                  onClick={() => {
+                    onChange("");
+                    setIsOpen(false);
+                  }}
+                >
+                  <div className="flex min-w-0 items-center gap-3">
+                    <span className="inline-flex h-9 w-9 shrink-0 rounded-full border border-dashed border-border/70 bg-muted/30" />
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium text-foreground">
+                        {unassignedLabel}
+                      </p>
+                      <p className="truncate text-xs text-muted-foreground">
+                        Leave without an assignee
+                      </p>
+                    </div>
+                  </div>
+                  {!selectedAssignee ? <Check className="h-4 w-4 text-foreground" /> : null}
+                </button>
+
+                {options.map((assignee) => {
+                  const isSelected = assignee.id === selectedAssignee?.id;
+
+                  return (
+                    <button
+                      key={assignee.id}
+                      type="button"
+                      role="option"
+                      aria-selected={isSelected}
+                      title={buildAssigneeHoverLabel(assignee)}
+                      className="flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-left transition hover:bg-muted"
+                      onClick={() => {
+                        onChange(assignee.id);
+                        setIsOpen(false);
+                      }}
+                    >
+                      <div className="flex min-w-0 items-center gap-3">
+                        <UserAvatar
+                          avatarSeed={assignee.avatarSeed}
+                          displayName={assignee.displayName}
+                          className="h-9 w-9 border-border/70"
+                          decorative
+                        />
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-medium text-foreground">
+                            {assignee.displayName}
+                          </p>
+                          <p className="truncate text-xs text-muted-foreground">
+                            {formatProjectRole(assignee.projectRole)}
+                          </p>
+                        </div>
+                      </div>
+                      {isSelected ? <Check className="h-4 w-4 text-foreground" /> : null}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>,
+            document.body
+          )
+        : null}
+    </div>
+  );
+}

--- a/journal.md
+++ b/journal.md
@@ -14,6 +14,21 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ### 2026-04-21
 - Type: Execution
+- Summary: TASK-101 implemented first-class task ownership and provenance end to end so tasks now persist creator, updater, and optional assignee metadata and surface avatar-backed attribution across task cards, task detail, create/edit flows, comments, and task-related attachment activity.
+- Evidence: Added task ownership fields plus migration `prisma/migrations/20260421131500_task101_task_ownership_and_provenance/migration.sql`; updated `prisma/schema.prisma`, `lib/services/project-task-service.ts`, `lib/services/project-service.ts`, `lib/services/project-task-comment-service.ts`, `lib/services/project-attachment-service.ts`, `app/api/projects/[projectId]/tasks/route.ts`, `app/projects/[projectId]/kanban-board-section.tsx`, `components/kanban-board.tsx`, `components/kanban/task-detail-modal.tsx`, `components/kanban/kanban-columns-grid.tsx`, `components/create-task-dialog.tsx`, `components/kanban-board-types.ts`, `lib/agent-onboarding.ts`, and related API/service tests.
+
+### 2026-04-21
+- Type: Validation
+- Summary: TASK-101 local validation passed for lint, targeted regressions, full Vitest suite, coverage, and production build after regenerating Prisma client artifacts with a Node `20.19.0` runtime compatible with the current Prisma `7.7` toolchain.
+- Evidence: `npm run lint`; `npx vitest run tests/lib/project-attachment-service.test.ts tests/api/task-create.route.test.ts tests/api/task-comments.route.test.ts tests/api/task-update.route.test.ts tests/api/tasks-reorder.route.test.ts tests/api/agent-project-routes.test.ts tests/lib/project-service.test.ts`; `$env:DATABASE_URL='postgresql://localhost:5432/postgres'; $env:DIRECT_URL='postgresql://localhost:5432/postgres'; npx -y -p node@20.19.0 node .\\node_modules\\vitest\\vitest.mjs run`; same env with `--coverage`; `npx -y -p node@20.19.0 node .\\node_modules\\prisma\\build\\index.js generate`; `$env:DATABASE_URL='postgresql://localhost:5432/postgres'; $env:DIRECT_URL='postgresql://localhost:5433/postgres'; $env:GOOGLE_TOKEN_ENCRYPTION_KEY='0123456789abcdef0123456789abcdef'; $env:AGENT_TOKEN_SIGNING_SECRET='0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'; npm run build`.
+
+### 2026-04-21
+- Type: Blocker
+- Summary: TASK-101 local Playwright validation is blocked before browser interaction because Playwright boots against the shared `.env` database, and that database has not yet had the TASK-101 ownership/provenance migration applied.
+- Evidence: `$env:DATABASE_URL='postgresql://localhost:5432/postgres'; $env:DIRECT_URL='postgresql://localhost:5433/postgres'; $env:GOOGLE_TOKEN_ENCRYPTION_KEY='0123456789abcdef0123456789abcdef'; npx -y -p node@20.19.0 node .\\node_modules\\playwright\\cli.js test` failed during seed user creation in `tests/e2e/helpers/auth-helpers.ts` / `tests/e2e/password-recovery.spec.ts` with `PrismaClientKnownRequestError` before UI flow execution; the controlled preview deployment workflow applies migrations and is the safe place to complete browser verification.
+
+### 2026-04-21
+- Type: Execution
 - Summary: TASK-089 follow-up extended the generated-avatar rollout by lowering pixel density, rendering avatars in task comments, and adding avatars to the project settings contributors list while keeping the same shared avatar primitive and collaborator/comment identity contracts.
 - Evidence: Updated `lib/avatar.ts`, `lib/services/project-task-comment-service.ts`, `components/kanban/task-detail-modal.tsx`, `lib/services/project-collaboration-service.ts`, `components/project-dashboard/project-dashboard-owner-access-panel.tsx`, `components/project-dashboard/project-dashboard-owner-actions.shared.ts`, `lib/agent-onboarding.ts`, `tasks/current.md`, and related tests in `tests/api/task-comments.route.test.ts` plus `tests/components/project-dashboard-owner-access-panel.test.tsx`.
 

--- a/lib/agent-onboarding.ts
+++ b/lib/agent-onboarding.ts
@@ -390,7 +390,7 @@ export function buildAgentTaskCreateExample(): string {
     'curl -X POST "$NEXUSDASH_BASE_URL/api/projects/$NEXUSDASH_PROJECT_ID/tasks" \\',
     `  -H "Authorization: Bearer $${AGENT_BEARER_TOKEN_ENV_NAME}" \\`,
     '  -H "Content-Type: application/json" \\',
-    "  -d '{\"title\":\"Draft release notes\",\"description\":\"<p>Summarize this week''s changes.</p>\",\"deadlineDate\":\"2026-04-24\",\"labels\":[\"release\",\"docs\"],\"attachmentLinks\":[{\"name\":\"Spec\",\"url\":\"https://example.com/spec\"}]}'",
+    "  -d '{\"title\":\"Draft release notes\",\"description\":\"<p>Summarize this week''s changes.</p>\",\"deadlineDate\":\"2026-04-24\",\"assigneeUserId\":\"user_456\",\"labels\":[\"release\",\"docs\"],\"attachmentLinks\":[{\"name\":\"Spec\",\"url\":\"https://example.com/spec\"}]}'",
   ].join("\n");
 }
 
@@ -408,7 +408,7 @@ export function buildAgentTaskUpdateExample(): string {
     'curl -X PATCH "$NEXUSDASH_BASE_URL/api/projects/$NEXUSDASH_PROJECT_ID/tasks/$TASK_ID" \\',
     `  -H "Authorization: Bearer $${AGENT_BEARER_TOKEN_ENV_NAME}" \\`,
     '  -H "Content-Type: application/json" \\',
-    '  -d \'{"title":"Draft release notes","description":"<p>Add release highlights.</p>","deadlineDate":"2026-04-25","labels":["release","ready"],"relatedTaskIds":["task_456"]}\'',
+    '  -d \'{"title":"Draft release notes","description":"<p>Add release highlights.</p>","deadlineDate":"2026-04-25","assigneeUserId":"user_456","labels":["release","ready"],"relatedTaskIds":["task_456"]}\'',
   ].join("\n");
 }
 
@@ -939,6 +939,9 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
             "labelsJson",
             "createdAt",
             "updatedAt",
+            "assignee",
+            "createdBy",
+            "updatedBy",
             "attachments",
             "relatedTasks",
             "blockedFollowUps",
@@ -961,6 +964,18 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
             labelsJson: { type: ["string", "null"] },
             createdAt: { type: "string", format: "date-time" },
             updatedAt: { type: "string", format: "date-time" },
+            assignee: {
+              anyOf: [
+                { $ref: "#/components/schemas/TaskCommentAuthor" },
+                { type: "null" },
+              ],
+            },
+            createdBy: {
+              $ref: "#/components/schemas/TaskCommentAuthor",
+            },
+            updatedBy: {
+              $ref: "#/components/schemas/TaskCommentAuthor",
+            },
             attachments: {
               type: "array",
               items: {
@@ -1000,6 +1015,7 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
             title: { type: "string" },
             description: { type: "string" },
             deadlineDate: { type: "string", format: "date" },
+            assigneeUserId: { type: ["string", "null"] },
             labels: {
               type: "array",
               items: {
@@ -1042,6 +1058,7 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
               type: ["string", "null"],
               format: "date",
             },
+            assigneeUserId: { type: ["string", "null"] },
             blockedFollowUpEntry: { type: "string" },
             relatedTaskIds: {
               type: "array",
@@ -1067,6 +1084,11 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
                 "status",
                 "position",
                 "archivedAt",
+                "assignee",
+                "createdBy",
+                "updatedBy",
+                "createdAt",
+                "updatedAt",
                 "relatedTasks",
                 "blockedFollowUps",
               ],
@@ -1085,6 +1107,20 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
                 },
                 position: { type: "integer" },
                 archivedAt: { type: ["string", "null"], format: "date-time" },
+                assignee: {
+                  anyOf: [
+                    { $ref: "#/components/schemas/TaskCommentAuthor" },
+                    { type: "null" },
+                  ],
+                },
+                createdBy: {
+                  $ref: "#/components/schemas/TaskCommentAuthor",
+                },
+                updatedBy: {
+                  $ref: "#/components/schemas/TaskCommentAuthor",
+                },
+                createdAt: { type: "string", format: "date-time" },
+                updatedAt: { type: "string", format: "date-time" },
                 relatedTasks: {
                   type: "array",
                   items: {

--- a/lib/avatar.ts
+++ b/lib/avatar.ts
@@ -3,6 +3,7 @@ const GRID_SIZE = 5;
 const GRID_INSET = 7;
 const CELL_SIZE = 10;
 const CELL_GAP = 0;
+const GRID_CENTER_INDEX = Math.floor(GRID_SIZE / 2);
 const PIXEL_COLORS = ["#F5F7FA", "#D5DBE3", "#5D6470"] as const;
 const BACKGROUND_COLORS = [
   "#E76F51",
@@ -83,52 +84,67 @@ function getNeighborCoordinates(row: number, column: number) {
   return neighbors;
 }
 
+function getDistanceFromCenter(row: number, column: number): number {
+  return Math.abs(row - GRID_CENTER_INDEX) + Math.abs(column - GRID_CENTER_INDEX);
+}
+
+function isEdgeCell(row: number, column: number): boolean {
+  return row === 0 || column === 0 || row === GRID_SIZE - 1 || column === GRID_SIZE - 1;
+}
+
+function buildFrontier(grid: boolean[][], filledCells: Array<{ row: number; column: number }>) {
+  const uniqueCandidates = new Map<string, { row: number; column: number }>();
+
+  for (const { row, column } of filledCells) {
+    for (const neighbor of getNeighborCoordinates(row, column)) {
+      if (grid[neighbor.row]![neighbor.column]) {
+        continue;
+      }
+
+      uniqueCandidates.set(`${neighbor.row}:${neighbor.column}`, neighbor);
+    }
+  }
+
+  return Array.from(uniqueCandidates.values());
+}
+
+function pickNextCell(
+  random: () => number,
+  candidates: Array<{ row: number; column: number }>
+) {
+  const scoredCandidates = candidates
+    .map((candidate) => {
+      const centerDistance = getDistanceFromCenter(candidate.row, candidate.column);
+      const edgePenalty = isEdgeCell(candidate.row, candidate.column) ? 1.25 : 0;
+
+      return {
+        candidate,
+        score: 5 - centerDistance - edgePenalty + random() * 0.35,
+      };
+    })
+    .sort((left, right) => right.score - left.score);
+
+  return scoredCandidates[0]?.candidate ?? null;
+}
+
 function buildPixelMask(random: () => number): boolean[][] {
   const grid = createEmptyGrid();
   const filledCells: Array<{ row: number; column: number }> = [];
-  const targetPixelCount = 6 + Math.floor(random() * 3);
+  const targetPixelCount = 9 + Math.floor(random() * 3);
 
-  const startRow = Math.floor(random() * GRID_SIZE);
-  const startColumn = Math.floor(random() * GRID_SIZE);
+  const startRow = GRID_CENTER_INDEX;
+  const startColumn = GRID_CENTER_INDEX;
 
   grid[startRow]![startColumn] = true;
   filledCells.push({ row: startRow, column: startColumn });
 
   while (filledCells.length < targetPixelCount) {
-    const anchor = filledCells[Math.floor(random() * filledCells.length)];
-    if (!anchor) {
+    const frontier = buildFrontier(grid, filledCells);
+    if (frontier.length === 0) {
       break;
     }
 
-    const availableNeighbors = getNeighborCoordinates(anchor.row, anchor.column).filter(
-      ({ row, column }) => !grid[row]![column]
-    );
-
-    if (availableNeighbors.length === 0) {
-      const fallbackNeighbors = filledCells.flatMap(({ row, column }) =>
-        getNeighborCoordinates(row, column).filter(
-          (neighbor) => !grid[neighbor.row]![neighbor.column]
-        )
-      );
-
-      if (fallbackNeighbors.length === 0) {
-        break;
-      }
-
-      const fallback =
-        fallbackNeighbors[Math.floor(random() * fallbackNeighbors.length)];
-
-      if (!fallback) {
-        break;
-      }
-
-      grid[fallback.row]![fallback.column] = true;
-      filledCells.push(fallback);
-      continue;
-    }
-
-    const nextCell =
-      availableNeighbors[Math.floor(random() * availableNeighbors.length)];
+    const nextCell = pickNextCell(random, frontier);
 
     if (!nextCell) {
       break;

--- a/lib/avatar.ts
+++ b/lib/avatar.ts
@@ -92,6 +92,16 @@ function isEdgeCell(row: number, column: number): boolean {
   return row === 0 || column === 0 || row === GRID_SIZE - 1 || column === GRID_SIZE - 1;
 }
 
+function countFilledNeighbors(
+  grid: boolean[][],
+  row: number,
+  column: number
+): number {
+  return getNeighborCoordinates(row, column).reduce((count, neighbor) => {
+    return count + (grid[neighbor.row]![neighbor.column] ? 1 : 0);
+  }, 0);
+}
+
 function buildFrontier(grid: boolean[][], filledCells: Array<{ row: number; column: number }>) {
   const uniqueCandidates = new Map<string, { row: number; column: number }>();
 
@@ -110,21 +120,43 @@ function buildFrontier(grid: boolean[][], filledCells: Array<{ row: number; colu
 
 function pickNextCell(
   random: () => number,
+  grid: boolean[][],
   candidates: Array<{ row: number; column: number }>
 ) {
-  const scoredCandidates = candidates
-    .map((candidate) => {
-      const centerDistance = getDistanceFromCenter(candidate.row, candidate.column);
-      const edgePenalty = isEdgeCell(candidate.row, candidate.column) ? 1.25 : 0;
+  const weightedCandidates = candidates.map((candidate) => {
+    const centerDistance = getDistanceFromCenter(candidate.row, candidate.column);
+    const filledNeighborCount = countFilledNeighbors(
+      grid,
+      candidate.row,
+      candidate.column
+    );
+    const edgePenalty = isEdgeCell(candidate.row, candidate.column) ? 0.85 : 0;
+    const weight = Math.max(
+      0.2,
+      4.2 - centerDistance * 0.8 + filledNeighborCount * 0.3 - edgePenalty
+    );
 
-      return {
-        candidate,
-        score: 5 - centerDistance - edgePenalty + random() * 0.35,
-      };
-    })
-    .sort((left, right) => right.score - left.score);
+    return {
+      candidate,
+      weight,
+    };
+  });
 
-  return scoredCandidates[0]?.candidate ?? null;
+  const totalWeight = weightedCandidates.reduce((sum, entry) => sum + entry.weight, 0);
+  if (totalWeight <= 0) {
+    return weightedCandidates[0]?.candidate ?? null;
+  }
+
+  let remainingWeight = random() * totalWeight;
+
+  for (const entry of weightedCandidates) {
+    remainingWeight -= entry.weight;
+    if (remainingWeight <= 0) {
+      return entry.candidate;
+    }
+  }
+
+  return weightedCandidates[weightedCandidates.length - 1]?.candidate ?? null;
 }
 
 function buildPixelMask(random: () => number): boolean[][] {
@@ -144,7 +176,7 @@ function buildPixelMask(random: () => number): boolean[][] {
       break;
     }
 
-    const nextCell = pickNextCell(random, frontier);
+    const nextCell = pickNextCell(random, grid, frontier);
 
     if (!nextCell) {
       break;

--- a/lib/avatar.ts
+++ b/lib/avatar.ts
@@ -1,8 +1,8 @@
 const AVATAR_SIZE = 64;
 const GRID_SIZE = 5;
-const GRID_INSET = 8;
-const CELL_SIZE = 8;
-const CELL_GAP = 2;
+const GRID_INSET = 7;
+const CELL_SIZE = 10;
+const CELL_GAP = 0;
 const PIXEL_COLORS = ["#F5F7FA", "#D5DBE3", "#5D6470"] as const;
 const BACKGROUND_COLORS = [
   "#E76F51",
@@ -50,6 +50,97 @@ function createMulberry32(seed: number) {
   };
 }
 
+function createEmptyGrid(): boolean[][] {
+  return Array.from({ length: GRID_SIZE }, () => Array.from({ length: GRID_SIZE }, () => false));
+}
+
+function getNeighborCoordinates(row: number, column: number) {
+  const neighbors: Array<{ row: number; column: number }> = [];
+
+  for (let rowOffset = -1; rowOffset <= 1; rowOffset += 1) {
+    for (let columnOffset = -1; columnOffset <= 1; columnOffset += 1) {
+      if (rowOffset === 0 && columnOffset === 0) {
+        continue;
+      }
+
+      const nextRow = row + rowOffset;
+      const nextColumn = column + columnOffset;
+      const isWithinBounds =
+        nextRow >= 0 &&
+        nextRow < GRID_SIZE &&
+        nextColumn >= 0 &&
+        nextColumn < GRID_SIZE;
+
+      if (isWithinBounds) {
+        neighbors.push({
+          row: nextRow,
+          column: nextColumn,
+        });
+      }
+    }
+  }
+
+  return neighbors;
+}
+
+function buildPixelMask(random: () => number): boolean[][] {
+  const grid = createEmptyGrid();
+  const filledCells: Array<{ row: number; column: number }> = [];
+  const targetPixelCount = 6 + Math.floor(random() * 3);
+
+  const startRow = Math.floor(random() * GRID_SIZE);
+  const startColumn = Math.floor(random() * GRID_SIZE);
+
+  grid[startRow]![startColumn] = true;
+  filledCells.push({ row: startRow, column: startColumn });
+
+  while (filledCells.length < targetPixelCount) {
+    const anchor = filledCells[Math.floor(random() * filledCells.length)];
+    if (!anchor) {
+      break;
+    }
+
+    const availableNeighbors = getNeighborCoordinates(anchor.row, anchor.column).filter(
+      ({ row, column }) => !grid[row]![column]
+    );
+
+    if (availableNeighbors.length === 0) {
+      const fallbackNeighbors = filledCells.flatMap(({ row, column }) =>
+        getNeighborCoordinates(row, column).filter(
+          (neighbor) => !grid[neighbor.row]![neighbor.column]
+        )
+      );
+
+      if (fallbackNeighbors.length === 0) {
+        break;
+      }
+
+      const fallback =
+        fallbackNeighbors[Math.floor(random() * fallbackNeighbors.length)];
+
+      if (!fallback) {
+        break;
+      }
+
+      grid[fallback.row]![fallback.column] = true;
+      filledCells.push(fallback);
+      continue;
+    }
+
+    const nextCell =
+      availableNeighbors[Math.floor(random() * availableNeighbors.length)];
+
+    if (!nextCell) {
+      break;
+    }
+
+    grid[nextCell.row]![nextCell.column] = true;
+    filledCells.push(nextCell);
+  }
+
+  return grid;
+}
+
 function buildAvatarSvg(seed: string): string {
   const normalizedSeed = normalizeSeed(seed);
   const random = createMulberry32(hashSeed(normalizedSeed));
@@ -57,11 +148,11 @@ function buildAvatarSvg(seed: string): string {
     BACKGROUND_COLORS[Math.floor(random() * BACKGROUND_COLORS.length)] ??
     BACKGROUND_COLORS[0];
   const pixels: string[] = [];
+  const pixelMask = buildPixelMask(random);
 
   for (let row = 0; row < GRID_SIZE; row += 1) {
     for (let column = 0; column < GRID_SIZE; column += 1) {
-      const shouldDrawPixel = random() >= 0.71;
-      if (!shouldDrawPixel) {
+      if (!pixelMask[row]![column]) {
         continue;
       }
 

--- a/lib/avatar.ts
+++ b/lib/avatar.ts
@@ -1,8 +1,8 @@
 const AVATAR_SIZE = 64;
-const GRID_SIZE = 7;
-const GRID_INSET = 11;
-const CELL_SIZE = 6;
-const CELL_GAP = 1;
+const GRID_SIZE = 5;
+const GRID_INSET = 8;
+const CELL_SIZE = 8;
+const CELL_GAP = 2;
 const PIXEL_COLORS = ["#F5F7FA", "#D5DBE3", "#5D6470"] as const;
 const BACKGROUND_COLORS = [
   "#E76F51",

--- a/lib/services/project-attachment-service.ts
+++ b/lib/services/project-attachment-service.ts
@@ -421,29 +421,25 @@ export async function createTaskAttachmentFromForm(input: {
       }
 
       try {
-        const attachment = await db.$transaction(async (tx) => {
-          const createdAttachment = await tx.taskAttachment.create({
-            data: {
-              taskId: input.taskId,
-              uploadedByUserId: actorUserId,
-              kind: ATTACHMENT_KIND_LINK,
-              name: providedName || new URL(normalizedUrl).hostname,
-              url: normalizedUrl,
-            },
-            select: {
-              id: true,
-              kind: true,
-              name: true,
-              url: true,
-              mimeType: true,
-              sizeBytes: true,
-            },
-          });
-
-          await touchTaskActivity(tx, input.taskId, actorUserId);
-
-          return createdAttachment;
+        const attachment = await db.taskAttachment.create({
+          data: {
+            taskId: input.taskId,
+            uploadedByUserId: actorUserId,
+            kind: ATTACHMENT_KIND_LINK,
+            name: providedName || new URL(normalizedUrl).hostname,
+            url: normalizedUrl,
+          },
+          select: {
+            id: true,
+            kind: true,
+            name: true,
+            url: true,
+            mimeType: true,
+            sizeBytes: true,
+          },
         });
+
+        await touchTaskActivity(db, input.taskId, actorUserId);
 
         return {
           ok: true,
@@ -497,31 +493,27 @@ export async function createTaskAttachmentFromForm(input: {
         resolveAttachmentMimeType(storedFile.mimeType, storedFile.originalName) ??
         resolvedFormMimeType;
 
-      const attachment = await db.$transaction(async (tx) => {
-        const createdAttachment = await tx.taskAttachment.create({
-          data: {
-            taskId: input.taskId,
-            uploadedByUserId: actorUserId,
-            kind: ATTACHMENT_KIND_FILE,
-            name: providedName || storedFile.originalName,
-            storageKey: storedFile.storageKey,
-            mimeType: resolvedStoredMimeType,
-            sizeBytes: storedFile.sizeBytes,
-          },
-          select: {
-            id: true,
-            kind: true,
-            name: true,
-            url: true,
-            mimeType: true,
-            sizeBytes: true,
-          },
-        });
-
-        await touchTaskActivity(tx, input.taskId, actorUserId);
-
-        return createdAttachment;
+      const attachment = await db.taskAttachment.create({
+        data: {
+          taskId: input.taskId,
+          uploadedByUserId: actorUserId,
+          kind: ATTACHMENT_KIND_FILE,
+          name: providedName || storedFile.originalName,
+          storageKey: storedFile.storageKey,
+          mimeType: resolvedStoredMimeType,
+          sizeBytes: storedFile.sizeBytes,
+        },
+        select: {
+          id: true,
+          kind: true,
+          name: true,
+          url: true,
+          mimeType: true,
+          sizeBytes: true,
+        },
       });
+
+      await touchTaskActivity(db, input.taskId, actorUserId);
 
       return {
         ok: true,
@@ -895,31 +887,27 @@ export async function finalizeTaskAttachmentDirectUpload(input: {
         );
       }
 
-      const attachment = await db.$transaction(async (tx) => {
-        const createdAttachment = await tx.taskAttachment.create({
-          data: {
-            taskId: input.taskId,
-            uploadedByUserId: actorUserId,
-            kind: ATTACHMENT_KIND_FILE,
-            name: normalizedUpload.data.name,
-            storageKey: normalizedStorageKey,
-            mimeType: resolvedMimeType,
-            sizeBytes: resolvedSizeBytes,
-          },
-          select: {
-            id: true,
-            kind: true,
-            name: true,
-            url: true,
-            mimeType: true,
-            sizeBytes: true,
-          },
-        });
-
-        await touchTaskActivity(tx, input.taskId, actorUserId);
-
-        return createdAttachment;
+      const attachment = await db.taskAttachment.create({
+        data: {
+          taskId: input.taskId,
+          uploadedByUserId: actorUserId,
+          kind: ATTACHMENT_KIND_FILE,
+          name: normalizedUpload.data.name,
+          storageKey: normalizedStorageKey,
+          mimeType: resolvedMimeType,
+          sizeBytes: resolvedSizeBytes,
+        },
+        select: {
+          id: true,
+          kind: true,
+          name: true,
+          url: true,
+          mimeType: true,
+          sizeBytes: true,
+        },
       });
+
+      await touchTaskActivity(db, input.taskId, actorUserId);
 
       return {
         ok: true,
@@ -1385,13 +1373,11 @@ export async function deleteTaskAttachmentForProject(input: {
         return createError(404, "Attachment not found");
       }
 
-      await db.$transaction(async (tx) => {
-        await tx.taskAttachment.delete({
-          where: { id: attachment.id },
-        });
-
-        await touchTaskActivity(tx, input.taskId, actorUserId);
+      await db.taskAttachment.delete({
+        where: { id: attachment.id },
       });
+
+      await touchTaskActivity(db, input.taskId, actorUserId);
 
       if (attachment.kind === ATTACHMENT_KIND_FILE && attachment.storageKey) {
         await deleteAttachmentFile(attachment.storageKey).catch((error) => {

--- a/lib/services/project-attachment-service.ts
+++ b/lib/services/project-attachment-service.ts
@@ -210,6 +210,22 @@ export function mapTaskAttachmentResponse(
   };
 }
 
+async function touchTaskActivity(
+  db: DbClient,
+  taskId: string,
+  actorUserId: string
+) {
+  await db.task.update({
+    where: { id: taskId },
+    data: {
+      updatedByUserId: actorUserId,
+    },
+    select: {
+      id: true,
+    },
+  });
+}
+
 export function mapContextAttachmentResponse(
   projectId: string,
   cardId: string,
@@ -405,22 +421,28 @@ export async function createTaskAttachmentFromForm(input: {
       }
 
       try {
-        const attachment = await db.taskAttachment.create({
-          data: {
-            taskId: input.taskId,
-            uploadedByUserId: actorUserId,
-            kind: ATTACHMENT_KIND_LINK,
-            name: providedName || new URL(normalizedUrl).hostname,
-            url: normalizedUrl,
-          },
-          select: {
-            id: true,
-            kind: true,
-            name: true,
-            url: true,
-            mimeType: true,
-            sizeBytes: true,
-          },
+        const attachment = await db.$transaction(async (tx) => {
+          const createdAttachment = await tx.taskAttachment.create({
+            data: {
+              taskId: input.taskId,
+              uploadedByUserId: actorUserId,
+              kind: ATTACHMENT_KIND_LINK,
+              name: providedName || new URL(normalizedUrl).hostname,
+              url: normalizedUrl,
+            },
+            select: {
+              id: true,
+              kind: true,
+              name: true,
+              url: true,
+              mimeType: true,
+              sizeBytes: true,
+            },
+          });
+
+          await touchTaskActivity(tx, input.taskId, actorUserId);
+
+          return createdAttachment;
         });
 
         return {
@@ -475,24 +497,30 @@ export async function createTaskAttachmentFromForm(input: {
         resolveAttachmentMimeType(storedFile.mimeType, storedFile.originalName) ??
         resolvedFormMimeType;
 
-      const attachment = await db.taskAttachment.create({
-        data: {
-          taskId: input.taskId,
-          uploadedByUserId: actorUserId,
-          kind: ATTACHMENT_KIND_FILE,
-          name: providedName || storedFile.originalName,
-          storageKey: storedFile.storageKey,
-          mimeType: resolvedStoredMimeType,
-          sizeBytes: storedFile.sizeBytes,
-        },
-        select: {
-          id: true,
-          kind: true,
-          name: true,
-          url: true,
-          mimeType: true,
-          sizeBytes: true,
-        },
+      const attachment = await db.$transaction(async (tx) => {
+        const createdAttachment = await tx.taskAttachment.create({
+          data: {
+            taskId: input.taskId,
+            uploadedByUserId: actorUserId,
+            kind: ATTACHMENT_KIND_FILE,
+            name: providedName || storedFile.originalName,
+            storageKey: storedFile.storageKey,
+            mimeType: resolvedStoredMimeType,
+            sizeBytes: storedFile.sizeBytes,
+          },
+          select: {
+            id: true,
+            kind: true,
+            name: true,
+            url: true,
+            mimeType: true,
+            sizeBytes: true,
+          },
+        });
+
+        await touchTaskActivity(tx, input.taskId, actorUserId);
+
+        return createdAttachment;
       });
 
       return {
@@ -867,24 +895,30 @@ export async function finalizeTaskAttachmentDirectUpload(input: {
         );
       }
 
-      const attachment = await db.taskAttachment.create({
-        data: {
-          taskId: input.taskId,
-          uploadedByUserId: actorUserId,
-          kind: ATTACHMENT_KIND_FILE,
-          name: normalizedUpload.data.name,
-          storageKey: normalizedStorageKey,
-          mimeType: resolvedMimeType,
-          sizeBytes: resolvedSizeBytes,
-        },
-        select: {
-          id: true,
-          kind: true,
-          name: true,
-          url: true,
-          mimeType: true,
-          sizeBytes: true,
-        },
+      const attachment = await db.$transaction(async (tx) => {
+        const createdAttachment = await tx.taskAttachment.create({
+          data: {
+            taskId: input.taskId,
+            uploadedByUserId: actorUserId,
+            kind: ATTACHMENT_KIND_FILE,
+            name: normalizedUpload.data.name,
+            storageKey: normalizedStorageKey,
+            mimeType: resolvedMimeType,
+            sizeBytes: resolvedSizeBytes,
+          },
+          select: {
+            id: true,
+            kind: true,
+            name: true,
+            url: true,
+            mimeType: true,
+            sizeBytes: true,
+          },
+        });
+
+        await touchTaskActivity(tx, input.taskId, actorUserId);
+
+        return createdAttachment;
       });
 
       return {
@@ -1351,8 +1385,12 @@ export async function deleteTaskAttachmentForProject(input: {
         return createError(404, "Attachment not found");
       }
 
-      await db.taskAttachment.delete({
-        where: { id: attachment.id },
+      await db.$transaction(async (tx) => {
+        await tx.taskAttachment.delete({
+          where: { id: attachment.id },
+        });
+
+        await touchTaskActivity(tx, input.taskId, actorUserId);
       });
 
       if (attachment.kind === ATTACHMENT_KIND_FILE && attachment.storageKey) {

--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -132,7 +132,9 @@ interface ProjectWithCountsRecord {
   };
 }
 
-export type ProjectCollaboratorIdentitySummary = TaskPersonSummary;
+export interface ProjectCollaboratorIdentitySummary extends TaskPersonSummary {
+  projectRole: ProjectMembershipRole;
+}
 
 interface ProjectUpsertInput {
   actorUserId: string;
@@ -178,8 +180,12 @@ function buildProjectCollaboratorIdentitySummary(input: {
   username: string | null;
   usernameDiscriminator: string | null;
   avatarSeed: string | null;
+  projectRole: ProjectMembershipRole;
 }): ProjectCollaboratorIdentitySummary {
-  return mapTaskPersonSummary(input)!;
+  return {
+    ...mapTaskPersonSummary(input)!,
+    projectRole: input.projectRole,
+  };
 }
 
 async function ensureSyntheticTestUserExists(actorUserId: string, db: DbClient = prisma) {
@@ -645,6 +651,7 @@ export async function listProjectCollaborators(
         memberships: {
           orderBy: [{ createdAt: "asc" }],
           select: {
+            role: true,
             user: {
               select: {
                 id: true,
@@ -665,7 +672,10 @@ export async function listProjectCollaborators(
     }
 
     const collaboratorById = new Map<string, ProjectCollaboratorIdentitySummary>();
-    const ownerSummary = buildProjectCollaboratorIdentitySummary(project.owner);
+    const ownerSummary = buildProjectCollaboratorIdentitySummary({
+      ...project.owner,
+      projectRole: "owner",
+    });
     collaboratorById.set(ownerSummary.id, ownerSummary);
 
     for (const membership of project.memberships) {
@@ -675,7 +685,10 @@ export async function listProjectCollaborators(
 
       collaboratorById.set(
         membership.user.id,
-        buildProjectCollaboratorIdentitySummary(membership.user)
+        buildProjectCollaboratorIdentitySummary({
+          ...membership.user,
+          projectRole: membership.role,
+        })
       );
     }
 

--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -1,6 +1,5 @@
 import { Prisma, ProjectMembershipRole } from "@prisma/client";
 
-import { resolveAvatarSeed } from "@/lib/avatar";
 import { prisma } from "@/lib/prisma";
 import { RESOURCE_TYPE_CONTEXT_CARD } from "@/lib/resource-type";
 import {
@@ -11,7 +10,10 @@ import {
 } from "@/lib/services/project-access-service";
 import { withActorRlsContext } from "@/lib/services/rls-context";
 import type { DbClient } from "@/lib/services/rls-context";
-import { validateUsernameDiscriminator } from "@/lib/services/account-security-policy";
+import {
+  mapTaskPersonSummary,
+  type TaskPersonSummary,
+} from "@/lib/task-person";
 
 const ARCHIVE_AFTER_DAYS = 7;
 const ARCHIVE_AFTER_MS = ARCHIVE_AFTER_DAYS * 24 * 60 * 60 * 1000;
@@ -130,12 +132,7 @@ interface ProjectWithCountsRecord {
   };
 }
 
-export interface ProjectCollaboratorIdentitySummary {
-  id: string;
-  displayName: string;
-  usernameTag: string | null;
-  avatarSeed: string;
-}
+export type ProjectCollaboratorIdentitySummary = TaskPersonSummary;
 
 interface ProjectUpsertInput {
   actorUserId: string;
@@ -174,29 +171,6 @@ function normalizeProjectDescription(
   return normalizedDescription.length > 0 ? normalizedDescription : null;
 }
 
-function buildUsernameTag(
-  username: string | null | undefined,
-  usernameDiscriminator: string | null | undefined
-): string | null {
-  if (
-    !username ||
-    !usernameDiscriminator ||
-    !validateUsernameDiscriminator(usernameDiscriminator)
-  ) {
-    return null;
-  }
-
-  return `${username}#${usernameDiscriminator}`;
-}
-
-function getEmailLocalPart(email: string | null | undefined): string | null {
-  if (!email || !email.includes("@")) {
-    return null;
-  }
-
-  return email.split("@", 1)[0] ?? null;
-}
-
 function buildProjectCollaboratorIdentitySummary(input: {
   id: string;
   name: string | null;
@@ -205,16 +179,7 @@ function buildProjectCollaboratorIdentitySummary(input: {
   usernameDiscriminator: string | null;
   avatarSeed: string | null;
 }): ProjectCollaboratorIdentitySummary {
-  return {
-    id: input.id,
-    displayName:
-      input.username ??
-      input.name ??
-      getEmailLocalPart(input.email) ??
-      "Account",
-    usernameTag: buildUsernameTag(input.username, input.usernameDiscriminator),
-    avatarSeed: resolveAvatarSeed(input.avatarSeed, input.id),
-  };
+  return mapTaskPersonSummary(input)!;
 }
 
 async function ensureSyntheticTestUserExists(actorUserId: string, db: DbClient = prisma) {

--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -1,5 +1,6 @@
 import { Prisma, ProjectMembershipRole } from "@prisma/client";
 
+import { resolveAvatarSeed } from "@/lib/avatar";
 import { prisma } from "@/lib/prisma";
 import { RESOURCE_TYPE_CONTEXT_CARD } from "@/lib/resource-type";
 import {
@@ -10,6 +11,7 @@ import {
 } from "@/lib/services/project-access-service";
 import { withActorRlsContext } from "@/lib/services/rls-context";
 import type { DbClient } from "@/lib/services/rls-context";
+import { validateUsernameDiscriminator } from "@/lib/services/account-security-policy";
 
 const ARCHIVE_AFTER_DAYS = 7;
 const ARCHIVE_AFTER_MS = ARCHIVE_AFTER_DAYS * 24 * 60 * 60 * 1000;
@@ -45,6 +47,36 @@ type ProjectKanbanTaskRecord = Prisma.TaskGetPayload<{
             archivedAt: true;
           };
         };
+      };
+    };
+    createdByUser: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+        username: true;
+        usernameDiscriminator: true;
+        avatarSeed: true;
+      };
+    };
+    updatedByUser: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+        username: true;
+        usernameDiscriminator: true;
+        avatarSeed: true;
+      };
+    };
+    assigneeUser: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+        username: true;
+        usernameDiscriminator: true;
+        avatarSeed: true;
       };
     };
   };
@@ -98,6 +130,13 @@ interface ProjectWithCountsRecord {
   };
 }
 
+export interface ProjectCollaboratorIdentitySummary {
+  id: string;
+  displayName: string;
+  usernameTag: string | null;
+  avatarSeed: string;
+}
+
 interface ProjectUpsertInput {
   actorUserId: string;
   name: string;
@@ -133,6 +172,49 @@ function normalizeProjectDescription(
 
   const normalizedDescription = description.trim();
   return normalizedDescription.length > 0 ? normalizedDescription : null;
+}
+
+function buildUsernameTag(
+  username: string | null | undefined,
+  usernameDiscriminator: string | null | undefined
+): string | null {
+  if (
+    !username ||
+    !usernameDiscriminator ||
+    !validateUsernameDiscriminator(usernameDiscriminator)
+  ) {
+    return null;
+  }
+
+  return `${username}#${usernameDiscriminator}`;
+}
+
+function getEmailLocalPart(email: string | null | undefined): string | null {
+  if (!email || !email.includes("@")) {
+    return null;
+  }
+
+  return email.split("@", 1)[0] ?? null;
+}
+
+function buildProjectCollaboratorIdentitySummary(input: {
+  id: string;
+  name: string | null;
+  email: string | null;
+  username: string | null;
+  usernameDiscriminator: string | null;
+  avatarSeed: string | null;
+}): ProjectCollaboratorIdentitySummary {
+  return {
+    id: input.id,
+    displayName:
+      input.username ??
+      input.name ??
+      getEmailLocalPart(input.email) ??
+      "Account",
+    usernameTag: buildUsernameTag(input.username, input.usernameDiscriminator),
+    avatarSeed: resolveAvatarSeed(input.avatarSeed, input.id),
+  };
 }
 
 async function ensureSyntheticTestUserExists(actorUserId: string, db: DbClient = prisma) {
@@ -534,8 +616,105 @@ export async function listProjectKanbanTasks(
             },
           },
         },
+        createdByUser: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            username: true,
+            usernameDiscriminator: true,
+            avatarSeed: true,
+          },
+        },
+        updatedByUser: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            username: true,
+            usernameDiscriminator: true,
+            avatarSeed: true,
+          },
+        },
+        assigneeUser: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            username: true,
+            usernameDiscriminator: true,
+            avatarSeed: true,
+          },
+        },
       },
     });
+  });
+}
+
+export async function listProjectCollaborators(
+  projectId: string,
+  actorUserId: string
+): Promise<ProjectCollaboratorIdentitySummary[]> {
+  const normalizedActorUserId = normalizeActorUserId(actorUserId);
+  if (!normalizedActorUserId) {
+    return [];
+  }
+
+  return withActorRlsContext(normalizedActorUserId, async (db) => {
+    const project = await db.project.findFirst({
+      where: {
+        id: projectId,
+        ...buildProjectPrincipalWhere(normalizedActorUserId),
+      },
+      select: {
+        owner: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            username: true,
+            usernameDiscriminator: true,
+            avatarSeed: true,
+          },
+        },
+        memberships: {
+          orderBy: [{ createdAt: "asc" }],
+          select: {
+            user: {
+              select: {
+                id: true,
+                name: true,
+                email: true,
+                username: true,
+                usernameDiscriminator: true,
+                avatarSeed: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!project) {
+      return [];
+    }
+
+    const collaboratorById = new Map<string, ProjectCollaboratorIdentitySummary>();
+    const ownerSummary = buildProjectCollaboratorIdentitySummary(project.owner);
+    collaboratorById.set(ownerSummary.id, ownerSummary);
+
+    for (const membership of project.memberships) {
+      if (collaboratorById.has(membership.user.id)) {
+        continue;
+      }
+
+      collaboratorById.set(
+        membership.user.id,
+        buildProjectCollaboratorIdentitySummary(membership.user)
+      );
+    }
+
+    return Array.from(collaboratorById.values());
   });
 }
 

--- a/lib/services/project-task-comment-service.ts
+++ b/lib/services/project-task-comment-service.ts
@@ -1,4 +1,3 @@
-import { resolveAvatarSeed } from "@/lib/avatar";
 import { logServerError } from "@/lib/observability/logger";
 import {
   requireAgentProjectScopes,
@@ -6,7 +5,10 @@ import {
   type AgentProjectAccessContext,
 } from "@/lib/services/project-access-service";
 import { type DbClient, withActorRlsContext } from "@/lib/services/rls-context";
-import { validateUsernameDiscriminator } from "@/lib/services/account-security-policy";
+import {
+  mapTaskPersonSummary,
+  type TaskPersonSummary,
+} from "@/lib/task-person";
 
 const MAX_TASK_COMMENT_LENGTH = 4000;
 
@@ -23,12 +25,7 @@ interface ServiceSuccessResult<T> {
 
 type ServiceResult<T> = ServiceSuccessResult<T> | ServiceErrorResult;
 
-export interface TaskCommentAuthorSummary {
-  id: string;
-  displayName: string;
-  usernameTag: string | null;
-  avatarSeed: string;
-}
+export type TaskCommentAuthorSummary = TaskPersonSummary;
 
 export interface TaskCommentSummary {
   id: string;
@@ -49,29 +46,6 @@ function normalizeActorUserId(actorUserId: string | null | undefined): string {
   return actorUserId.trim();
 }
 
-function getEmailLocalPart(email: string | null | undefined): string | null {
-  if (!email || !email.includes("@")) {
-    return null;
-  }
-
-  return email.split("@", 1)[0] ?? null;
-}
-
-function buildUsernameTag(
-  username: string | null | undefined,
-  usernameDiscriminator: string | null | undefined
-): string | null {
-  if (
-    !username ||
-    !usernameDiscriminator ||
-    !validateUsernameDiscriminator(usernameDiscriminator)
-  ) {
-    return null;
-  }
-
-  return `${username}#${usernameDiscriminator}`;
-}
-
 function mapTaskComment(input: {
   id: string;
   content: string;
@@ -85,26 +59,11 @@ function mapTaskComment(input: {
     avatarSeed: string | null;
   };
 }): TaskCommentSummary {
-  const usernameTag = buildUsernameTag(
-    input.author.username,
-    input.author.usernameDiscriminator
-  );
-  const displayName =
-    input.author.username ??
-    input.author.name ??
-    getEmailLocalPart(input.author.email) ??
-    "Account";
-
   return {
     id: input.id,
     content: input.content,
     createdAt: input.createdAt,
-    author: {
-      id: input.author.id,
-      displayName,
-      usernameTag,
-      avatarSeed: resolveAvatarSeed(input.author.avatarSeed, input.author.id),
-    },
+    author: mapTaskPersonSummary(input.author)!,
   };
 }
 
@@ -256,34 +215,30 @@ export async function createTaskCommentForProject(input: {
     }
 
     try {
-      const comment = await db.$transaction(async (tx) => {
-        const createdComment = await tx.taskComment.create({
-          data: {
-            taskId: input.taskId,
-            authorUserId: actorUserId,
-            content,
-          },
-          select: {
-            id: true,
-            content: true,
-            createdAt: true,
-            author: {
-              select: {
-                id: true,
-                name: true,
-                email: true,
-                username: true,
-                usernameDiscriminator: true,
-                avatarSeed: true,
-              },
+      const comment = await db.taskComment.create({
+        data: {
+          taskId: input.taskId,
+          authorUserId: actorUserId,
+          content,
+        },
+        select: {
+          id: true,
+          content: true,
+          createdAt: true,
+          author: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+              username: true,
+              usernameDiscriminator: true,
+              avatarSeed: true,
             },
           },
-        });
-
-        await touchTaskActivity(tx, input.taskId, actorUserId);
-
-        return createdComment;
+        },
       });
+
+      await touchTaskActivity(db, input.taskId, actorUserId);
 
       return {
         ok: true,

--- a/lib/services/project-task-comment-service.ts
+++ b/lib/services/project-task-comment-service.ts
@@ -5,7 +5,7 @@ import {
   requireProjectRole,
   type AgentProjectAccessContext,
 } from "@/lib/services/project-access-service";
-import { withActorRlsContext } from "@/lib/services/rls-context";
+import { type DbClient, withActorRlsContext } from "@/lib/services/rls-context";
 import { validateUsernameDiscriminator } from "@/lib/services/account-security-policy";
 
 const MAX_TASK_COMMENT_LENGTH = 4000;
@@ -106,6 +106,22 @@ function mapTaskComment(input: {
       avatarSeed: resolveAvatarSeed(input.author.avatarSeed, input.author.id),
     },
   };
+}
+
+async function touchTaskActivity(
+  db: DbClient,
+  taskId: string,
+  actorUserId: string
+) {
+  await db.task.update({
+    where: { id: taskId },
+    data: {
+      updatedByUserId: actorUserId,
+    },
+    select: {
+      id: true,
+    },
+  });
 }
 
 export async function listTaskCommentsForProject(input: {
@@ -240,27 +256,33 @@ export async function createTaskCommentForProject(input: {
     }
 
     try {
-      const comment = await db.taskComment.create({
-        data: {
-          taskId: input.taskId,
-          authorUserId: actorUserId,
-          content,
-        },
-        select: {
-          id: true,
-          content: true,
-          createdAt: true,
-          author: {
-            select: {
-              id: true,
-              name: true,
-              email: true,
-              username: true,
-              usernameDiscriminator: true,
-              avatarSeed: true,
+      const comment = await db.$transaction(async (tx) => {
+        const createdComment = await tx.taskComment.create({
+          data: {
+            taskId: input.taskId,
+            authorUserId: actorUserId,
+            content,
+          },
+          select: {
+            id: true,
+            content: true,
+            createdAt: true,
+            author: {
+              select: {
+                id: true,
+                name: true,
+                email: true,
+                username: true,
+                usernameDiscriminator: true,
+                avatarSeed: true,
+              },
             },
           },
-        },
+        });
+
+        await touchTaskActivity(tx, input.taskId, actorUserId);
+
+        return createdComment;
       });
 
       return {

--- a/lib/services/project-task-service.ts
+++ b/lib/services/project-task-service.ts
@@ -1,6 +1,5 @@
 import { deleteAttachmentFile } from "@/lib/attachment-storage";
 import { sanitizeRichText } from "@/lib/rich-text";
-import { resolveAvatarSeed } from "@/lib/avatar";
 import {
   buildCanonicalTaskRelation,
   mapRelatedTaskSummary,
@@ -29,7 +28,11 @@ import {
   requireProjectRole,
   type AgentProjectAccessContext,
 } from "@/lib/services/project-access-service";
-import { validateUsernameDiscriminator } from "@/lib/services/account-security-policy";
+import {
+  mapTaskPersonSummary,
+  taskPersonSummarySelect,
+  type TaskPersonSummary,
+} from "@/lib/task-person";
 import { type DbClient, withActorRlsContext } from "@/lib/services/rls-context";
 
 const MIN_TITLE_LENGTH = 2;
@@ -81,13 +84,6 @@ interface CreateTaskForProjectInput {
   agentAccess?: AgentProjectAccessContext;
 }
 
-interface TaskPersonSummary {
-  id: string;
-  displayName: string;
-  usernameTag: string | null;
-  avatarSeed: string;
-}
-
 interface UpdatedTaskPayload {
   id: string;
   title: string;
@@ -122,49 +118,6 @@ function normalizeText(value: unknown): string {
     return "";
   }
   return value.trim();
-}
-
-function buildUsernameTag(
-  username: string | null | undefined,
-  usernameDiscriminator: string | null | undefined
-): string | null {
-  if (
-    !username ||
-    !usernameDiscriminator ||
-    !validateUsernameDiscriminator(usernameDiscriminator)
-  ) {
-    return null;
-  }
-
-  return `${username}#${usernameDiscriminator}`;
-}
-
-function getEmailLocalPart(email: string | null | undefined): string | null {
-  if (!email || !email.includes("@")) {
-    return null;
-  }
-
-  return email.split("@", 1)[0] ?? null;
-}
-
-function mapTaskPersonSummary(input: {
-  id: string;
-  name: string | null;
-  email: string | null;
-  username: string | null;
-  usernameDiscriminator: string | null;
-  avatarSeed: string | null;
-}): TaskPersonSummary {
-  return {
-    id: input.id,
-    displayName:
-      input.username ??
-      input.name ??
-      getEmailLocalPart(input.email) ??
-      "Account",
-    usernameTag: buildUsernameTag(input.username, input.usernameDiscriminator),
-    avatarSeed: resolveAvatarSeed(input.avatarSeed, input.id),
-  };
 }
 
 function parseDeadlineInput(
@@ -253,15 +206,6 @@ const relatedTaskSummarySelect = {
   title: true,
   status: true,
   archivedAt: true,
-} as const;
-
-const taskPersonSummarySelect = {
-  id: true,
-  name: true,
-  email: true,
-  username: true,
-  usernameDiscriminator: true,
-  avatarSeed: true,
 } as const;
 
 function mergeRelatedTaskSummaries(task: {
@@ -920,8 +864,8 @@ export async function updateTaskForProject(
             assignee: updatedTask.assigneeUser
               ? mapTaskPersonSummary(updatedTask.assigneeUser)
               : null,
-            createdBy: mapTaskPersonSummary(updatedTask.createdByUser),
-            updatedBy: mapTaskPersonSummary(updatedTask.updatedByUser),
+            createdBy: mapTaskPersonSummary(updatedTask.createdByUser)!,
+            updatedBy: mapTaskPersonSummary(updatedTask.updatedByUser)!,
             createdAt: updatedTask.createdAt,
             updatedAt: updatedTask.updatedAt,
             relatedTasks: mergeRelatedTaskSummaries(updatedTask),

--- a/lib/services/project-task-service.ts
+++ b/lib/services/project-task-service.ts
@@ -1,5 +1,6 @@
 import { deleteAttachmentFile } from "@/lib/attachment-storage";
 import { sanitizeRichText } from "@/lib/rich-text";
+import { resolveAvatarSeed } from "@/lib/avatar";
 import {
   buildCanonicalTaskRelation,
   mapRelatedTaskSummary,
@@ -28,6 +29,7 @@ import {
   requireProjectRole,
   type AgentProjectAccessContext,
 } from "@/lib/services/project-access-service";
+import { validateUsernameDiscriminator } from "@/lib/services/account-security-policy";
 import { type DbClient, withActorRlsContext } from "@/lib/services/rls-context";
 
 const MIN_TITLE_LENGTH = 2;
@@ -62,6 +64,7 @@ export interface UpdateTaskPayload {
   deadlineDate?: string | null;
   blockedFollowUpEntry?: string;
   relatedTaskIds?: string[];
+  assigneeUserId?: string | null;
 }
 
 interface CreateTaskForProjectInput {
@@ -70,11 +73,19 @@ interface CreateTaskForProjectInput {
   title: string;
   description: string;
   deadlineDate: string;
+  assigneeUserId: string | null;
   labelsJsonRaw: string;
   relatedTaskIdsJsonRaw: string;
   attachmentLinksJsonRaw: string;
   attachmentFiles: File[];
   agentAccess?: AgentProjectAccessContext;
+}
+
+interface TaskPersonSummary {
+  id: string;
+  displayName: string;
+  usernameTag: string | null;
+  avatarSeed: string;
 }
 
 interface UpdatedTaskPayload {
@@ -89,6 +100,11 @@ interface UpdatedTaskPayload {
   status: string;
   position: number;
   archivedAt: Date | null;
+  assignee: TaskPersonSummary | null;
+  createdBy: TaskPersonSummary;
+  updatedBy: TaskPersonSummary;
+  createdAt: Date;
+  updatedAt: Date;
   relatedTasks: RelatedTaskSummary[];
   blockedFollowUps: {
     id: string;
@@ -106,6 +122,49 @@ function normalizeText(value: unknown): string {
     return "";
   }
   return value.trim();
+}
+
+function buildUsernameTag(
+  username: string | null | undefined,
+  usernameDiscriminator: string | null | undefined
+): string | null {
+  if (
+    !username ||
+    !usernameDiscriminator ||
+    !validateUsernameDiscriminator(usernameDiscriminator)
+  ) {
+    return null;
+  }
+
+  return `${username}#${usernameDiscriminator}`;
+}
+
+function getEmailLocalPart(email: string | null | undefined): string | null {
+  if (!email || !email.includes("@")) {
+    return null;
+  }
+
+  return email.split("@", 1)[0] ?? null;
+}
+
+function mapTaskPersonSummary(input: {
+  id: string;
+  name: string | null;
+  email: string | null;
+  username: string | null;
+  usernameDiscriminator: string | null;
+  avatarSeed: string | null;
+}): TaskPersonSummary {
+  return {
+    id: input.id,
+    displayName:
+      input.username ??
+      input.name ??
+      getEmailLocalPart(input.email) ??
+      "Account",
+    usernameTag: buildUsernameTag(input.username, input.usernameDiscriminator),
+    avatarSeed: resolveAvatarSeed(input.avatarSeed, input.id),
+  };
 }
 
 function parseDeadlineInput(
@@ -196,6 +255,15 @@ const relatedTaskSummarySelect = {
   archivedAt: true,
 } as const;
 
+const taskPersonSummarySelect = {
+  id: true,
+  name: true,
+  email: true,
+  username: true,
+  usernameDiscriminator: true,
+  avatarSeed: true,
+} as const;
+
 function mergeRelatedTaskSummaries(task: {
   outgoingRelations: { rightTask: { id: string; title: string; status: string; archivedAt: Date | null } }[];
   incomingRelations: { leftTask: { id: string; title: string; status: string; archivedAt: Date | null } }[];
@@ -252,6 +320,46 @@ async function validateRelatedTaskIds(input: {
     ok: true,
     data: {
       relatedTaskIds: filteredRelatedTaskIds,
+    },
+  };
+}
+
+async function validateAssigneeUserId(input: {
+  db: DbClient;
+  projectId: string;
+  assigneeUserId: string | null;
+}): Promise<ServiceResult<{ assigneeUserId: string | null }>> {
+  const assigneeUserId = normalizeText(input.assigneeUserId);
+  if (!assigneeUserId) {
+    return {
+      ok: true,
+      data: {
+        assigneeUserId: null,
+      },
+    };
+  }
+
+  const collaborator = await input.db.project.findFirst({
+    where: {
+      id: input.projectId,
+      OR: [
+        { ownerId: assigneeUserId },
+        { memberships: { some: { userId: assigneeUserId } } },
+      ],
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  if (!collaborator) {
+    return createError(400, "assignee-invalid");
+  }
+
+  return {
+    ok: true,
+    data: {
+      assigneeUserId,
     },
   };
 }
@@ -399,6 +507,15 @@ export async function createTaskForProject(
         return relatedTaskValidation;
       }
 
+      const assigneeValidation = await validateAssigneeUserId({
+        db,
+        projectId: input.projectId,
+        assigneeUserId: input.assigneeUserId,
+      });
+      if (!assigneeValidation.ok) {
+        return assigneeValidation;
+      }
+
       const maxPosition = await db.task.aggregate({
         where: {
           projectId: input.projectId,
@@ -425,6 +542,9 @@ export async function createTaskForProject(
           labelsJson: serializedLabels,
           status,
           position: nextPosition,
+          createdByUserId: actorUserId,
+          updatedByUserId: actorUserId,
+          assigneeUserId: assigneeValidation.data.assigneeUserId,
         },
         select: { id: true },
       });
@@ -551,6 +671,7 @@ export async function reorderProjectTasks(
                 status: column.status,
                 position: index,
                 archivedAt: null,
+                updatedByUserId: normalizedActorUserId,
                 completedAt:
                   column.status === "Done"
                     ? movedToDone
@@ -604,6 +725,10 @@ export async function updateTaskForProject(
   }
   const blockedFollowUpEntry = normalizeText(payload.blockedFollowUpEntry);
   const relatedTaskIds = normalizeRelatedTaskIds(payload.relatedTaskIds ?? []);
+  const assigneeProvided = Object.prototype.hasOwnProperty.call(payload, "assigneeUserId");
+  const assigneeUserId = assigneeProvided
+    ? normalizeText(payload.assigneeUserId)
+    : null;
   const agentScopeAccess = requireAgentProjectScopes({
     agentAccess,
     projectId,
@@ -636,6 +761,7 @@ export async function updateTaskForProject(
           projectId: true,
           status: true,
           position: true,
+          assigneeUserId: true,
           outgoingRelations: {
             select: {
               rightTaskId: true,
@@ -667,6 +793,22 @@ export async function updateTaskForProject(
         return relatedTaskValidation;
       }
 
+      const assigneeValidation = assigneeProvided
+        ? await validateAssigneeUserId({
+            db,
+            projectId,
+            assigneeUserId: assigneeUserId || null,
+          })
+        : {
+            ok: true as const,
+            data: {
+              assigneeUserId: existingTask.assigneeUserId,
+            },
+          };
+      if (!assigneeValidation.ok) {
+        return assigneeValidation;
+      }
+
       const updateWithClient = async (tx: typeof db) => {
         await tx.task.update({
           where: { id: taskId },
@@ -675,6 +817,8 @@ export async function updateTaskForProject(
             label: normalizedLabels[0] ?? null,
             labelsJson: serializedLabels,
             description,
+            updatedByUserId: normalizedActorUserId,
+            assigneeUserId: assigneeValidation.data.assigneeUserId,
             ...(deadlineInput.data.provided
               ? { deadlineAt: deadlineInput.data.deadlineAt }
               : {}),
@@ -715,6 +859,17 @@ export async function updateTaskForProject(
             status: true,
             position: true,
             archivedAt: true,
+            createdAt: true,
+            updatedAt: true,
+            createdByUser: {
+              select: taskPersonSummarySelect,
+            },
+            updatedByUser: {
+              select: taskPersonSummarySelect,
+            },
+            assigneeUser: {
+              select: taskPersonSummarySelect,
+            },
             outgoingRelations: {
               select: {
                 rightTask: {
@@ -762,6 +917,13 @@ export async function updateTaskForProject(
             status: updatedTask.status,
             position: updatedTask.position,
             archivedAt: updatedTask.archivedAt,
+            assignee: updatedTask.assigneeUser
+              ? mapTaskPersonSummary(updatedTask.assigneeUser)
+              : null,
+            createdBy: mapTaskPersonSummary(updatedTask.createdByUser),
+            updatedBy: mapTaskPersonSummary(updatedTask.updatedByUser),
+            createdAt: updatedTask.createdAt,
+            updatedAt: updatedTask.updatedAt,
             relatedTasks: mergeRelatedTaskSummaries(updatedTask),
             blockedFollowUps: updatedTask.blockedFollowUps,
           },
@@ -837,6 +999,7 @@ export async function archiveTaskForProject(
         where: { id: taskId },
         data: {
           archivedAt: new Date(),
+          updatedByUserId: normalizedActorUserId,
         },
         select: {
           archivedAt: true,
@@ -929,6 +1092,7 @@ export async function unarchiveTaskForProject(
         where: { id: taskId },
         data: {
           archivedAt: null,
+          updatedByUserId: normalizedActorUserId,
         },
         select: {
           id: true,

--- a/lib/task-person.ts
+++ b/lib/task-person.ts
@@ -1,0 +1,69 @@
+import { resolveAvatarSeed } from "@/lib/avatar";
+import { validateUsernameDiscriminator } from "@/lib/services/account-security-policy";
+
+export interface TaskPersonSummary {
+  id: string;
+  displayName: string;
+  usernameTag: string | null;
+  avatarSeed: string;
+}
+
+export interface TaskPersonRecord {
+  id: string;
+  name: string | null;
+  email: string | null;
+  username: string | null;
+  usernameDiscriminator: string | null;
+  avatarSeed: string | null;
+}
+
+export const taskPersonSummarySelect = {
+  id: true,
+  name: true,
+  email: true,
+  username: true,
+  usernameDiscriminator: true,
+  avatarSeed: true,
+} as const;
+
+function buildUsernameTag(
+  username: string | null | undefined,
+  usernameDiscriminator: string | null | undefined
+): string | null {
+  if (
+    !username ||
+    !usernameDiscriminator ||
+    !validateUsernameDiscriminator(usernameDiscriminator)
+  ) {
+    return null;
+  }
+
+  return `${username}#${usernameDiscriminator}`;
+}
+
+function getEmailLocalPart(email: string | null | undefined): string | null {
+  if (!email || !email.includes("@")) {
+    return null;
+  }
+
+  return email.split("@", 1)[0] ?? null;
+}
+
+export function mapTaskPersonSummary(
+  input: TaskPersonRecord | null
+): TaskPersonSummary | null {
+  if (!input) {
+    return null;
+  }
+
+  return {
+    id: input.id,
+    displayName:
+      input.username ??
+      input.name ??
+      getEmailLocalPart(input.email) ??
+      "Account",
+    usernameTag: buildUsernameTag(input.username, input.usernameDiscriminator),
+    avatarSeed: resolveAvatarSeed(input.avatarSeed, input.id),
+  };
+}

--- a/prisma/migrations/20260421131500_task101_task_ownership_and_provenance/migration.sql
+++ b/prisma/migrations/20260421131500_task101_task_ownership_and_provenance/migration.sql
@@ -1,0 +1,32 @@
+ALTER TABLE "Task"
+ADD COLUMN "createdByUserId" TEXT,
+ADD COLUMN "updatedByUserId" TEXT,
+ADD COLUMN "assigneeUserId" TEXT;
+
+UPDATE "Task" AS task
+SET
+  "createdByUserId" = project."ownerId",
+  "updatedByUserId" = project."ownerId"
+FROM "Project" AS project
+WHERE project.id = task."projectId";
+
+ALTER TABLE "Task"
+ALTER COLUMN "createdByUserId" SET NOT NULL,
+ALTER COLUMN "updatedByUserId" SET NOT NULL;
+
+CREATE INDEX "Task_createdByUserId_idx" ON "Task"("createdByUserId");
+CREATE INDEX "Task_updatedByUserId_idx" ON "Task"("updatedByUserId");
+CREATE INDEX "Task_assigneeUserId_idx" ON "Task"("assigneeUserId");
+CREATE INDEX "Task_projectId_assigneeUserId_idx" ON "Task"("projectId", "assigneeUserId");
+
+ALTER TABLE "Task"
+ADD CONSTRAINT "Task_createdByUserId_fkey"
+FOREIGN KEY ("createdByUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "Task"
+ADD CONSTRAINT "Task_updatedByUserId_fkey"
+FOREIGN KEY ("updatedByUserId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "Task"
+ADD CONSTRAINT "Task_assigneeUserId_fkey"
+FOREIGN KEY ("assigneeUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,9 @@ model User {
   projectInvitationsSent     ProjectInvitation[]       @relation("ProjectInvitationInviter")
   taskAttachments            TaskAttachment[]          @relation("TaskAttachmentUploader")
   taskComments               TaskComment[]             @relation("TaskCommentAuthor")
+  tasksCreated              Task[]                    @relation("TaskCreatedBy")
+  tasksUpdated              Task[]                    @relation("TaskUpdatedBy")
+  tasksAssigned             Task[]                    @relation("TaskAssignee")
   resourceAttachments        ResourceAttachment[]      @relation("ResourceAttachmentUploader")
   googleCalendarCredential   GoogleCalendarCredential?
   emailVerificationTokens    EmailVerificationToken[]
@@ -196,7 +199,13 @@ model Task {
   label             String?
   labelsJson        String?
   projectId         String
+  createdByUserId   String
+  updatedByUserId   String
+  assigneeUserId    String?
   project           Project               @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  createdByUser     User                  @relation("TaskCreatedBy", fields: [createdByUserId], references: [id])
+  updatedByUser     User                  @relation("TaskUpdatedBy", fields: [updatedByUserId], references: [id])
+  assigneeUser      User?                 @relation("TaskAssignee", fields: [assigneeUserId], references: [id], onDelete: SetNull)
   attachments       TaskAttachment[]
   comments          TaskComment[]
   blockedFollowUps  TaskBlockedFollowUp[]
@@ -207,6 +216,10 @@ model Task {
 
   @@index([projectId])
   @@index([projectId, deadlineAt])
+  @@index([createdByUserId])
+  @@index([updatedByUserId])
+  @@index([assigneeUserId])
+  @@index([projectId, assigneeUserId])
 }
 
 model TaskComment {

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,217 +1,139 @@
-# Current Task: TASK-089 Automatic Avatar Creation - Generated Identity Avatar Baseline
+# Current Task: TASK-101 Task Ownership And Provenance
 
 ## Task ID
-TASK-089
+TASK-101
 
 ## Status
-Implemented locally on branch `feature/task-089-generated-avatar-baseline`;
-local validation is complete and the task is ready for the repository review /
-PR path.
+Implementation complete on branch
+`feature/task-101-task-ownership-and-provenance`, stacked on top of `TASK-089`
+so the avatar baseline can be reused immediately across task ownership
+surfaces. Local validation is green aside from Playwright being blocked by the
+shared database schema not yet reflecting this branch migration; PR/review and
+preview deployment are the remaining release steps.
 
 ## Objective
-Introduce a deterministic generated-avatar baseline with persisted seed and
-user-triggered regeneration so NexusDash can render a consistent visual
-identity across account-owned surfaces now and unblock later collaboration
-surfaces without waiting for a full profile-photo management feature.
+Add first-class task ownership metadata so every task can show who created it,
+who is currently assigned to it, and who last touched it, with the data model,
+API contracts, and UI all aligned around the same provenance source of truth.
 
 ## Why This Task Matters
-- The data model already supports optional user images, but only social-auth
-  users reliably get one today. Credentials users still appear as text-only
-  identities across the product.
-- Upcoming collaboration and task-provenance work benefits from a reusable
-  avatar foundation instead of inventing ad hoc text badges for every new
-  person-oriented surface.
-- `TASK-101` needs a clean visual identity affordance for assignee,
-  created-by, and modified-by metadata. Shipping a baseline avatar system first
-  reduces rework and gives those future surfaces a stronger default UX.
-- `TASK-119` is intended to expose collaborator presence on project pages, and
-  that feature should build on a shared avatar primitive rather than defining a
-  second identity presentation model.
+- Collaboration is already live, but task ownership is still implicit and
+  depends on outside context instead of product-visible metadata.
+- `TASK-089` established a shared avatar foundation; `TASK-101` is the first
+  feature that needs to apply that foundation to real work attribution.
+- Assignee and provenance data are prerequisites for later filtering,
+  accountability, notification, and richer project-presence work.
+- Shipping this cleanly now reduces the risk of inventing multiple incompatible
+  identity models across task comments, assignee chips, and future activity
+  surfaces.
 
 ## Current Baseline Confirmed In Repo
-- `User.image` already exists in `prisma/schema.prisma`.
-- Social auth ingestion already preserves provider-supplied avatar URLs in
-  `lib/services/social-auth-service.ts`.
-- Human-readable identity summaries already exist via:
-  - `lib/services/account-identity-service.ts`
-  - `lib/services/account-profile-service.ts`
-  - `lib/services/project-collaboration-service.ts`
-  - `lib/services/project-task-comment-service.ts`
-- The top-right signed-in affordance currently shows text identity only through
-  `components/account-menu.tsx` and `components/top-right-controls.tsx`.
-- The account page (`app/account/page.tsx`) already exposes identity/settings
-  surfaces, but it does not yet render avatar state or avatar-specific copy.
+- `Task` currently has no creator, updater, or assignee relationship fields in
+  `prisma/schema.prisma`.
+- Kanban task reads come from `listProjectKanbanTasks` and the task routes, so
+  provenance data needs to be added at the service/API layer rather than only
+  in the UI.
+- Task comments already resolve avatar-backed author identities after
+  `TASK-089`.
+- The board already has a stable task detail modal, task create dialog, and
+  task edit flow, which are the right surfaces to introduce ownership and
+  provenance.
 
 ## Working Product Assumptions
-- `TASK-089` ships a generated avatar baseline, not a full avatar-management
-  system.
-- The generated avatar is the active account avatar for this milestone, even if
-  provider-supplied `user.image` exists today.
-- The visual should be deterministic from a stable persisted seed until the
-  user explicitly regenerates it.
-- The generated avatar must not depend on external avatar services.
-- The generated avatar must stay privacy-safe and cheap to compute:
-  - no external fetch
-  - no separate object storage pipeline
-  - no requirement for uploaded image assets
-- A user must be able to regenerate the avatar from the account page without
-  needing admin involvement or direct database changes.
-- The baseline should be reusable by future task/collaboration work, but this
-  task should not broaden into task ownership/provenance or project presence
-  rollout by itself.
+- A task must always retain a creator and last-updater once the migration is
+  applied.
+- Assignee is optional and should support explicit clearing back to an
+  unassigned state.
+- Valid assignees are current project collaborators, including the owner.
+- "Last touched" should reflect task mutations that materially change the task
+  record or task activity, including comment and attachment writes.
+- Existing tasks need a practical backfill path; project owner is the baseline
+  provenance fallback for legacy rows.
 
 ## Scope
-- Add a reusable avatar rendering primitive for NexusDash identity surfaces.
-- Add deterministic generated-avatar helpers, including:
-  - stable seed handling
-  - color/style derivation
-  - pixel-pattern generation
-- Persist a generated-avatar seed on the user record so the avatar remains
-  stable until explicit regeneration.
-- Extend account-level identity data flow so the signed-in shell and account
-  surfaces can render resolved avatar state.
-- Add account-level avatar regeneration through the existing account-management
-  flow.
-- Apply the new avatar baseline to the first consumer surfaces:
-  - top-right account icon/menu
-  - account/settings identity surfaces
-  - task comments
-  - project settings contributors tab
-- Add targeted regression coverage for avatar resolution and the first UI
-  consumer surfaces.
-- Update tracking docs in the same task PR.
+- Extend the task schema with:
+  - creator relationship
+  - updater relationship
+  - optional assignee relationship
+- Backfill provenance for existing tasks through a migration.
+- Validate assignee changes against current project collaborators.
+- Update task create, update, reorder, archive, unarchive, comment, and
+  attachment flows so provenance stays accurate.
+- Expose provenance and assignee metadata through task list/update API
+  responses.
+- Add assignee selection to task create/edit flows.
+- Render avatar-backed ownership UI on the main task surfaces:
+  - board card assignee display
+  - task detail assignee display
+  - task detail created-by / modified-by display
+- Update agent/OpenAPI documentation where task payloads change.
+- Add targeted regression coverage for the new task contracts and provenance
+  behavior.
+- Update tracking docs in the same task branch.
 
 ## Out Of Scope
-- User-uploaded avatar management or avatar file storage.
-- Rendering provider-supplied `user.image` through the shared avatar path.
-- Project-page collaborator presence rollout; that belongs to `TASK-119`.
-- Task-surface avatar rollout for:
-  - assignee
-  - created-by / modified-by
-  Those are expected follow-ons for `TASK-101`.
-- Notification, activity-feed, or presence semantics.
-- Reworking auth or social-account linking behavior.
-
-## Desired Follow-On Consumers
-These are not all part of `TASK-089`, but this task should make them easy:
-- After `TASK-089` + `TASK-101`, avatars should be usable in:
-  - assignee display
-  - created-by / modified-by metadata
-  - top-right account icon
-  - settings/account identity surfaces
-  - task comments
-  - project settings contributors
-- Later, `TASK-119` should reuse the same avatar foundation for:
-  - project-page collaborator presence and member rows
-
-## Design Constraints
-### 1. Determinism
-- A given user should receive the same generated avatar every time.
-- The seed should prefer a stable principal identifier and not rely only on
-  mutable presentation text.
-
-### 2. Fallback Quality
-- The generated fallback should feel intentional rather than like a generic
-  placeholder.
-- If initials are used, they should complement the visual treatment rather than
-  becoming the entire design.
-
-### 3. Reusability
-- The avatar primitive should support future compact and expanded contexts:
-  - menu trigger
-  - inline person metadata
-  - collaborator rows
-  - task provenance chips
-
-### 4. Safe Incremental Rollout
-- First ship the avatar baseline in account-owned surfaces that already exist.
-- Avoid coupling this task to collaboration-presence or task-provenance schema
-  changes.
-
-## Likely Implementation Touchpoints
-- `components/account-menu.tsx`
-- `components/top-right-controls.tsx`
-- `app/account/page.tsx`
-- `app/account/settings/**` if settings-shell identity chrome is updated
-- `components/kanban/task-detail-modal.tsx`
-- `components/project-dashboard/project-dashboard-owner-access-panel.tsx`
-- `lib/services/account-identity-service.ts`
-- `lib/services/account-profile-service.ts`
-- `lib/services/project-task-comment-service.ts`
-- `lib/services/project-collaboration-service.ts` if shared identity types are
-  expanded for future reuse
-- a new shared avatar helper under `lib/**`
-- a new shared avatar UI component under `components/**`
-- relevant `tests/**`
-
-## Expected Output
-- an active `tasks/current.md` brief for `TASK-089`
-- a reusable avatar component + deterministic generated-avatar helpers
-- persisted avatar seed + account-page regeneration flow
-- top-right account/menu avatar rendering
-- account/settings identity surfaces updated to use the generated avatar
-  baseline
-- task comments and project-settings contributor rows updated to use the shared
-  avatar baseline
-- aligned tests and documentation updates
-- a dedicated task branch and PR that follow the repository shipping workflow
+- User-uploaded avatars or alternative avatar rendering systems.
+- Project-page collaborator rollups; that remains later work (`TASK-119`).
+- Notification delivery, reminders, or ownership-based inbox features.
+- Complex assignee filtering/search UX on the board.
+- Historic provenance reconstruction beyond a sensible legacy backfill.
 
 ## Acceptance Criteria
-- Users render a deterministic generated avatar from a stable persisted seed.
-- Users can regenerate their avatar from the account page and immediately see
-  the updated result on account-owned surfaces.
-- The top-right signed-in account affordance uses the new avatar system.
-- Account/settings identity surfaces use the new avatar system.
-- Task comments use the new avatar system.
-- Project settings contributor rows use the new avatar system.
-- The avatar baseline is implemented in a reusable way that can support
-  `TASK-101` and `TASK-119` without redesigning the primitive.
+- New tasks persist creator and updater metadata automatically.
+- Tasks can store an optional assignee and reject non-collaborator assignees.
+- Task update flows keep updater metadata current.
+- Comment and attachment task activity updates the task attribution trail.
+- The kanban board can render assignee identity with the avatar baseline.
+- The task detail modal shows assignee, created-by, and modified-by metadata.
+- Task create/edit flows allow selecting or clearing an assignee.
+- Task API and agent docs stay aligned with the new payload shape.
 - Required tracking docs are updated consistently in the same PR.
 
 ## Definition Of Done
-1. `TASK-089` is the active task in `tasks/current.md`.
-2. The avatar baseline is implemented end to end across helpers and the first
-   account-owned UI surfaces.
-3. Validation is green for the relevant scope:
+1. `TASK-101` is the active brief in `tasks/current.md`.
+2. Schema, services, routes, and UI all support task assignee + provenance end
+   to end.
+3. Relevant validation is green:
    - `npm run lint`
    - `npm test`
    - `npm run test:coverage`
    - `npm run build`
-   - `npm run test:e2e` if the final UI changes materially affect an existing
-     covered authenticated flow and local prerequisites are available
+   - preview validation once the branch is published
 4. Tracking docs are updated consistently (`tasks/current.md`, `journal.md`,
-   `adr/decisions.md` if the final design introduces an architecture-level
-   identity-rendering decision).
-5. The task ships through a dedicated PR whose title includes `TASK-089`, with
-   Copilot's initial review state monitored and any valid feedback handled
-   before handoff.
+   and `adr/decisions.md` only if an architecture-level decision is introduced).
+5. The task ships through its own dedicated PR with the normal review and
+   preview workflow handled before handoff.
 
 ## Dependencies
-- `TASK-047`
-- `TASK-082`
+- `TASK-058`
+- `TASK-076`
+- `TASK-079`
+- `TASK-089`
 
 ## Evidence Plan
 - Repo source of truth:
   - `agent.md`
-  - `project.md`
-  - `README.md`
+  - `tasks/backlog.md`
   - `prisma/schema.prisma`
-  - `lib/services/social-auth-service.ts`
-  - `lib/services/account-identity-service.ts`
-  - `lib/services/account-profile-service.ts`
-  - `components/account-menu.tsx`
-  - `components/top-right-controls.tsx`
-  - `app/account/page.tsx`
+  - `lib/services/project-service.ts`
+  - `lib/services/project-task-service.ts`
+  - `lib/services/project-task-comment-service.ts`
+  - `lib/services/project-attachment-service.ts`
+  - `app/api/projects/[projectId]/tasks/**`
+  - `app/projects/[projectId]/kanban-board-section.tsx`
+  - `components/kanban-board.tsx`
+  - `components/kanban/task-detail-modal.tsx`
+  - `components/create-task-dialog.tsx`
 - Validation source of truth:
-  - local lint/unit/coverage/build runs
-  - PR checks: `check-name`, `Quality Core`, `E2E Smoke`, and
-    `Container Image`
+  - local lint/unit/build runs
+  - PR review comments and CI checks
+  - preview deployment verification
 
 ## Outcome Target
-- NexusDash gains a consistent visual identity baseline for every user, even
-  without uploaded photos.
-- The resulting avatar system should make `TASK-101` and `TASK-119` additive
-  consumer rollouts rather than forcing a second identity-UI rewrite.
+- NexusDash gains explicit task ownership and provenance instead of relying on
+  chat context or naming conventions.
+- The avatar baseline from `TASK-089` becomes visible where ownership actually
+  matters: assignee, creator, and last modifier.
 
 ---
 

--- a/tests/api/agent-project-routes.test.ts
+++ b/tests/api/agent-project-routes.test.ts
@@ -52,6 +52,23 @@ vi.mock("@/lib/services/context-card-service", () => ({
   createContextCardForProject: contextCardServiceMock.createContextCardForProject,
 }));
 
+vi.mock("@/lib/services/project-attachment-service", () => ({
+  mapTaskAttachmentResponse: vi.fn((projectId: string, taskId: string, attachment: Record<string, unknown>) => ({
+    ...attachment,
+    downloadUrl:
+      attachment.kind === "file"
+        ? `/api/projects/${projectId}/tasks/${taskId}/attachments/${attachment.id}/download`
+        : null,
+  })),
+  mapContextAttachmentResponse: vi.fn((projectId: string, cardId: string, attachment: Record<string, unknown>) => ({
+    ...attachment,
+    downloadUrl:
+      attachment.kind === "file"
+        ? `/api/projects/${projectId}/context-cards/${cardId}/attachments/${attachment.id}/download`
+        : null,
+  })),
+}));
+
 import { GET as getProject } from "@/app/api/projects/[projectId]/route";
 import { GET as getTasks } from "@/app/api/projects/[projectId]/tasks/route";
 import { GET as getContextCards } from "@/app/api/projects/[projectId]/context-cards/route";
@@ -176,6 +193,30 @@ describe("agent project routes", () => {
         labelsJson: '["docs"]',
         createdAt: "2026-04-03T09:00:00.000Z",
         updatedAt: "2026-04-03T10:00:00.000Z",
+        createdByUser: {
+          id: "user-1",
+          name: "Alice Example",
+          email: "alice@example.com",
+          username: "alice",
+          usernameDiscriminator: "1234",
+          avatarSeed: null,
+        },
+        updatedByUser: {
+          id: "user-2",
+          name: null,
+          email: "bob@example.com",
+          username: "bob",
+          usernameDiscriminator: "4321",
+          avatarSeed: "seed-bob",
+        },
+        assigneeUser: {
+          id: "user-3",
+          name: "Casey Example",
+          email: "casey@example.com",
+          username: null,
+          usernameDiscriminator: null,
+          avatarSeed: null,
+        },
         attachments: [
           {
             id: "att-1",
@@ -215,6 +256,24 @@ describe("agent project routes", () => {
           labelsJson: '["docs"]',
           createdAt: "2026-04-03T09:00:00.000Z",
           updatedAt: "2026-04-03T10:00:00.000Z",
+          createdBy: {
+            id: "user-1",
+            displayName: "alice",
+            usernameTag: "alice#1234",
+            avatarSeed: "user-1",
+          },
+          updatedBy: {
+            id: "user-2",
+            displayName: "bob",
+            usernameTag: "bob#4321",
+            avatarSeed: "seed-bob",
+          },
+          assignee: {
+            id: "user-3",
+            displayName: "Casey Example",
+            usernameTag: null,
+            avatarSeed: "user-3",
+          },
           attachments: [
             {
               id: "att-1",

--- a/tests/api/task-comments.route.test.ts
+++ b/tests/api/task-comments.route.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const prismaMock = vi.hoisted(() => ({
+  $transaction: vi.fn(),
   project: {
     findFirst: vi.fn(),
   },
   task: {
     findUnique: vi.fn(),
+    update: vi.fn(),
   },
   taskComment: {
     findMany: vi.fn(),
@@ -39,6 +41,7 @@ async function readJson(response: Response): Promise<Record<string, unknown>> {
 describe("task comments route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    prismaMock.$transaction.mockImplementation(async (callback) => callback(prismaMock));
     apiGuardMock.requireApiPrincipal.mockResolvedValue({
       ok: true,
       principal: {
@@ -241,6 +244,15 @@ describe("task comments route", () => {
             avatarSeed: true,
           },
         },
+      },
+    });
+    expect(prismaMock.task.update).toHaveBeenCalledWith({
+      where: { id: "task-1" },
+      data: {
+        updatedByUserId: "test-user",
+      },
+      select: {
+        id: true,
       },
     });
   });

--- a/tests/api/task-create.route.test.ts
+++ b/tests/api/task-create.route.test.ts
@@ -18,6 +18,24 @@ vi.mock("@/lib/services/project-task-service", () => ({
   createTaskForProject: projectTaskServiceMock.createTaskForProject,
 }));
 
+vi.mock("@/lib/services/project-attachment-service", () => ({
+  mapTaskAttachmentResponse: vi.fn((projectId: string, taskId: string, attachment: Record<string, unknown>) => ({
+    ...attachment,
+    downloadUrl:
+      attachment.kind === "file"
+        ? `/api/projects/${projectId}/tasks/${taskId}/attachments/${attachment.id}/download`
+        : null,
+  })),
+}));
+
+vi.mock("@/lib/services/project-service", () => ({
+  listProjectKanbanTasks: vi.fn(),
+}));
+
+vi.mock("@/lib/services/project-access-service", () => ({
+  requireAgentProjectScopes: vi.fn(() => ({ ok: true })),
+}));
+
 import { POST } from "@/app/api/projects/[projectId]/tasks/route";
 
 async function readJson(response: Response): Promise<Record<string, unknown>> {
@@ -65,6 +83,7 @@ describe("POST /api/projects/:projectId/tasks", () => {
     formData.set("title", "  New Task  ");
     formData.set("description", "  Description  ");
     formData.set("deadlineDate", "2026-04-24");
+    formData.set("assigneeUserId", "user-2");
     formData.set("labels", '["backend"]');
     formData.set("relatedTaskIds", '["task-a","task-b"]');
     formData.set(
@@ -94,6 +113,7 @@ describe("POST /api/projects/:projectId/tasks", () => {
     expect(call.title).toBe("New Task");
     expect(call.description).toBe("Description");
     expect(call.deadlineDate).toBe("2026-04-24");
+    expect(call.assigneeUserId).toBe("user-2");
     expect(call.labelsJsonRaw).toBe('["backend"]');
     expect(call.relatedTaskIdsJsonRaw).toBe('["task-a","task-b"]');
     expect(call.attachmentLinksJsonRaw).toBe(
@@ -119,6 +139,7 @@ describe("POST /api/projects/:projectId/tasks", () => {
         title: "  Draft API smoke test  ",
         description: "  <p>Validate the agent route.</p>  ",
         deadlineDate: "2026-04-25",
+        assigneeUserId: "user-2",
         labels: ["agent", "qa"],
         relatedTaskIds: ["task-a"],
         attachmentLinks: [{ name: "Spec", url: "https://example.com/spec" }],
@@ -137,6 +158,7 @@ describe("POST /api/projects/:projectId/tasks", () => {
       title: "Draft API smoke test",
       description: "<p>Validate the agent route.</p>",
       deadlineDate: "2026-04-25",
+      assigneeUserId: "user-2",
       labelsJsonRaw: '["agent","qa"]',
       relatedTaskIdsJsonRaw: '["task-a"]',
       attachmentLinksJsonRaw:
@@ -165,6 +187,29 @@ describe("POST /api/projects/:projectId/tasks", () => {
     expect(response.status).toBe(400);
     await expect(readJson(response)).resolves.toEqual({
       error: "deadline-invalid",
+    });
+    expect(projectTaskServiceMock.createTaskForProject).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 when json assigneeUserId is not a string", async () => {
+    const request = new Request("http://localhost/api/projects/p1/tasks", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        title: "Draft API smoke test",
+        assigneeUserId: 123,
+      }),
+    });
+
+    const response = await POST(request as never, {
+      params: { projectId: "p1" },
+    });
+
+    expect(response.status).toBe(400);
+    await expect(readJson(response)).resolves.toEqual({
+      error: "assignee-invalid",
     });
     expect(projectTaskServiceMock.createTaskForProject).not.toHaveBeenCalled();
   });

--- a/tests/api/task-update.route.test.ts
+++ b/tests/api/task-update.route.test.ts
@@ -139,6 +139,7 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       status: "Blocked",
       position: 0,
       archivedAt: null,
+      assigneeUserId: "user-2",
       outgoingRelations: [],
       incomingRelations: [],
     });
@@ -156,6 +157,32 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       status: "Blocked",
       position: 0,
       archivedAt: null,
+      createdAt: new Date("2026-04-20T08:00:00.000Z"),
+      updatedAt: new Date("2026-04-21T09:00:00.000Z"),
+      createdByUser: {
+        id: "user-1",
+        name: "Alice Example",
+        email: "alice@example.com",
+        username: "alice",
+        usernameDiscriminator: "1234",
+        avatarSeed: null,
+      },
+      updatedByUser: {
+        id: "test-user",
+        name: "Reviewer",
+        email: "reviewer@example.com",
+        username: "reviewer",
+        usernameDiscriminator: "0007",
+        avatarSeed: "seed-reviewer",
+      },
+      assigneeUser: {
+        id: "user-2",
+        name: "Bob Example",
+        email: "bob@example.com",
+        username: null,
+        usernameDiscriminator: null,
+        avatarSeed: null,
+      },
       outgoingRelations: [
         {
           rightTask: {
@@ -201,6 +228,26 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
         status: "Blocked",
         position: 0,
         archivedAt: null,
+        assignee: {
+          id: "user-2",
+          displayName: "Bob Example",
+          usernameTag: null,
+          avatarSeed: "user-2",
+        },
+        createdBy: {
+          id: "user-1",
+          displayName: "alice",
+          usernameTag: "alice#1234",
+          avatarSeed: "user-1",
+        },
+        updatedBy: {
+          id: "test-user",
+          displayName: "reviewer",
+          usernameTag: "reviewer#0007",
+          avatarSeed: "seed-reviewer",
+        },
+        createdAt: "2026-04-20T08:00:00.000Z",
+        updatedAt: "2026-04-21T09:00:00.000Z",
         relatedTasks: [
           {
             id: "t2",
@@ -222,6 +269,7 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       labelsJson: JSON.stringify(["Critical", "backend"]),
       description: "<p>Hello</p>",
       deadlineAt: new Date("2026-04-24T00:00:00.000Z"),
+      updatedByUserId: "test-user",
     });
 
     expect(prismaMock.taskBlockedFollowUp.create).toHaveBeenCalledTimes(1);
@@ -256,6 +304,7 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       status: "In Progress",
       position: 2,
       archivedAt: null,
+      assigneeUserId: null,
       outgoingRelations: [],
       incomingRelations: [],
     });
@@ -273,6 +322,25 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       status: "In Progress",
       position: 2,
       archivedAt: null,
+      createdAt: new Date("2026-04-18T08:00:00.000Z"),
+      updatedAt: new Date("2026-04-18T09:00:00.000Z"),
+      createdByUser: {
+        id: "user-1",
+        name: "Alice Example",
+        email: "alice@example.com",
+        username: "alice",
+        usernameDiscriminator: "1234",
+        avatarSeed: null,
+      },
+      updatedByUser: {
+        id: "test-user",
+        name: "Reviewer",
+        email: "reviewer@example.com",
+        username: "reviewer",
+        usernameDiscriminator: "0007",
+        avatarSeed: null,
+      },
+      assigneeUser: null,
       outgoingRelations: [],
       incomingRelations: [],
       blockedFollowUps: [],
@@ -303,6 +371,7 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       status: "In Progress",
       position: 2,
       archivedAt: null,
+      assigneeUserId: null,
       outgoingRelations: [
         {
           rightTaskId: "archived-task",
@@ -339,6 +408,7 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       status: "In Progress",
       position: 2,
       archivedAt: null,
+      assigneeUserId: null,
       outgoingRelations: [
         {
           rightTaskId: "archived-task",
@@ -361,6 +431,25 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       status: "In Progress",
       position: 2,
       archivedAt: null,
+      createdAt: new Date("2026-04-10T08:00:00.000Z"),
+      updatedAt: new Date("2026-04-18T09:00:00.000Z"),
+      createdByUser: {
+        id: "user-1",
+        name: "Alice Example",
+        email: "alice@example.com",
+        username: "alice",
+        usernameDiscriminator: "1234",
+        avatarSeed: null,
+      },
+      updatedByUser: {
+        id: "test-user",
+        name: "Reviewer",
+        email: "reviewer@example.com",
+        username: "reviewer",
+        usernameDiscriminator: "0007",
+        avatarSeed: null,
+      },
+      assigneeUser: null,
       outgoingRelations: [
         {
           rightTask: {
@@ -402,6 +491,21 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
         status: "In Progress",
         position: 2,
         archivedAt: null,
+        assignee: null,
+        createdBy: {
+          id: "user-1",
+          displayName: "alice",
+          usernameTag: "alice#1234",
+          avatarSeed: "user-1",
+        },
+        updatedBy: {
+          id: "test-user",
+          displayName: "reviewer",
+          usernameTag: "reviewer#0007",
+          avatarSeed: "test-user",
+        },
+        createdAt: "2026-04-10T08:00:00.000Z",
+        updatedAt: "2026-04-18T09:00:00.000Z",
         relatedTasks: [
           {
             id: "archived-task",
@@ -574,6 +678,7 @@ describe("POST /api/projects/:projectId/tasks/:taskId/archive", () => {
       where: { id: "t1" },
       data: {
         archivedAt: expect.any(Date),
+        updatedByUserId: "test-user",
       },
       select: {
         archivedAt: true,
@@ -665,6 +770,7 @@ describe("DELETE /api/projects/:projectId/tasks/:taskId/archive", () => {
       where: { id: "t1" },
       data: {
         archivedAt: null,
+        updatedByUserId: "test-user",
       },
       select: {
         id: true,

--- a/tests/api/tasks-reorder.route.test.ts
+++ b/tests/api/tasks-reorder.route.test.ts
@@ -162,6 +162,7 @@ describe("POST /api/projects/:projectId/tasks/reorder", () => {
     expect(firstUpdate.data.status).toBe("Done");
     expect(firstUpdate.data.position).toBe(0);
     expect(firstUpdate.data.archivedAt).toBeNull();
+    expect(firstUpdate.data.updatedByUserId).toBe("test-user");
     expect(firstUpdate.data.completedAt).toBeInstanceOf(Date);
 
     const secondUpdate = prismaMock.task.update.mock.calls[1][0];
@@ -169,6 +170,7 @@ describe("POST /api/projects/:projectId/tasks/reorder", () => {
     expect(secondUpdate.data.status).toBe("Done");
     expect(secondUpdate.data.position).toBe(1);
     expect(secondUpdate.data.archivedAt).toBeNull();
+    expect(secondUpdate.data.updatedByUserId).toBe("test-user");
     expect(secondUpdate.data.completedAt).toBe(existingDoneDate);
   });
 

--- a/tests/lib/avatar.test.ts
+++ b/tests/lib/avatar.test.ts
@@ -31,6 +31,15 @@ describe("avatar helpers", () => {
     expect(svg).not.toContain("seed-123");
   });
 
+  test("always includes the center pixel block in the generated pattern", () => {
+    const encodedUri = buildGeneratedAvatarDataUri("seed-123");
+    const svg = decodeURIComponent(
+      encodedUri.replace("data:image/svg+xml;charset=UTF-8,", "")
+    );
+
+    expect(svg).toContain('<rect x="27" y="27" width="10" height="10"');
+  });
+
   test("resolves avatar seed from stored seed or stable fallback key", () => {
     expect(resolveAvatarSeed(" custom-seed ", "user-1")).toBe("custom-seed");
     expect(resolveAvatarSeed(null, "user-1")).toBe("user-1");

--- a/tests/lib/project-attachment-service.test.ts
+++ b/tests/lib/project-attachment-service.test.ts
@@ -4,11 +4,13 @@ import { RESOURCE_TYPE_CONTEXT_CARD } from "@/lib/resource-type";
 import { AttachmentStorageUnavailableError } from "@/lib/storage/errors";
 
 const prismaMock = vi.hoisted(() => ({
+  $transaction: vi.fn(),
   project: {
     findFirst: vi.fn(),
   },
   task: {
     findUnique: vi.fn(),
+    update: vi.fn(),
   },
   resource: {
     findUnique: vi.fn(),
@@ -67,6 +69,7 @@ describe("project-attachment-service", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    prismaMock.$transaction.mockImplementation(async (callback) => callback(prismaMock));
     prismaMock.project.findFirst.mockResolvedValue({ ownerId: actorUserId, memberships: [] });
   });
 
@@ -256,6 +259,10 @@ describe("project-attachment-service", () => {
       mimeType: "application/pdf",
       sizeBytes: 2048,
     });
+    prismaMock.task.update.mockResolvedValueOnce({
+      id: "task-1",
+    });
+    attachmentStorageMock.deleteAttachmentFile.mockResolvedValue(undefined);
 
     const result = await finalizeTaskAttachmentDirectUpload({
       actorUserId,
@@ -281,6 +288,11 @@ describe("project-attachment-service", () => {
       },
     });
     expect(prismaMock.taskAttachment.create).toHaveBeenCalledTimes(1);
+    expect(prismaMock.task.update).toHaveBeenCalledWith({
+      where: { id: "task-1" },
+      data: { updatedByUserId: actorUserId },
+      select: { id: true },
+    });
     expect(attachmentStorageMock.deleteAttachmentFile).not.toHaveBeenCalled();
   });
 

--- a/tests/lib/project-service.test.ts
+++ b/tests/lib/project-service.test.ts
@@ -41,6 +41,7 @@ import {
   createProject,
   getProjectDashboardById,
   getProjectSummaryById,
+  listProjectCollaborators,
   listProjectsWithCounts,
   listProjectContextResources,
   listProjectKanbanTasks,
@@ -280,6 +281,124 @@ describe("project-service", () => {
                 title: true,
                 status: true,
                 archivedAt: true,
+              },
+            },
+          },
+        },
+        createdByUser: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            username: true,
+            usernameDiscriminator: true,
+            avatarSeed: true,
+          },
+        },
+        updatedByUser: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            username: true,
+            usernameDiscriminator: true,
+            avatarSeed: true,
+          },
+        },
+        assigneeUser: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            username: true,
+            usernameDiscriminator: true,
+            avatarSeed: true,
+          },
+        },
+      },
+    });
+  });
+
+  test("lists project collaborators with owner included once", async () => {
+    prismaMock.project.findFirst.mockResolvedValueOnce({
+      owner: {
+        id: "user-1",
+        name: "Owner",
+        email: "owner@example.com",
+        username: "owner",
+        usernameDiscriminator: "1111",
+        avatarSeed: null,
+      },
+      memberships: [
+        {
+          user: {
+            id: "user-1",
+            name: "Owner Duplicate",
+            email: "owner@example.com",
+            username: "owner",
+            usernameDiscriminator: "1111",
+            avatarSeed: null,
+          },
+        },
+        {
+          user: {
+            id: "user-2",
+            name: "Editor",
+            email: "editor@example.com",
+            username: null,
+            usernameDiscriminator: null,
+            avatarSeed: "seed-editor",
+          },
+        },
+      ],
+    });
+
+    const result = await listProjectCollaborators("project-1", actorUserId);
+
+    expect(result).toEqual([
+      {
+        id: "user-1",
+        displayName: "owner",
+        usernameTag: "owner#1111",
+        avatarSeed: "user-1",
+      },
+      {
+        id: "user-2",
+        displayName: "Editor",
+        usernameTag: null,
+        avatarSeed: "seed-editor",
+      },
+    ]);
+    expect(prismaMock.project.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: "project-1",
+        OR: [
+          { ownerId: actorUserId },
+          { memberships: { some: { userId: actorUserId } } },
+        ],
+      },
+      select: {
+        owner: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            username: true,
+            usernameDiscriminator: true,
+            avatarSeed: true,
+          },
+        },
+        memberships: {
+          orderBy: [{ createdAt: "asc" }],
+          select: {
+            user: {
+              select: {
+                id: true,
+                name: true,
+                email: true,
+                username: true,
+                usernameDiscriminator: true,
+                avatarSeed: true,
               },
             },
           },

--- a/tests/lib/project-service.test.ts
+++ b/tests/lib/project-service.test.ts
@@ -331,6 +331,7 @@ describe("project-service", () => {
       },
       memberships: [
         {
+          role: "owner",
           user: {
             id: "user-1",
             name: "Owner Duplicate",
@@ -341,6 +342,7 @@ describe("project-service", () => {
           },
         },
         {
+          role: "editor",
           user: {
             id: "user-2",
             name: "Editor",
@@ -361,12 +363,14 @@ describe("project-service", () => {
         displayName: "owner",
         usernameTag: "owner#1111",
         avatarSeed: "user-1",
+        projectRole: "owner",
       },
       {
         id: "user-2",
         displayName: "Editor",
         usernameTag: null,
         avatarSeed: "seed-editor",
+        projectRole: "editor",
       },
     ]);
     expect(prismaMock.project.findFirst).toHaveBeenCalledWith({
@@ -391,6 +395,7 @@ describe("project-service", () => {
         memberships: {
           orderBy: [{ createdAt: "asc" }],
           select: {
+            role: true,
             user: {
               select: {
                 id: true,


### PR DESCRIPTION
## Summary
- add first-class task creator, updater, and optional assignee persistence with a backfill migration for legacy tasks
- keep task provenance current across task updates, reorder/archive flows, comments, and task attachment activity
- surface avatar-backed assignee/creator/updater identity in the kanban board, task detail modal, and create/edit flows while updating agent docs and regression coverage

## Why
TASK-101 makes task ownership explicit instead of relying on chat context or naming conventions. It also turns the TASK-089 avatar foundation into real collaboration metadata that later work can build on.

## Validation
- `npm run lint`
- `npx vitest run tests/lib/project-attachment-service.test.ts tests/api/task-create.route.test.ts tests/api/task-comments.route.test.ts tests/api/task-update.route.test.ts tests/api/tasks-reorder.route.test.ts tests/api/agent-project-routes.test.ts tests/lib/project-service.test.ts`
- `$env:DATABASE_URL='postgresql://localhost:5432/postgres'; $env:DIRECT_URL='postgresql://localhost:5432/postgres'; npx -y -p node@20.19.0 node .\\node_modules\\vitest\\vitest.mjs run`
- same env with `--coverage`
- `npx -y -p node@20.19.0 node .\\node_modules\\prisma\\build\\index.js generate`
- `$env:DATABASE_URL='postgresql://localhost:5432/postgres'; $env:DIRECT_URL='postgresql://localhost:5433/postgres'; $env:GOOGLE_TOKEN_ENCRYPTION_KEY='test-key-0123456789abcdef0123456789'; $env:AGENT_TOKEN_SIGNING_SECRET='test-agent-signing-secret-0123456789abcdef0123456789abcdef'; npm run build`

## Notes
- This PR is intentionally stacked on top of `#192` (`TASK-089`) so reviewers only see the ownership/provenance delta.
- Local Playwright is blocked before UI execution because the shared `.env` database has not yet had the TASK-101 migration applied. I will complete browser verification against the preview deployment after the branch preview workflow runs.