### PR TITLE
TASK-107: add project epics and task epic links

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -43,6 +43,7 @@ If `tasks/current.md` is complete or invalid, pick the next `Pending` item in `t
   - do not use generic prefixes like `[codex]`
 - Push the active branch remotely after meaningful implementation/validation progress and before handoff.
 - If the current task does not already have an open PR, create one once the branch is reviewable; continue updating the same PR for that task.
+- Do not treat PR creation as optional. A coding task that changes product code is not ready for handoff until its dedicated branch has an open PR, unless the user explicitly says not to open one.
 - Open PRs in a ready-for-review state once they are reviewable so automatic
   Copilot review can start immediately.
 - Use draft PRs only when the user explicitly asks for a draft or when the work
@@ -52,6 +53,9 @@ If `tasks/current.md` is complete or invalid, pick the next `Pending` item in `t
 - Triage Copilot review comments: apply relevant changes, respond on threads, resolve every conversation you addressed before handoff, and leave clear rationale when a suggestion is intentionally not applied.
 - Final task/PR handoff must mention the commit SHA or SHAs that contain the delivered changes.
 - When preview validation is part of the task, review, or acceptance flow, trigger a preview deploy from the active branch git ref through the expected workflow and include both the workflow reference and preview result in the handoff.
+- For manual preview workflows that accept a `git_ref` or equivalent input, pass the active branch name explicitly and verify from the workflow logs that the job checked out that branch ref.
+- Do not rely only on the workflow UI `headBranch` field for branch-scoped preview evidence when the workflow itself runs from the default branch file; the handoff must mention the explicit `git_ref` used and the log evidence that the requested branch ref was checked out.
+- A task that requires preview validation is not ready for handoff until the preview workflow has completed for the active branch ref and the resulting preview URL or artifact has been recorded.
 
 ## 4. Architecture Boundaries (Non-Negotiable)
 

--- a/app/api/projects/[projectId]/epics/[epicId]/route.ts
+++ b/app/api/projects/[projectId]/epics/[epicId]/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import {
+  getAgentProjectAccessContext,
+  requireApiPrincipal,
+} from "@/lib/auth/api-guard";
+import { logServerWarning } from "@/lib/observability/logger";
+import {
+  deleteProjectEpic,
+  updateProjectEpic,
+} from "@/lib/services/project-epic-service";
+
+interface ProjectEpicRequestBody {
+  name?: unknown;
+  description?: unknown;
+}
+
+export async function PATCH(
+  request: NextRequest,
+  props: { params: Promise<{ projectId: string; epicId: string }> }
+) {
+  const params = await props.params;
+  const principalResult = await requireApiPrincipal(request);
+  if (!principalResult.ok) {
+    return principalResult.response;
+  }
+
+  let payload: ProjectEpicRequestBody;
+  try {
+    payload = (await request.json()) as ProjectEpicRequestBody;
+  } catch (error) {
+    logServerWarning(
+      "PATCH /api/projects/:projectId/epics/:epicId.invalidJson",
+      "Invalid JSON payload",
+      { error }
+    );
+    return NextResponse.json({ error: "invalid-json" }, { status: 400 });
+  }
+
+  const result = await updateProjectEpic({
+    actorUserId: principalResult.principal.actorUserId,
+    projectId: params.projectId,
+    epicId: params.epicId,
+    name: typeof payload.name === "string" ? payload.name : "",
+    description: typeof payload.description === "string" ? payload.description : "",
+    agentAccess: getAgentProjectAccessContext(principalResult.principal),
+  });
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json({
+    epic: {
+      ...result.data.epic,
+      createdAt: result.data.epic.createdAt.toISOString(),
+      updatedAt: result.data.epic.updatedAt.toISOString(),
+    },
+  });
+}
+
+export async function DELETE(
+  request: NextRequest,
+  props: { params: Promise<{ projectId: string; epicId: string }> }
+) {
+  const params = await props.params;
+  const principalResult = await requireApiPrincipal(request);
+  if (!principalResult.ok) {
+    return principalResult.response;
+  }
+
+  const result = await deleteProjectEpic({
+    actorUserId: principalResult.principal.actorUserId,
+    projectId: params.projectId,
+    epicId: params.epicId,
+    agentAccess: getAgentProjectAccessContext(principalResult.principal),
+  });
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/projects/[projectId]/epics/route.ts
+++ b/app/api/projects/[projectId]/epics/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import {
+  getAgentProjectAccessContext,
+  requireApiPrincipal,
+} from "@/lib/auth/api-guard";
+import { logServerWarning } from "@/lib/observability/logger";
+import {
+  createProjectEpic,
+  listProjectEpics,
+} from "@/lib/services/project-epic-service";
+
+interface ProjectEpicRequestBody {
+  name?: unknown;
+  description?: unknown;
+}
+
+export async function GET(
+  request: NextRequest,
+  props: { params: Promise<{ projectId: string }> }
+) {
+  const params = await props.params;
+  const principalResult = await requireApiPrincipal(request);
+  if (!principalResult.ok) {
+    return principalResult.response;
+  }
+
+  const epics = await listProjectEpics(
+    params.projectId,
+    principalResult.principal.actorUserId,
+    getAgentProjectAccessContext(principalResult.principal)
+  );
+
+  return NextResponse.json({
+    epics: epics.map((epic) => ({
+      ...epic,
+      createdAt: epic.createdAt.toISOString(),
+      updatedAt: epic.updatedAt.toISOString(),
+    })),
+  });
+}
+
+export async function POST(
+  request: NextRequest,
+  props: { params: Promise<{ projectId: string }> }
+) {
+  const params = await props.params;
+  const principalResult = await requireApiPrincipal(request);
+  if (!principalResult.ok) {
+    return principalResult.response;
+  }
+
+  let payload: ProjectEpicRequestBody;
+  try {
+    payload = (await request.json()) as ProjectEpicRequestBody;
+  } catch (error) {
+    logServerWarning(
+      "POST /api/projects/:projectId/epics.invalidJson",
+      "Invalid JSON payload",
+      { error }
+    );
+    return NextResponse.json({ error: "invalid-json" }, { status: 400 });
+  }
+
+  const result = await createProjectEpic({
+    actorUserId: principalResult.principal.actorUserId,
+    projectId: params.projectId,
+    name: typeof payload.name === "string" ? payload.name : "",
+    description: typeof payload.description === "string" ? payload.description : "",
+    agentAccess: getAgentProjectAccessContext(principalResult.principal),
+  });
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json(
+    {
+      epic: {
+        ...result.data.epic,
+        createdAt: result.data.epic.createdAt.toISOString(),
+        updatedAt: result.data.epic.updatedAt.toISOString(),
+      },
+    },
+    { status: 201 }
+  );
+}

--- a/app/api/projects/[projectId]/tasks/route.ts
+++ b/app/api/projects/[projectId]/tasks/route.ts
@@ -9,6 +9,7 @@ import { mapTaskAttachmentResponse } from "@/lib/services/project-attachment-ser
 import { listProjectKanbanTasks } from "@/lib/services/project-service";
 import { createTaskForProject } from "@/lib/services/project-task-service";
 import { requireAgentProjectScopes } from "@/lib/services/project-access-service";
+import { mapTaskEpicSummary } from "@/lib/epic";
 import { mapTaskPersonSummary } from "@/lib/task-person";
 import { formatTaskDeadlineDate } from "@/lib/task-deadline";
 
@@ -19,6 +20,7 @@ interface TaskCreateJsonRequestBody {
   title?: unknown;
   description?: unknown;
   deadlineDate?: unknown;
+  epicId?: unknown;
   assigneeUserId?: unknown;
   labels?: unknown;
   relatedTaskIds?: unknown;
@@ -121,6 +123,7 @@ export async function GET(request: NextRequest, props: { params: Promise<{ proje
       labelsJson: task.labelsJson,
       createdAt: task.createdAt,
       updatedAt: task.updatedAt,
+      epic: mapTaskEpicSummary(task.epic),
       assignee: mapTaskPersonSummary(task.assigneeUser),
       createdBy: mapTaskPersonSummary(task.createdByUser),
       updatedBy: mapTaskPersonSummary(task.updatedByUser),
@@ -149,6 +152,7 @@ export async function POST(request: NextRequest, props: { params: Promise<{ proj
   let title = "";
   let description = "";
   let deadlineDate = "";
+  let epicId: string | null = null;
   let assigneeUserId: string | null = null;
   let labelsJsonRaw = "";
   let relatedTaskIdsJsonRaw = "";
@@ -181,6 +185,14 @@ export async function POST(request: NextRequest, props: { params: Promise<{ proj
     deadlineDate =
       typeof payload.deadlineDate === "string" ? payload.deadlineDate.trim() : "";
     if (
+      payload.epicId !== undefined &&
+      payload.epicId !== null &&
+      typeof payload.epicId !== "string"
+    ) {
+      return NextResponse.json({ error: "epic-invalid" }, { status: 400 });
+    }
+    epicId = typeof payload.epicId === "string" ? payload.epicId.trim() || null : null;
+    if (
       payload.assigneeUserId !== undefined &&
       payload.assigneeUserId !== null &&
       typeof payload.assigneeUserId !== "string"
@@ -210,6 +222,7 @@ export async function POST(request: NextRequest, props: { params: Promise<{ proj
     title = readText(formData, "title");
     description = readText(formData, "description");
     deadlineDate = readText(formData, "deadlineDate");
+    epicId = readText(formData, "epicId") || null;
     assigneeUserId = readText(formData, "assigneeUserId") || null;
     labelsJsonRaw = readText(formData, "labels");
     relatedTaskIdsJsonRaw = readText(formData, "relatedTaskIds");
@@ -230,6 +243,7 @@ export async function POST(request: NextRequest, props: { params: Promise<{ proj
     title,
     description,
     deadlineDate,
+    epicId,
     assigneeUserId,
     labelsJsonRaw,
     relatedTaskIdsJsonRaw,

--- a/app/projects/[projectId]/kanban-board-section.tsx
+++ b/app/projects/[projectId]/kanban-board-section.tsx
@@ -4,6 +4,7 @@ import {
   KanbanBoard,
   type KanbanTask,
 } from "@/components/kanban-board";
+import type { ProjectEpicOption } from "@/components/kanban-board-types";
 import {
   PROJECT_SECTION_CARD_CLASS,
   PROJECT_SECTION_HEADER_CLASS,
@@ -13,6 +14,8 @@ import {
   listProjectCollaborators,
   listProjectKanbanTasks,
 } from "@/lib/services/project-service";
+import { listProjectEpics } from "@/lib/services/project-epic-service";
+import { mapTaskEpicSummary } from "@/lib/epic";
 import { mapTaskPersonSummary } from "@/lib/task-person";
 import { mapRelatedTaskSummary } from "@/lib/task-related";
 import { ATTACHMENT_KIND_FILE } from "@/lib/task-attachment";
@@ -40,12 +43,20 @@ export async function KanbanBoardSection({
   canEdit,
   storageProvider,
 }: KanbanBoardSectionProps) {
-  const [tasks, collaborators] = await Promise.all([
+  const [tasks, collaborators, epics] = await Promise.all([
     listProjectKanbanTasks(projectId, actorUserId),
     listProjectCollaborators(projectId, actorUserId),
+    listProjectEpics(projectId, actorUserId),
   ]);
   const kanbanTasks: KanbanTask[] = [];
   const archivedDoneTasks: KanbanTask[] = [];
+  const epicOptions: ProjectEpicOption[] = epics.map((epic) => ({
+    id: epic.id,
+    name: epic.name,
+    status: epic.status,
+    progressPercent: epic.progressPercent,
+    taskCount: epic.taskCount,
+  }));
 
   tasks.forEach((task: ProjectKanbanTask) => {
     if (!isTaskStatus(task.status)) {
@@ -64,6 +75,7 @@ export async function KanbanBoardSection({
         content: entry.content,
         createdAt: entry.createdAt.toISOString(),
       })),
+      epic: mapTaskEpicSummary(task.epic),
       assignee: mapTaskPersonSummary(task.assigneeUser),
       createdBy: mapTaskPersonSummary(task.createdByUser)!,
       updatedBy: mapTaskPersonSummary(task.updatedByUser)!,
@@ -108,6 +120,7 @@ export async function KanbanBoardSection({
       storageProvider={storageProvider}
       initialTasks={kanbanTasks}
       archivedDoneTasks={archivedDoneTasks}
+      epics={epicOptions}
       collaborators={collaborators}
       actorUserId={actorUserId}
     />

--- a/app/projects/[projectId]/page.tsx
+++ b/app/projects/[projectId]/page.tsx
@@ -29,6 +29,10 @@ import {
   ProjectContextPanelSection,
   ProjectContextPanelSkeleton,
 } from "./project-context-panel-section";
+import {
+  ProjectEpicPanelSection,
+  ProjectEpicPanelSkeleton,
+} from "./project-epic-panel-section";
 
 type SearchParams = Record<string, string | string[] | undefined>;
 
@@ -206,6 +210,14 @@ export default async function ProjectDashboardPage({
           {ERROR_MESSAGES[error]}
         </div>
       ) : null}
+
+      <Suspense fallback={<ProjectEpicPanelSkeleton />}>
+        <ProjectEpicPanelSection
+          projectId={project.id}
+          actorUserId={actorUserId}
+          canEdit={canEditProjectContent}
+        />
+      </Suspense>
 
       <Suspense fallback={<ProjectContextPanelSkeleton />}>
         <ProjectContextPanelSection

--- a/app/projects/[projectId]/page.tsx
+++ b/app/projects/[projectId]/page.tsx
@@ -211,20 +211,20 @@ export default async function ProjectDashboardPage({
         </div>
       ) : null}
 
-      <Suspense fallback={<ProjectEpicPanelSkeleton />}>
-        <ProjectEpicPanelSection
-          projectId={project.id}
-          actorUserId={actorUserId}
-          canEdit={canEditProjectContent}
-        />
-      </Suspense>
-
       <Suspense fallback={<ProjectContextPanelSkeleton />}>
         <ProjectContextPanelSection
           projectId={project.id}
           actorUserId={actorUserId}
           canEdit={canEditProjectContent}
           storageProvider={storageProvider}
+        />
+      </Suspense>
+
+      <Suspense fallback={<ProjectEpicPanelSkeleton />}>
+        <ProjectEpicPanelSection
+          projectId={project.id}
+          actorUserId={actorUserId}
+          canEdit={canEditProjectContent}
         />
       </Suspense>
 

--- a/app/projects/[projectId]/project-epic-panel-section.tsx
+++ b/app/projects/[projectId]/project-epic-panel-section.tsx
@@ -10,6 +10,7 @@ import {
   type ProjectEpicPanelEpic,
 } from "@/components/project-epic-panel";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { logServerError } from "@/lib/observability/logger";
 import { listProjectEpics } from "@/lib/services/project-epic-service";
 
 interface ProjectEpicPanelSectionProps {
@@ -23,19 +24,31 @@ export async function ProjectEpicPanelSection({
   actorUserId,
   canEdit,
 }: ProjectEpicPanelSectionProps) {
-  const epics = await listProjectEpics(projectId, actorUserId);
+  let serializableEpics: ProjectEpicPanelEpic[] = [];
+  let loadError: string | null = null;
 
-  const serializableEpics: ProjectEpicPanelEpic[] = epics.map((epic) => ({
-    ...epic,
-    createdAt: epic.createdAt.toISOString(),
-    updatedAt: epic.updatedAt.toISOString(),
-  }));
+  try {
+    const epics = await listProjectEpics(projectId, actorUserId);
+
+    serializableEpics = epics.map((epic) => ({
+      ...epic,
+      createdAt: epic.createdAt.toISOString(),
+      updatedAt: epic.updatedAt.toISOString(),
+    }));
+  } catch (error) {
+    logServerError("ProjectEpicPanelSection", error, {
+      actorUserId,
+      projectId,
+    });
+    loadError = "Epics are temporarily unavailable. Reload to try again.";
+  }
 
   return (
     <ProjectEpicPanel
       projectId={projectId}
       canEdit={canEdit}
       epics={serializableEpics}
+      loadError={loadError}
     />
   );
 }

--- a/app/projects/[projectId]/project-epic-panel-section.tsx
+++ b/app/projects/[projectId]/project-epic-panel-section.tsx
@@ -1,0 +1,58 @@
+import { Flag } from "lucide-react";
+
+import {
+  PROJECT_SECTION_CARD_CLASS,
+  PROJECT_SECTION_CONTENT_CLASS,
+  PROJECT_SECTION_HEADER_CLASS,
+} from "@/components/project-dashboard/project-section-chrome";
+import {
+  ProjectEpicPanel,
+  type ProjectEpicPanelEpic,
+} from "@/components/project-epic-panel";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { listProjectEpics } from "@/lib/services/project-epic-service";
+
+interface ProjectEpicPanelSectionProps {
+  projectId: string;
+  actorUserId: string;
+  canEdit: boolean;
+}
+
+export async function ProjectEpicPanelSection({
+  projectId,
+  actorUserId,
+  canEdit,
+}: ProjectEpicPanelSectionProps) {
+  const epics = await listProjectEpics(projectId, actorUserId);
+
+  const serializableEpics: ProjectEpicPanelEpic[] = epics.map((epic) => ({
+    ...epic,
+    createdAt: epic.createdAt.toISOString(),
+    updatedAt: epic.updatedAt.toISOString(),
+  }));
+
+  return (
+    <ProjectEpicPanel
+      projectId={projectId}
+      canEdit={canEdit}
+      epics={serializableEpics}
+    />
+  );
+}
+
+export function ProjectEpicPanelSkeleton() {
+  return (
+    <Card className={PROJECT_SECTION_CARD_CLASS}>
+      <CardHeader className={PROJECT_SECTION_HEADER_CLASS}>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Flag className="h-4 w-4" />
+          Epics
+        </CardTitle>
+      </CardHeader>
+      <CardContent className={`space-y-3 ${PROJECT_SECTION_CONTENT_CLASS}`}>
+        <div className="h-28 w-full animate-pulse rounded-2xl bg-muted" />
+        <div className="h-28 w-full animate-pulse rounded-2xl bg-muted" />
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/create-task-dialog.tsx
+++ b/components/create-task-dialog.tsx
@@ -8,6 +8,7 @@ import { useRouter } from "next/navigation";
 import { TaskDeadlineField } from "@/components/kanban/task-deadline-field";
 import { RelatedTaskSelector, type RelatedTaskOption } from "@/components/kanban/related-task-field";
 import type {
+  ProjectEpicOption,
   ProjectTaskCollaborator,
   TaskRelatedSummary,
 } from "@/components/kanban-board-types";
@@ -16,6 +17,7 @@ import { useToast } from "@/components/toast-provider";
 import { AttachmentLinkComposer } from "@/components/ui/attachment-link-composer";
 import { AssigneeSelect } from "@/components/ui/assignee-select";
 import { Button } from "@/components/ui/button";
+import { EpicSelect } from "@/components/ui/epic-select";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { EmojiInputField } from "@/components/ui/emoji-field";
 import {
@@ -36,6 +38,7 @@ interface CreateTaskDialogProps {
   storageProvider: "local" | "r2";
   existingLabels: string[];
   availableTasks: RelatedTaskOption[];
+  availableEpics: ProjectEpicOption[];
   availableAssignees: ProjectTaskCollaborator[];
 }
 
@@ -53,6 +56,7 @@ export function CreateTaskDialog({
   storageProvider,
   existingLabels,
   availableTasks,
+  availableEpics,
   availableAssignees,
 }: CreateTaskDialogProps) {
   const isMountedRef = useRef(true);
@@ -61,6 +65,7 @@ export function CreateTaskDialog({
   const [isOpen, setIsOpen] = useState(false);
   const [description, setDescription] = useState("");
   const [deadlineDate, setDeadlineDate] = useState("");
+  const [epicId, setEpicId] = useState("");
   const [assigneeUserId, setAssigneeUserId] = useState("");
   const [labels, setLabels] = useState<string[]>([]);
   const [labelInput, setLabelInput] = useState("");
@@ -95,6 +100,7 @@ export function CreateTaskDialog({
   const resetDraft = () => {
     setDescription("");
     setDeadlineDate("");
+    setEpicId("");
     setAssigneeUserId("");
     setLabels([]);
     setLabelInput("");
@@ -128,6 +134,8 @@ export function CreateTaskDialog({
         return "One or more attachment links are invalid. Use http:// or https:// URLs.";
       case "deadline-invalid":
         return "Deadline must use a valid date.";
+      case "epic-invalid":
+        return "Epic must belong to this project.";
       case "assignee-invalid":
         return "Assignee must be a current collaborator on this project.";
       case "attachment-file-too-large":
@@ -475,6 +483,23 @@ export function CreateTaskDialog({
                         disabled={isSubmitting}
                         helperText="Optional. Near deadlines are highlighted automatically on the board."
                       />
+
+                      <div className="grid gap-2">
+                        <label htmlFor="task-epic" className="text-sm font-medium">
+                          Epic
+                        </label>
+                        <EpicSelect
+                          id="task-epic"
+                          name="epicId"
+                          value={epicId}
+                          onChange={setEpicId}
+                          options={availableEpics}
+                        />
+                        <p className="text-xs text-muted-foreground">
+                          Optional. Link this task to a broader initiative without turning the
+                          epic into a task.
+                        </p>
+                      </div>
 
                       <div className="grid gap-2">
                         <label htmlFor="task-assignee" className="text-sm font-medium">

--- a/components/kanban-board-types.ts
+++ b/components/kanban-board-types.ts
@@ -22,6 +22,17 @@ export interface TaskRelatedSummary {
   archivedAt: string | null;
 }
 
+export interface TaskEpicSummary {
+  id: string;
+  name: string;
+}
+
+export interface ProjectEpicOption extends TaskEpicSummary {
+  status: "Ready" | "In progress" | "Completed";
+  progressPercent: number;
+  taskCount: number;
+}
+
 export type TaskCommentAuthor = TaskPersonSummary;
 
 export interface TaskComment {
@@ -53,6 +64,7 @@ export interface KanbanTask {
   archivedAt: string | null;
   attachments: TaskAttachment[];
   relatedTasks: TaskRelatedSummary[];
+  epic: TaskEpicSummary | null;
   assignee: TaskPersonSummary | null;
   createdBy: TaskPersonSummary;
   updatedBy: TaskPersonSummary;

--- a/components/kanban-board.tsx
+++ b/components/kanban-board.tsx
@@ -90,6 +90,75 @@ function stampTaskActivity(
   };
 }
 
+interface TaskMutationResponseTask {
+  id: string;
+  title: string;
+  label: string | null;
+  labelsJson: string | null;
+  description: string | null;
+  deadlineDate: string | null;
+  commentCount: number;
+  blockedNote: string | null;
+  status: TaskStatus;
+  position: number;
+  archivedAt: string | null;
+  epic: TaskEpicSummary | null;
+  assignee: TaskPersonSummary | null;
+  createdBy: TaskPersonSummary;
+  updatedBy: TaskPersonSummary;
+  createdAt: string;
+  updatedAt: string;
+  relatedTasks: TaskRelatedSummary[];
+  blockedFollowUps: {
+    id: string;
+    content: string;
+    createdAt: string;
+  }[];
+}
+
+function getTaskMutationErrorMessage(errorCode?: string): string {
+  switch (errorCode) {
+    case "related-tasks-invalid":
+      return "Related tasks must stay active and belong to this project.";
+    case "epic-invalid":
+      return "Epic must belong to this project.";
+    case "assignee-invalid":
+      return "Assignee must be a current collaborator on this project.";
+    case "deadline-invalid":
+      return "Deadline must use a valid date.";
+    default:
+      return errorCode ?? "Failed to update task";
+  }
+}
+
+function mapTaskMutationResponseTask(
+  task: TaskMutationResponseTask,
+  attachments: TaskAttachment[]
+): KanbanTask {
+  return {
+    id: task.id,
+    title: task.title,
+    labels: getTaskLabelsFromStorage(task.labelsJson, task.label),
+    description: task.description,
+    deadlineDate: task.deadlineDate,
+    commentCount: task.commentCount,
+    epic: task.epic,
+    assignee: task.assignee,
+    createdBy: task.createdBy,
+    updatedBy: task.updatedBy,
+    createdAt: task.createdAt,
+    updatedAt: task.updatedAt,
+    blockedFollowUps: task.blockedFollowUps.map((entry) => ({
+      ...entry,
+      createdAt: entry.createdAt,
+    })),
+    status: task.status,
+    archivedAt: task.archivedAt,
+    relatedTasks: task.relatedTasks,
+    attachments,
+  };
+}
+
 export function KanbanBoard({
   canEdit,
   projectId,
@@ -748,6 +817,132 @@ export function KanbanBoard({
     [canEdit, resetTaskEditDraft, selectedTask]
   );
 
+  const applyUpdatedTask = useCallback(
+    (updatedTask: KanbanTask) => {
+      setColumns((previousColumns) => {
+        const nextColumns = cloneColumns(previousColumns);
+        const taskColumn = nextColumns[updatedTask.status];
+        const taskIndex = taskColumn.findIndex((task) => task.id === updatedTask.id);
+
+        if (taskIndex === -1) {
+          return previousColumns;
+        }
+
+        taskColumn[taskIndex] = {
+          ...taskColumn[taskIndex],
+          ...updatedTask,
+        };
+
+        return nextColumns;
+      });
+
+      setArchivedDoneTasks((previousArchivedTasks) => {
+        const taskIndex = previousArchivedTasks.findIndex((task) => task.id === updatedTask.id);
+
+        if (taskIndex === -1) {
+          return previousArchivedTasks;
+        }
+
+        if (updatedTask.status !== "Done") {
+          return previousArchivedTasks.filter((task) => task.id !== updatedTask.id);
+        }
+
+        const nextArchivedTasks = [...previousArchivedTasks];
+        nextArchivedTasks[taskIndex] = {
+          ...nextArchivedTasks[taskIndex],
+          ...updatedTask,
+        };
+        return nextArchivedTasks;
+      });
+
+      setSelectedTask((previousTask) => {
+        if (!previousTask || previousTask.id !== updatedTask.id) {
+          return previousTask;
+        }
+        return updatedTask;
+      });
+      setEditEpicId(updatedTask.epic?.id ?? "");
+      setEditAssigneeUserId(updatedTask.assignee?.id ?? "");
+      syncRelatedTaskSummary(updatedTask.id, {
+        title: updatedTask.title,
+        status: updatedTask.status,
+        archivedAt: updatedTask.archivedAt,
+      });
+    },
+    [syncRelatedTaskSummary]
+  );
+
+  const patchSelectedTask = useCallback(
+    async ({
+      payload,
+      successMessage,
+      fallbackErrorMessage,
+    }: {
+      payload: Record<string, unknown>;
+      successMessage: string;
+      fallbackErrorMessage: string;
+    }) => {
+      if (!selectedTask || !canEdit) {
+        return false;
+      }
+
+      setIsUpdatingTask(true);
+      setTaskModalError(null);
+
+      try {
+        const response = await fetch(`/api/projects/${projectId}/tasks/${selectedTask.id}`, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+          const responsePayload = (await response.json().catch(() => null)) as
+            | {
+                error?: string;
+              }
+            | null;
+          throw new Error(getTaskMutationErrorMessage(responsePayload?.error));
+        }
+
+        const responsePayload = (await response.json()) as {
+          task: TaskMutationResponseTask;
+        };
+
+        if (!isTaskStatus(responsePayload.task.status)) {
+          throw new Error("Invalid task status returned by server");
+        }
+
+        const updatedTask = mapTaskMutationResponseTask(
+          responsePayload.task,
+          selectedTask.attachments
+        );
+        applyUpdatedTask(updatedTask);
+        router.refresh();
+        pushToast({
+          variant: "success",
+          message: successMessage,
+        });
+        return true;
+      } catch (error) {
+        console.error("[KanbanBoard.patchSelectedTask]", error);
+        const message =
+          error instanceof Error ? error.message : fallbackErrorMessage;
+        setTaskModalError(message);
+        pushToast({
+          variant: "error",
+          message,
+        });
+        return false;
+      } finally {
+        setIsUpdatingTask(false);
+      }
+    },
+    [applyUpdatedTask, canEdit, projectId, pushToast, router, selectedTask]
+  );
+
   const persistTaskChanges = useCallback(
     async (options?: { exitEditMode?: boolean }) => {
       if (!selectedTask) {
@@ -794,130 +989,19 @@ export function KanbanBoard({
           const payload = (await response.json().catch(() => null)) as {
             error?: string;
           } | null;
-          const message =
-            payload?.error === "related-tasks-invalid"
-              ? "Related tasks must stay active and belong to this project."
-              : payload?.error === "epic-invalid"
-                ? "Epic must belong to this project."
-              : payload?.error === "assignee-invalid"
-                ? "Assignee must be a current collaborator on this project."
-              : payload?.error === "deadline-invalid"
-                ? "Deadline must use a valid date."
-              : (payload?.error ?? "Failed to update task");
-          throw new Error(message);
+          throw new Error(getTaskMutationErrorMessage(payload?.error));
         }
 
         const payload = (await response.json()) as {
-          task: {
-            id: string;
-            title: string;
-            label: string | null;
-            labelsJson: string | null;
-            description: string | null;
-            deadlineDate: string | null;
-            commentCount: number;
-            blockedNote: string | null;
-            status: string;
-            position: number;
-            archivedAt: string | null;
-            epic: TaskEpicSummary | null;
-            assignee: TaskPersonSummary | null;
-            createdBy: TaskPersonSummary;
-            updatedBy: TaskPersonSummary;
-            createdAt: string;
-            updatedAt: string;
-            relatedTasks: TaskRelatedSummary[];
-            blockedFollowUps: {
-              id: string;
-              content: string;
-              createdAt: string;
-            }[];
-          };
+          task: TaskMutationResponseTask;
         };
 
         if (!isTaskStatus(payload.task.status)) {
           throw new Error("Invalid task status returned by server");
         }
 
-        const updatedTask: KanbanTask = {
-          id: payload.task.id,
-          title: payload.task.title,
-          labels: getTaskLabelsFromStorage(
-            payload.task.labelsJson,
-            payload.task.label
-          ),
-          description: payload.task.description,
-          deadlineDate: payload.task.deadlineDate,
-          commentCount: payload.task.commentCount,
-          epic: payload.task.epic,
-          assignee: payload.task.assignee,
-          createdBy: payload.task.createdBy,
-          updatedBy: payload.task.updatedBy,
-          createdAt: payload.task.createdAt,
-          updatedAt: payload.task.updatedAt,
-          blockedFollowUps: payload.task.blockedFollowUps.map((entry) => ({
-            ...entry,
-            createdAt: entry.createdAt,
-          })),
-          status: payload.task.status,
-          archivedAt: payload.task.archivedAt,
-          relatedTasks: payload.task.relatedTasks,
-          attachments: selectedTask.attachments,
-        };
-
-        setColumns((previousColumns) => {
-          const nextColumns = cloneColumns(previousColumns);
-          const taskColumn = nextColumns[updatedTask.status];
-          const taskIndex = taskColumn.findIndex(
-            (task) => task.id === updatedTask.id
-          );
-
-          if (taskIndex === -1) {
-            return previousColumns;
-          }
-
-          taskColumn[taskIndex] = {
-            ...taskColumn[taskIndex],
-            ...updatedTask,
-          };
-
-          return nextColumns;
-        });
-
-        setArchivedDoneTasks((previousArchivedTasks) => {
-          const taskIndex = previousArchivedTasks.findIndex(
-            (task) => task.id === updatedTask.id
-          );
-
-          if (taskIndex === -1) {
-            return previousArchivedTasks;
-          }
-
-          if (updatedTask.status !== "Done") {
-            return previousArchivedTasks.filter(
-              (task) => task.id !== updatedTask.id
-            );
-          }
-
-          const nextArchivedTasks = [...previousArchivedTasks];
-          nextArchivedTasks[taskIndex] = {
-            ...nextArchivedTasks[taskIndex],
-            ...updatedTask,
-          };
-          return nextArchivedTasks;
-        });
-
-        setSelectedTask((previousTask) => {
-          if (!previousTask || previousTask.id !== updatedTask.id) {
-            return previousTask;
-          }
-          return updatedTask;
-        });
-        syncRelatedTaskSummary(updatedTask.id, {
-          title: updatedTask.title,
-          status: updatedTask.status,
-          archivedAt: updatedTask.archivedAt,
-        });
+        const updatedTask = mapTaskMutationResponseTask(payload.task, selectedTask.attachments);
+        applyUpdatedTask(updatedTask);
         setTaskModalError(null);
         if (options?.exitEditMode !== false) {
           setIsEditMode(false);
@@ -948,8 +1032,26 @@ export function KanbanBoard({
       projectId,
       router,
       selectedTask,
-      syncRelatedTaskSummary,
+      applyUpdatedTask,
     ]
+  );
+
+  const handleQuickEpicUpdate = useCallback(
+    async (nextEpicId: string) => {
+      const nextEpicLabel =
+        availableEpicOptions.find((epic) => epic.id === nextEpicId)?.name ?? null;
+
+      await patchSelectedTask({
+        payload: {
+          epicId: nextEpicId || null,
+        },
+        successMessage: nextEpicLabel
+          ? `Epic updated to ${nextEpicLabel}.`
+          : "Epic cleared.",
+        fallbackErrorMessage: "Could not update epic.",
+      });
+    },
+    [availableEpicOptions, patchSelectedTask]
   );
 
   const handleTaskUpdate = useCallback(async () => {
@@ -1768,6 +1870,7 @@ export function KanbanBoard({
         onNewBlockedFollowUpEntryChange={setNewBlockedFollowUpEntry}
         onAddBlockedFollowUpEntry={handleAddBlockedFollowUpEntry}
         onSaveTask={handleTaskUpdate}
+        onQuickEpicChange={handleQuickEpicUpdate}
         onToggleLinkComposer={() =>
           setIsLinkComposerOpen((previous) => !previous)
         }

--- a/components/kanban-board.tsx
+++ b/components/kanban-board.tsx
@@ -9,16 +9,19 @@ import {
   useTransition,
 } from "react";
 import type { DropResult } from "@hello-pangea/dnd";
+import { useRouter } from "next/navigation";
 
 import type { RelatedTaskOption } from "@/components/kanban/related-task-field";
 import {
   type KanbanTask,
+  type ProjectEpicOption,
   type ProjectTaskCollaborator,
   type TaskComment,
   type PendingAttachmentUpload,
   type TaskPersonSummary,
   type TaskAttachment,
   type TaskRelatedSummary,
+  type TaskEpicSummary,
 } from "@/components/kanban-board-types";
 import { CreateTaskDialog } from "@/components/create-task-dialog";
 import { KanbanBoardHeader } from "@/components/kanban/kanban-board-header";
@@ -64,6 +67,7 @@ interface KanbanBoardProps {
   storageProvider: "local" | "r2";
   initialTasks: KanbanTask[];
   archivedDoneTasks?: KanbanTask[];
+  epics: ProjectEpicOption[];
   collaborators: ProjectTaskCollaborator[];
 }
 
@@ -93,8 +97,10 @@ export function KanbanBoard({
   storageProvider,
   initialTasks,
   archivedDoneTasks: initialArchivedDoneTasks = [],
+  epics,
   collaborators,
 }: KanbanBoardProps) {
+  const router = useRouter();
   const initialColumns = useMemo(
     () => mapTasksToColumns(initialTasks),
     [initialTasks]
@@ -127,6 +133,7 @@ export function KanbanBoard({
   const [editLabelInput, setEditLabelInput] = useState("");
   const [editDescription, setEditDescription] = useState("");
   const [editDeadlineDate, setEditDeadlineDate] = useState("");
+  const [editEpicId, setEditEpicId] = useState("");
   const [editAssigneeUserId, setEditAssigneeUserId] = useState("");
   const [editRelatedTasks, setEditRelatedTasks] = useState<TaskRelatedSummary[]>([]);
   const [relatedTaskSearch, setRelatedTaskSearch] = useState("");
@@ -171,6 +178,7 @@ export function KanbanBoard({
     setEditLabelInput("");
     setEditDescription(task.description ?? "");
     setEditDeadlineDate(task.deadlineDate ?? "");
+    setEditEpicId(task.epic?.id ?? "");
     setEditAssigneeUserId(task.assignee?.id ?? "");
     setEditRelatedTasks(task.relatedTasks);
     setRelatedTaskSearch("");
@@ -192,6 +200,28 @@ export function KanbanBoard({
   useEffect(() => {
     setArchivedDoneTasks(initialArchivedDoneTasks);
   }, [initialArchivedDoneTasks]);
+
+  useEffect(() => {
+    if (!selectedTask) {
+      return;
+    }
+
+    const nextTask =
+      TASK_STATUSES.flatMap((status) => columns[status]).find(
+        (task) => task.id === selectedTask.id
+      ) ??
+      archivedDoneTasks.find((task) => task.id === selectedTask.id) ??
+      null;
+
+    if (!nextTask) {
+      setSelectedTask(null);
+      return;
+    }
+
+    if (nextTask !== selectedTask) {
+      setSelectedTask(nextTask);
+    }
+  }, [archivedDoneTasks, columns, selectedTask]);
 
   useEffect(() => {
     if (!selectedTask) {
@@ -371,6 +401,11 @@ export function KanbanBoard({
         }))
         .sort((left, right) => left.title.localeCompare(right.title)),
     [columns]
+  );
+
+  const availableEpicOptions = useMemo<ProjectEpicOption[]>(
+    () => [...epics].sort((left, right) => left.name.localeCompare(right.name)),
+    [epics]
   );
 
   const availableAssignees = useMemo<ProjectTaskCollaborator[]>(
@@ -567,16 +602,17 @@ export function KanbanBoard({
 
         if (!response.ok) {
           throw new Error("Persist request failed");
-        }
-
-        setPersistError(null);
-      } catch (error) {
-        console.error("[KanbanBoard.persistColumns]", error);
-        setColumns(previousColumns);
-        setPersistError("Could not save task movement. Board reverted.");
       }
-    },
-    [projectId]
+
+      setPersistError(null);
+      router.refresh();
+    } catch (error) {
+      console.error("[KanbanBoard.persistColumns]", error);
+      setColumns(previousColumns);
+      setPersistError("Could not save task movement. Board reverted.");
+    }
+  },
+    [projectId, router]
   );
 
   const onDragEnd = useCallback(
@@ -746,6 +782,7 @@ export function KanbanBoard({
               labels: editLabels,
               description: editDescription,
               deadlineDate: editDeadlineDate || null,
+              epicId: editEpicId || null,
               assigneeUserId: editAssigneeUserId || null,
               blockedFollowUpEntry: normalizedBlockedEntry,
               relatedTaskIds,
@@ -760,6 +797,8 @@ export function KanbanBoard({
           const message =
             payload?.error === "related-tasks-invalid"
               ? "Related tasks must stay active and belong to this project."
+              : payload?.error === "epic-invalid"
+                ? "Epic must belong to this project."
               : payload?.error === "assignee-invalid"
                 ? "Assignee must be a current collaborator on this project."
               : payload?.error === "deadline-invalid"
@@ -781,6 +820,7 @@ export function KanbanBoard({
             status: string;
             position: number;
             archivedAt: string | null;
+            epic: TaskEpicSummary | null;
             assignee: TaskPersonSummary | null;
             createdBy: TaskPersonSummary;
             updatedBy: TaskPersonSummary;
@@ -809,6 +849,7 @@ export function KanbanBoard({
           description: payload.task.description,
           deadlineDate: payload.task.deadlineDate,
           commentCount: payload.task.commentCount,
+          epic: payload.task.epic,
           assignee: payload.task.assignee,
           createdBy: payload.task.createdBy,
           updatedBy: payload.task.updatedBy,
@@ -882,6 +923,7 @@ export function KanbanBoard({
           setIsEditMode(false);
         }
         setNewBlockedFollowUpEntry("");
+        router.refresh();
         return true;
       } catch (error) {
         console.error("[KanbanBoard.handleTaskUpdate]", error);
@@ -898,11 +940,13 @@ export function KanbanBoard({
       editAssigneeUserId,
       editDeadlineDate,
       editDescription,
+      editEpicId,
       editLabels,
       editRelatedTasks,
       editTitle,
       newBlockedFollowUpEntry,
       projectId,
+      router,
       selectedTask,
       syncRelatedTaskSummary,
     ]
@@ -1054,6 +1098,7 @@ export function KanbanBoard({
         return null;
       });
       removeRelatedTaskReferences(pendingDeleteTask.id);
+      router.refresh();
 
       pushToast({
         variant: "success",
@@ -1069,7 +1114,7 @@ export function KanbanBoard({
       setPendingDeleteTask(null);
       setIsDeletingTask(false);
     }
-  }, [canEdit, isDeletingTask, pendingDeleteTask, projectId, pushToast, removeRelatedTaskReferences]);
+  }, [canEdit, isDeletingTask, pendingDeleteTask, projectId, pushToast, removeRelatedTaskReferences, router]);
 
   const handleArchiveTask = useCallback(async () => {
     if (!canEdit) {
@@ -1124,6 +1169,7 @@ export function KanbanBoard({
         archivedAt: payload.archivedAt,
       });
       closeTaskModal();
+      router.refresh();
       pushToast({
         variant: "success",
         message: "Task moved to archive.",
@@ -1144,6 +1190,7 @@ export function KanbanBoard({
     isArchivingTask,
     projectId,
     pushToast,
+    router,
     selectedTask,
     syncRelatedTaskSummary,
   ]);
@@ -1198,6 +1245,7 @@ export function KanbanBoard({
         status: taskToRestore.status,
         archivedAt: null,
       });
+      router.refresh();
       pushToast({
         variant: "success",
         message: "Task moved back to Done.",
@@ -1218,6 +1266,7 @@ export function KanbanBoard({
     isSelectedTaskArchived,
     projectId,
     pushToast,
+    router,
     selectedTask,
     syncRelatedTaskSummary,
   ]);
@@ -1333,6 +1382,7 @@ export function KanbanBoard({
           currentActorSummary
         )
       );
+      router.refresh();
       pushToast({
         variant: "success",
         message: "Comment added.",
@@ -1356,6 +1406,7 @@ export function KanbanBoard({
     newTaskComment,
     projectId,
     pushToast,
+    router,
     selectedTask,
   ]);
 
@@ -1637,6 +1688,7 @@ export function KanbanBoard({
             storageProvider={storageProvider}
             existingLabels={allKnownLabels}
             availableTasks={createDialogAvailableTasks}
+            availableEpics={availableEpicOptions}
             availableAssignees={availableAssignees}
           />
         ) : null}
@@ -1673,6 +1725,7 @@ export function KanbanBoard({
         editLabelSuggestions={editLabelSuggestions}
         editDescription={editDescription}
         editDeadlineDate={editDeadlineDate}
+        editEpicId={editEpicId}
         editAssigneeUserId={editAssigneeUserId}
         editRelatedTasks={editRelatedTasks}
         relatedTaskSearch={relatedTaskSearch}
@@ -1703,10 +1756,12 @@ export function KanbanBoard({
         onRemoveEditLabel={removeEditLabel}
         onEditDescriptionChange={setEditDescription}
         onEditDeadlineDateChange={setEditDeadlineDate}
+        onEditEpicIdChange={setEditEpicId}
         onEditAssigneeUserIdChange={setEditAssigneeUserId}
         onRelatedTaskSearchChange={setRelatedTaskSearch}
         onAddRelatedTask={addRelatedTask}
         onRemoveRelatedTask={removeRelatedTask}
+        availableEpicOptions={availableEpicOptions}
         availableAssignees={availableAssignees}
         availableRelatedTaskOptions={availableRelatedTaskOptions}
         onOpenRelatedTask={openRelatedTask}

--- a/components/kanban/kanban-columns-grid.tsx
+++ b/components/kanban/kanban-columns-grid.tsx
@@ -216,115 +216,121 @@ function KanbanColumn({
                   index={index}
                   isDragDisabled={!canEdit}
                 >
-                  {(draggableProvided, draggableSnapshot) => (
-                    <article
-                      ref={draggableProvided.innerRef}
-                      {...draggableProvided.draggableProps}
-                      {...(canEdit ? draggableProvided.dragHandleProps : {})}
-                      style={buildDragStyle(
-                        draggableProvided.draggableProps.style,
-                        draggableSnapshot.isDragging
-                      )}
-                      className={cn(
-                        "rounded-xl border border-border/70 bg-card/95 p-3 shadow-sm transition duration-150",
-                        canEdit ? "cursor-grab active:cursor-grabbing" : "cursor-pointer",
-                        draggableSnapshot.isDragging && "shadow-lg",
-                        highlightedTaskIds.has(task.id) &&
-                          "border-border/80 bg-muted/35 shadow-[0_0_0_1px_rgba(148,163,184,0.08)]"
-                      )}
-                      onClick={() => {
-                        if (!draggableSnapshot.isDragging) {
-                          onSelectTask(task);
-                        }
-                      }}
-                      onMouseEnter={() => onTaskHoverChange(task.id)}
-                      onMouseLeave={() => onTaskHoverChange(null)}
-                      onDoubleClick={(event) => {
-                        if (!canEdit) {
-                          return;
-                        }
-                        event.stopPropagation();
-                        onEditTask(task);
-                      }}
-                    >
-                      <div className="mb-2 flex items-start justify-between gap-2">
-                        <h3 className="text-sm font-medium leading-snug">{task.title}</h3>
-                        <div className="flex items-center gap-1">
-                          {status === "Blocked" ? (
-                            <span
-                              className="rounded-sm p-1 text-amber-500"
-                              aria-label="Blocked task"
-                              title="Blocked task"
-                            >
-                              <TriangleAlert className="h-4 w-4" />
-                            </span>
-                          ) : null}
-                          {canEdit ? (
-                            <span
-                              className="rounded-sm p-1 text-muted-foreground"
-                              aria-label="Drag task"
-                              title="Drag task"
-                            >
-                              <GripVertical className="h-4 w-4" />
-                            </span>
-                          ) : null}
+                  {(draggableProvided, draggableSnapshot) => {
+                    const epicColor = task.epic
+                      ? getEpicColorFromName(task.epic.name)
+                      : null;
+
+                    return (
+                      <article
+                        ref={draggableProvided.innerRef}
+                        {...draggableProvided.draggableProps}
+                        {...(canEdit ? draggableProvided.dragHandleProps : {})}
+                        style={buildDragStyle(
+                          draggableProvided.draggableProps.style,
+                          draggableSnapshot.isDragging
+                        )}
+                        className={cn(
+                          "rounded-xl border border-border/70 bg-card/95 p-3 shadow-sm transition duration-150",
+                          canEdit ? "cursor-grab active:cursor-grabbing" : "cursor-pointer",
+                          draggableSnapshot.isDragging && "shadow-lg",
+                          highlightedTaskIds.has(task.id) &&
+                            "border-border/80 bg-muted/35 shadow-[0_0_0_1px_rgba(148,163,184,0.08)]"
+                        )}
+                        onClick={() => {
+                          if (!draggableSnapshot.isDragging) {
+                            onSelectTask(task);
+                          }
+                        }}
+                        onMouseEnter={() => onTaskHoverChange(task.id)}
+                        onMouseLeave={() => onTaskHoverChange(null)}
+                        onDoubleClick={(event) => {
+                          if (!canEdit) {
+                            return;
+                          }
+                          event.stopPropagation();
+                          onEditTask(task);
+                        }}
+                      >
+                        <div className="mb-2 flex items-start justify-between gap-2">
+                          <h3 className="text-sm font-medium leading-snug">{task.title}</h3>
+                          <div className="flex items-center gap-1">
+                            {status === "Blocked" ? (
+                              <span
+                                className="rounded-sm p-1 text-amber-500"
+                                aria-label="Blocked task"
+                                title="Blocked task"
+                              >
+                                <TriangleAlert className="h-4 w-4" />
+                              </span>
+                            ) : null}
+                            {canEdit ? (
+                              <span
+                                className="rounded-sm p-1 text-muted-foreground"
+                                aria-label="Drag task"
+                                title="Drag task"
+                              >
+                                <GripVertical className="h-4 w-4" />
+                              </span>
+                            ) : null}
+                          </div>
                         </div>
-                      </div>
 
-                      <TaskCardIndicators task={task} className="-mt-1 mb-2" />
+                        <TaskCardIndicators task={task} className="-mt-1 mb-2" />
 
-                      {task.description ? (
-                        <p className="break-words text-xs text-muted-foreground">
-                          {getDescriptionPreview(task.description)}
-                        </p>
-                      ) : null}
+                        {task.description ? (
+                          <p className="break-words text-xs text-muted-foreground">
+                            {getDescriptionPreview(task.description)}
+                          </p>
+                        ) : null}
 
-                      {task.epic ? (
-                        <div className="mt-3">
-                          <span
-                            className="inline-flex max-w-full items-center gap-1.5 rounded-full border px-2 py-1 text-[11px] font-medium"
-                            style={{
-                              backgroundColor: getEpicColorFromName(task.epic.name).soft,
-                              borderColor: getEpicColorFromName(task.epic.name).border,
-                              color: getEpicColorFromName(task.epic.name).accent,
-                            }}
-                            title={task.epic.name}
-                          >
-                            <Flag className="h-3 w-3" />
-                            <span className="truncate">{task.epic.name}</span>
-                          </span>
-                        </div>
-                      ) : null}
-
-                      {task.assignee ? (
-                        <div className="mt-3 flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-2 py-1 text-xs text-muted-foreground">
-                          <UserAvatar
-                            avatarSeed={task.assignee.avatarSeed}
-                            displayName={task.assignee.displayName}
-                            className="h-5 w-5 border-border/70"
-                            decorative
-                          />
-                          <span className="truncate">{task.assignee.displayName}</span>
-                        </div>
-                      ) : null}
-
-                      {task.labels.length > 0 ? (
-                        <div className="mt-3 flex flex-wrap gap-1">
-                          {task.labels.map((label) => (
+                        {task.epic && epicColor ? (
+                          <div className="mt-3">
                             <span
-                              key={label}
-                              className="inline-flex items-center rounded-full px-2.5 py-1 text-[11px] font-medium text-slate-900"
+                              className="inline-flex max-w-full items-center gap-1.5 rounded-full border px-2 py-1 text-[11px] font-medium"
                               style={{
-                                backgroundColor: getTaskLabelColor(label),
+                                backgroundColor: epicColor.soft,
+                                borderColor: epicColor.border,
+                                color: epicColor.accent,
                               }}
+                              title={task.epic.name}
                             >
-                              {label}
+                              <Flag className="h-3 w-3" />
+                              <span className="truncate">{task.epic.name}</span>
                             </span>
-                          ))}
-                        </div>
-                      ) : null}
-                    </article>
-                  )}
+                          </div>
+                        ) : null}
+
+                        {task.assignee ? (
+                          <div className="mt-3 flex items-center gap-2 rounded-full border border-border/60 bg-background/70 px-2 py-1 text-xs text-muted-foreground">
+                            <UserAvatar
+                              avatarSeed={task.assignee.avatarSeed}
+                              displayName={task.assignee.displayName}
+                              className="h-5 w-5 border-border/70"
+                              decorative
+                            />
+                            <span className="truncate">{task.assignee.displayName}</span>
+                          </div>
+                        ) : null}
+
+                        {task.labels.length > 0 ? (
+                          <div className="mt-3 flex flex-wrap gap-1">
+                            {task.labels.map((label) => (
+                              <span
+                                key={label}
+                                className="inline-flex items-center rounded-full px-2.5 py-1 text-[11px] font-medium text-slate-900"
+                                style={{
+                                  backgroundColor: getTaskLabelColor(label),
+                                }}
+                              >
+                                {label}
+                              </span>
+                            ))}
+                          </div>
+                        ) : null}
+                      </article>
+                    );
+                  }}
                 </Draggable>
               ))}
               {provided.placeholder}

--- a/components/kanban/kanban-columns-grid.tsx
+++ b/components/kanban/kanban-columns-grid.tsx
@@ -4,12 +4,13 @@ import {
   Droppable,
   type DropResult,
 } from "@hello-pangea/dnd";
-import { Archive, Clock3, GripVertical, Link2, MessageSquare, Paperclip, TriangleAlert } from "lucide-react";
+import { Archive, Clock3, Flag, GripVertical, Link2, MessageSquare, Paperclip, TriangleAlert } from "lucide-react";
 
 import type { KanbanTask } from "@/components/kanban-board-types";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { UserAvatar } from "@/components/ui/user-avatar";
+import { getEpicColorFromName } from "@/lib/epic";
 import {
   buildDragStyle,
   getDescriptionPreview,
@@ -276,6 +277,23 @@ function KanbanColumn({
                         <p className="break-words text-xs text-muted-foreground">
                           {getDescriptionPreview(task.description)}
                         </p>
+                      ) : null}
+
+                      {task.epic ? (
+                        <div className="mt-3">
+                          <span
+                            className="inline-flex max-w-full items-center gap-1.5 rounded-full border px-2 py-1 text-[11px] font-medium"
+                            style={{
+                              backgroundColor: getEpicColorFromName(task.epic.name).soft,
+                              borderColor: getEpicColorFromName(task.epic.name).border,
+                              color: getEpicColorFromName(task.epic.name).accent,
+                            }}
+                            title={task.epic.name}
+                          >
+                            <Flag className="h-3 w-3" />
+                            <span className="truncate">{task.epic.name}</span>
+                          </span>
+                        </div>
                       ) : null}
 
                       {task.assignee ? (

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -597,7 +597,14 @@ function TaskOptionsMenu({
   onRequestDeleteTask,
 }: TaskOptionsMenuProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const menuRef = useDismissibleMenu<HTMLDivElement>(isMenuOpen, () => setIsMenuOpen(false));
+  const [activeSubmenu, setActiveSubmenu] = useState<"move" | "epic" | null>(null);
+
+  const closeMenu = () => {
+    setIsMenuOpen(false);
+    setActiveSubmenu(null);
+  };
+
+  const menuRef = useDismissibleMenu<HTMLDivElement>(isMenuOpen, closeMenu);
 
   return (
     <div ref={menuRef} className="relative">
@@ -607,7 +614,15 @@ function TaskOptionsMenu({
         size="icon"
         aria-label="Task options"
         aria-expanded={isMenuOpen}
-        onClick={() => setIsMenuOpen((previous) => !previous)}
+        onClick={() => {
+          setIsMenuOpen((previous) => {
+            if (previous) {
+              setActiveSubmenu(null);
+            }
+
+            return !previous;
+          });
+        }}
       >
         <MoreHorizontal className="h-4 w-4" />
       </Button>
@@ -620,19 +635,25 @@ function TaskOptionsMenu({
             disabled={isMutating}
             onClick={() => {
               onStartEdit();
-              setIsMenuOpen(false);
+              closeMenu();
             }}
           >
             <Pencil className="h-4 w-4" />
             Edit
           </Button>
           {!isArchived ? (
-            <div className="group relative">
+            <div className="relative">
               <Button
                 type="button"
                 variant="ghost"
                 className="w-full justify-between"
                 disabled={isMutating}
+                aria-haspopup="menu"
+                aria-expanded={activeSubmenu === "move"}
+                aria-controls="task-options-submenu-move"
+                onClick={() =>
+                  setActiveSubmenu((previous) => (previous === "move" ? null : "move"))
+                }
               >
                 <span className="inline-flex items-center gap-2">
                   <ArrowRightLeft className="h-4 w-4" />
@@ -640,7 +661,16 @@ function TaskOptionsMenu({
                 </span>
                 <ChevronRight className="h-4 w-4" />
               </Button>
-              <div className="invisible pointer-events-none absolute right-full top-0 z-30 mr-1 w-36 rounded-md border border-border/70 bg-background p-1 opacity-0 shadow-md transition group-hover:visible group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:visible group-focus-within:pointer-events-auto group-focus-within:opacity-100">
+              <div
+                id="task-options-submenu-move"
+                role="menu"
+                className={[
+                  "absolute right-full top-0 z-30 mr-1 w-36 rounded-md border border-border/70 bg-background p-1 shadow-md transition",
+                  activeSubmenu === "move"
+                    ? "visible pointer-events-auto opacity-100"
+                    : "invisible pointer-events-none opacity-0",
+                ].join(" ")}
+              >
                 {TASK_STATUSES.map((nextStatus) => (
                   <Button
                     key={nextStatus}
@@ -650,7 +680,7 @@ function TaskOptionsMenu({
                     disabled={nextStatus === currentStatus || isMutating}
                     onClick={() => {
                       onMoveTask(nextStatus);
-                      setIsMenuOpen(false);
+                      closeMenu();
                     }}
                   >
                     {nextStatus}
@@ -659,13 +689,19 @@ function TaskOptionsMenu({
               </div>
             </div>
           ) : null}
-          <div className="group relative">
+          <div className="relative">
             <Button
               type="button"
               variant="ghost"
               className="w-full justify-between"
               aria-label="Epic options"
               disabled={isMutating}
+              aria-haspopup="menu"
+              aria-expanded={activeSubmenu === "epic"}
+              aria-controls="task-options-submenu-epic"
+              onClick={() =>
+                setActiveSubmenu((previous) => (previous === "epic" ? null : "epic"))
+              }
             >
               <span className="inline-flex items-center gap-2">
                 <Flag className="h-4 w-4" />
@@ -676,7 +712,17 @@ function TaskOptionsMenu({
                 <ChevronRight className="h-4 w-4 shrink-0" />
               </span>
             </Button>
-            <div className="invisible pointer-events-none absolute right-full top-0 z-30 mr-1 w-64 rounded-md border border-border/70 bg-background p-1 opacity-0 shadow-md transition group-hover:visible group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:visible group-focus-within:pointer-events-auto group-focus-within:opacity-100">
+            <div
+              id="task-options-submenu-epic"
+              role="menu"
+              data-task-options-submenu="epic"
+              className={[
+                "absolute right-full top-0 z-30 mr-1 w-64 rounded-md border border-border/70 bg-background p-1 shadow-md transition",
+                activeSubmenu === "epic"
+                  ? "visible pointer-events-auto opacity-100"
+                  : "invisible pointer-events-none opacity-0",
+              ].join(" ")}
+            >
               <div className="max-h-72 space-y-1 overflow-y-auto">
                 <Button
                   type="button"
@@ -685,7 +731,7 @@ function TaskOptionsMenu({
                   disabled={!currentEpic || isMutating}
                   onClick={() => {
                     void onQuickEpicChange("");
-                    setIsMenuOpen(false);
+                    closeMenu();
                   }}
                 >
                   <span className="inline-flex min-w-0 items-center gap-2">
@@ -720,7 +766,7 @@ function TaskOptionsMenu({
                         disabled={isSelected || isMutating}
                         onClick={() => {
                           void onQuickEpicChange(epic.id);
-                          setIsMenuOpen(false);
+                          closeMenu();
                         }}
                       >
                         <span className="inline-flex min-w-0 items-center gap-2">
@@ -758,7 +804,7 @@ function TaskOptionsMenu({
               disabled={isMutating}
               onClick={() => {
                 void onArchiveTask();
-                setIsMenuOpen(false);
+                closeMenu();
               }}
             >
               <Archive className="h-4 w-4" />
@@ -773,7 +819,7 @@ function TaskOptionsMenu({
               disabled={isMutating}
               onClick={() => {
                 void onUnarchiveTask();
-                setIsMenuOpen(false);
+                closeMenu();
               }}
             >
               <Undo2 className="h-4 w-4" />
@@ -786,7 +832,7 @@ function TaskOptionsMenu({
             className="w-full justify-start text-destructive hover:bg-destructive/10 hover:text-destructive"
             disabled={isMutating}
             onClick={() => {
-              setIsMenuOpen(false);
+              closeMenu();
               onRequestDeleteTask();
             }}
           >

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -238,7 +238,7 @@ export function TaskDetailModal({
                   {isArchivedTask ? "Archived" : selectedTask.status}
                 </Badge>
                 {!isEditing ? (
-                  <div className="space-y-3">
+                  <div className="space-y-3 sm:flex sm:items-end sm:justify-between sm:gap-4 sm:space-y-0">
                     <CardTitle
                       className="min-w-0 flex-1 text-xl leading-tight"
                       onDoubleClick={() => {
@@ -251,7 +251,7 @@ export function TaskDetailModal({
                     >
                       {selectedTask.title}
                     </CardTitle>
-                    <div className="flex flex-wrap items-center gap-2">
+                    <div className="flex flex-wrap items-start gap-3 sm:justify-end">
                       {selectedTask.epic ? <TaskEpicBadge epic={selectedTask.epic} /> : null}
                       <TaskAssigneeBadge assignee={selectedTask.assignee} />
                     </div>
@@ -466,7 +466,7 @@ function TaskEpicBadge({
   const color = getEpicColorFromName(epic.name);
 
   return (
-    <div className="flex flex-col gap-1 sm:items-end">
+    <div className="flex flex-col items-center gap-1 text-center sm:items-end sm:text-right">
       {showLabel ? (
         <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
           Epic
@@ -490,7 +490,7 @@ function TaskEpicBadge({
 
 function TaskAssigneeBadge({ assignee }: { assignee: TaskPersonSummary | null }) {
   return (
-    <div className="flex flex-col gap-1 sm:items-end">
+    <div className="flex flex-col items-center gap-1 text-center sm:items-end sm:text-right">
       <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
         Assignee
       </p>
@@ -874,7 +874,6 @@ function TaskReadOnlyContent({
 }) {
   const hasAttachments = selectedTask.attachments.length > 0;
   const hasRelatedTasks = selectedTask.relatedTasks.length > 0;
-  const hasEpic = Boolean(selectedTask.epic);
   const commentInputRef = useRef<HTMLTextAreaElement | null>(null);
 
   useEffect(() => {
@@ -912,14 +911,6 @@ function TaskReadOnlyContent({
               {label}
             </span>
           ))}
-        </div>
-      ) : null}
-      {hasEpic ? (
-        <div className="grid gap-2 rounded-md border border-border/60 bg-muted/20 p-3">
-          <p className="text-sm font-medium">Epic</p>
-          <div className="flex flex-wrap gap-2">
-            <TaskEpicBadge epic={selectedTask.epic} showLabel={false} />
-          </div>
         </div>
       ) : null}
       {selectedTask.status === "Blocked" ? (

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import {
   Archive,
   ArrowRightLeft,
+  Check,
   ChevronRight,
   Clock3,
   Flag,
@@ -119,6 +120,7 @@ interface TaskDetailModalProps {
   onNewBlockedFollowUpEntryChange: (value: string) => void;
   onAddBlockedFollowUpEntry: () => void | Promise<void>;
   onSaveTask: () => void | Promise<void>;
+  onQuickEpicChange: (value: string) => void | Promise<void>;
   onToggleLinkComposer: () => void;
   onLinkUrlChange: (value: string) => void;
   onAddLinkAttachment: () => void | Promise<void>;
@@ -187,6 +189,7 @@ export function TaskDetailModal({
   onNewBlockedFollowUpEntryChange,
   onAddBlockedFollowUpEntry,
   onSaveTask,
+  onQuickEpicChange,
   onToggleLinkComposer,
   onLinkUrlChange,
   onAddLinkAttachment,
@@ -266,9 +269,12 @@ export function TaskDetailModal({
                 {!isEditing && canEdit ? (
                   <TaskOptionsMenu
                     currentStatus={selectedTask.status}
+                    currentEpic={selectedTask.epic}
+                    epicOptions={availableEpicOptions}
                     isArchived={isArchivedTask}
-                    isArchiving={isArchivingTask}
+                    isMutating={isArchivingTask || isUpdatingTask}
                     onStartEdit={() => onToggleEditMode(true)}
+                    onQuickEpicChange={onQuickEpicChange}
                     onMoveTask={onMoveTask}
                     onArchiveTask={onArchiveTask}
                     onUnarchiveTask={onUnarchiveTask}
@@ -565,9 +571,12 @@ function TaskActivityInline({
 
 interface TaskOptionsMenuProps {
   currentStatus: TaskStatus;
+  currentEpic: KanbanTask["epic"];
+  epicOptions: ProjectEpicOption[];
   isArchived: boolean;
-  isArchiving: boolean;
+  isMutating: boolean;
   onStartEdit: () => void;
+  onQuickEpicChange: (value: string) => void | Promise<void>;
   onMoveTask: (nextStatus: TaskStatus) => void;
   onArchiveTask: () => void | Promise<void>;
   onUnarchiveTask: () => void | Promise<void>;
@@ -576,9 +585,12 @@ interface TaskOptionsMenuProps {
 
 function TaskOptionsMenu({
   currentStatus,
+  currentEpic,
+  epicOptions,
   isArchived,
-  isArchiving,
+  isMutating,
   onStartEdit,
+  onQuickEpicChange,
   onMoveTask,
   onArchiveTask,
   onUnarchiveTask,
@@ -605,7 +617,7 @@ function TaskOptionsMenu({
             type="button"
             variant="ghost"
             className="w-full justify-start"
-            disabled={isArchiving}
+            disabled={isMutating}
             onClick={() => {
               onStartEdit();
               setIsMenuOpen(false);
@@ -620,7 +632,7 @@ function TaskOptionsMenu({
                 type="button"
                 variant="ghost"
                 className="w-full justify-between"
-                disabled={isArchiving}
+                disabled={isMutating}
               >
                 <span className="inline-flex items-center gap-2">
                   <ArrowRightLeft className="h-4 w-4" />
@@ -635,7 +647,7 @@ function TaskOptionsMenu({
                     type="button"
                     variant="ghost"
                     className="w-full justify-start"
-                    disabled={nextStatus === currentStatus || isArchiving}
+                    disabled={nextStatus === currentStatus || isMutating}
                     onClick={() => {
                       onMoveTask(nextStatus);
                       setIsMenuOpen(false);
@@ -647,19 +659,110 @@ function TaskOptionsMenu({
               </div>
             </div>
           ) : null}
+          <div className="group relative">
+            <Button
+              type="button"
+              variant="ghost"
+              className="w-full justify-between"
+              aria-label="Epic options"
+              disabled={isMutating}
+            >
+              <span className="inline-flex items-center gap-2">
+                <Flag className="h-4 w-4" />
+                Epic
+              </span>
+              <span className="inline-flex min-w-0 items-center gap-1 text-xs text-muted-foreground">
+                <span className="max-w-[76px] truncate">{currentEpic?.name ?? "None"}</span>
+                <ChevronRight className="h-4 w-4 shrink-0" />
+              </span>
+            </Button>
+            <div className="invisible pointer-events-none absolute right-full top-0 z-30 mr-1 w-64 rounded-md border border-border/70 bg-background p-1 opacity-0 shadow-md transition group-hover:visible group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:visible group-focus-within:pointer-events-auto group-focus-within:opacity-100">
+              <div className="max-h-72 space-y-1 overflow-y-auto">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="w-full justify-between"
+                  disabled={!currentEpic || isMutating}
+                  onClick={() => {
+                    void onQuickEpicChange("");
+                    setIsMenuOpen(false);
+                  }}
+                >
+                  <span className="inline-flex min-w-0 items-center gap-2">
+                    <span className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-dashed border-border/70 bg-muted/30">
+                      <Flag className="h-3.5 w-3.5 text-muted-foreground" />
+                    </span>
+                    <span className="min-w-0 text-left">
+                      <span className="block truncate text-sm font-medium">No epic</span>
+                      <span className="block truncate text-xs text-muted-foreground">
+                        Leave this task outside an epic
+                      </span>
+                    </span>
+                  </span>
+                  {!currentEpic ? <Check className="h-4 w-4" /> : null}
+                </Button>
+
+                {epicOptions.length === 0 ? (
+                  <p className="px-3 py-2 text-xs text-muted-foreground">
+                    Create an epic in the Epics section to link it here.
+                  </p>
+                ) : (
+                  epicOptions.map((epic) => {
+                    const color = getEpicColorFromName(epic.name);
+                    const isSelected = epic.id === currentEpic?.id;
+
+                    return (
+                      <Button
+                        key={epic.id}
+                        type="button"
+                        variant="ghost"
+                        className="h-auto w-full justify-between py-2"
+                        disabled={isSelected || isMutating}
+                        onClick={() => {
+                          void onQuickEpicChange(epic.id);
+                          setIsMenuOpen(false);
+                        }}
+                      >
+                        <span className="inline-flex min-w-0 items-center gap-2">
+                          <span
+                            className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border"
+                            style={{
+                              backgroundColor: color.soft,
+                              borderColor: color.border,
+                              color: color.accent,
+                            }}
+                          >
+                            <Flag className="h-3.5 w-3.5" />
+                          </span>
+                          <span className="min-w-0 text-left">
+                            <span className="block truncate text-sm font-medium">{epic.name}</span>
+                            <span className="block truncate text-xs text-muted-foreground">
+                              {epic.status} · {epic.progressPercent}% complete · {epic.taskCount} task
+                              {epic.taskCount === 1 ? "" : "s"}
+                            </span>
+                          </span>
+                        </span>
+                        {isSelected ? <Check className="h-4 w-4" /> : null}
+                      </Button>
+                    );
+                  })
+                )}
+              </div>
+            </div>
+          </div>
           {currentStatus === "Done" && !isArchived ? (
             <Button
               type="button"
               variant="ghost"
               className="w-full justify-start"
-              disabled={isArchiving}
+              disabled={isMutating}
               onClick={() => {
                 void onArchiveTask();
                 setIsMenuOpen(false);
               }}
             >
               <Archive className="h-4 w-4" />
-              {isArchiving ? "Archiving..." : "Archive"}
+              {isMutating ? "Working..." : "Archive"}
             </Button>
           ) : null}
           {isArchived ? (
@@ -667,7 +770,7 @@ function TaskOptionsMenu({
               type="button"
               variant="ghost"
               className="w-full justify-start"
-              disabled={isArchiving}
+              disabled={isMutating}
               onClick={() => {
                 void onUnarchiveTask();
                 setIsMenuOpen(false);
@@ -681,7 +784,7 @@ function TaskOptionsMenu({
             type="button"
             variant="ghost"
             className="w-full justify-start text-destructive hover:bg-destructive/10 hover:text-destructive"
-            disabled={isArchiving}
+            disabled={isMutating}
             onClick={() => {
               setIsMenuOpen(false);
               onRequestDeleteTask();

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -5,6 +5,7 @@ import {
   ArrowRightLeft,
   ChevronRight,
   Clock3,
+  Flag,
   Link2,
   MessageSquare,
   MoreHorizontal,
@@ -21,6 +22,7 @@ import {
   type KanbanTask,
   type TaskComment,
   type PendingAttachmentUpload,
+  type ProjectEpicOption,
   type ProjectTaskCollaborator,
   type TaskPersonSummary,
   type TaskAttachment,
@@ -44,7 +46,9 @@ import { AttachmentLinkComposer } from "@/components/ui/attachment-link-composer
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { EmojiInputField, EmojiTextareaField } from "@/components/ui/emoji-field";
+import { EpicSelect } from "@/components/ui/epic-select";
 import { UserAvatar } from "@/components/ui/user-avatar";
+import { getEpicColorFromName } from "@/lib/epic";
 import { useDismissibleMenu } from "@/lib/hooks/use-dismissible-menu";
 import {
   ATTACHMENT_KIND_FILE,
@@ -72,6 +76,7 @@ interface TaskDetailModalProps {
   editLabelSuggestions: string[];
   editDescription: string;
   editDeadlineDate: string;
+  editEpicId: string;
   editAssigneeUserId: string;
   editRelatedTasks: KanbanTask["relatedTasks"];
   relatedTaskSearch: string;
@@ -102,10 +107,12 @@ interface TaskDetailModalProps {
   onRemoveEditLabel: (label: string) => void;
   onEditDescriptionChange: (value: string) => void;
   onEditDeadlineDateChange: (value: string) => void;
+  onEditEpicIdChange: (value: string) => void;
   onEditAssigneeUserIdChange: (value: string) => void;
   onRelatedTaskSearchChange: (value: string) => void;
   onAddRelatedTask: (taskId: string) => void;
   onRemoveRelatedTask: (taskId: string) => void;
+  availableEpicOptions: ProjectEpicOption[];
   availableAssignees: ProjectTaskCollaborator[];
   availableRelatedTaskOptions: RelatedTaskOption[];
   onOpenRelatedTask: (taskId: string) => void;
@@ -137,6 +144,7 @@ export function TaskDetailModal({
   editLabelSuggestions,
   editDescription,
   editDeadlineDate,
+  editEpicId,
   editAssigneeUserId,
   editRelatedTasks,
   relatedTaskSearch,
@@ -167,10 +175,12 @@ export function TaskDetailModal({
   onRemoveEditLabel,
   onEditDescriptionChange,
   onEditDeadlineDateChange,
+  onEditEpicIdChange,
   onEditAssigneeUserIdChange,
   onRelatedTaskSearchChange,
   onAddRelatedTask,
   onRemoveRelatedTask,
+  availableEpicOptions,
   availableAssignees,
   availableRelatedTaskOptions,
   onOpenRelatedTask,
@@ -238,7 +248,10 @@ export function TaskDetailModal({
                     >
                       {selectedTask.title}
                     </CardTitle>
-                    <TaskAssigneeBadge assignee={selectedTask.assignee} />
+                    <div className="flex flex-col gap-2 sm:items-end">
+                      <TaskEpicBadge epic={selectedTask.epic} />
+                      <TaskAssigneeBadge assignee={selectedTask.assignee} />
+                    </div>
                   </div>
                 ) : (
                   <EmojiInputField
@@ -299,6 +312,7 @@ export function TaskDetailModal({
                   editLabelSuggestions={editLabelSuggestions}
                   editDescription={editDescription}
                   editDeadlineDate={editDeadlineDate}
+                  editEpicId={editEpicId}
                   editAssigneeUserId={editAssigneeUserId}
                   editRelatedTasks={editRelatedTasks}
                   relatedTaskSearch={relatedTaskSearch}
@@ -317,10 +331,12 @@ export function TaskDetailModal({
                   onRemoveEditLabel={onRemoveEditLabel}
                   onEditDescriptionChange={onEditDescriptionChange}
                   onEditDeadlineDateChange={onEditDeadlineDateChange}
+                  onEditEpicIdChange={onEditEpicIdChange}
                   onEditAssigneeUserIdChange={onEditAssigneeUserIdChange}
                   onRelatedTaskSearchChange={onRelatedTaskSearchChange}
                   onAddRelatedTask={onAddRelatedTask}
                   onRemoveRelatedTask={onRemoveRelatedTask}
+                  availableEpicOptions={availableEpicOptions}
                   availableAssignees={availableAssignees}
                   availableRelatedTaskOptions={availableRelatedTaskOptions}
                   onNewBlockedFollowUpEntryChange={onNewBlockedFollowUpEntryChange}
@@ -428,6 +444,42 @@ function formatTaskActivityDate(value: string): string {
 
 function buildTaskPersonHoverLabel(person: TaskPersonSummary): string {
   return person.usernameTag ?? person.displayName;
+}
+
+function TaskEpicBadge({
+  epic,
+  showLabel = true,
+}: {
+  epic: KanbanTask["epic"];
+  showLabel?: boolean;
+}) {
+  if (!epic) {
+    return null;
+  }
+
+  const color = getEpicColorFromName(epic.name);
+
+  return (
+    <div className="flex flex-col gap-1 sm:items-end">
+      {showLabel ? (
+        <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+          Epic
+        </p>
+      ) : null}
+      <div
+        className="inline-flex max-w-full items-center gap-2 rounded-full border px-2.5 py-1.5"
+        style={{
+          backgroundColor: color.soft,
+          borderColor: color.border,
+          color: color.accent,
+        }}
+        title={epic.name}
+      >
+        <Flag className="h-3.5 w-3.5" />
+        <span className="max-w-[180px] truncate text-sm font-medium">{epic.name}</span>
+      </div>
+    </div>
+  );
 }
 
 function TaskAssigneeBadge({ assignee }: { assignee: TaskPersonSummary | null }) {
@@ -673,6 +725,7 @@ function TaskReadOnlyContent({
 }) {
   const hasAttachments = selectedTask.attachments.length > 0;
   const hasRelatedTasks = selectedTask.relatedTasks.length > 0;
+  const hasEpic = Boolean(selectedTask.epic);
   const commentInputRef = useRef<HTMLTextAreaElement | null>(null);
 
   useEffect(() => {
@@ -710,6 +763,14 @@ function TaskReadOnlyContent({
               {label}
             </span>
           ))}
+        </div>
+      ) : null}
+      {hasEpic ? (
+        <div className="grid gap-2 rounded-md border border-border/60 bg-muted/20 p-3">
+          <p className="text-sm font-medium">Epic</p>
+          <div className="flex flex-wrap gap-2">
+            <TaskEpicBadge epic={selectedTask.epic} showLabel={false} />
+          </div>
         </div>
       ) : null}
       {selectedTask.status === "Blocked" ? (
@@ -954,6 +1015,7 @@ interface TaskEditContentProps {
   editLabelSuggestions: string[];
   editDescription: string;
   editDeadlineDate: string;
+  editEpicId: string;
   editAssigneeUserId: string;
   editRelatedTasks: KanbanTask["relatedTasks"];
   relatedTaskSearch: string;
@@ -972,10 +1034,12 @@ interface TaskEditContentProps {
   onRemoveEditLabel: (label: string) => void;
   onEditDescriptionChange: (value: string) => void;
   onEditDeadlineDateChange: (value: string) => void;
+  onEditEpicIdChange: (value: string) => void;
   onEditAssigneeUserIdChange: (value: string) => void;
   onRelatedTaskSearchChange: (value: string) => void;
   onAddRelatedTask: (taskId: string) => void;
   onRemoveRelatedTask: (taskId: string) => void;
+  availableEpicOptions: ProjectEpicOption[];
   availableAssignees: ProjectTaskCollaborator[];
   availableRelatedTaskOptions: RelatedTaskOption[];
   onNewBlockedFollowUpEntryChange: (value: string) => void;
@@ -997,6 +1061,7 @@ function TaskEditContent({
   editLabelSuggestions,
   editDescription,
   editDeadlineDate,
+  editEpicId,
   editAssigneeUserId,
   editRelatedTasks,
   relatedTaskSearch,
@@ -1015,10 +1080,12 @@ function TaskEditContent({
   onRemoveEditLabel,
   onEditDescriptionChange,
   onEditDeadlineDateChange,
+  onEditEpicIdChange,
   onEditAssigneeUserIdChange,
   onRelatedTaskSearchChange,
   onAddRelatedTask,
   onRemoveRelatedTask,
+  availableEpicOptions,
   availableAssignees,
   availableRelatedTaskOptions,
   onNewBlockedFollowUpEntryChange,
@@ -1114,6 +1181,19 @@ function TaskEditContent({
           onChange={onEditDeadlineDateChange}
           disabled={isUpdatingTask}
         />
+
+        <div className="grid gap-2">
+          <label htmlFor="task-edit-epic" className="text-sm font-medium">
+            Epic
+          </label>
+          <EpicSelect
+            id="task-edit-epic"
+            value={editEpicId}
+            onChange={onEditEpicIdChange}
+            disabled={isUpdatingTask}
+            options={availableEpicOptions}
+          />
+        </div>
 
         <div className="grid gap-2">
           <label htmlFor="task-edit-assignee" className="text-sm font-medium">

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -238,7 +238,7 @@ export function TaskDetailModal({
                   {isArchivedTask ? "Archived" : selectedTask.status}
                 </Badge>
                 {!isEditing ? (
-                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="space-y-3">
                     <CardTitle
                       className="min-w-0 flex-1 text-xl leading-tight"
                       onDoubleClick={() => {
@@ -251,8 +251,8 @@ export function TaskDetailModal({
                     >
                       {selectedTask.title}
                     </CardTitle>
-                    <div className="flex flex-col gap-2 sm:items-end">
-                      <TaskEpicBadge epic={selectedTask.epic} />
+                    <div className="flex flex-wrap items-center gap-2">
+                      {selectedTask.epic ? <TaskEpicBadge epic={selectedTask.epic} /> : null}
                       <TaskAssigneeBadge assignee={selectedTask.assignee} />
                     </div>
                   </div>

--- a/components/project-epic-panel.tsx
+++ b/components/project-epic-panel.tsx
@@ -1,0 +1,652 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  ChevronDown,
+  ChevronUp,
+  Flag,
+  Pencil,
+  PlusSquare,
+  Trash2,
+} from "lucide-react";
+
+import {
+  PROJECT_SECTION_CARD_CLASS,
+  PROJECT_SECTION_CONTENT_CLASS,
+  PROJECT_SECTION_HEADER_CLASS,
+} from "@/components/project-dashboard/project-section-chrome";
+import { useToast } from "@/components/toast-provider";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { EmojiInputField, EmojiTextareaField } from "@/components/ui/emoji-field";
+import { getEpicColorFromName } from "@/lib/epic";
+import { useProjectSectionExpanded } from "@/lib/hooks/use-project-section-expanded";
+import { cn } from "@/lib/utils";
+
+interface ProjectEpicPanelTask {
+  id: string;
+  title: string;
+  status: string;
+  archivedAt: string | null;
+}
+
+export interface ProjectEpicPanelEpic {
+  id: string;
+  name: string;
+  description: string;
+  status: "Ready" | "In progress" | "Completed";
+  progressPercent: number;
+  taskCount: number;
+  completedTaskCount: number;
+  linkedTasks: ProjectEpicPanelTask[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ProjectEpicPanelProps {
+  projectId: string;
+  canEdit: boolean;
+  epics: ProjectEpicPanelEpic[];
+}
+
+function mapEpicMutationError(errorCode: string): string {
+  switch (errorCode) {
+    case "epic-name-too-short":
+      return "Epic name must be at least 2 characters.";
+    case "epic-description-too-short":
+      return "Epic description must be at least 2 characters.";
+    case "epic-name-conflict":
+      return "Epic names must stay unique within this project.";
+    case "epic-not-found":
+      return "Epic not found.";
+    case "epic-create-failed":
+      return "Could not create epic. Please retry.";
+    case "epic-update-failed":
+      return "Could not update epic. Please retry.";
+    case "epic-delete-failed":
+      return "Could not delete epic. Please retry.";
+    default:
+      return "Could not save epic changes. Please retry.";
+  }
+}
+
+function EpicStatusBadge({ status }: { status: ProjectEpicPanelEpic["status"] }) {
+  const toneClass =
+    status === "Completed"
+      ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200"
+      : status === "In progress"
+        ? "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-200"
+        : "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-200";
+
+  return (
+    <Badge variant="outline" className={toneClass}>
+      {status}
+    </Badge>
+  );
+}
+
+function EpicTaskChip({ task }: { task: ProjectEpicPanelTask }) {
+  const toneClass =
+    task.archivedAt != null || task.status === "Done"
+      ? "border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200"
+      : task.status === "In Progress"
+        ? "border-sky-500/20 bg-sky-500/10 text-sky-700 dark:text-sky-200"
+        : task.status === "Blocked"
+          ? "border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-200"
+          : "border-border/60 bg-background/70 text-muted-foreground";
+
+  return (
+    <span
+      className={cn(
+        "inline-flex max-w-full items-center gap-1.5 rounded-full border px-2 py-1 text-[11px] font-medium",
+        toneClass
+      )}
+      title={task.title}
+    >
+      <span className="truncate">{task.title}</span>
+      <span className="opacity-75">
+        {task.archivedAt != null ? "Archived" : task.status}
+      </span>
+    </span>
+  );
+}
+
+export function ProjectEpicPanel({
+  projectId,
+  canEdit,
+  epics,
+}: ProjectEpicPanelProps) {
+  const router = useRouter();
+  const { pushToast } = useToast();
+  const { isExpanded, setIsExpanded } = useProjectSectionExpanded({
+    projectId,
+    sectionKey: "epics",
+    defaultExpanded: true,
+    logLabel: "ProjectEpicPanel",
+  });
+  const [localEpics, setLocalEpics] = useState<ProjectEpicPanelEpic[]>(epics);
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [createName, setCreateName] = useState("");
+  const [createDescription, setCreateDescription] = useState("");
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [editingEpicId, setEditingEpicId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [editError, setEditError] = useState<string | null>(null);
+  const [isSavingEdit, setIsSavingEdit] = useState(false);
+  const [pendingDeleteEpicId, setPendingDeleteEpicId] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  useEffect(() => {
+    setLocalEpics(epics);
+  }, [epics]);
+
+  const editingEpic = useMemo(
+    () => localEpics.find((epic) => epic.id === editingEpicId) ?? null,
+    [editingEpicId, localEpics]
+  );
+
+  const pendingDeleteEpic = useMemo(
+    () => localEpics.find((epic) => epic.id === pendingDeleteEpicId) ?? null,
+    [localEpics, pendingDeleteEpicId]
+  );
+
+  const resetCreateDraft = () => {
+    setCreateName("");
+    setCreateDescription("");
+    setCreateError(null);
+  };
+
+  const closeCreate = () => {
+    if (isCreating) {
+      return;
+    }
+
+    setIsCreateOpen(false);
+    resetCreateDraft();
+  };
+
+  const startEdit = (epic: ProjectEpicPanelEpic) => {
+    setEditingEpicId(epic.id);
+    setEditName(epic.name);
+    setEditDescription(epic.description);
+    setEditError(null);
+  };
+
+  const cancelEdit = () => {
+    if (isSavingEdit) {
+      return;
+    }
+
+    setEditingEpicId(null);
+    setEditName("");
+    setEditDescription("");
+    setEditError(null);
+  };
+
+  const refreshProjectData = () => {
+    router.refresh();
+  };
+
+  const handleCreateEpic = async () => {
+    const normalizedName = createName.trim();
+    const normalizedDescription = createDescription.trim();
+    if (!normalizedName || !normalizedDescription) {
+      setCreateError("Epic name and description are required.");
+      return;
+    }
+
+    setIsCreating(true);
+    setCreateError(null);
+
+    try {
+      const response = await fetch(`/api/projects/${projectId}/epics`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: normalizedName,
+          description: normalizedDescription,
+        }),
+      });
+
+      const payload = (await response.json().catch(() => null)) as
+        | { error?: string; epic?: ProjectEpicPanelEpic }
+        | null;
+
+      if (!response.ok || !payload?.epic) {
+        throw new Error(mapEpicMutationError(payload?.error ?? "epic-create-failed"));
+      }
+
+      const createdEpic = payload.epic;
+      setLocalEpics((previousEpics) => [createdEpic, ...previousEpics]);
+      closeCreate();
+      refreshProjectData();
+      pushToast({
+        variant: "success",
+        message: "Epic created.",
+      });
+    } catch (error) {
+      setCreateError(error instanceof Error ? error.message : "Could not create epic.");
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleSaveEpic = async () => {
+    if (!editingEpic) {
+      return;
+    }
+
+    const normalizedName = editName.trim();
+    const normalizedDescription = editDescription.trim();
+    if (!normalizedName || !normalizedDescription) {
+      setEditError("Epic name and description are required.");
+      return;
+    }
+
+    setIsSavingEdit(true);
+    setEditError(null);
+
+    try {
+      const response = await fetch(`/api/projects/${projectId}/epics/${editingEpic.id}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: normalizedName,
+          description: normalizedDescription,
+        }),
+      });
+
+      const payload = (await response.json().catch(() => null)) as
+        | { error?: string; epic?: ProjectEpicPanelEpic }
+        | null;
+
+      if (!response.ok || !payload?.epic) {
+        throw new Error(mapEpicMutationError(payload?.error ?? "epic-update-failed"));
+      }
+
+      const updatedEpic = payload.epic;
+      setLocalEpics((previousEpics) =>
+        previousEpics.map((epic) => (epic.id === updatedEpic.id ? updatedEpic : epic))
+      );
+      cancelEdit();
+      refreshProjectData();
+      pushToast({
+        variant: "success",
+        message: "Epic updated.",
+      });
+    } catch (error) {
+      setEditError(error instanceof Error ? error.message : "Could not update epic.");
+    } finally {
+      setIsSavingEdit(false);
+    }
+  };
+
+  const handleDeleteEpic = async () => {
+    if (!pendingDeleteEpic || isDeleting) {
+      return;
+    }
+
+    setIsDeleting(true);
+
+    try {
+      const response = await fetch(`/api/projects/${projectId}/epics/${pendingDeleteEpic.id}`, {
+        method: "DELETE",
+      });
+
+      const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+
+      if (!response.ok) {
+        throw new Error(mapEpicMutationError(payload?.error ?? "epic-delete-failed"));
+      }
+
+      setLocalEpics((previousEpics) =>
+        previousEpics.filter((epic) => epic.id !== pendingDeleteEpic.id)
+      );
+      setPendingDeleteEpicId(null);
+      refreshProjectData();
+      pushToast({
+        variant: "success",
+        message: "Epic deleted. Linked tasks were left without an epic.",
+      });
+    } catch (error) {
+      pushToast({
+        variant: "error",
+        message: error instanceof Error ? error.message : "Could not delete epic.",
+      });
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <Card className={PROJECT_SECTION_CARD_CLASS}>
+      <CardHeader className={PROJECT_SECTION_HEADER_CLASS}>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <button
+            type="button"
+            onClick={() => setIsExpanded((previous) => !previous)}
+            aria-expanded={isExpanded}
+            className="flex min-w-0 flex-1 items-center gap-3 rounded-xl px-1 py-1 text-left transition hover:bg-muted/40"
+          >
+            {isExpanded ? (
+              <ChevronUp className="h-4 w-4 text-muted-foreground" />
+            ) : (
+              <ChevronDown className="h-4 w-4 text-muted-foreground" />
+            )}
+            <div className="min-w-0">
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Flag className="h-4 w-4" />
+                Epics
+              </CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Higher-level initiatives with automatic state and progress.
+              </p>
+            </div>
+            <span className="rounded-full border border-border/60 bg-background/70 px-2.5 py-1 text-xs text-muted-foreground">
+              {localEpics.length} epic{localEpics.length === 1 ? "" : "s"}
+            </span>
+          </button>
+
+          {canEdit ? (
+            <Button
+              type="button"
+              size="sm"
+              className="w-full sm:w-auto"
+              onClick={() => {
+                resetCreateDraft();
+                setIsCreateOpen(true);
+              }}
+            >
+              <PlusSquare className="h-4 w-4" />
+              New epic
+            </Button>
+          ) : null}
+        </div>
+      </CardHeader>
+
+      {isExpanded ? (
+        <CardContent className={cn("space-y-4", PROJECT_SECTION_CONTENT_CLASS)}>
+          {isCreateOpen ? (
+            <section className="space-y-3 rounded-2xl border border-border/70 bg-background/70 p-4">
+              <div className="space-y-1">
+                <h3 className="text-sm font-semibold">Create epic</h3>
+                <p className="text-xs text-muted-foreground">
+                  Give the initiative a clear flag and enough context to stay useful on the
+                  project page.
+                </p>
+              </div>
+              <div className="grid gap-3">
+                <div className="grid gap-2">
+                  <label htmlFor="create-epic-name" className="text-sm font-medium">
+                    Name
+                  </label>
+                  <EmojiInputField
+                    id="create-epic-name"
+                    value={createName}
+                    onChange={(event) => setCreateName(event.target.value)}
+                    className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+                    placeholder="Launch workspace sharing"
+                    maxLength={80}
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <label htmlFor="create-epic-description" className="text-sm font-medium">
+                    Description
+                  </label>
+                  <EmojiTextareaField
+                    id="create-epic-description"
+                    value={createDescription}
+                    onChange={(event) => setCreateDescription(event.target.value)}
+                    className="min-h-28 rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    placeholder="Explain the initiative and what success looks like."
+                    maxLength={3000}
+                  />
+                </div>
+              </div>
+              {createError ? (
+                <div className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                  {createError}
+                </div>
+              ) : null}
+              <div className="flex flex-col-reverse gap-2 sm:flex-row sm:items-center">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={closeCreate}
+                  disabled={isCreating}
+                  className="w-full sm:w-auto"
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  onClick={() => void handleCreateEpic()}
+                  disabled={isCreating}
+                  className="w-full sm:w-auto"
+                >
+                  {isCreating ? "Creating..." : "Create epic"}
+                </Button>
+              </div>
+            </section>
+          ) : null}
+
+          {localEpics.length === 0 ? (
+            <div className="rounded-2xl border border-dashed border-border/70 bg-muted/20 px-5 py-8 text-center">
+              <p className="text-sm font-medium text-foreground">No epics yet.</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Create one to group related work under a clear initiative.
+              </p>
+            </div>
+          ) : (
+            <div className="grid gap-4 lg:grid-cols-2">
+              {localEpics.map((epic) => {
+                const color = getEpicColorFromName(epic.name);
+                const isEditing = editingEpicId === epic.id;
+                const visibleTasks = epic.linkedTasks.slice(0, 6);
+                const hiddenTaskCount = Math.max(0, epic.linkedTasks.length - visibleTasks.length);
+
+                return (
+                  <article
+                    key={epic.id}
+                    className="rounded-2xl border p-4 shadow-[0_18px_48px_-42px_rgba(15,23,42,0.45)]"
+                    style={{
+                      borderColor: color.border,
+                      background: `linear-gradient(180deg, ${color.soft}, rgba(255,255,255,0.9))`,
+                    }}
+                  >
+                    {isEditing ? (
+                      <div className="space-y-3">
+                        <div className="grid gap-2">
+                          <label
+                            htmlFor={`edit-epic-name-${epic.id}`}
+                            className="text-sm font-medium"
+                          >
+                            Name
+                          </label>
+                          <EmojiInputField
+                            id={`edit-epic-name-${epic.id}`}
+                            value={editName}
+                            onChange={(event) => setEditName(event.target.value)}
+                            className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+                            maxLength={80}
+                          />
+                        </div>
+                        <div className="grid gap-2">
+                          <label
+                            htmlFor={`edit-epic-description-${epic.id}`}
+                            className="text-sm font-medium"
+                          >
+                            Description
+                          </label>
+                          <EmojiTextareaField
+                            id={`edit-epic-description-${epic.id}`}
+                            value={editDescription}
+                            onChange={(event) => setEditDescription(event.target.value)}
+                            className="min-h-28 rounded-md border border-input bg-background px-3 py-2 text-sm"
+                            maxLength={3000}
+                          />
+                        </div>
+                        {editError ? (
+                          <div className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                            {editError}
+                          </div>
+                        ) : null}
+                        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:items-center">
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            onClick={cancelEdit}
+                            disabled={isSavingEdit}
+                            className="w-full sm:w-auto"
+                          >
+                            Cancel
+                          </Button>
+                          <Button
+                            type="button"
+                            onClick={() => void handleSaveEpic()}
+                            disabled={isSavingEdit}
+                            className="w-full sm:w-auto"
+                          >
+                            {isSavingEdit ? "Saving..." : "Save epic"}
+                          </Button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="space-y-4">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0 space-y-2">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <span
+                                className="inline-flex items-center gap-2 rounded-full border px-2.5 py-1 text-xs font-semibold"
+                                style={{
+                                  backgroundColor: color.soft,
+                                  borderColor: color.border,
+                                  color: color.accent,
+                                }}
+                              >
+                                <Flag className="h-3.5 w-3.5" />
+                                {epic.name}
+                              </span>
+                              <EpicStatusBadge status={epic.status} />
+                            </div>
+                            <p className="text-sm leading-6 text-foreground/85">
+                              {epic.description}
+                            </p>
+                          </div>
+                          {canEdit ? (
+                            <div className="flex items-center gap-1">
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => startEdit(epic)}
+                                aria-label={`Edit epic ${epic.name}`}
+                              >
+                                <Pencil className="h-4 w-4" />
+                              </Button>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => setPendingDeleteEpicId(epic.id)}
+                                aria-label={`Delete epic ${epic.name}`}
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </div>
+                          ) : null}
+                        </div>
+
+                        <div className="space-y-2 rounded-xl border border-border/50 bg-background/70 p-3">
+                          <div className="flex items-center justify-between gap-3">
+                            <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                              Progress
+                            </p>
+                            <p className="text-sm font-semibold text-foreground">
+                              {epic.progressPercent}%
+                            </p>
+                          </div>
+                          <div className="h-2 overflow-hidden rounded-full bg-muted">
+                            <div
+                              className="h-full rounded-full transition-[width]"
+                              style={{
+                                width: `${epic.progressPercent}%`,
+                                backgroundColor: color.accent,
+                              }}
+                            />
+                          </div>
+                          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                            <span>
+                              {epic.completedTaskCount}/{epic.taskCount} task
+                              {epic.taskCount === 1 ? "" : "s"} completed
+                            </span>
+                          </div>
+                        </div>
+
+                        <div className="space-y-2">
+                          <div className="flex items-center justify-between gap-2">
+                            <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                              Linked tasks
+                            </p>
+                            <span className="text-xs text-muted-foreground">
+                              {epic.taskCount} total
+                            </span>
+                          </div>
+                          {epic.linkedTasks.length > 0 ? (
+                            <div className="flex flex-wrap gap-2">
+                              {visibleTasks.map((task) => (
+                                <EpicTaskChip key={task.id} task={task} />
+                              ))}
+                              {hiddenTaskCount > 0 ? (
+                                <span className="inline-flex items-center rounded-full border border-border/60 bg-background/70 px-2 py-1 text-[11px] text-muted-foreground">
+                                  +{hiddenTaskCount} more
+                                </span>
+                              ) : null}
+                            </div>
+                          ) : (
+                            <p className="text-sm text-muted-foreground">
+                              No tasks linked yet.
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    )}
+                  </article>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      ) : null}
+
+      <ConfirmDialog
+        isOpen={Boolean(pendingDeleteEpic)}
+        title="Delete epic?"
+        description={
+          pendingDeleteEpic
+            ? `Delete "${pendingDeleteEpic.name}"? Linked tasks will remain, but their epic link will be cleared.`
+            : ""
+        }
+        confirmLabel={isDeleting ? "Deleting..." : "Delete epic"}
+        onConfirm={() => void handleDeleteEpic()}
+        onCancel={() => {
+          if (isDeleting) {
+            return;
+          }
+
+          setPendingDeleteEpicId(null);
+        }}
+        isConfirming={isDeleting}
+      />
+    </Card>
+  );
+}

--- a/components/project-epic-panel.tsx
+++ b/components/project-epic-panel.tsx
@@ -161,8 +161,8 @@ export function ProjectEpicPanel({
     setCreateError(null);
   };
 
-  const closeCreate = () => {
-    if (isCreating) {
+  const closeCreate = (force = false) => {
+    if (isCreating && !force) {
       return;
     }
 
@@ -177,8 +177,8 @@ export function ProjectEpicPanel({
     setEditError(null);
   };
 
-  const cancelEdit = () => {
-    if (isSavingEdit) {
+  const cancelEdit = (force = false) => {
+    if (isSavingEdit && !force) {
       return;
     }
 
@@ -225,7 +225,7 @@ export function ProjectEpicPanel({
 
       const createdEpic = payload.epic;
       setLocalEpics((previousEpics) => [createdEpic, ...previousEpics]);
-      closeCreate();
+      closeCreate(true);
       refreshProjectData();
       pushToast({
         variant: "success",
@@ -277,7 +277,7 @@ export function ProjectEpicPanel({
       setLocalEpics((previousEpics) =>
         previousEpics.map((epic) => (epic.id === updatedEpic.id ? updatedEpic : epic))
       );
-      cancelEdit();
+      cancelEdit(true);
       refreshProjectData();
       pushToast({
         variant: "success",
@@ -421,7 +421,7 @@ export function ProjectEpicPanel({
                 <Button
                   type="button"
                   variant="ghost"
-                  onClick={closeCreate}
+                  onClick={() => closeCreate()}
                   disabled={isCreating}
                   className="w-full sm:w-auto"
                 >
@@ -504,7 +504,7 @@ export function ProjectEpicPanel({
                           <Button
                             type="button"
                             variant="ghost"
-                            onClick={cancelEdit}
+                            onClick={() => cancelEdit()}
                             disabled={isSavingEdit}
                             className="w-full sm:w-auto"
                           >

--- a/components/project-epic-panel.tsx
+++ b/components/project-epic-panel.tsx
@@ -50,6 +50,7 @@ interface ProjectEpicPanelProps {
   projectId: string;
   canEdit: boolean;
   epics: ProjectEpicPanelEpic[];
+  loadError?: string | null;
 }
 
 function mapEpicMutationError(errorCode: string): string {
@@ -118,6 +119,7 @@ export function ProjectEpicPanel({
   projectId,
   canEdit,
   epics,
+  loadError = null,
 }: ProjectEpicPanelProps) {
   const router = useRouter();
   const { pushToast } = useToast();
@@ -347,9 +349,6 @@ export function ProjectEpicPanel({
                 <Flag className="h-4 w-4" />
                 Epics
               </CardTitle>
-              <p className="text-sm text-muted-foreground">
-                Higher-level initiatives with automatic state and progress.
-              </p>
             </div>
             <span className="rounded-full border border-border/60 bg-background/70 px-2.5 py-1 text-xs text-muted-foreground">
               {localEpics.length} epic{localEpics.length === 1 ? "" : "s"}
@@ -363,6 +362,7 @@ export function ProjectEpicPanel({
               className="w-full sm:w-auto"
               onClick={() => {
                 resetCreateDraft();
+                setIsExpanded(true);
                 setIsCreateOpen(true);
               }}
             >
@@ -375,6 +375,12 @@ export function ProjectEpicPanel({
 
       {isExpanded ? (
         <CardContent className={cn("space-y-4", PROJECT_SECTION_CONTENT_CLASS)}>
+          {loadError ? (
+            <div className="rounded-xl border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-200">
+              {loadError}
+            </div>
+          ) : null}
+
           {isCreateOpen ? (
             <section className="space-y-3 rounded-2xl border border-border/70 bg-background/70 p-4">
               <div className="space-y-1">
@@ -457,14 +463,19 @@ export function ProjectEpicPanel({
                 return (
                   <article
                     key={epic.id}
-                    className="rounded-2xl border p-4 shadow-[0_18px_48px_-42px_rgba(15,23,42,0.45)]"
+                    className="overflow-hidden rounded-2xl border bg-card/85 shadow-[0_18px_48px_-42px_rgba(15,23,42,0.45)] backdrop-blur-sm"
                     style={{
                       borderColor: color.border,
-                      background: `linear-gradient(180deg, ${color.soft}, rgba(255,255,255,0.9))`,
                     }}
                   >
+                    <div
+                      className="h-1.5 w-full"
+                      style={{
+                        backgroundColor: color.accent,
+                      }}
+                    />
                     {isEditing ? (
-                      <div className="space-y-3">
+                      <div className="space-y-3 p-4">
                         <div className="grid gap-2">
                           <label
                             htmlFor={`edit-epic-name-${epic.id}`}
@@ -521,7 +532,7 @@ export function ProjectEpicPanel({
                         </div>
                       </div>
                     ) : (
-                      <div className="space-y-4">
+                      <div className="space-y-4 p-4">
                         <div className="flex items-start justify-between gap-3">
                           <div className="min-w-0 space-y-2">
                             <div className="flex flex-wrap items-center gap-2">
@@ -538,7 +549,7 @@ export function ProjectEpicPanel({
                               </span>
                               <EpicStatusBadge status={epic.status} />
                             </div>
-                            <p className="text-sm leading-6 text-foreground/85">
+                            <p className="text-sm leading-6 text-foreground">
                               {epic.description}
                             </p>
                           </div>

--- a/components/ui/epic-select.tsx
+++ b/components/ui/epic-select.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { createPortal } from "react-dom";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Check, ChevronDown, Flag } from "lucide-react";
+
+import type { ProjectEpicOption } from "@/components/kanban-board-types";
+import { getEpicColorFromName } from "@/lib/epic";
+import { cn } from "@/lib/utils";
+
+interface EpicSelectProps {
+  id?: string;
+  name?: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: ProjectEpicOption[];
+  disabled?: boolean;
+  className?: string;
+  noEpicLabel?: string;
+}
+
+export function EpicSelect({
+  id,
+  name,
+  value,
+  onChange,
+  options,
+  disabled = false,
+  className,
+  noEpicLabel = "No epic",
+}: EpicSelectProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [dropdownPosition, setDropdownPosition] = useState<{
+    top: number;
+    left: number;
+    width: number;
+    maxHeight: number;
+  } | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
+
+  const selectedEpic = useMemo(
+    () => options.find((option) => option.id === value) ?? null,
+    [options, value]
+  );
+
+  useEffect(() => {
+    if (!isOpen) {
+      setDropdownPosition(null);
+      return;
+    }
+
+    const updateDropdownPosition = () => {
+      const trigger = triggerRef.current;
+      if (!trigger) {
+        return;
+      }
+
+      const rect = trigger.getBoundingClientRect();
+      const viewportPadding = 12;
+      const estimatedHeight = Math.min(72 * (options.length + 1), 320);
+      const availableBelow = window.innerHeight - rect.bottom - viewportPadding;
+      const availableAbove = rect.top - viewportPadding;
+      const shouldOpenAbove =
+        availableBelow < estimatedHeight && availableAbove > availableBelow;
+      const maxHeight = Math.max(
+        140,
+        shouldOpenAbove ? availableAbove - 6 : availableBelow - 6
+      );
+
+      setDropdownPosition({
+        top: shouldOpenAbove
+          ? Math.max(viewportPadding, rect.top - Math.min(estimatedHeight, maxHeight) - 6)
+          : rect.bottom + 6,
+        left: rect.left,
+        width: Math.max(rect.width, 280),
+        maxHeight,
+      });
+    };
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node | null;
+      if (!target) {
+        return;
+      }
+
+      if (triggerRef.current?.contains(target) || dropdownRef.current?.contains(target)) {
+        return;
+      }
+
+      setIsOpen(false);
+    };
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+
+    updateDropdownPosition();
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleEscape);
+    window.addEventListener("resize", updateDropdownPosition);
+    window.addEventListener("scroll", updateDropdownPosition, true);
+
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleEscape);
+      window.removeEventListener("resize", updateDropdownPosition);
+      window.removeEventListener("scroll", updateDropdownPosition, true);
+    };
+  }, [isOpen, options.length]);
+
+  const selectedColor = selectedEpic ? getEpicColorFromName(selectedEpic.name) : null;
+
+  return (
+    <div className="relative">
+      {name ? <input type="hidden" name={name} value={value} /> : null}
+      <button
+        ref={triggerRef}
+        id={id}
+        type="button"
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        className={cn(
+          "flex min-h-10 w-full items-center justify-between gap-3 rounded-md border border-input bg-background px-3 py-2 text-left transition-colors",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+          "disabled:cursor-not-allowed disabled:opacity-60",
+          className
+        )}
+        onClick={() => {
+          if (disabled) {
+            return;
+          }
+
+          setIsOpen((previous) => !previous);
+        }}
+      >
+        {selectedEpic ? (
+          <div className="flex min-w-0 items-center gap-3">
+            <span
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border"
+              style={{
+                backgroundColor: selectedColor?.soft,
+                borderColor: selectedColor?.border,
+                color: selectedColor?.accent,
+              }}
+            >
+              <Flag className="h-4 w-4" />
+            </span>
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium text-foreground">{selectedEpic.name}</p>
+              <p className="truncate text-xs text-muted-foreground">
+                {selectedEpic.status} · {selectedEpic.progressPercent}% complete
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="flex min-w-0 items-center gap-3">
+            <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-dashed border-border/70 bg-muted/30">
+              <Flag className="h-4 w-4 text-muted-foreground" />
+            </span>
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium text-foreground">{noEpicLabel}</p>
+              <p className="truncate text-xs text-muted-foreground">
+                Leave this task outside an epic
+              </p>
+            </div>
+          </div>
+        )}
+        <ChevronDown
+          className={cn(
+            "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
+            isOpen && "rotate-180"
+          )}
+        />
+      </button>
+
+      {isOpen && dropdownPosition && typeof document !== "undefined"
+        ? createPortal(
+            <div
+              ref={dropdownRef}
+              role="listbox"
+              className="z-[140] overflow-hidden rounded-xl border border-border/70 bg-popover p-1 shadow-lg"
+              style={{
+                position: "fixed",
+                top: dropdownPosition.top,
+                left: dropdownPosition.left,
+                width: dropdownPosition.width,
+                maxHeight: dropdownPosition.maxHeight,
+              }}
+            >
+              <div className="scrollbar-hidden space-y-1 overflow-y-auto p-0.5">
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={!selectedEpic}
+                  className="flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-left transition hover:bg-muted"
+                  onClick={() => {
+                    onChange("");
+                    setIsOpen(false);
+                  }}
+                >
+                  <div className="flex min-w-0 items-center gap-3">
+                    <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-dashed border-border/70 bg-muted/30">
+                      <Flag className="h-4 w-4 text-muted-foreground" />
+                    </span>
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium text-foreground">
+                        {noEpicLabel}
+                      </p>
+                      <p className="truncate text-xs text-muted-foreground">
+                        Leave this task outside an epic
+                      </p>
+                    </div>
+                  </div>
+                  {!selectedEpic ? <Check className="h-4 w-4 text-foreground" /> : null}
+                </button>
+
+                {options.map((epic) => {
+                  const isSelected = epic.id === selectedEpic?.id;
+                  const color = getEpicColorFromName(epic.name);
+
+                  return (
+                    <button
+                      key={epic.id}
+                      type="button"
+                      role="option"
+                      aria-selected={isSelected}
+                      className="flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-left transition hover:bg-muted"
+                      onClick={() => {
+                        onChange(epic.id);
+                        setIsOpen(false);
+                      }}
+                    >
+                      <div className="flex min-w-0 items-center gap-3">
+                        <span
+                          className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border"
+                          style={{
+                            backgroundColor: color.soft,
+                            borderColor: color.border,
+                            color: color.accent,
+                          }}
+                        >
+                          <Flag className="h-4 w-4" />
+                        </span>
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-medium text-foreground">
+                            {epic.name}
+                          </p>
+                          <p className="truncate text-xs text-muted-foreground">
+                            {epic.status} · {epic.progressPercent}% complete · {epic.taskCount} task
+                            {epic.taskCount === 1 ? "" : "s"}
+                          </p>
+                        </div>
+                      </div>
+                      {isSelected ? <Check className="h-4 w-4 text-foreground" /> : null}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>,
+            document.body
+          )
+        : null}
+    </div>
+  );
+}

--- a/journal.md
+++ b/journal.md
@@ -788,6 +788,16 @@ Low-value entries to avoid going forward:
 - minor UI tweaks without task linkage
 - repetitive step-by-step notes that already exist in PR history
 
+### 2026-04-22
+- Type: Execution
+- Summary: TASK-107 follow-up added quick epic assignment directly from the task options menu and tightened backlog tracking for API-capability audit plus mobile navigation bug-fix scope.
+- Evidence: Updated `components/kanban-board.tsx` and `components/kanban/task-detail-modal.tsx` to patch task epic links from the existing dots menu without entering full edit mode; updated `tasks/current.md` acceptance/scope wording; added `TASK-127` in `tasks/backlog.md` and expanded `TASK-100` to explicitly cover mobile navigation bug fixing.
+
+### 2026-04-22
+- Type: Validation
+- Summary: TASK-107 quick-epic follow-up passed local lint, targeted epic service/API tests, and production build; targeted Playwright remains blocked by local E2E database fixture state before the new UI path executes.
+- Evidence: `npm run lint`; `npx -y -p node@20.19.0 node .\\node_modules\\vitest\\vitest.mjs run tests\\api\\project-epics.route.test.ts tests\\lib\\project-epic-service.test.ts`; `npm run build` with local env overrides; `npx playwright test tests/e2e/smoke-project-task-calendar.spec.ts --grep "task lifecycle and attachment interaction flow"` failed in `tests/e2e/helpers/auth-helpers.ts` during seeded-user creation via Prisma before the browser reached the new epic quick-action flow.
+
 ### 2026-03-02
 - Type: Execution
 - Summary: ISSUE-070 targeted remediation implemented as low-risk performance patch set (no broad architecture rewrite).

--- a/journal.md
+++ b/journal.md
@@ -12,6 +12,21 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ## Recent Entries (Most Relevant)
 
+### 2026-04-22
+- Type: Execution
+- Summary: TASK-107 implemented project-scoped epics end to end as dedicated planning entities with CRUD support, nullable task-to-epic links, automatic epic status/progress rollups, a colorful project epic registry section, and epic visibility across task create/edit/detail/Kanban plus agent-facing API documentation.
+- Evidence: Added `Epic` plus `Task.epicId` in `prisma/schema.prisma` with migration `prisma/migrations/20260422103000_task107_project_epics/migration.sql`; added `lib/epic.ts` and `lib/services/project-epic-service.ts`; added epic routes in `app/api/projects/[projectId]/epics/route.ts` and `app/api/projects/[projectId]/epics/[epicId]/route.ts`; updated task/project service and API contracts in `lib/services/project-service.ts`, `lib/services/project-task-service.ts`, `app/api/projects/[projectId]/tasks/route.ts`, and `app/api/projects/[projectId]/tasks/[taskId]/route.ts`; added the project epic section and epic task surfaces in `app/projects/[projectId]/project-epic-panel-section.tsx`, `components/project-epic-panel.tsx`, `components/create-task-dialog.tsx`, `components/kanban-board.tsx`, `components/kanban/kanban-columns-grid.tsx`, `components/kanban/task-detail-modal.tsx`, and related onboarding/docs updates in `lib/agent-onboarding.ts`, `components/agent-onboarding/agent-onboarding-guide.tsx`, and `project.md`.
+
+### 2026-04-22
+- Type: Validation
+- Summary: TASK-107 local validation passed for lint, focused regressions, full Vitest, coverage, Prisma client generation, and production build; the follow-up Copilot review fixes also passed the same baseline after tightening epic form close-state handling and aligning epic name uniqueness with the database layer.
+- Evidence: `npm run lint`; `npx -y -p node@20.19.0 node .\\node_modules\\prisma\\build\\index.js generate`; `npx -y -p node@20.19.0 node .\\node_modules\\vitest\\vitest.mjs run tests\\lib\\project-epic-service.test.ts tests\\lib\\epic.test.ts tests\\api\\project-epics.route.test.ts --pool=threads --maxWorkers=1 --no-file-parallelism`; `$env:DATABASE_URL='postgresql://localhost:5432/postgres'; $env:DIRECT_URL='postgresql://localhost:5433/postgres'; npx -y -p node@20.19.0 node .\\node_modules\\vitest\\vitest.mjs run --pool=threads --maxWorkers=1 --no-file-parallelism`; same env with `--coverage`; same env plus `GOOGLE_TOKEN_ENCRYPTION_KEY` and `AGENT_TOKEN_SIGNING_SECRET` with `npx -y -p node@20.19.0 node .\\node_modules\\next\\dist\\bin\\next build`.
+
+### 2026-04-22
+- Type: Blocker
+- Summary: TASK-107 local Playwright coverage remains blocked in this workstation session before browser interaction because the required PostgreSQL-backed fixture state is unavailable, so authenticated E2E seed user creation fails before the app can boot into the smoke flows.
+- Evidence: `$env:DATABASE_URL='postgresql://localhost:5432/postgres'; $env:DIRECT_URL='postgresql://localhost:5433/postgres'; $env:GOOGLE_TOKEN_ENCRYPTION_KEY='0123456789abcdef0123456789abcdef'; $env:AGENT_TOKEN_SIGNING_SECRET='0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'; npx -y -p node@20.19.0 node .\\node_modules\\playwright\\cli.js test` failed in `tests/e2e/password-recovery.spec.ts` and `tests/e2e/helpers/auth-helpers.ts` with `PrismaClientKnownRequestError` during `prisma.user.create(...)` setup.
+
 ### 2026-04-21
 - Type: Execution
 - Summary: TASK-101 implemented first-class task ownership and provenance end to end so tasks now persist creator, updater, and optional assignee metadata and surface avatar-backed attribution across task cards, task detail, create/edit flows, comments, and task-related attachment activity.

--- a/journal.md
+++ b/journal.md
@@ -14,6 +14,21 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ### 2026-04-22
 - Type: Execution
+- Summary: TASK-107 follow-up refined the epic registry UX to sit between project context and Kanban, removed the extra epic-header subtitle for better section consistency, made `New epic` expand the collapsed section before opening the form, and replaced the full-card light gradient treatment with a more consistent accent-strip/card treatment that stays readable in dark mode.
+- Evidence: Updated `app/projects/[projectId]/page.tsx`, `components/project-epic-panel.tsx`, and added focused regression coverage in `tests/components/project-epic-panel.test.tsx`.
+
+### 2026-04-22
+- Type: Execution
+- Summary: Hardened the new epic server section so an epic-fetch failure no longer crashes the whole project page; the section now logs the server error and degrades to an inline epic-panel warning instead of surfacing a route-level error boundary.
+- Evidence: Updated `app/projects/[projectId]/project-epic-panel-section.tsx` to catch/log `listProjectEpics(...)` failures and render `ProjectEpicPanel` with a temporary load error banner.
+
+### 2026-04-22
+- Type: Governance
+- Summary: Clarified the repository release workflow so coding tasks are not considered handoff-ready without an open PR, and branch-scoped preview validation now explicitly requires passing the branch `git_ref` and confirming from workflow logs that the requested branch ref was checked out.
+- Evidence: Updated `agent.md` execution-contract bullets covering mandatory PR creation, branch-ref preview invocation, and workflow-log verification expectations.
+
+### 2026-04-22
+- Type: Execution
 - Summary: TASK-107 implemented project-scoped epics end to end as dedicated planning entities with CRUD support, nullable task-to-epic links, automatic epic status/progress rollups, a colorful project epic registry section, and epic visibility across task create/edit/detail/Kanban plus agent-facing API documentation.
 - Evidence: Added `Epic` plus `Task.epicId` in `prisma/schema.prisma` with migration `prisma/migrations/20260422103000_task107_project_epics/migration.sql`; added `lib/epic.ts` and `lib/services/project-epic-service.ts`; added epic routes in `app/api/projects/[projectId]/epics/route.ts` and `app/api/projects/[projectId]/epics/[epicId]/route.ts`; updated task/project service and API contracts in `lib/services/project-service.ts`, `lib/services/project-task-service.ts`, `app/api/projects/[projectId]/tasks/route.ts`, and `app/api/projects/[projectId]/tasks/[taskId]/route.ts`; added the project epic section and epic task surfaces in `app/projects/[projectId]/project-epic-panel-section.tsx`, `components/project-epic-panel.tsx`, `components/create-task-dialog.tsx`, `components/kanban-board.tsx`, `components/kanban/kanban-columns-grid.tsx`, `components/kanban/task-detail-modal.tsx`, and related onboarding/docs updates in `lib/agent-onboarding.ts`, `components/agent-onboarding/agent-onboarding-guide.tsx`, and `project.md`.
 

--- a/lib/agent-onboarding.ts
+++ b/lib/agent-onboarding.ts
@@ -1,5 +1,6 @@
 import { AGENT_SCOPE_DEFINITIONS, type AgentScope } from "@/lib/agent-access";
 import { CONTEXT_CARD_COLORS } from "@/lib/context-card-colors";
+import { EPIC_STATUSES } from "@/lib/epic";
 import { TASK_STATUSES, type TaskStatus } from "@/lib/task-status";
 
 export const AGENT_API_VERSION = "v1";
@@ -11,7 +12,7 @@ export const AGENT_API_KEY_PLACEHOLDER = "nda_public.secret";
 export const AGENT_BEARER_TOKEN_ENV_NAME = "NEXUSDASH_AGENT_BEARER_TOKEN";
 export const AGENT_ATTACHMENT_MAX_FILE_SIZE_LABEL = "25MB";
 
-type AgentApiTag = "Auth" | "Projects" | "Tasks" | "Context";
+type AgentApiTag = "Auth" | "Projects" | "Epics" | "Tasks" | "Context";
 type AgentHttpMethod = "GET" | "POST" | "PATCH" | "DELETE";
 type AgentRequestContentType = "application/json" | "multipart/form-data";
 
@@ -56,6 +57,47 @@ export const AGENT_API_ENDPOINTS: ReadonlyArray<AgentApiEndpointDefinition> = [
     title: "Read project summary",
     description: "Read project metadata and dashboard summary metrics.",
     requiredScopes: ["project:read"],
+  },
+  {
+    tag: "Epics",
+    method: "GET",
+    path: "/api/projects/{projectId}/epics",
+    title: "List epics",
+    description: "List project epics with automatic status, progress, and linked task summaries.",
+    requiredScopes: ["task:read"],
+    notes: [
+      "Epic status is derived automatically from linked task states.",
+      "Epics are dedicated project entities, not tasks on the kanban board.",
+    ],
+  },
+  {
+    tag: "Epics",
+    method: "POST",
+    path: "/api/projects/{projectId}/epics",
+    title: "Create epic",
+    description: "Create a new project epic.",
+    requiredScopes: ["task:write"],
+    requestContentType: "application/json",
+    notes: ["Epic names must stay unique within a project."],
+  },
+  {
+    tag: "Epics",
+    method: "PATCH",
+    path: "/api/projects/{projectId}/epics/{epicId}",
+    title: "Update epic",
+    description: "Update an existing project epic.",
+    requiredScopes: ["task:write"],
+    requestContentType: "application/json",
+    notes: ["Epic names must stay unique within a project."],
+  },
+  {
+    tag: "Epics",
+    method: "DELETE",
+    path: "/api/projects/{projectId}/epics/{epicId}",
+    title: "Delete epic",
+    description: "Delete an epic and clear the epic link from its tasks.",
+    requiredScopes: ["task:write"],
+    notes: ["Deleting an epic does not delete its tasks."],
   },
   {
     tag: "Tasks",
@@ -299,6 +341,7 @@ export const AGENT_LIMITATIONS: readonly string[] = [
   "Use application/json for agent write requests unless you are intentionally following a browser-oriented multipart flow.",
   "Binary files and images use the direct-upload attachment routes; non-file writes should not rely on multipart/form-data.",
   "attachmentLinks must be arrays of { name, url } objects. Plain string URL arrays are not the canonical v1 format.",
+  "Epic status and progress are automatic. Agents should not try to set them directly.",
   "Task status changes happen through POST /api/projects/{projectId}/tasks/reorder, not PATCH /api/projects/{projectId}/tasks/{taskId}.",
   "Rich HTML is sanitized. Inline <img> content should not be treated as a supported image-delivery path; use attachments instead.",
   "Preview deployments may still be protected by Vercel. If a preview returns Vercel's auth wall, make the preview reachable or use an approved bypass before testing the agent flow.",
@@ -390,7 +433,7 @@ export function buildAgentTaskCreateExample(): string {
     'curl -X POST "$NEXUSDASH_BASE_URL/api/projects/$NEXUSDASH_PROJECT_ID/tasks" \\',
     `  -H "Authorization: Bearer $${AGENT_BEARER_TOKEN_ENV_NAME}" \\`,
     '  -H "Content-Type: application/json" \\',
-    "  -d '{\"title\":\"Draft release notes\",\"description\":\"<p>Summarize this week''s changes.</p>\",\"deadlineDate\":\"2026-04-24\",\"assigneeUserId\":\"user_456\",\"labels\":[\"release\",\"docs\"],\"attachmentLinks\":[{\"name\":\"Spec\",\"url\":\"https://example.com/spec\"}]}'",
+    "  -d '{\"title\":\"Draft release notes\",\"description\":\"<p>Summarize this week''s changes.</p>\",\"deadlineDate\":\"2026-04-24\",\"epicId\":\"epic_456\",\"assigneeUserId\":\"user_456\",\"labels\":[\"release\",\"docs\"],\"attachmentLinks\":[{\"name\":\"Spec\",\"url\":\"https://example.com/spec\"}]}'",
   ].join("\n");
 }
 
@@ -408,7 +451,7 @@ export function buildAgentTaskUpdateExample(): string {
     'curl -X PATCH "$NEXUSDASH_BASE_URL/api/projects/$NEXUSDASH_PROJECT_ID/tasks/$TASK_ID" \\',
     `  -H "Authorization: Bearer $${AGENT_BEARER_TOKEN_ENV_NAME}" \\`,
     '  -H "Content-Type: application/json" \\',
-    '  -d \'{"title":"Draft release notes","description":"<p>Add release highlights.</p>","deadlineDate":"2026-04-25","assigneeUserId":"user_456","labels":["release","ready"],"relatedTaskIds":["task_456"]}\'',
+    '  -d \'{"title":"Draft release notes","description":"<p>Add release highlights.</p>","deadlineDate":"2026-04-25","epicId":"epic_456","assigneeUserId":"user_456","labels":["release","ready"],"relatedTaskIds":["task_456"]}\'',
   ].join("\n");
 }
 
@@ -726,6 +769,11 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
         description: "Read project metadata and summary metrics.",
       },
       {
+        name: "Epics",
+        description:
+          "Create, read, update, and delete project epics with automatic status and progress.",
+      },
+      {
         name: "Tasks",
         description:
           "Create, read, update, reorder, archive, delete, and attach files to project tasks.",
@@ -910,6 +958,105 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
             },
           },
         },
+        TaskEpicSummary: {
+          type: "object",
+          required: ["id", "name"],
+          properties: {
+            id: { type: "string" },
+            name: { type: "string" },
+          },
+        },
+        ProjectEpicRecord: {
+          type: "object",
+          required: [
+            "id",
+            "name",
+            "description",
+            "status",
+            "progressPercent",
+            "taskCount",
+            "completedTaskCount",
+            "linkedTasks",
+            "createdAt",
+            "updatedAt",
+          ],
+          properties: {
+            id: { type: "string" },
+            name: { type: "string" },
+            description: { type: "string" },
+            status: {
+              type: "string",
+              enum: EPIC_STATUSES,
+            },
+            progressPercent: {
+              type: "integer",
+              minimum: 0,
+              maximum: 100,
+            },
+            taskCount: {
+              type: "integer",
+              minimum: 0,
+            },
+            completedTaskCount: {
+              type: "integer",
+              minimum: 0,
+            },
+            linkedTasks: {
+              type: "array",
+              items: {
+                $ref: "#/components/schemas/RelatedTaskSummary",
+              },
+            },
+            createdAt: { type: "string", format: "date-time" },
+            updatedAt: { type: "string", format: "date-time" },
+          },
+        },
+        ProjectEpicListResponse: {
+          type: "object",
+          required: ["epics"],
+          properties: {
+            epics: {
+              type: "array",
+              items: {
+                $ref: "#/components/schemas/ProjectEpicRecord",
+              },
+            },
+          },
+        },
+        ProjectEpicCreateRequest: {
+          type: "object",
+          required: ["name", "description"],
+          properties: {
+            name: { type: "string" },
+            description: { type: "string" },
+          },
+        },
+        ProjectEpicCreateResponse: {
+          type: "object",
+          required: ["epic"],
+          properties: {
+            epic: {
+              $ref: "#/components/schemas/ProjectEpicRecord",
+            },
+          },
+        },
+        ProjectEpicUpdateRequest: {
+          type: "object",
+          required: ["name", "description"],
+          properties: {
+            name: { type: "string" },
+            description: { type: "string" },
+          },
+        },
+        ProjectEpicUpdateResponse: {
+          type: "object",
+          required: ["epic"],
+          properties: {
+            epic: {
+              $ref: "#/components/schemas/ProjectEpicRecord",
+            },
+          },
+        },
         TaskBlockedFollowUp: {
           type: "object",
           required: ["id", "content", "createdAt"],
@@ -939,6 +1086,7 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
             "labelsJson",
             "createdAt",
             "updatedAt",
+            "epic",
             "assignee",
             "createdBy",
             "updatedBy",
@@ -964,6 +1112,12 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
             labelsJson: { type: ["string", "null"] },
             createdAt: { type: "string", format: "date-time" },
             updatedAt: { type: "string", format: "date-time" },
+            epic: {
+              anyOf: [
+                { $ref: "#/components/schemas/TaskEpicSummary" },
+                { type: "null" },
+              ],
+            },
             assignee: {
               anyOf: [
                 { $ref: "#/components/schemas/TaskCommentAuthor" },
@@ -1015,6 +1169,7 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
             title: { type: "string" },
             description: { type: "string" },
             deadlineDate: { type: "string", format: "date" },
+            epicId: { type: ["string", "null"] },
             assigneeUserId: { type: ["string", "null"] },
             labels: {
               type: "array",
@@ -1058,6 +1213,7 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
               type: ["string", "null"],
               format: "date",
             },
+            epicId: { type: ["string", "null"] },
             assigneeUserId: { type: ["string", "null"] },
             blockedFollowUpEntry: { type: "string" },
             relatedTaskIds: {
@@ -1084,6 +1240,7 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
                 "status",
                 "position",
                 "archivedAt",
+                "epic",
                 "assignee",
                 "createdBy",
                 "updatedBy",
@@ -1107,6 +1264,12 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
                 },
                 position: { type: "integer" },
                 archivedAt: { type: ["string", "null"], format: "date-time" },
+                epic: {
+                  anyOf: [
+                    { $ref: "#/components/schemas/TaskEpicSummary" },
+                    { type: "null" },
+                  ],
+                },
                 assignee: {
                   anyOf: [
                     { $ref: "#/components/schemas/TaskCommentAuthor" },
@@ -1414,6 +1577,14 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
             type: "string",
           },
         },
+        EpicId: {
+          name: "epicId",
+          in: "path",
+          required: true,
+          schema: {
+            type: "string",
+          },
+        },
         TaskId: {
           name: "taskId",
           in: "path",
@@ -1554,6 +1725,108 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
                 "application/json": {
                   schema: {
                     $ref: "#/components/schemas/TaskCreateResponse",
+                  },
+                },
+              },
+            },
+            ...commonErrorResponses,
+          },
+        },
+      },
+      "/api/projects/{projectId}/epics": {
+        get: {
+          ...buildOperationMetadata("GET", "/api/projects/{projectId}/epics"),
+          security: [{ BearerAuth: [] }],
+          parameters: [{ $ref: "#/components/parameters/ProjectId" }],
+          responses: {
+            200: {
+              description: "Epic list returned",
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "#/components/schemas/ProjectEpicListResponse",
+                  },
+                },
+              },
+            },
+            ...commonErrorResponses,
+          },
+        },
+        post: {
+          ...buildOperationMetadata("POST", "/api/projects/{projectId}/epics"),
+          security: [{ BearerAuth: [] }],
+          parameters: [{ $ref: "#/components/parameters/ProjectId" }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ProjectEpicCreateRequest",
+                },
+              },
+            },
+          },
+          responses: {
+            201: {
+              description: "Epic created",
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "#/components/schemas/ProjectEpicCreateResponse",
+                  },
+                },
+              },
+            },
+            ...commonErrorResponses,
+          },
+        },
+      },
+      "/api/projects/{projectId}/epics/{epicId}": {
+        patch: {
+          ...buildOperationMetadata("PATCH", "/api/projects/{projectId}/epics/{epicId}"),
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            { $ref: "#/components/parameters/ProjectId" },
+            { $ref: "#/components/parameters/EpicId" },
+          ],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/ProjectEpicUpdateRequest",
+                },
+              },
+            },
+          },
+          responses: {
+            200: {
+              description: "Epic updated",
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "#/components/schemas/ProjectEpicUpdateResponse",
+                  },
+                },
+              },
+            },
+            ...commonErrorResponses,
+          },
+        },
+        delete: {
+          ...buildOperationMetadata("DELETE", "/api/projects/{projectId}/epics/{epicId}"),
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            { $ref: "#/components/parameters/ProjectId" },
+            { $ref: "#/components/parameters/EpicId" },
+          ],
+          responses: {
+            200: {
+              description: "Epic deleted",
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "#/components/schemas/OkResponse",
                   },
                 },
               },

--- a/lib/epic.ts
+++ b/lib/epic.ts
@@ -1,0 +1,136 @@
+import { TASK_STATUSES, type TaskStatus } from "@/lib/task-status";
+
+export const EPIC_STATUSES = [
+  "Ready",
+  "In progress",
+  "Completed",
+] as const;
+
+export type EpicStatus = (typeof EPIC_STATUSES)[number];
+
+export interface EpicLinkedTaskStatus {
+  status: TaskStatus;
+  archivedAt: Date | string | null;
+}
+
+export interface EpicTaskSummary {
+  id: string;
+  title: string;
+  status: string;
+  archivedAt: string | null;
+}
+
+export interface TaskEpicSummary {
+  id: string;
+  name: string;
+}
+
+const EPIC_COLOR_PALETTE = [
+  {
+    accent: "#EA580C",
+    soft: "#FFEDD5",
+    border: "#FDBA74",
+  },
+  {
+    accent: "#0F766E",
+    soft: "#CCFBF1",
+    border: "#5EEAD4",
+  },
+  {
+    accent: "#1D4ED8",
+    soft: "#DBEAFE",
+    border: "#93C5FD",
+  },
+  {
+    accent: "#7C3AED",
+    soft: "#EDE9FE",
+    border: "#C4B5FD",
+  },
+  {
+    accent: "#BE185D",
+    soft: "#FCE7F3",
+    border: "#F9A8D4",
+  },
+  {
+    accent: "#15803D",
+    soft: "#DCFCE7",
+    border: "#86EFAC",
+  },
+] as const;
+
+function isTaskCompleted(task: EpicLinkedTaskStatus): boolean {
+  return task.archivedAt != null || task.status === "Done";
+}
+
+export function deriveEpicStatus(tasks: EpicLinkedTaskStatus[]): EpicStatus {
+  if (tasks.length === 0) {
+    return "Ready";
+  }
+
+  if (tasks.every((task) => isTaskCompleted(task))) {
+    return "Completed";
+  }
+
+  if (tasks.some((task) => task.status === "In Progress" || task.status === "Blocked")) {
+    return "In progress";
+  }
+
+  if (tasks.every((task) => task.status === "Backlog")) {
+    return "Ready";
+  }
+
+  return "In progress";
+}
+
+export function calculateEpicProgressPercent(tasks: EpicLinkedTaskStatus[]): number {
+  if (tasks.length === 0) {
+    return 0;
+  }
+
+  const completedCount = tasks.filter((task) => isTaskCompleted(task)).length;
+  return Math.round((completedCount / tasks.length) * 100);
+}
+
+function hashSeed(seed: string): number {
+  let hash = 0;
+
+  for (const character of seed) {
+    hash = (hash * 31 + character.charCodeAt(0)) >>> 0;
+  }
+
+  return hash;
+}
+
+export function getEpicColorFromName(name: string) {
+  const normalizedName = name.trim().toLowerCase();
+  const paletteIndex = hashSeed(normalizedName || TASK_STATUSES[0]) % EPIC_COLOR_PALETTE.length;
+  return EPIC_COLOR_PALETTE[paletteIndex]!;
+}
+
+export function mapEpicTaskSummary(task: {
+  id: string;
+  title: string;
+  status: string;
+  archivedAt: Date | string | null;
+}): EpicTaskSummary {
+  return {
+    id: task.id,
+    title: task.title,
+    status: task.status,
+    archivedAt:
+      task.archivedAt instanceof Date
+        ? task.archivedAt.toISOString()
+        : task.archivedAt ?? null,
+  };
+}
+
+export function mapTaskEpicSummary(epic: { id: string; name: string } | null): TaskEpicSummary | null {
+  if (!epic) {
+    return null;
+  }
+
+  return {
+    id: epic.id,
+    name: epic.name,
+  };
+}

--- a/lib/services/project-epic-service.ts
+++ b/lib/services/project-epic-service.ts
@@ -1,0 +1,501 @@
+import {
+  calculateEpicProgressPercent,
+  deriveEpicStatus,
+  mapEpicTaskSummary,
+  type EpicLinkedTaskStatus,
+  type EpicTaskSummary,
+} from "@/lib/epic";
+import { logServerError } from "@/lib/observability/logger";
+import {
+  requireAgentProjectScopes,
+  requireProjectRole,
+  type AgentProjectAccessContext,
+} from "@/lib/services/project-access-service";
+import { type DbClient, withActorRlsContext } from "@/lib/services/rls-context";
+import { type TaskStatus } from "@/lib/task-status";
+
+const MIN_EPIC_NAME_LENGTH = 2;
+const MIN_EPIC_DESCRIPTION_LENGTH = 2;
+
+interface ServiceErrorResult {
+  ok: false;
+  status: number;
+  error: string;
+}
+
+interface ServiceSuccessResult<T> {
+  ok: true;
+  data: T;
+}
+
+type ServiceResult<T> = ServiceSuccessResult<T> | ServiceErrorResult;
+
+export interface ProjectEpicSummary {
+  id: string;
+  name: string;
+  description: string;
+  status: "Ready" | "In progress" | "Completed";
+  progressPercent: number;
+  taskCount: number;
+  completedTaskCount: number;
+  linkedTasks: EpicTaskSummary[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface CreateProjectEpicInput {
+  actorUserId: string;
+  projectId: string;
+  name: string;
+  description: string;
+  agentAccess?: AgentProjectAccessContext;
+}
+
+interface UpdateProjectEpicInput extends CreateProjectEpicInput {
+  epicId: string;
+}
+
+const epicTaskSelect = {
+  id: true,
+  title: true,
+  status: true,
+  archivedAt: true,
+  position: true,
+  createdAt: true,
+} as const;
+
+function createError(status: number, error: string): ServiceErrorResult {
+  return { ok: false, status, error };
+}
+
+function normalizeText(value: unknown): string {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  return value.trim();
+}
+
+function isPrismaUniqueError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  return "code" in error && (error as { code?: string }).code === "P2002";
+}
+
+function mapProjectEpicSummary(epic: {
+  id: string;
+  name: string;
+  description: string;
+  createdAt: Date;
+  updatedAt: Date;
+  tasks: Array<{
+    id: string;
+    title: string;
+    status: string;
+    archivedAt: Date | null;
+    position?: number;
+    createdAt?: Date;
+  }>;
+}): ProjectEpicSummary {
+  const epicTasks = epic.tasks.map((task) => ({
+    status: task.status as TaskStatus,
+    archivedAt: task.archivedAt,
+  })) satisfies EpicLinkedTaskStatus[];
+  const linkedTasks = epic.tasks
+    .slice()
+    .sort((left, right) => {
+      if (typeof left.position === "number" && typeof right.position === "number") {
+        if (left.status === right.status && left.position !== right.position) {
+          return left.position - right.position;
+        }
+      }
+
+      if (left.status !== right.status) {
+        return left.status.localeCompare(right.status);
+      }
+
+      if (left.createdAt && right.createdAt) {
+        return left.createdAt.getTime() - right.createdAt.getTime();
+      }
+
+      return left.title.localeCompare(right.title);
+    })
+    .map((task) => mapEpicTaskSummary(task));
+  const completedTaskCount = epic.tasks.filter(
+    (task) => task.archivedAt != null || task.status === "Done"
+  ).length;
+
+  return {
+    id: epic.id,
+    name: epic.name,
+    description: epic.description,
+    status: deriveEpicStatus(epicTasks),
+    progressPercent: calculateEpicProgressPercent(epicTasks),
+    taskCount: epic.tasks.length,
+    completedTaskCount,
+    linkedTasks,
+    createdAt: epic.createdAt,
+    updatedAt: epic.updatedAt,
+  };
+}
+
+async function ensureUniqueEpicName(input: {
+  db: DbClient;
+  projectId: string;
+  name: string;
+  excludeEpicId?: string;
+}): Promise<ServiceResult<true>> {
+  const existingEpic = await input.db.epic.findFirst({
+    where: {
+      projectId: input.projectId,
+      name: {
+        equals: input.name,
+        mode: "insensitive",
+      },
+      ...(input.excludeEpicId ? { id: { not: input.excludeEpicId } } : {}),
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  if (existingEpic) {
+    return createError(400, "epic-name-conflict");
+  }
+
+  return {
+    ok: true,
+    data: true,
+  };
+}
+
+async function readEpicSummaryById(input: {
+  db: DbClient;
+  epicId: string;
+  projectId: string;
+}): Promise<ProjectEpicSummary | null> {
+  const epic = await input.db.epic.findFirst({
+    where: {
+      id: input.epicId,
+      projectId: input.projectId,
+    },
+    select: {
+      id: true,
+      name: true,
+      description: true,
+      createdAt: true,
+      updatedAt: true,
+      tasks: {
+        orderBy: [{ status: "asc" }, { position: "asc" }, { createdAt: "asc" }],
+        select: epicTaskSelect,
+      },
+    },
+  });
+
+  return epic ? mapProjectEpicSummary(epic) : null;
+}
+
+export async function listProjectEpics(
+  projectId: string,
+  actorUserId: string,
+  agentAccess?: AgentProjectAccessContext
+): Promise<ProjectEpicSummary[]> {
+  const normalizedActorUserId = normalizeText(actorUserId);
+  if (!normalizedActorUserId) {
+    return [];
+  }
+
+  const agentScopeAccess = requireAgentProjectScopes({
+    agentAccess,
+    projectId,
+    requiredScopes: ["task:read"],
+  });
+  if (!agentScopeAccess.ok) {
+    return [];
+  }
+
+  return withActorRlsContext(normalizedActorUserId, async (db) => {
+    const access = await requireProjectRole({
+      actorUserId: normalizedActorUserId,
+      projectId,
+      minimumRole: "viewer",
+      db,
+    });
+    if (!access.ok) {
+      return [];
+    }
+
+    const epics = await db.epic.findMany({
+      where: {
+        projectId,
+      },
+      orderBy: [{ updatedAt: "desc" }, { createdAt: "desc" }],
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        createdAt: true,
+        updatedAt: true,
+        tasks: {
+          orderBy: [{ status: "asc" }, { position: "asc" }, { createdAt: "asc" }],
+          select: epicTaskSelect,
+        },
+      },
+    });
+
+    return epics.map((epic) => mapProjectEpicSummary(epic));
+  }) as Promise<ProjectEpicSummary[]>;
+}
+
+export async function createProjectEpic(
+  input: CreateProjectEpicInput
+): Promise<ServiceResult<{ epic: ProjectEpicSummary }>> {
+  const actorUserId = normalizeText(input.actorUserId);
+  const name = normalizeText(input.name);
+  const description = normalizeText(input.description);
+  if (!actorUserId) {
+    return createError(401, "unauthorized");
+  }
+  if (name.length < MIN_EPIC_NAME_LENGTH) {
+    return createError(400, "epic-name-too-short");
+  }
+  if (description.length < MIN_EPIC_DESCRIPTION_LENGTH) {
+    return createError(400, "epic-description-too-short");
+  }
+
+  const agentScopeAccess = requireAgentProjectScopes({
+    agentAccess: input.agentAccess,
+    projectId: input.projectId,
+    requiredScopes: ["task:write"],
+  });
+  if (!agentScopeAccess.ok) {
+    return createError(agentScopeAccess.status, agentScopeAccess.error);
+  }
+
+  return withActorRlsContext(actorUserId, async (db) => {
+    const access = await requireProjectRole({
+      actorUserId,
+      projectId: input.projectId,
+      minimumRole: "editor",
+      db,
+    });
+    if (!access.ok) {
+      return createError(access.status, access.error);
+    }
+
+    const uniquenessCheck = await ensureUniqueEpicName({
+      db,
+      projectId: input.projectId,
+      name,
+    });
+    if (!uniquenessCheck.ok) {
+      return uniquenessCheck;
+    }
+
+    try {
+      const createdEpic = await db.epic.create({
+        data: {
+          projectId: input.projectId,
+          name,
+          description,
+        },
+        select: {
+          id: true,
+        },
+      });
+
+      const epic = await readEpicSummaryById({
+        db,
+        epicId: createdEpic.id,
+        projectId: input.projectId,
+      });
+      if (!epic) {
+        return createError(500, "epic-create-failed");
+      }
+
+      return {
+        ok: true,
+        data: {
+          epic,
+        },
+      };
+    } catch (error) {
+      if (isPrismaUniqueError(error)) {
+        return createError(400, "epic-name-conflict");
+      }
+
+      logServerError("createProjectEpic", error);
+      return createError(500, "epic-create-failed");
+    }
+  });
+}
+
+export async function updateProjectEpic(
+  input: UpdateProjectEpicInput
+): Promise<ServiceResult<{ epic: ProjectEpicSummary }>> {
+  const actorUserId = normalizeText(input.actorUserId);
+  const epicId = normalizeText(input.epicId);
+  const name = normalizeText(input.name);
+  const description = normalizeText(input.description);
+  if (!actorUserId) {
+    return createError(401, "unauthorized");
+  }
+  if (!epicId) {
+    return createError(400, "epic-not-found");
+  }
+  if (name.length < MIN_EPIC_NAME_LENGTH) {
+    return createError(400, "epic-name-too-short");
+  }
+  if (description.length < MIN_EPIC_DESCRIPTION_LENGTH) {
+    return createError(400, "epic-description-too-short");
+  }
+
+  const agentScopeAccess = requireAgentProjectScopes({
+    agentAccess: input.agentAccess,
+    projectId: input.projectId,
+    requiredScopes: ["task:write"],
+  });
+  if (!agentScopeAccess.ok) {
+    return createError(agentScopeAccess.status, agentScopeAccess.error);
+  }
+
+  return withActorRlsContext(actorUserId, async (db) => {
+    const access = await requireProjectRole({
+      actorUserId,
+      projectId: input.projectId,
+      minimumRole: "editor",
+      db,
+    });
+    if (!access.ok) {
+      return createError(access.status, access.error);
+    }
+
+    const existingEpic = await db.epic.findFirst({
+      where: {
+        id: epicId,
+        projectId: input.projectId,
+      },
+      select: {
+        id: true,
+      },
+    });
+    if (!existingEpic) {
+      return createError(404, "epic-not-found");
+    }
+
+    const uniquenessCheck = await ensureUniqueEpicName({
+      db,
+      projectId: input.projectId,
+      name,
+      excludeEpicId: epicId,
+    });
+    if (!uniquenessCheck.ok) {
+      return uniquenessCheck;
+    }
+
+    try {
+      await db.epic.update({
+        where: {
+          id: epicId,
+        },
+        data: {
+          name,
+          description,
+        },
+      });
+
+      const epic = await readEpicSummaryById({
+        db,
+        epicId,
+        projectId: input.projectId,
+      });
+      if (!epic) {
+        return createError(404, "epic-not-found");
+      }
+
+      return {
+        ok: true,
+        data: {
+          epic,
+        },
+      };
+    } catch (error) {
+      if (isPrismaUniqueError(error)) {
+        return createError(400, "epic-name-conflict");
+      }
+
+      logServerError("updateProjectEpic", error);
+      return createError(500, "epic-update-failed");
+    }
+  });
+}
+
+export async function deleteProjectEpic(input: {
+  actorUserId: string;
+  projectId: string;
+  epicId: string;
+  agentAccess?: AgentProjectAccessContext;
+}): Promise<ServiceResult<{ ok: true }>> {
+  const actorUserId = normalizeText(input.actorUserId);
+  const epicId = normalizeText(input.epicId);
+  if (!actorUserId) {
+    return createError(401, "unauthorized");
+  }
+  if (!epicId) {
+    return createError(400, "epic-not-found");
+  }
+
+  const agentScopeAccess = requireAgentProjectScopes({
+    agentAccess: input.agentAccess,
+    projectId: input.projectId,
+    requiredScopes: ["task:write"],
+  });
+  if (!agentScopeAccess.ok) {
+    return createError(agentScopeAccess.status, agentScopeAccess.error);
+  }
+
+  return withActorRlsContext(actorUserId, async (db) => {
+    const access = await requireProjectRole({
+      actorUserId,
+      projectId: input.projectId,
+      minimumRole: "editor",
+      db,
+    });
+    if (!access.ok) {
+      return createError(access.status, access.error);
+    }
+
+    const existingEpic = await db.epic.findFirst({
+      where: {
+        id: epicId,
+        projectId: input.projectId,
+      },
+      select: {
+        id: true,
+      },
+    });
+    if (!existingEpic) {
+      return createError(404, "epic-not-found");
+    }
+
+    try {
+      await db.epic.delete({
+        where: {
+          id: epicId,
+        },
+      });
+
+      return {
+        ok: true,
+        data: {
+          ok: true,
+        },
+      };
+    } catch (error) {
+      logServerError("deleteProjectEpic", error);
+      return createError(500, "epic-delete-failed");
+    }
+  });
+}

--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -81,6 +81,12 @@ type ProjectKanbanTaskRecord = Prisma.TaskGetPayload<{
         avatarSeed: true;
       };
     };
+    epic: {
+      select: {
+        id: true;
+        name: true;
+      };
+    };
   };
 }>;
 
@@ -615,6 +621,12 @@ export async function listProjectKanbanTasks(
             username: true,
             usernameDiscriminator: true,
             avatarSeed: true,
+          },
+        },
+        epic: {
+          select: {
+            id: true,
+            name: true,
           },
         },
       },

--- a/lib/services/project-task-service.ts
+++ b/lib/services/project-task-service.ts
@@ -703,7 +703,11 @@ export async function updateTaskForProject(
     return createError(401, "unauthorized");
   }
 
+  const titleProvided = Object.prototype.hasOwnProperty.call(payload, "title");
   const title = normalizeText(payload.title);
+  const labelsProvided =
+    Object.prototype.hasOwnProperty.call(payload, "labels") ||
+    Object.prototype.hasOwnProperty.call(payload, "label");
   const rawLabels =
     Array.isArray(payload.labels) && payload.labels.length > 0
       ? payload.labels
@@ -711,6 +715,7 @@ export async function updateTaskForProject(
   const labels = rawLabels.map((entry) => normalizeText(entry)).filter(Boolean);
   const normalizedLabels = normalizeTaskLabels(labels);
   const serializedLabels = serializeTaskLabels(normalizedLabels);
+  const descriptionProvided = Object.prototype.hasOwnProperty.call(payload, "description");
   const description = sanitizeRichText(normalizeText(payload.description));
   const deadlineInput = parseDeadlineInput(payload.deadlineDate, {
     preserveWhenMissing: true,
@@ -719,7 +724,10 @@ export async function updateTaskForProject(
     return deadlineInput;
   }
   const blockedFollowUpEntry = normalizeText(payload.blockedFollowUpEntry);
-  const relatedTaskIds = normalizeRelatedTaskIds(payload.relatedTaskIds ?? []);
+  const relatedTaskIdsProvided = Object.prototype.hasOwnProperty.call(payload, "relatedTaskIds");
+  const relatedTaskIds = relatedTaskIdsProvided
+    ? normalizeRelatedTaskIds(payload.relatedTaskIds ?? [])
+    : [];
   const epicProvided = Object.prototype.hasOwnProperty.call(payload, "epicId");
   const epicId = epicProvided ? normalizeText(payload.epicId) : null;
   const assigneeProvided = Object.prototype.hasOwnProperty.call(payload, "assigneeUserId");
@@ -735,7 +743,7 @@ export async function updateTaskForProject(
     return createError(agentScopeAccess.status, agentScopeAccess.error);
   }
 
-  if (title.length < MIN_TITLE_LENGTH) {
+  if (titleProvided && title.length < MIN_TITLE_LENGTH) {
     return createError(400, "Task title must be at least 2 characters");
   }
 
@@ -777,16 +785,26 @@ export async function updateTaskForProject(
         return createError(404, "Task not found");
       }
 
-      const relatedTaskValidation = await validateRelatedTaskIds({
-        db,
-        projectId,
-        taskId,
-        relatedTaskIds,
-        allowArchivedTaskIds: [
-          ...existingTask.outgoingRelations.map((entry) => entry.rightTaskId),
-          ...existingTask.incomingRelations.map((entry) => entry.leftTaskId),
-        ],
-      });
+      const relatedTaskValidation = relatedTaskIdsProvided
+        ? await validateRelatedTaskIds({
+            db,
+            projectId,
+            taskId,
+            relatedTaskIds,
+            allowArchivedTaskIds: [
+              ...existingTask.outgoingRelations.map((entry) => entry.rightTaskId),
+              ...existingTask.incomingRelations.map((entry) => entry.leftTaskId),
+            ],
+          })
+        : {
+            ok: true as const,
+            data: {
+              relatedTaskIds: [
+                ...existingTask.outgoingRelations.map((entry) => entry.rightTaskId),
+                ...existingTask.incomingRelations.map((entry) => entry.leftTaskId),
+              ],
+            },
+          };
       if (!relatedTaskValidation.ok) {
         return relatedTaskValidation;
       }
@@ -827,13 +845,17 @@ export async function updateTaskForProject(
         await tx.task.update({
           where: { id: taskId },
           data: {
-            title,
-            label: normalizedLabels[0] ?? null,
-            labelsJson: serializedLabels,
-            description,
             updatedByUserId: normalizedActorUserId,
             epicId: epicValidation.data.epicId,
             assigneeUserId: assigneeValidation.data.assigneeUserId,
+            ...(titleProvided ? { title } : {}),
+            ...(labelsProvided
+              ? {
+                  label: normalizedLabels[0] ?? null,
+                  labelsJson: serializedLabels,
+                }
+              : {}),
+            ...(descriptionProvided ? { description } : {}),
             ...(deadlineInput.data.provided
               ? { deadlineAt: deadlineInput.data.deadlineAt }
               : {}),
@@ -849,12 +871,14 @@ export async function updateTaskForProject(
           });
         }
 
-        await replaceTaskRelations({
-          db: tx,
-          projectId,
-          taskId,
-          relatedTaskIds: relatedTaskValidation.data.relatedTaskIds,
-        });
+        if (relatedTaskIdsProvided) {
+          await replaceTaskRelations({
+            db: tx,
+            projectId,
+            taskId,
+            relatedTaskIds: relatedTaskValidation.data.relatedTaskIds,
+          });
+        }
 
         return tx.task.findUnique({
           where: { id: taskId },

--- a/lib/services/project-task-service.ts
+++ b/lib/services/project-task-service.ts
@@ -6,6 +6,7 @@ import {
   normalizeRelatedTaskIds,
   type RelatedTaskSummary,
 } from "@/lib/task-related";
+import { mapTaskEpicSummary, type TaskEpicSummary } from "@/lib/epic";
 import { ATTACHMENT_KIND_FILE } from "@/lib/task-attachment";
 import {
   normalizeTaskLabels,
@@ -67,6 +68,7 @@ export interface UpdateTaskPayload {
   deadlineDate?: string | null;
   blockedFollowUpEntry?: string;
   relatedTaskIds?: string[];
+  epicId?: string | null;
   assigneeUserId?: string | null;
 }
 
@@ -76,6 +78,7 @@ interface CreateTaskForProjectInput {
   title: string;
   description: string;
   deadlineDate: string;
+  epicId: string | null;
   assigneeUserId: string | null;
   labelsJsonRaw: string;
   relatedTaskIdsJsonRaw: string;
@@ -96,6 +99,7 @@ interface UpdatedTaskPayload {
   status: string;
   position: number;
   archivedAt: Date | null;
+  epic: TaskEpicSummary | null;
   assignee: TaskPersonSummary | null;
   createdBy: TaskPersonSummary;
   updatedBy: TaskPersonSummary;
@@ -308,6 +312,43 @@ async function validateAssigneeUserId(input: {
   };
 }
 
+async function validateEpicId(input: {
+  db: DbClient;
+  projectId: string;
+  epicId: string | null;
+}): Promise<ServiceResult<{ epicId: string | null }>> {
+  const epicId = normalizeText(input.epicId);
+  if (!epicId) {
+    return {
+      ok: true,
+      data: {
+        epicId: null,
+      },
+    };
+  }
+
+  const epic = await input.db.epic.findFirst({
+    where: {
+      id: epicId,
+      projectId: input.projectId,
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  if (!epic) {
+    return createError(400, "epic-invalid");
+  }
+
+  return {
+    ok: true,
+    data: {
+      epicId,
+    },
+  };
+}
+
 async function replaceTaskRelations(input: {
   db: DbClient;
   projectId: string;
@@ -460,6 +501,15 @@ export async function createTaskForProject(
         return assigneeValidation;
       }
 
+      const epicValidation = await validateEpicId({
+        db,
+        projectId: input.projectId,
+        epicId: input.epicId,
+      });
+      if (!epicValidation.ok) {
+        return epicValidation;
+      }
+
       const maxPosition = await db.task.aggregate({
         where: {
           projectId: input.projectId,
@@ -482,6 +532,7 @@ export async function createTaskForProject(
           title,
           description,
           deadlineAt: deadlineInput.data.deadlineAt,
+          epicId: epicValidation.data.epicId,
           label: labels[0] ?? null,
           labelsJson: serializedLabels,
           status,
@@ -669,6 +720,8 @@ export async function updateTaskForProject(
   }
   const blockedFollowUpEntry = normalizeText(payload.blockedFollowUpEntry);
   const relatedTaskIds = normalizeRelatedTaskIds(payload.relatedTaskIds ?? []);
+  const epicProvided = Object.prototype.hasOwnProperty.call(payload, "epicId");
+  const epicId = epicProvided ? normalizeText(payload.epicId) : null;
   const assigneeProvided = Object.prototype.hasOwnProperty.call(payload, "assigneeUserId");
   const assigneeUserId = assigneeProvided
     ? normalizeText(payload.assigneeUserId)
@@ -705,6 +758,7 @@ export async function updateTaskForProject(
           projectId: true,
           status: true,
           position: true,
+          epicId: true,
           assigneeUserId: true,
           outgoingRelations: {
             select: {
@@ -737,6 +791,22 @@ export async function updateTaskForProject(
         return relatedTaskValidation;
       }
 
+      const epicValidation = epicProvided
+        ? await validateEpicId({
+            db,
+            projectId,
+            epicId: epicId || null,
+          })
+        : {
+            ok: true as const,
+            data: {
+              epicId: existingTask.epicId,
+            },
+          };
+      if (!epicValidation.ok) {
+        return epicValidation;
+      }
+
       const assigneeValidation = assigneeProvided
         ? await validateAssigneeUserId({
             db,
@@ -762,6 +832,7 @@ export async function updateTaskForProject(
             labelsJson: serializedLabels,
             description,
             updatedByUserId: normalizedActorUserId,
+            epicId: epicValidation.data.epicId,
             assigneeUserId: assigneeValidation.data.assigneeUserId,
             ...(deadlineInput.data.provided
               ? { deadlineAt: deadlineInput.data.deadlineAt }
@@ -805,6 +876,12 @@ export async function updateTaskForProject(
             archivedAt: true,
             createdAt: true,
             updatedAt: true,
+            epic: {
+              select: {
+                id: true,
+                name: true,
+              },
+            },
             createdByUser: {
               select: taskPersonSummarySelect,
             },
@@ -861,6 +938,7 @@ export async function updateTaskForProject(
             status: updatedTask.status,
             position: updatedTask.position,
             archivedAt: updatedTask.archivedAt,
+            epic: mapTaskEpicSummary(updatedTask.epic),
             assignee: updatedTask.assigneeUser
               ? mapTaskPersonSummary(updatedTask.assigneeUser)
               : null,

--- a/prisma/migrations/20260422103000_task107_project_epics/migration.sql
+++ b/prisma/migrations/20260422103000_task107_project_epics/migration.sql
@@ -4,13 +4,13 @@ CREATE TABLE "Epic" (
     "name" VARCHAR(80) NOT NULL,
     "description" TEXT NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
 
     CONSTRAINT "Epic_pkey" PRIMARY KEY ("id"),
     CONSTRAINT "Epic_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
 
-CREATE UNIQUE INDEX "Epic_projectId_name_key" ON "Epic"("projectId", "name");
+CREATE UNIQUE INDEX "Epic_projectId_lower_name_key" ON "Epic"("projectId", LOWER("name"));
 CREATE INDEX "Epic_projectId_updatedAt_idx" ON "Epic"("projectId", "updatedAt");
 
 ALTER TABLE "Task"

--- a/prisma/migrations/20260422103000_task107_project_epics/migration.sql
+++ b/prisma/migrations/20260422103000_task107_project_epics/migration.sql
@@ -1,0 +1,156 @@
+CREATE TABLE "Epic" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "name" VARCHAR(80) NOT NULL,
+    "description" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Epic_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "Epic_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "Epic_projectId_name_key" ON "Epic"("projectId", "name");
+CREATE INDEX "Epic_projectId_updatedAt_idx" ON "Epic"("projectId", "updatedAt");
+
+ALTER TABLE "Task"
+ADD COLUMN "epicId" TEXT;
+
+CREATE INDEX "Task_epicId_idx" ON "Task"("epicId");
+CREATE INDEX "Task_projectId_epicId_idx" ON "Task"("projectId", "epicId");
+
+ALTER TABLE "Task"
+ADD CONSTRAINT "Task_epicId_fkey"
+FOREIGN KEY ("epicId") REFERENCES "Epic"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE OR REPLACE FUNCTION app.enforce_task_epic_project()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  epic_project_id TEXT;
+BEGIN
+  IF NEW."epicId" IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT e."projectId"
+    INTO epic_project_id
+  FROM "Epic" e
+  WHERE e.id = NEW."epicId";
+
+  IF epic_project_id IS NULL THEN
+    RAISE EXCEPTION 'Epic must exist before linking';
+  END IF;
+
+  IF epic_project_id <> NEW."projectId" THEN
+    RAISE EXCEPTION 'Epic must belong to the same project as the task';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER enforce_task_epic_project_trigger
+BEFORE INSERT OR UPDATE ON "Task"
+FOR EACH ROW
+EXECUTE FUNCTION app.enforce_task_epic_project();
+
+ALTER TABLE "Epic" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "Epic" FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY epic_select_policy ON "Epic"
+FOR SELECT
+USING (
+  EXISTS (
+    SELECT 1
+    FROM "Project" p
+    WHERE p.id = "Epic"."projectId"
+      AND (
+        p."ownerId" = app.current_user_id()
+        OR EXISTS (
+          SELECT 1
+          FROM "ProjectMembership" pm
+          WHERE pm."projectId" = p.id
+            AND pm."userId" = app.current_user_id()
+        )
+      )
+  )
+);
+
+CREATE POLICY epic_insert_policy ON "Epic"
+FOR INSERT
+WITH CHECK (
+  EXISTS (
+    SELECT 1
+    FROM "Project" p
+    WHERE p.id = "Epic"."projectId"
+      AND (
+        p."ownerId" = app.current_user_id()
+        OR EXISTS (
+          SELECT 1
+          FROM "ProjectMembership" pm
+          WHERE pm."projectId" = p.id
+            AND pm."userId" = app.current_user_id()
+            AND pm.role IN ('owner', 'editor')
+        )
+      )
+  )
+);
+
+CREATE POLICY epic_update_policy ON "Epic"
+FOR UPDATE
+USING (
+  EXISTS (
+    SELECT 1
+    FROM "Project" p
+    WHERE p.id = "Epic"."projectId"
+      AND (
+        p."ownerId" = app.current_user_id()
+        OR EXISTS (
+          SELECT 1
+          FROM "ProjectMembership" pm
+          WHERE pm."projectId" = p.id
+            AND pm."userId" = app.current_user_id()
+            AND pm.role IN ('owner', 'editor')
+        )
+      )
+  )
+)
+WITH CHECK (
+  EXISTS (
+    SELECT 1
+    FROM "Project" p
+    WHERE p.id = "Epic"."projectId"
+      AND (
+        p."ownerId" = app.current_user_id()
+        OR EXISTS (
+          SELECT 1
+          FROM "ProjectMembership" pm
+          WHERE pm."projectId" = p.id
+            AND pm."userId" = app.current_user_id()
+            AND pm.role IN ('owner', 'editor')
+        )
+      )
+  )
+);
+
+CREATE POLICY epic_delete_policy ON "Epic"
+FOR DELETE
+USING (
+  EXISTS (
+    SELECT 1
+    FROM "Project" p
+    WHERE p.id = "Epic"."projectId"
+      AND (
+        p."ownerId" = app.current_user_id()
+        OR EXISTS (
+          SELECT 1
+          FROM "ProjectMembership" pm
+          WHERE pm."projectId" = p.id
+            AND pm."userId" = app.current_user_id()
+            AND pm.role IN ('owner', 'editor')
+        )
+      )
+  )
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -198,7 +198,6 @@ model Epic {
   project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
   tasks   Task[]
 
-  @@unique([projectId, name])
   @@index([projectId, updatedAt])
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -138,12 +138,13 @@ model Project {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
-  owner         User                @relation("ProjectOwner", fields: [ownerId], references: [id], onDelete: Cascade)
-  tasks         Task[]
-  resources     Resource[]
-  memberships   ProjectMembership[]
-  invitations   ProjectInvitation[]
-  taskRelations TaskRelation[]
+  owner          User                 @relation("ProjectOwner", fields: [ownerId], references: [id], onDelete: Cascade)
+  tasks          Task[]
+  epics          Epic[]
+  resources      Resource[]
+  memberships    ProjectMembership[]
+  invitations    ProjectInvitation[]
+  taskRelations  TaskRelation[]
   apiCredentials ApiCredential[]
   authAuditEvents AuthAuditEvent[]
 
@@ -186,6 +187,21 @@ model ProjectInvitation {
   @@index([invitedByUserId])
 }
 
+model Epic {
+  id          String   @id @default(cuid())
+  projectId   String
+  name        String   @db.VarChar(80)
+  description String
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  tasks   Task[]
+
+  @@unique([projectId, name])
+  @@index([projectId, updatedAt])
+}
+
 model Task {
   id                String                @id @default(cuid())
   title             String
@@ -199,10 +215,12 @@ model Task {
   label             String?
   labelsJson        String?
   projectId         String
+  epicId            String?
   createdByUserId   String
   updatedByUserId   String
   assigneeUserId    String?
   project           Project               @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  epic              Epic?                 @relation(fields: [epicId], references: [id], onDelete: SetNull)
   createdByUser     User                  @relation("TaskCreatedBy", fields: [createdByUserId], references: [id])
   updatedByUser     User                  @relation("TaskUpdatedBy", fields: [updatedByUserId], references: [id])
   assigneeUser      User?                 @relation("TaskAssignee", fields: [assigneeUserId], references: [id], onDelete: SetNull)
@@ -216,6 +234,8 @@ model Task {
 
   @@index([projectId])
   @@index([projectId, deadlineAt])
+  @@index([epicId])
+  @@index([projectId, epicId])
   @@index([createdByUserId])
   @@index([updatedByUserId])
   @@index([assigneeUserId])

--- a/project.md
+++ b/project.md
@@ -1,6 +1,6 @@
 # NexusDash Project Blueprint (Current State)
 
-Last verified: 2026-04-19
+Last verified: 2026-04-22
 
 ## 1. Vision
 
@@ -15,7 +15,8 @@ NexusDash is a personal/team execution workspace that keeps project planning, de
 - Project sharing v2 with owner-managed invites, role-based membership, email-bound invitation flows, and resumable invite acceptance.
 - Project dashboard with three core panels:
   - Context cards (create/edit/delete + attachments)
-  - Kanban board (`Backlog`, `In Progress`, `Blocked`, `Done`) with reorder, deadline/comment visibility, and task detail modal
+  - Kanban board (`Backlog`, `In Progress`, `Blocked`, `Done`) with reorder, deadline/comment visibility, task epic links, and task detail modal
+  - Project epics registry with dedicated epic CRUD, automatic status/progress, and linked-task rollups
   - Google Calendar panel (read/create/update/delete events when connected)
 - Task comments:
   - project-scoped, append-only task discussion threads
@@ -57,7 +58,7 @@ Current schema includes:
 - Auth/session: `User`, `Account`, `Session`, `VerificationToken`
 - Authorization boundaries: `Project.ownerId`, `ProjectMembership` (`owner|editor|viewer`)
 - Agent auth: `ApiCredential`, `ApiCredentialScopeGrant`, `AuthAuditEvent`
-- Domain: `Project`, `Task`, `Resource` (context cards), `TaskBlockedFollowUp`
+- Domain: `Project`, `Epic`, `Task`, `Resource` (context cards), `TaskBlockedFollowUp`
 - Collaboration on tasks: `TaskComment`
 - Attachments: `TaskAttachment`, `ResourceAttachment` with `uploadedByUserId`
 - Calendar: `GoogleCalendarCredential` (one row per user)

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -14,6 +14,11 @@ Use this file to capture tasks discovered during development. Each entry should 
   Status: Pending
   Rationale: Add a roadmap-oriented project view so teams can see planned direction, upcoming milestones, and sequencing at a higher level than the current Kanban board, improving long-range visibility without losing the existing execution detail.
   Dependencies: TASK-076, TASK-079, TASK-096
+- ID: TASK-127
+  Title: API capability audit - confirm every shipped feature remains fully manageable through the API
+  Status: Pending
+  Rationale: Run a focused audit across current product features to verify that core entities and workflows remain fully manageable through the public app API, close gaps where the UI can do more than the API, and keep the agent-facing contract trustworthy as NexusDash adds richer planning and collaboration features.
+  Dependencies: TASK-107, TASK-115
 
 ### Deferred (Intentional)
 - ID: TASK-098
@@ -89,7 +94,7 @@ Use this file to capture tasks discovered during development. Each entry should 
 - ID: TASK-100
   Title: Mobile UI/UX refinement - touch ergonomics, compact layouts, and small-screen polish
   Status: Pending
-  Rationale: After the baseline responsive pass, refine the mobile experience so it feels intentionally designed rather than merely supported by tightening spacing, improving touch targets, reducing modal friction, and smoothing small-screen navigation patterns across high-traffic flows. This refinement scope should explicitly include Google Calendar behavior on mobile, especially event readability, interaction density, and create/edit usability on narrow viewports.
+  Rationale: After the baseline responsive pass, refine the mobile experience so it feels intentionally designed rather than merely supported by tightening spacing, improving touch targets, reducing modal friction, and smoothing small-screen navigation patterns across high-traffic flows. This refinement scope should explicitly include concrete mobile navigation bug fixing, plus Google Calendar behavior on mobile, especially event readability, interaction density, and create/edit usability on narrow viewports.
   Dependencies: TASK-091, TASK-079, TASK-096
 - ID: TASK-063
   Title: Background jobs phase 1 - maintenance workload extraction (deferred)

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -5,9 +5,9 @@ Use this file to capture tasks discovered during development. Each entry should 
 ## Pending
 ### Execution Queue (Now / Next)
 - ID: TASK-107
-  Title: Task epic links - parent epic relationship and grouped execution context
-  Status: Pending
-  Rationale: Let tasks link to a higher-level epic so day-to-day work can roll up into larger initiatives, improving planning, grouping, and future roadmap/reporting surfaces beyond the current symmetric related-task model.
+  Title: Project epics and task epic flags
+  Status: In review (PR #194)
+  Rationale: Add first-class project epics as dedicated planning entities, with one optional epic flag per task, so teams can group execution work under visible initiatives without turning epics into pseudo-tasks or weakening Kanban clarity.
   Dependencies: TASK-079, TASK-095
 - ID: TASK-106
   Title: Project roadmap feature - milestone/timeline visibility for better execution sight

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -113,6 +113,8 @@ the existing Kanban model.
   - able to show all epics with name, description, derived status, progress,
     and linked-task count
 - Add task create/edit support for linking or clearing one epic.
+- Allow task detail quick actions to assign or clear an epic from the existing
+  task options menu without entering full edit mode.
 - Render the epic flag/chip on task surfaces where it matters:
   - task card
   - task detail
@@ -136,6 +138,8 @@ the existing Kanban model.
 - Epic names are unique within a project and duplicate-name writes are rejected.
 - Each task can store zero or one linked epic from the same project.
 - Task create/edit flows can assign an epic or clear it back to no epic.
+- Task options in task detail can assign or clear the linked epic without
+  switching into full edit mode.
 - Task cards and task detail surfaces display the linked epic flag when present.
 - The project page includes a dedicated epic section showing all epics with:
   - name

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,7 +4,7 @@
 TASK-107
 
 ## Status
-Ready for implementation.
+In review.
 
 ## Objective
 Introduce first-class project epics as a dedicated project-scoped planning

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,98 +1,158 @@
-# Current Task: TASK-101 Task Ownership And Provenance
+# Current Task: TASK-107 Task Epic Flags And Project Epic Registry
 
 ## Task ID
-TASK-101
+TASK-107
 
 ## Status
-Implementation complete on branch
-`feature/task-101-task-ownership-and-provenance`, stacked on top of `TASK-089`
-so the avatar baseline can be reused immediately across task ownership
-surfaces. Local validation is green aside from Playwright being blocked by the
-shared database schema not yet reflecting this branch migration; PR/review and
-preview deployment are the remaining release steps.
+Ready for implementation.
 
 ## Objective
-Add first-class task ownership metadata so every task can show who created it,
-who is currently assigned to it, and who last touched it, with the data model,
-API contracts, and UI all aligned around the same provenance source of truth.
+Introduce first-class project epics as a dedicated project-scoped planning
+entity, separate from tasks, so work can be grouped under a clear higher-level
+ initiative without turning epics into pseudo-tasks or weakening the clarity of
+the existing Kanban model.
 
 ## Why This Task Matters
-- Collaboration is already live, but task ownership is still implicit and
-  depends on outside context instead of product-visible metadata.
-- `TASK-089` established a shared avatar foundation; `TASK-101` is the first
-  feature that needs to apply that foundation to real work attribution.
-- Assignee and provenance data are prerequisites for later filtering,
-  accountability, notification, and richer project-presence work.
-- Shipping this cleanly now reduces the risk of inventing multiple incompatible
-  identity models across task comments, assignee chips, and future activity
-  surfaces.
+- The task system already supports labels, related-task links, comments,
+  deadlines, and ownership, but it still lacks a clear way to group several
+  execution tasks under one larger initiative.
+- Treating epics as tasks would blur the distinction between planning context
+  and executable work, which would make the board harder to understand.
+- A dedicated epic model gives NexusDash a clearer planning layer now and a
+  cleaner foundation for later roadmap/reporting work (`TASK-106`) without
+  forcing users to overload task semantics.
+- Epics should feel visible and useful in daily workflow, which means the
+  feature needs both task-level linking and a project-level epic surface rather
+  than a hidden settings-only implementation.
 
 ## Current Baseline Confirmed In Repo
-- `Task` currently has no creator, updater, or assignee relationship fields in
-  `prisma/schema.prisma`.
-- Kanban task reads come from `listProjectKanbanTasks` and the task routes, so
-  provenance data needs to be added at the service/API layer rather than only
-  in the UI.
-- Task comments already resolve avatar-backed author identities after
-  `TASK-089`.
-- The board already has a stable task detail modal, task create dialog, and
-  task edit flow, which are the right surfaces to introduce ownership and
-  provenance.
+- Tasks already support project-scoped metadata and linked relationships
+  through the service/API/UI stack:
+  - labels
+  - related tasks
+  - deadlines
+  - assignee / provenance
+  - comments
+  - attachments
+- The Kanban board already has stable create/edit/read task flows that can host
+  one additional optional task field without inventing a new interaction model.
+- Project pages already support multiple section-level panels, so a dedicated
+  epic section fits the existing dashboard composition better than a settings
+  detour.
+- The repo already maintains agent-facing task contracts in
+  `lib/agent-onboarding.ts`, so epic-aware API changes must stay aligned there
+  too.
 
-## Working Product Assumptions
-- A task must always retain a creator and last-updater once the migration is
-  applied.
-- Assignee is optional and should support explicit clearing back to an
-  unassigned state.
-- Valid assignees are current project collaborators, including the owner.
-- "Last touched" should reflect task mutations that materially change the task
-  record or task activity, including comment and attachment writes.
-- Existing tasks need a practical backfill path; project owner is the baseline
-  provenance fallback for legacy rows.
+## Product Contract
+- Epics are not tasks.
+- Epics are project-scoped entities with their own CRUD lifecycle.
+- Each epic has:
+  - a unique project-scoped name / flag
+  - a description
+  - an automatically derived status
+- Each task may link to zero or one epic.
+- Tasks never become parents of other tasks through this feature.
+- Epic status is derived automatically from linked task states and is never
+  edited directly.
+- Deleting an epic must clear the linked `epicId` from affected tasks rather
+  than deleting or mutating those tasks otherwise.
+- Epic names must be unique within a project.
+
+## Automatic Epic Status Rules
+- `Ready`
+  - epic has zero linked tasks, or
+  - every linked task is in `Backlog`
+- `In progress`
+  - at least one linked task is in `In Progress`, or
+  - at least one linked task is in `Blocked`, or
+  - linked tasks are mixed between `Backlog` and `Done` / archived with no task
+    currently in `In Progress`
+- `Completed`
+  - every linked task is `Done` or archived
+
+## Progress Bar Rules
+- Every epic shown in the dedicated epic section should include a visible
+  progress bar.
+- Progress is derived automatically from linked tasks.
+- Progress percent for v1 is:
+  - numerator: linked tasks that are `Done` or archived
+  - denominator: all linked tasks currently linked to the epic
+- An epic with zero linked tasks shows `0%` progress and still resolves to
+  status `Ready`.
 
 ## Scope
-- Extend the task schema with:
-  - creator relationship
-  - updater relationship
-  - optional assignee relationship
-- Backfill provenance for existing tasks through a migration.
-- Validate assignee changes against current project collaborators.
-- Update task create, update, reorder, archive, unarchive, comment, and
-  attachment flows so provenance stays accurate.
-- Expose provenance and assignee metadata through task list/update API
-  responses.
-- Add assignee selection to task create/edit flows.
-- Render avatar-backed ownership UI on the main task surfaces:
-  - board card assignee display
-  - task detail assignee display
-  - task detail created-by / modified-by display
-- Update agent/OpenAPI documentation where task payloads change.
-- Add targeted regression coverage for the new task contracts and provenance
-  behavior.
-- Update tracking docs in the same task branch.
+- Add a dedicated `Epic` persistence model to the Prisma schema with:
+  - `id`
+  - `projectId`
+  - unique project-scoped `name`
+  - `description`
+  - timestamps
+- Add an optional `epicId` relationship on `Task`.
+- Ship a migration that:
+  - creates the epic table
+  - adds the nullable task-to-epic foreign key
+  - enforces unique epic names per project
+- Add epic-aware service support for:
+  - create epic
+  - list epics
+  - update epic
+  - delete epic
+  - task create with optional epic link
+  - task update with epic assignment or clearing
+  - task reads that return epic summary metadata when linked
+- Enforce epic/task validation in services:
+  - epic must belong to the same project
+  - tasks may link to at most one epic
+  - clearing epic linkage must be supported explicitly
+- Add API routes for epic CRUD under the project scope.
+- Extend task APIs so create/update payloads can set or clear a linked epic.
+- Add a dedicated project-page epic section that is:
+  - visible
+  - colorful
+  - easy to scan
+  - able to show all epics with name, description, derived status, progress,
+    and linked-task count
+- Add task create/edit support for linking or clearing one epic.
+- Render the epic flag/chip on task surfaces where it matters:
+  - task card
+  - task detail
+  - task create/edit flow
+- Show linked task rollup inside the epic section so users can understand the
+  initiative without turning the epic into a task card.
+- Keep agent/OpenAPI documentation aligned with the new epic and task payloads.
+- Add targeted regression coverage across schema/service/API/component layers.
+- Update task tracking docs in the same branch.
 
 ## Out Of Scope
-- User-uploaded avatars or alternative avatar rendering systems.
-- Project-page collaborator rollups; that remains later work (`TASK-119`).
-- Notification delivery, reminders, or ownership-based inbox features.
-- Complex assignee filtering/search UX on the board.
-- Historic provenance reconstruction beyond a sensible legacy backfill.
+- Turning epics into executable Kanban tasks.
+- Nested epics or epic hierarchies.
+- Multiple epics per task.
+- Board regrouping, lane regrouping, or epic-based board filtering in v1.
+- Roadmap/timeline planning beyond the dedicated epic section.
+- Notifications, reminders, or epic activity feeds.
 
 ## Acceptance Criteria
-- New tasks persist creator and updater metadata automatically.
-- Tasks can store an optional assignee and reject non-collaborator assignees.
-- Task update flows keep updater metadata current.
-- Comment and attachment task activity updates the task attribution trail.
-- The kanban board can render assignee identity with the avatar baseline.
-- The task detail modal shows assignee, created-by, and modified-by metadata.
-- Task create/edit flows allow selecting or clearing an assignee.
-- Task API and agent docs stay aligned with the new payload shape.
+- A project can create, list, update, and delete epics through the app and API.
+- Epic names are unique within a project and duplicate-name writes are rejected.
+- Each task can store zero or one linked epic from the same project.
+- Task create/edit flows can assign an epic or clear it back to no epic.
+- Task cards and task detail surfaces display the linked epic flag when present.
+- The project page includes a dedicated epic section showing all epics with:
+  - name
+  - description
+  - derived status
+  - linked-task count
+  - progress bar
+- Epic status is derived automatically using the locked product rules in this
+  brief and is never manually edited.
+- Epic deletion leaves tasks intact and clears their epic link.
+- API and agent docs stay aligned with the new epic-aware contracts.
 - Required tracking docs are updated consistently in the same PR.
 
 ## Definition Of Done
-1. `TASK-101` is the active brief in `tasks/current.md`.
-2. Schema, services, routes, and UI all support task assignee + provenance end
-   to end.
+1. `TASK-107` is the active brief in `tasks/current.md`.
+2. Schema, services, routes, task flows, and the new project epic section all
+   support epics end to end.
 3. Relevant validation is green:
    - `npm run lint`
    - `npm test`
@@ -100,15 +160,14 @@ API contracts, and UI all aligned around the same provenance source of truth.
    - `npm run build`
    - preview validation once the branch is published
 4. Tracking docs are updated consistently (`tasks/current.md`, `journal.md`,
-   and `adr/decisions.md` only if an architecture-level decision is introduced).
-5. The task ships through its own dedicated PR with the normal review and
-   preview workflow handled before handoff.
+   and `adr/decisions.md` only if an architecture-level decision is
+   introduced).
+5. The task ships through its own dedicated branch and PR with the normal
+   review and preview workflow handled before handoff.
 
 ## Dependencies
-- `TASK-058`
-- `TASK-076`
 - `TASK-079`
-- `TASK-089`
+- `TASK-095`
 
 ## Evidence Plan
 - Repo source of truth:
@@ -117,25 +176,28 @@ API contracts, and UI all aligned around the same provenance source of truth.
   - `prisma/schema.prisma`
   - `lib/services/project-service.ts`
   - `lib/services/project-task-service.ts`
-  - `lib/services/project-task-comment-service.ts`
-  - `lib/services/project-attachment-service.ts`
-  - `app/api/projects/[projectId]/tasks/**`
+  - `app/api/projects/[projectId]/**`
+  - `app/projects/[projectId]/page.tsx`
   - `app/projects/[projectId]/kanban-board-section.tsx`
   - `components/kanban-board.tsx`
   - `components/kanban/task-detail-modal.tsx`
   - `components/create-task-dialog.tsx`
+  - new epic section/components introduced by this task
+  - `lib/agent-onboarding.ts`
 - Validation source of truth:
   - local lint/unit/build runs
   - PR review comments and CI checks
   - preview deployment verification
 
 ## Outcome Target
-- NexusDash gains explicit task ownership and provenance instead of relying on
-  chat context or naming conventions.
-- The avatar baseline from `TASK-089` becomes visible where ownership actually
-  matters: assignee, creator, and last modifier.
+- NexusDash gains a clear planning layer above tasks without turning epics into
+  confusing pseudo-work items.
+- Users can understand project initiatives at a glance through a visible epic
+  section, while still linking day-to-day tasks to one clear execution context.
+- The task model stays simple: tasks remain tasks, epics remain project-scoped
+  planning flags with richer meaning.
 
 ---
 
-Last Updated: 2026-04-21
+Last Updated: 2026-04-22
 Assigned To: Agent

--- a/tests/api/agent-openapi.route.test.ts
+++ b/tests/api/agent-openapi.route.test.ts
@@ -48,6 +48,8 @@ describe("GET /api/docs/agent/v1/openapi.json", () => {
     });
     expect(servers?.[0]?.url).toBe("https://preview.nexusdash.test");
     expect(paths).toHaveProperty("/api/auth/agent/token");
+    expect(paths).toHaveProperty("/api/projects/{projectId}/epics");
+    expect(paths).toHaveProperty("/api/projects/{projectId}/epics/{epicId}");
     expect(paths).toHaveProperty("/api/projects/{projectId}/tasks");
     expect(paths).toHaveProperty("/api/projects/{projectId}/tasks/{taskId}/comments");
     expect(paths).toHaveProperty(
@@ -65,6 +67,8 @@ describe("GET /api/docs/agent/v1/openapi.json", () => {
       { AgentApiKeyHeader: [] },
     ]);
     expect(JSON.stringify(payload)).toContain("deadlineDate");
+    expect(JSON.stringify(payload)).toContain("epicId");
+    expect(JSON.stringify(payload)).toContain("progressPercent");
     expect(JSON.stringify(payload)).toContain("commentCount");
     expect(resolveRequestOriginFromHeadersMock).toHaveBeenCalledWith(expect.any(Headers));
   });

--- a/tests/api/agent-project-routes.test.ts
+++ b/tests/api/agent-project-routes.test.ts
@@ -77,6 +77,10 @@ async function readJson(response: Response): Promise<Record<string, unknown>> {
   return (await response.json()) as Record<string, unknown>;
 }
 
+function projectRouteParams(projectId: string) {
+  return { params: Promise.resolve({ projectId }) };
+}
+
 describe("agent project routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -118,7 +122,7 @@ describe("agent project routes", () => {
 
     const response = await getProject(
       new Request("http://localhost/api/projects/project-1") as never,
-      { params: { projectId: "project-1" } }
+      projectRouteParams("project-1")
     );
 
     expect(response.status).toBe(200);
@@ -164,7 +168,7 @@ describe("agent project routes", () => {
 
     const response = await getProject(
       new Request("http://localhost/api/projects/project-2") as never,
-      { params: { projectId: "project-2" } }
+      projectRouteParams("project-2")
     );
 
     expect(response.status).toBe(404);
@@ -193,6 +197,7 @@ describe("agent project routes", () => {
         labelsJson: '["docs"]',
         createdAt: "2026-04-03T09:00:00.000Z",
         updatedAt: "2026-04-03T10:00:00.000Z",
+        epic: null,
         createdByUser: {
           id: "user-1",
           name: "Alice Example",
@@ -235,7 +240,7 @@ describe("agent project routes", () => {
 
     const response = await getTasks(
       new Request("http://localhost/api/projects/project-1/tasks") as never,
-      { params: { projectId: "project-1" } }
+      projectRouteParams("project-1")
     );
 
     expect(response.status).toBe(200);
@@ -256,6 +261,7 @@ describe("agent project routes", () => {
           labelsJson: '["docs"]',
           createdAt: "2026-04-03T09:00:00.000Z",
           updatedAt: "2026-04-03T10:00:00.000Z",
+          epic: null,
           createdBy: {
             id: "user-1",
             displayName: "alice",
@@ -302,7 +308,7 @@ describe("agent project routes", () => {
 
     const response = await getTasks(
       new Request("http://localhost/api/projects/project-1/tasks") as never,
-      { params: { projectId: "project-1" } }
+      projectRouteParams("project-1")
     );
 
     expect(response.status).toBe(403);
@@ -344,7 +350,7 @@ describe("agent project routes", () => {
 
     const response = await getContextCards(
       new Request("http://localhost/api/projects/project-1/context-cards") as never,
-      { params: { projectId: "project-1" } }
+      projectRouteParams("project-1")
     );
 
     expect(response.status).toBe(200);

--- a/tests/api/project-epics.route.test.ts
+++ b/tests/api/project-epics.route.test.ts
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const apiGuardMock = vi.hoisted(() => ({
+  getAgentProjectAccessContext: vi.fn(),
+  requireApiPrincipal: vi.fn(),
+}));
+
+const projectEpicServiceMock = vi.hoisted(() => ({
+  listProjectEpics: vi.fn(),
+  createProjectEpic: vi.fn(),
+  updateProjectEpic: vi.fn(),
+  deleteProjectEpic: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/api-guard", () => ({
+  getAgentProjectAccessContext: apiGuardMock.getAgentProjectAccessContext,
+  requireApiPrincipal: apiGuardMock.requireApiPrincipal,
+}));
+
+vi.mock("@/lib/services/project-epic-service", () => ({
+  listProjectEpics: projectEpicServiceMock.listProjectEpics,
+  createProjectEpic: projectEpicServiceMock.createProjectEpic,
+  updateProjectEpic: projectEpicServiceMock.updateProjectEpic,
+  deleteProjectEpic: projectEpicServiceMock.deleteProjectEpic,
+}));
+
+import {
+  GET as getEpics,
+  POST as createEpic,
+} from "@/app/api/projects/[projectId]/epics/route";
+import {
+  DELETE as deleteEpic,
+  PATCH as updateEpic,
+} from "@/app/api/projects/[projectId]/epics/[epicId]/route";
+
+async function readJson(response: Response): Promise<Record<string, unknown>> {
+  return (await response.json()) as Record<string, unknown>;
+}
+
+function projectParams(projectId: string) {
+  return { params: Promise.resolve({ projectId }) };
+}
+
+function epicParams(projectId: string, epicId: string) {
+  return { params: Promise.resolve({ projectId, epicId }) };
+}
+
+describe("project epic routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiGuardMock.requireApiPrincipal.mockResolvedValue({
+      ok: true,
+      principal: {
+        kind: "human",
+        actorUserId: "user-1",
+        requestId: "request-1",
+      },
+    });
+    apiGuardMock.getAgentProjectAccessContext.mockReturnValue(undefined);
+  });
+
+  test("GET /api/projects/:projectId/epics returns serialized epic data", async () => {
+    projectEpicServiceMock.listProjectEpics.mockResolvedValueOnce([
+      {
+        id: "epic-1",
+        name: "Workspace launch",
+        description: "Deliver the first launch slice.",
+        status: "In progress",
+        progressPercent: 50,
+        taskCount: 4,
+        completedTaskCount: 2,
+        linkedTasks: [
+          {
+            id: "task-1",
+            title: "Ship hero",
+            status: "Done",
+            archivedAt: null,
+          },
+        ],
+        createdAt: new Date("2026-04-20T08:00:00.000Z"),
+        updatedAt: new Date("2026-04-21T09:00:00.000Z"),
+      },
+    ]);
+
+    const response = await getEpics(
+      new Request("http://localhost/api/projects/p1/epics") as never,
+      projectParams("p1")
+    );
+
+    expect(response.status).toBe(200);
+    await expect(readJson(response)).resolves.toEqual({
+      epics: [
+        {
+          id: "epic-1",
+          name: "Workspace launch",
+          description: "Deliver the first launch slice.",
+          status: "In progress",
+          progressPercent: 50,
+          taskCount: 4,
+          completedTaskCount: 2,
+          linkedTasks: [
+            {
+              id: "task-1",
+              title: "Ship hero",
+              status: "Done",
+              archivedAt: null,
+            },
+          ],
+          createdAt: "2026-04-20T08:00:00.000Z",
+          updatedAt: "2026-04-21T09:00:00.000Z",
+        },
+      ],
+    });
+    expect(projectEpicServiceMock.listProjectEpics).toHaveBeenCalledWith(
+      "p1",
+      "user-1",
+      undefined
+    );
+  });
+
+  test("POST /api/projects/:projectId/epics returns 400 for invalid json", async () => {
+    const response = await createEpic(
+      new Request("http://localhost/api/projects/p1/epics", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: "{",
+      }) as never,
+      projectParams("p1")
+    );
+
+    expect(response.status).toBe(400);
+    await expect(readJson(response)).resolves.toEqual({
+      error: "invalid-json",
+    });
+    expect(projectEpicServiceMock.createProjectEpic).not.toHaveBeenCalled();
+  });
+
+  test("POST /api/projects/:projectId/epics creates an epic", async () => {
+    projectEpicServiceMock.createProjectEpic.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        epic: {
+          id: "epic-1",
+          name: "Workspace launch",
+          description: "Deliver the first launch slice.",
+          status: "Ready",
+          progressPercent: 0,
+          taskCount: 0,
+          completedTaskCount: 0,
+          linkedTasks: [],
+          createdAt: new Date("2026-04-20T08:00:00.000Z"),
+          updatedAt: new Date("2026-04-20T08:00:00.000Z"),
+        },
+      },
+    });
+
+    const response = await createEpic(
+      new Request("http://localhost/api/projects/p1/epics", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          name: "Workspace launch",
+          description: "Deliver the first launch slice.",
+        }),
+      }) as never,
+      projectParams("p1")
+    );
+
+    expect(response.status).toBe(201);
+    await expect(readJson(response)).resolves.toEqual({
+      epic: {
+        id: "epic-1",
+        name: "Workspace launch",
+        description: "Deliver the first launch slice.",
+        status: "Ready",
+        progressPercent: 0,
+        taskCount: 0,
+        completedTaskCount: 0,
+        linkedTasks: [],
+        createdAt: "2026-04-20T08:00:00.000Z",
+        updatedAt: "2026-04-20T08:00:00.000Z",
+      },
+    });
+    expect(projectEpicServiceMock.createProjectEpic).toHaveBeenCalledWith({
+      actorUserId: "user-1",
+      projectId: "p1",
+      name: "Workspace launch",
+      description: "Deliver the first launch slice.",
+      agentAccess: undefined,
+    });
+  });
+
+  test("PATCH /api/projects/:projectId/epics/:epicId updates an epic", async () => {
+    projectEpicServiceMock.updateProjectEpic.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        epic: {
+          id: "epic-1",
+          name: "Workspace launch",
+          description: "Refined description.",
+          status: "In progress",
+          progressPercent: 25,
+          taskCount: 4,
+          completedTaskCount: 1,
+          linkedTasks: [],
+          createdAt: new Date("2026-04-20T08:00:00.000Z"),
+          updatedAt: new Date("2026-04-22T10:00:00.000Z"),
+        },
+      },
+    });
+
+    const response = await updateEpic(
+      new Request("http://localhost/api/projects/p1/epics/epic-1", {
+        method: "PATCH",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          name: "Workspace launch",
+          description: "Refined description.",
+        }),
+      }) as never,
+      epicParams("p1", "epic-1")
+    );
+
+    expect(response.status).toBe(200);
+    await expect(readJson(response)).resolves.toEqual({
+      epic: {
+        id: "epic-1",
+        name: "Workspace launch",
+        description: "Refined description.",
+        status: "In progress",
+        progressPercent: 25,
+        taskCount: 4,
+        completedTaskCount: 1,
+        linkedTasks: [],
+        createdAt: "2026-04-20T08:00:00.000Z",
+        updatedAt: "2026-04-22T10:00:00.000Z",
+      },
+    });
+  });
+
+  test("DELETE /api/projects/:projectId/epics/:epicId deletes an epic", async () => {
+    projectEpicServiceMock.deleteProjectEpic.mockResolvedValueOnce({
+      ok: true,
+      data: { ok: true },
+    });
+
+    const response = await deleteEpic(
+      new Request("http://localhost/api/projects/p1/epics/epic-1", {
+        method: "DELETE",
+      }) as never,
+      epicParams("p1", "epic-1")
+    );
+
+    expect(response.status).toBe(200);
+    await expect(readJson(response)).resolves.toEqual({ ok: true });
+    expect(projectEpicServiceMock.deleteProjectEpic).toHaveBeenCalledWith({
+      actorUserId: "user-1",
+      projectId: "p1",
+      epicId: "epic-1",
+      agentAccess: undefined,
+    });
+  });
+});

--- a/tests/api/task-create.route.test.ts
+++ b/tests/api/task-create.route.test.ts
@@ -42,6 +42,10 @@ async function readJson(response: Response): Promise<Record<string, unknown>> {
   return (await response.json()) as Record<string, unknown>;
 }
 
+function taskRouteParams(projectId: string) {
+  return { params: Promise.resolve({ projectId }) };
+}
+
 describe("POST /api/projects/:projectId/tasks", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -63,7 +67,7 @@ describe("POST /api/projects/:projectId/tasks", () => {
     });
 
     const response = await POST(request as never, {
-      params: { projectId: "" },
+      params: Promise.resolve({ projectId: "" }),
     });
 
     expect(response.status).toBe(400);
@@ -83,6 +87,7 @@ describe("POST /api/projects/:projectId/tasks", () => {
     formData.set("title", "  New Task  ");
     formData.set("description", "  Description  ");
     formData.set("deadlineDate", "2026-04-24");
+    formData.set("epicId", "epic-9");
     formData.set("assigneeUserId", "user-2");
     formData.set("labels", '["backend"]');
     formData.set("relatedTaskIds", '["task-a","task-b"]');
@@ -100,9 +105,7 @@ describe("POST /api/projects/:projectId/tasks", () => {
       body: formData,
     });
 
-    const response = await POST(request as never, {
-      params: { projectId: "p1" },
-    });
+    const response = await POST(request as never, taskRouteParams("p1"));
 
     expect(response.status).toBe(201);
     await expect(readJson(response)).resolves.toEqual({ taskId: "task-created" });
@@ -113,6 +116,7 @@ describe("POST /api/projects/:projectId/tasks", () => {
     expect(call.title).toBe("New Task");
     expect(call.description).toBe("Description");
     expect(call.deadlineDate).toBe("2026-04-24");
+    expect(call.epicId).toBe("epic-9");
     expect(call.assigneeUserId).toBe("user-2");
     expect(call.labelsJsonRaw).toBe('["backend"]');
     expect(call.relatedTaskIdsJsonRaw).toBe('["task-a","task-b"]');
@@ -139,6 +143,7 @@ describe("POST /api/projects/:projectId/tasks", () => {
         title: "  Draft API smoke test  ",
         description: "  <p>Validate the agent route.</p>  ",
         deadlineDate: "2026-04-25",
+        epicId: "epic-7",
         assigneeUserId: "user-2",
         labels: ["agent", "qa"],
         relatedTaskIds: ["task-a"],
@@ -146,9 +151,7 @@ describe("POST /api/projects/:projectId/tasks", () => {
       }),
     });
 
-    const response = await POST(request as never, {
-      params: { projectId: "p1" },
-    });
+    const response = await POST(request as never, taskRouteParams("p1"));
 
     expect(response.status).toBe(201);
     await expect(readJson(response)).resolves.toEqual({ taskId: "task-json" });
@@ -158,6 +161,7 @@ describe("POST /api/projects/:projectId/tasks", () => {
       title: "Draft API smoke test",
       description: "<p>Validate the agent route.</p>",
       deadlineDate: "2026-04-25",
+      epicId: "epic-7",
       assigneeUserId: "user-2",
       labelsJsonRaw: '["agent","qa"]',
       relatedTaskIdsJsonRaw: '["task-a"]',
@@ -180,13 +184,32 @@ describe("POST /api/projects/:projectId/tasks", () => {
       }),
     });
 
-    const response = await POST(request as never, {
-      params: { projectId: "p1" },
-    });
+    const response = await POST(request as never, taskRouteParams("p1"));
 
     expect(response.status).toBe(400);
     await expect(readJson(response)).resolves.toEqual({
       error: "deadline-invalid",
+    });
+    expect(projectTaskServiceMock.createTaskForProject).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 when json epicId is not a string", async () => {
+    const request = new Request("http://localhost/api/projects/p1/tasks", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        title: "Draft API smoke test",
+        epicId: 123,
+      }),
+    });
+
+    const response = await POST(request as never, taskRouteParams("p1"));
+
+    expect(response.status).toBe(400);
+    await expect(readJson(response)).resolves.toEqual({
+      error: "epic-invalid",
     });
     expect(projectTaskServiceMock.createTaskForProject).not.toHaveBeenCalled();
   });
@@ -203,9 +226,7 @@ describe("POST /api/projects/:projectId/tasks", () => {
       }),
     });
 
-    const response = await POST(request as never, {
-      params: { projectId: "p1" },
-    });
+    const response = await POST(request as never, taskRouteParams("p1"));
 
     expect(response.status).toBe(400);
     await expect(readJson(response)).resolves.toEqual({
@@ -229,9 +250,7 @@ describe("POST /api/projects/:projectId/tasks", () => {
       body: formData,
     });
 
-    const response = await POST(request as never, {
-      params: { projectId: "p1" },
-    });
+    const response = await POST(request as never, taskRouteParams("p1"));
 
     expect(response.status).toBe(400);
     await expect(readJson(response)).resolves.toEqual({
@@ -271,9 +290,7 @@ describe("POST /api/projects/:projectId/tasks", () => {
       body: formData,
     });
 
-    const response = await POST(request as never, {
-      params: { projectId: "p1" },
-    });
+    const response = await POST(request as never, taskRouteParams("p1"));
 
     expect(response.status).toBe(400);
     await expect(readJson(response)).resolves.toEqual({
@@ -291,9 +308,7 @@ describe("POST /api/projects/:projectId/tasks", () => {
       body: "{",
     });
 
-    const response = await POST(request as never, {
-      params: { projectId: "p1" },
-    });
+    const response = await POST(request as never, taskRouteParams("p1"));
 
     expect(response.status).toBe(400);
     await expect(readJson(response)).resolves.toEqual({

--- a/tests/api/task-update.route.test.ts
+++ b/tests/api/task-update.route.test.ts
@@ -475,6 +475,181 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
     });
   });
 
+  test("preserves untouched fields during epic-only quick updates", async () => {
+    prismaMock.task.findUnique.mockResolvedValueOnce({
+      id: "t1",
+      projectId: "p1",
+      status: "In Progress",
+      position: 2,
+      archivedAt: null,
+      epicId: null,
+      assigneeUserId: null,
+      outgoingRelations: [
+        {
+          rightTaskId: "t2",
+        },
+      ],
+      incomingRelations: [],
+    });
+    prismaMock.epic.findFirst.mockResolvedValueOnce({ id: "epic-1" });
+    prismaMock.task.findUnique.mockResolvedValueOnce({
+      id: "t1",
+      title: "Keep title",
+      label: "ship",
+      labelsJson: JSON.stringify(["ship"]),
+      description: "<p>Keep description</p>",
+      deadlineAt: new Date("2026-04-24T00:00:00.000Z"),
+      _count: {
+        comments: 1,
+      },
+      blockedNote: null,
+      status: "In Progress",
+      position: 2,
+      archivedAt: null,
+      epic: {
+        id: "epic-1",
+        name: "Workspace launch",
+      },
+      createdAt: new Date("2026-04-18T08:00:00.000Z"),
+      updatedAt: new Date("2026-04-18T09:00:00.000Z"),
+      createdByUser: {
+        id: "user-1",
+        name: "Alice Example",
+        email: "alice@example.com",
+        username: "alice",
+        usernameDiscriminator: "1234",
+        avatarSeed: null,
+      },
+      updatedByUser: {
+        id: "test-user",
+        name: "Reviewer",
+        email: "reviewer@example.com",
+        username: "reviewer",
+        usernameDiscriminator: "0007",
+        avatarSeed: null,
+      },
+      assigneeUser: null,
+      outgoingRelations: [
+        {
+          rightTask: {
+            id: "t2",
+            title: "Sibling task",
+            status: "Backlog",
+            archivedAt: null,
+          },
+        },
+      ],
+      incomingRelations: [],
+      blockedFollowUps: [],
+    });
+
+    const request = new Request("http://localhost/api/projects/p1/tasks/t1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        epicId: "epic-1",
+      }),
+    });
+
+    const response = await PATCH(request as never, taskRouteParams("p1", "t1"));
+
+    expect(response.status).toBe(200);
+    const updateCall = prismaMock.task.update.mock.calls.at(-1)?.[0];
+    expect(updateCall?.data).toMatchObject({
+      epicId: "epic-1",
+      updatedByUserId: "test-user",
+    });
+    expect(updateCall?.data).not.toHaveProperty("title");
+    expect(updateCall?.data).not.toHaveProperty("label");
+    expect(updateCall?.data).not.toHaveProperty("labelsJson");
+    expect(updateCall?.data).not.toHaveProperty("description");
+    expect(prismaMock.taskRelation.deleteMany).not.toHaveBeenCalled();
+  });
+
+  test("preserves untouched fields during assignee-only quick updates", async () => {
+    prismaMock.task.findUnique.mockResolvedValueOnce({
+      id: "t1",
+      projectId: "p1",
+      status: "In Progress",
+      position: 2,
+      archivedAt: null,
+      epicId: "epic-1",
+      assigneeUserId: null,
+      outgoingRelations: [],
+      incomingRelations: [],
+    });
+    prismaMock.task.findUnique.mockResolvedValueOnce({
+      id: "t1",
+      title: "Keep title",
+      label: "ship",
+      labelsJson: JSON.stringify(["ship"]),
+      description: "<p>Keep description</p>",
+      deadlineAt: null,
+      _count: {
+        comments: 0,
+      },
+      blockedNote: null,
+      status: "In Progress",
+      position: 2,
+      archivedAt: null,
+      epic: {
+        id: "epic-1",
+        name: "Workspace launch",
+      },
+      createdAt: new Date("2026-04-18T08:00:00.000Z"),
+      updatedAt: new Date("2026-04-18T09:00:00.000Z"),
+      createdByUser: {
+        id: "user-1",
+        name: "Alice Example",
+        email: "alice@example.com",
+        username: "alice",
+        usernameDiscriminator: "1234",
+        avatarSeed: null,
+      },
+      updatedByUser: {
+        id: "test-user",
+        name: "Reviewer",
+        email: "reviewer@example.com",
+        username: "reviewer",
+        usernameDiscriminator: "0007",
+        avatarSeed: null,
+      },
+      assigneeUser: {
+        id: "user-2",
+        name: "Bob Example",
+        email: "bob@example.com",
+        username: "bob",
+        usernameDiscriminator: "2222",
+        avatarSeed: null,
+      },
+      outgoingRelations: [],
+      incomingRelations: [],
+      blockedFollowUps: [],
+    });
+
+    const request = new Request("http://localhost/api/projects/p1/tasks/t1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        assigneeUserId: "user-2",
+      }),
+    });
+
+    const response = await PATCH(request as never, taskRouteParams("p1", "t1"));
+
+    expect(response.status).toBe(200);
+    const updateCall = prismaMock.task.update.mock.calls.at(-1)?.[0];
+    expect(updateCall?.data).toMatchObject({
+      assigneeUserId: "user-2",
+      updatedByUserId: "test-user",
+    });
+    expect(updateCall?.data).not.toHaveProperty("title");
+    expect(updateCall?.data).not.toHaveProperty("label");
+    expect(updateCall?.data).not.toHaveProperty("labelsJson");
+    expect(updateCall?.data).not.toHaveProperty("description");
+    expect(prismaMock.taskRelation.deleteMany).not.toHaveBeenCalled();
+  });
+
   test("returns 400 when related tasks are invalid", async () => {
     prismaMock.task.findUnique.mockResolvedValueOnce({
       id: "t1",

--- a/tests/api/task-update.route.test.ts
+++ b/tests/api/task-update.route.test.ts
@@ -10,6 +10,9 @@ const prismaMock = vi.hoisted(() => ({
     update: vi.fn(),
     delete: vi.fn(),
   },
+  epic: {
+    findFirst: vi.fn(),
+  },
   taskRelation: {
     deleteMany: vi.fn(),
     createMany: vi.fn(),
@@ -41,6 +44,10 @@ async function readJson(response: Response): Promise<Record<string, unknown>> {
   return (await response.json()) as Record<string, unknown>;
 }
 
+function taskRouteParams(projectId: string, taskId: string) {
+  return { params: Promise.resolve({ projectId, taskId }) };
+}
+
 describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -61,9 +68,7 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       body: "{",
     });
 
-    const response = await PATCH(request as never, {
-      params: { projectId: "p1", taskId: "t1" },
-    });
+    const response = await PATCH(request as never, taskRouteParams("p1", "t1"));
 
     expect(response.status).toBe(400);
     await expect(readJson(response)).resolves.toEqual({
@@ -80,9 +85,7 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       }),
     });
 
-    const response = await PATCH(request as never, {
-      params: { projectId: "p1", taskId: "t1" },
-    });
+    const response = await PATCH(request as never, taskRouteParams("p1", "t1"));
 
     expect(response.status).toBe(400);
     await expect(readJson(response)).resolves.toEqual({
@@ -101,9 +104,7 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       }),
     });
 
-    const response = await PATCH(request as never, {
-      params: { projectId: "p1", taskId: "t1" },
-    });
+    const response = await PATCH(request as never, taskRouteParams("p1", "t1"));
 
     expect(response.status).toBe(400);
     await expect(readJson(response)).resolves.toEqual({
@@ -123,9 +124,7 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       }),
     });
 
-    const response = await PATCH(request as never, {
-      params: { projectId: "p1", taskId: "t1" },
-    });
+    const response = await PATCH(request as never, taskRouteParams("p1", "t1"));
 
     expect(response.status).toBe(404);
     await expect(readJson(response)).resolves.toEqual({ error: "Task not found" });
@@ -210,9 +209,7 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       }),
     });
 
-    const response = await PATCH(request as never, {
-      params: { projectId: "p1", taskId: "t1" },
-    });
+    const response = await PATCH(request as never, taskRouteParams("p1", "t1"));
 
     expect(response.status).toBe(200);
     await expect(readJson(response)).resolves.toEqual({
@@ -228,6 +225,7 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
         status: "Blocked",
         position: 0,
         archivedAt: null,
+        epic: null,
         assignee: {
           id: "user-2",
           displayName: "Bob Example",
@@ -356,12 +354,125 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       }),
     });
 
-    const response = await PATCH(request as never, {
-      params: { projectId: "p1", taskId: "t1" },
-    });
+    const response = await PATCH(request as never, taskRouteParams("p1", "t1"));
 
     expect(response.status).toBe(200);
     expect(prismaMock.taskBlockedFollowUp.create).not.toHaveBeenCalled();
+  });
+
+  test("updates the linked epic when epicId is provided", async () => {
+    prismaMock.task.findUnique.mockResolvedValueOnce({
+      id: "t1",
+      projectId: "p1",
+      status: "In Progress",
+      position: 2,
+      archivedAt: null,
+      epicId: null,
+      assigneeUserId: null,
+      outgoingRelations: [],
+      incomingRelations: [],
+    });
+    prismaMock.epic.findFirst.mockResolvedValueOnce({ id: "epic-1" });
+    prismaMock.task.findUnique.mockResolvedValueOnce({
+      id: "t1",
+      title: "Updated",
+      label: null,
+      labelsJson: null,
+      description: null,
+      deadlineAt: null,
+      _count: {
+        comments: 0,
+      },
+      blockedNote: null,
+      status: "In Progress",
+      position: 2,
+      archivedAt: null,
+      epic: {
+        id: "epic-1",
+        name: "Workspace launch",
+      },
+      createdAt: new Date("2026-04-18T08:00:00.000Z"),
+      updatedAt: new Date("2026-04-18T09:00:00.000Z"),
+      createdByUser: {
+        id: "user-1",
+        name: "Alice Example",
+        email: "alice@example.com",
+        username: "alice",
+        usernameDiscriminator: "1234",
+        avatarSeed: null,
+      },
+      updatedByUser: {
+        id: "test-user",
+        name: "Reviewer",
+        email: "reviewer@example.com",
+        username: "reviewer",
+        usernameDiscriminator: "0007",
+        avatarSeed: null,
+      },
+      assigneeUser: null,
+      outgoingRelations: [],
+      incomingRelations: [],
+      blockedFollowUps: [],
+    });
+
+    const request = new Request("http://localhost/api/projects/p1/tasks/t1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Updated",
+        epicId: "epic-1",
+        relatedTaskIds: [],
+      }),
+    });
+
+    const response = await PATCH(request as never, taskRouteParams("p1", "t1"));
+
+    expect(response.status).toBe(200);
+    await expect(readJson(response)).resolves.toEqual({
+      task: {
+        id: "t1",
+        title: "Updated",
+        label: null,
+        labelsJson: null,
+        description: null,
+        deadlineDate: null,
+        commentCount: 0,
+        blockedNote: null,
+        status: "In Progress",
+        position: 2,
+        archivedAt: null,
+        epic: {
+          id: "epic-1",
+          name: "Workspace launch",
+        },
+        assignee: null,
+        createdBy: {
+          id: "user-1",
+          displayName: "alice",
+          usernameTag: "alice#1234",
+          avatarSeed: "user-1",
+        },
+        updatedBy: {
+          id: "test-user",
+          displayName: "reviewer",
+          usernameTag: "reviewer#0007",
+          avatarSeed: "test-user",
+        },
+        createdAt: "2026-04-18T08:00:00.000Z",
+        updatedAt: "2026-04-18T09:00:00.000Z",
+        relatedTasks: [],
+        blockedFollowUps: [],
+      },
+    });
+
+    expect(prismaMock.task.update).toHaveBeenCalledWith({
+      where: { id: "t1" },
+      data: expect.objectContaining({
+        title: "Updated",
+        epicId: "epic-1",
+        updatedByUserId: "test-user",
+      }),
+    });
   });
 
   test("returns 400 when related tasks are invalid", async () => {
@@ -390,9 +501,7 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       }),
     });
 
-    const response = await PATCH(request as never, {
-      params: { projectId: "p1", taskId: "t1" },
-    });
+    const response = await PATCH(request as never, taskRouteParams("p1", "t1"));
 
     expect(response.status).toBe(400);
     await expect(readJson(response)).resolves.toEqual({
@@ -473,9 +582,7 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       }),
     });
 
-    const response = await PATCH(request as never, {
-      params: { projectId: "p1", taskId: "t1" },
-    });
+    const response = await PATCH(request as never, taskRouteParams("p1", "t1"));
 
     expect(response.status).toBe(200);
     await expect(readJson(response)).resolves.toEqual({
@@ -491,6 +598,7 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
         status: "In Progress",
         position: 2,
         archivedAt: null,
+        epic: null,
         assignee: null,
         createdBy: {
           id: "user-1",
@@ -530,9 +638,7 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
       }),
     });
 
-    const response = await PATCH(request as never, {
-      params: { projectId: "p1", taskId: "t1" },
-    });
+    const response = await PATCH(request as never, taskRouteParams("p1", "t1"));
 
     expect(response.status).toBe(500);
     await expect(readJson(response)).resolves.toEqual({
@@ -558,9 +664,7 @@ describe("DELETE /api/projects/:projectId/tasks/:taskId", () => {
       method: "DELETE",
     });
 
-    const response = await DELETE(request as never, {
-      params: { projectId: "p1", taskId: "t1" },
-    });
+    const response = await DELETE(request as never, taskRouteParams("p1", "t1"));
 
     expect(response.status).toBe(404);
     await expect(readJson(response)).resolves.toEqual({ error: "Task not found" });
@@ -578,9 +682,7 @@ describe("DELETE /api/projects/:projectId/tasks/:taskId", () => {
       method: "DELETE",
     });
 
-    const response = await DELETE(request as never, {
-      params: { projectId: "p1", taskId: "t1" },
-    });
+    const response = await DELETE(request as never, taskRouteParams("p1", "t1"));
 
     expect(response.status).toBe(200);
     await expect(readJson(response)).resolves.toEqual({ ok: true });
@@ -605,9 +707,7 @@ describe("DELETE /api/projects/:projectId/tasks/:taskId", () => {
       method: "DELETE",
     });
 
-    const response = await DELETE(request as never, {
-      params: { projectId: "p1", taskId: "t1" },
-    });
+    const response = await DELETE(request as never, taskRouteParams("p1", "t1"));
 
     expect(response.status).toBe(500);
     await expect(readJson(response)).resolves.toEqual({
@@ -630,9 +730,7 @@ describe("DELETE /api/projects/:projectId/tasks/:taskId", () => {
       method: "DELETE",
     });
 
-    const response = await DELETE(request as never, {
-      params: { projectId: "p1", taskId: "t1" },
-    });
+    const response = await DELETE(request as never, taskRouteParams("p1", "t1"));
 
     expect(response.status).toBe(404);
     await expect(readJson(response)).resolves.toEqual({
@@ -665,9 +763,7 @@ describe("POST /api/projects/:projectId/tasks/:taskId/archive", () => {
       method: "POST",
     });
 
-    const response = await archiveTask(request as never, {
-      params: { projectId: "p1", taskId: "t1" },
-    });
+    const response = await archiveTask(request as never, taskRouteParams("p1", "t1"));
 
     expect(response.status).toBe(200);
     await expect(readJson(response)).resolves.toEqual({
@@ -698,9 +794,7 @@ describe("POST /api/projects/:projectId/tasks/:taskId/archive", () => {
       method: "POST",
     });
 
-    const response = await archiveTask(request as never, {
-      params: { projectId: "p1", taskId: "t1" },
-    });
+    const response = await archiveTask(request as never, taskRouteParams("p1", "t1"));
 
     expect(response.status).toBe(400);
     await expect(readJson(response)).resolves.toEqual({
@@ -721,9 +815,7 @@ describe("POST /api/projects/:projectId/tasks/:taskId/archive", () => {
       method: "POST",
     });
 
-    const response = await archiveTask(request as never, {
-      params: { projectId: "p1", taskId: "t1" },
-    });
+    const response = await archiveTask(request as never, taskRouteParams("p1", "t1"));
 
     expect(response.status).toBe(200);
     await expect(readJson(response)).resolves.toEqual({
@@ -758,9 +850,7 @@ describe("DELETE /api/projects/:projectId/tasks/:taskId/archive", () => {
       method: "DELETE",
     });
 
-    const response = await unarchiveTask(request as never, {
-      params: { projectId: "p1", taskId: "t1" },
-    });
+    const response = await unarchiveTask(request as never, taskRouteParams("p1", "t1"));
 
     expect(response.status).toBe(200);
     await expect(readJson(response)).resolves.toEqual({
@@ -790,9 +880,7 @@ describe("DELETE /api/projects/:projectId/tasks/:taskId/archive", () => {
       method: "DELETE",
     });
 
-    const response = await unarchiveTask(request as never, {
-      params: { projectId: "p1", taskId: "t1" },
-    });
+    const response = await unarchiveTask(request as never, taskRouteParams("p1", "t1"));
 
     expect(response.status).toBe(400);
     await expect(readJson(response)).resolves.toEqual({

--- a/tests/components/agent-onboarding-guide.test.ts
+++ b/tests/components/agent-onboarding-guide.test.ts
@@ -19,10 +19,12 @@ describe("agent-onboarding-guide", () => {
     expect(result).toContain("NEXUSDASH_AGENT_OPENAPI_URL=https://preview.nexusdash.test/api/docs/agent/v1/openapi.json");
     expect(result).toContain("Authentication flow");
     expect(result).toContain("Supported endpoints");
+    expect(result).toContain("/api/projects/{projectId}/epics");
     expect(result).toContain("/api/projects/{projectId}/tasks");
     expect(result).toContain("/api/projects/{projectId}/tasks/{taskId}/comments");
     expect(result).toContain("application/json");
     expect(result).toContain("deadlineDate");
+    expect(result).toContain("epicId");
     expect(result).toContain("Agent limitations");
     expect(result).toContain("/attachments/upload-url");
     expect(result).toContain("/context-cards/$CARD_ID/attachments/upload-url");

--- a/tests/components/project-epic-panel.test.tsx
+++ b/tests/components/project-epic-panel.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const routerRefreshMock = vi.hoisted(() => vi.fn());
+const pushToastMock = vi.hoisted(() => vi.fn());
+const setIsExpandedMock = vi.hoisted(() => vi.fn());
+const projectSectionExpandedMock = vi.hoisted(() => ({
+  isExpanded: false,
+  setIsExpanded: setIsExpandedMock,
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: routerRefreshMock,
+  }),
+}));
+
+vi.mock("@/components/toast-provider", () => ({
+  useToast: () => ({
+    pushToast: pushToastMock,
+  }),
+}));
+
+vi.mock("@/lib/hooks/use-project-section-expanded", () => ({
+  useProjectSectionExpanded: () => projectSectionExpandedMock,
+}));
+
+import { ProjectEpicPanel } from "@/components/project-epic-panel";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function createTestRenderer() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  return {
+    container,
+    root,
+  };
+}
+
+async function renderWithRoot(root: Root, ui: React.ReactElement) {
+  await act(async () => {
+    root.render(ui);
+  });
+}
+
+describe("project-epic-panel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    projectSectionExpandedMock.isExpanded = false;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("expands the section before opening the create flow", async () => {
+    const { container, root } = createTestRenderer();
+
+    await renderWithRoot(
+      root,
+      React.createElement(ProjectEpicPanel, {
+        projectId: "project-1",
+        canEdit: true,
+        epics: [],
+      })
+    );
+
+    const newEpicButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("New epic")
+    );
+
+    expect(newEpicButton).not.toBeUndefined();
+
+    await act(async () => {
+      newEpicButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(setIsExpandedMock).toHaveBeenCalledWith(true);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  test("keeps the header aligned with other section UIs by omitting the subtitle copy", async () => {
+    projectSectionExpandedMock.isExpanded = true;
+    const { container, root } = createTestRenderer();
+
+    await renderWithRoot(
+      root,
+      React.createElement(ProjectEpicPanel, {
+        projectId: "project-1",
+        canEdit: true,
+        epics: [],
+      })
+    );
+
+    expect(container.textContent).toContain("Epics");
+    expect(container.textContent).not.toContain(
+      "Higher-level initiatives with automatic state and progress."
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/tests/e2e/smoke-project-task-calendar.spec.ts
+++ b/tests/e2e/smoke-project-task-calendar.spec.ts
@@ -82,7 +82,7 @@ test.describe("critical UI smoke flows", () => {
     );
     await epicOptionButtons.nth(1).click();
     await quickEpicUpdateRequest;
-    await expect(page.getByText(epicName)).toBeVisible();
+    await expect(page.getByText(`Epic updated to ${epicName}.`)).toBeVisible();
 
     await page.getByRole("button", { name: "Task options" }).click();
     await page.getByRole("button", { name: /^Edit$/ }).click();

--- a/tests/e2e/smoke-project-task-calendar.spec.ts
+++ b/tests/e2e/smoke-project-task-calendar.spec.ts
@@ -60,7 +60,9 @@ test.describe("critical UI smoke flows", () => {
     await page.locator("input[placeholder='https://...']").press("Enter");
     await page.getByRole("button", { name: "Create task" }).click();
 
-    const createdTaskCard = page.locator("article").filter({ hasText: createdTaskTitle }).first();
+    const createdTaskCard = page
+      .getByRole("button", { name: new RegExp(createdTaskTitle) })
+      .first();
     await expect(createdTaskCard).toBeVisible();
 
     await createdTaskCard.click();
@@ -117,10 +119,13 @@ test.describe("critical UI smoke flows", () => {
     await expect(page.getByRole("button", { name: "Task options" })).toBeVisible();
     await page.getByRole("button", { name: "Close task" }).click();
 
-    const editedTaskCard = page.locator("article").filter({ hasText: editedTaskTitle }).first();
+    const editedTaskCard = page
+      .getByRole("button", { name: new RegExp(editedTaskTitle) })
+      .first();
     await expect(editedTaskCard).toBeVisible();
 
     await editedTaskCard.click();
+    await expect(page.getByRole("button", { name: "Close task" })).toBeVisible();
     await expect(page.getByText(taskComment)).toBeVisible();
     await page.getByRole("button", { name: "Close task" }).click();
   });

--- a/tests/e2e/smoke-project-task-calendar.spec.ts
+++ b/tests/e2e/smoke-project-task-calendar.spec.ts
@@ -68,14 +68,20 @@ test.describe("critical UI smoke flows", () => {
     await expect(page.getByText("example.com")).toBeVisible();
 
     await page.getByRole("button", { name: "Task options" }).click();
-    await page.getByRole("button", { name: "Epic options" }).click();
+    const epicOptionsButton = page.getByRole("button", { name: "Epic options" });
+    await epicOptionsButton.click();
+    const epicOptionsGroup = epicOptionsButton.locator(
+      "xpath=ancestor::div[contains(@class,'group relative')][1]"
+    );
+    const epicOptionButtons = epicOptionsGroup.locator("div.absolute button");
+    await expect(epicOptionButtons).toHaveCount(2);
     const quickEpicUpdateRequest = page.waitForResponse(
       (response) =>
         response.request().method() === "PATCH" &&
         /\/tasks\/[^/]+$/.test(response.url()) &&
         response.ok()
     );
-    await page.getByRole("button", { name: new RegExp(epicName) }).click();
+    await epicOptionButtons.nth(1).click();
     await quickEpicUpdateRequest;
     await expect(page.getByText(epicName)).toBeVisible();
 

--- a/tests/e2e/smoke-project-task-calendar.spec.ts
+++ b/tests/e2e/smoke-project-task-calendar.spec.ts
@@ -30,9 +30,23 @@ test.describe("critical UI smoke flows", () => {
     const createdTaskTitle = uniqueProjectName("task");
     const editedTaskTitle = `${createdTaskTitle}-edited`;
     const taskComment = `Comment ${uniqueProjectName("note")}`;
+    const epicName = uniqueProjectName("epic");
 
     await createProjectFromProjectsPage(page, projectName);
     await openNewestProjectDashboard(page, projectName);
+
+    const projectId = page.url().match(/\/projects\/([^/?#]+)/)?.[1];
+    expect(projectId).toBeTruthy();
+
+    const createEpicResponse = await page.request.post(`/api/projects/${projectId}/epics`, {
+      data: {
+        name: epicName,
+        description: "Smoke-test epic for quick assignment coverage.",
+      },
+    });
+    expect(createEpicResponse.ok()).toBeTruthy();
+    await page.reload();
+    await expect(page.getByRole("heading", { name: "Kanban board" })).toBeVisible();
 
     await page.getByRole("button", { name: "New task" }).click();
     await expect(page.locator("#task-title")).toBeVisible();
@@ -52,6 +66,18 @@ test.describe("critical UI smoke flows", () => {
     await createdTaskCard.click();
     await expect(page.getByRole("button", { name: "Task options" })).toBeVisible();
     await expect(page.getByText("example.com")).toBeVisible();
+
+    await page.getByRole("button", { name: "Task options" }).click();
+    await page.getByRole("button", { name: "Epic options" }).click();
+    const quickEpicUpdateRequest = page.waitForResponse(
+      (response) =>
+        response.request().method() === "PATCH" &&
+        /\/tasks\/[^/]+$/.test(response.url()) &&
+        response.ok()
+    );
+    await page.getByRole("button", { name: new RegExp(epicName) }).click();
+    await quickEpicUpdateRequest;
+    await expect(page.getByText(epicName)).toBeVisible();
 
     await page.getByRole("button", { name: "Task options" }).click();
     await page.getByRole("button", { name: /^Edit$/ }).click();

--- a/tests/e2e/smoke-project-task-calendar.spec.ts
+++ b/tests/e2e/smoke-project-task-calendar.spec.ts
@@ -70,10 +70,9 @@ test.describe("critical UI smoke flows", () => {
     await page.getByRole("button", { name: "Task options" }).click();
     const epicOptionsButton = page.getByRole("button", { name: "Epic options" });
     await epicOptionsButton.click();
-    const epicOptionsGroup = epicOptionsButton.locator(
-      "xpath=ancestor::div[contains(@class,'group relative')][1]"
-    );
-    const epicOptionButtons = epicOptionsGroup.locator("div.absolute button");
+    const epicOptionsGroup = page.locator("[data-task-options-submenu='epic']");
+    await expect(epicOptionsGroup).toBeVisible();
+    const epicOptionButtons = epicOptionsGroup.getByRole("button");
     await expect(epicOptionButtons).toHaveCount(2);
     const quickEpicUpdateRequest = page.waitForResponse(
       (response) =>

--- a/tests/lib/epic.test.ts
+++ b/tests/lib/epic.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "vitest";
+
+import { calculateEpicProgressPercent, deriveEpicStatus } from "@/lib/epic";
+
+describe("epic helpers", () => {
+  test("treats empty epics as ready with zero progress", () => {
+    expect(deriveEpicStatus([])).toBe("Ready");
+    expect(calculateEpicProgressPercent([])).toBe(0);
+  });
+
+  test("treats all backlog tasks as ready", () => {
+    expect(
+      deriveEpicStatus([
+        { status: "Backlog", archivedAt: null },
+        { status: "Backlog", archivedAt: null },
+      ])
+    ).toBe("Ready");
+  });
+
+  test("treats any in-progress or blocked task as in progress", () => {
+    expect(
+      deriveEpicStatus([
+        { status: "Backlog", archivedAt: null },
+        { status: "In Progress", archivedAt: null },
+      ])
+    ).toBe("In progress");
+
+    expect(
+      deriveEpicStatus([
+        { status: "Backlog", archivedAt: null },
+        { status: "Blocked", archivedAt: null },
+      ])
+    ).toBe("In progress");
+  });
+
+  test("treats mixed backlog and completed work as in progress", () => {
+    expect(
+      deriveEpicStatus([
+        { status: "Backlog", archivedAt: null },
+        { status: "Done", archivedAt: null },
+      ])
+    ).toBe("In progress");
+  });
+
+  test("treats done or archived tasks as completed", () => {
+    expect(
+      deriveEpicStatus([
+        { status: "Done", archivedAt: null },
+        { status: "Done", archivedAt: new Date("2026-04-20T08:00:00.000Z") },
+      ])
+    ).toBe("Completed");
+
+    expect(
+      calculateEpicProgressPercent([
+        { status: "Backlog", archivedAt: null },
+        { status: "Done", archivedAt: null },
+        { status: "Done", archivedAt: new Date("2026-04-20T08:00:00.000Z") },
+      ])
+    ).toBe(67);
+  });
+});

--- a/tests/lib/project-epic-service.test.ts
+++ b/tests/lib/project-epic-service.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const projectAccessServiceMock = vi.hoisted(() => ({
+  requireAgentProjectScopes: vi.fn(),
+  requireProjectRole: vi.fn(),
+}));
+
+const rlsContextMock = vi.hoisted(() => ({
+  withActorRlsContext: vi.fn(),
+}));
+
+const loggerMock = vi.hoisted(() => ({
+  logServerError: vi.fn(),
+}));
+
+const dbMock = vi.hoisted(() => ({
+  epic: {
+    findFirst: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/services/project-access-service", () => ({
+  requireAgentProjectScopes: projectAccessServiceMock.requireAgentProjectScopes,
+  requireProjectRole: projectAccessServiceMock.requireProjectRole,
+}));
+
+vi.mock("@/lib/services/rls-context", () => ({
+  withActorRlsContext: rlsContextMock.withActorRlsContext,
+}));
+
+vi.mock("@/lib/observability/logger", () => ({
+  logServerError: loggerMock.logServerError,
+}));
+
+import {
+  createProjectEpic,
+  updateProjectEpic,
+} from "@/lib/services/project-epic-service";
+
+describe("project-epic-service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    projectAccessServiceMock.requireAgentProjectScopes.mockReturnValue({ ok: true });
+    projectAccessServiceMock.requireProjectRole.mockResolvedValue({
+      ok: true,
+      role: "owner",
+    });
+    rlsContextMock.withActorRlsContext.mockImplementation(
+      async (_actorUserId: string, operation: (db: typeof dbMock) => unknown) =>
+        operation(dbMock)
+    );
+  });
+
+  test("maps concurrent create uniqueness failures to epic-name-conflict", async () => {
+    dbMock.epic.findFirst.mockResolvedValueOnce(null);
+    dbMock.epic.create.mockRejectedValueOnce({ code: "P2002" });
+
+    const result = await createProjectEpic({
+      actorUserId: "user-1",
+      projectId: "project-1",
+      name: "Launch workspace",
+      description: "Deliver the workspace launch slice.",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 400,
+      error: "epic-name-conflict",
+    });
+    expect(loggerMock.logServerError).not.toHaveBeenCalled();
+  });
+
+  test("maps concurrent update uniqueness failures to epic-name-conflict", async () => {
+    dbMock.epic.findFirst
+      .mockResolvedValueOnce({ id: "epic-1" })
+      .mockResolvedValueOnce(null);
+    dbMock.epic.update.mockRejectedValueOnce({ code: "P2002" });
+
+    const result = await updateProjectEpic({
+      actorUserId: "user-1",
+      projectId: "project-1",
+      epicId: "epic-1",
+      name: "Launch workspace",
+      description: "Refine the launch scope.",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 400,
+      error: "epic-name-conflict",
+    });
+    expect(loggerMock.logServerError).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/project-service.test.ts
+++ b/tests/lib/project-service.test.ts
@@ -315,6 +315,12 @@ describe("project-service", () => {
             avatarSeed: true,
           },
         },
+        epic: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
       },
     });
   });


### PR DESCRIPTION
## Summary
Adds first-class project epics as dedicated project-scoped entities instead of pseudo-tasks.

This PR:
- adds the `Epic` model, task-to-epic relation, migration, and project/task validation
- ships epic CRUD APIs plus epic-aware task create/update/read contracts
- adds a dedicated project epic section with automatic status, progress bars, and linked-task rollups
- surfaces epic assignment and epic badges across task create/edit/detail/card flows
- updates agent onboarding/OpenAPI docs and regression coverage for the new contracts

## Why
TASK-107 introduces a planning layer above tasks without confusing the kanban model. Tasks remain executable work items, while epics become visible project-level initiative flags with automatic status and progress.

## Validation
- `npm run lint`
- `npx -y -p node@20.19.0 node .\\node_modules\\vitest\\vitest.mjs run --pool=threads --maxWorkers=1 --no-file-parallelism`
- `npx -y -p node@20.19.0 node .\\node_modules\\vitest\\vitest.mjs run --coverage --pool=threads --maxWorkers=1 --no-file-parallelism`
- `npx -y -p node@20.19.0 node .\\node_modules\\next\\dist\\bin\\next build`
- `npx -y -p node@20.19.0 node .\\node_modules\\playwright\\cli.js test` currently fails locally before browser interaction because the required local PostgreSQL fixture service is unreachable on `127.0.0.1:5432`

## Notes
- Preview deployment will be triggered from `feature/task-107-epic-flags` through the repository Vercel workflow.
- Follow-up review/preview evidence will be added before handoff.