### PR TITLE
TASK-128: add task assignee quick action

### DIFF
--- a/components/kanban-board.tsx
+++ b/components/kanban-board.tsx
@@ -854,7 +854,14 @@ export function KanbanBoard({
           headers: {
             "Content-Type": "application/json",
           },
-          body: JSON.stringify(payload),
+          body: JSON.stringify({
+            title: selectedTask.title,
+            labels: selectedTask.labels,
+            description: selectedTask.description ?? "",
+            deadlineDate: selectedTask.deadlineDate ?? null,
+            relatedTaskIds: selectedTask.relatedTasks.map((task) => task.id),
+            ...payload,
+          }),
         });
 
         if (!response.ok) {

--- a/components/kanban-board.tsx
+++ b/components/kanban-board.tsx
@@ -1054,6 +1054,25 @@ export function KanbanBoard({
     [availableEpicOptions, patchSelectedTask]
   );
 
+  const handleQuickAssigneeUpdate = useCallback(
+    async (nextAssigneeUserId: string) => {
+      const nextAssigneeLabel =
+        availableAssignees.find((assignee) => assignee.id === nextAssigneeUserId)
+          ?.displayName ?? null;
+
+      await patchSelectedTask({
+        payload: {
+          assigneeUserId: nextAssigneeUserId || null,
+        },
+        successMessage: nextAssigneeLabel
+          ? `Assignee updated to ${nextAssigneeLabel}.`
+          : "Assignee cleared.",
+        fallbackErrorMessage: "Could not update assignee.",
+      });
+    },
+    [availableAssignees, patchSelectedTask]
+  );
+
   const handleTaskUpdate = useCallback(async () => {
     if (!selectedTask) {
       return;
@@ -1871,6 +1890,7 @@ export function KanbanBoard({
         onAddBlockedFollowUpEntry={handleAddBlockedFollowUpEntry}
         onSaveTask={handleTaskUpdate}
         onQuickEpicChange={handleQuickEpicUpdate}
+        onQuickAssigneeChange={handleQuickAssigneeUpdate}
         onToggleLinkComposer={() =>
           setIsLinkComposerOpen((previous) => !previous)
         }

--- a/components/kanban-board.tsx
+++ b/components/kanban-board.tsx
@@ -895,7 +895,14 @@ export function KanbanBoard({
           headers: {
             "Content-Type": "application/json",
           },
-          body: JSON.stringify(payload),
+          body: JSON.stringify({
+            title: selectedTask.title,
+            labels: selectedTask.labels,
+            description: selectedTask.description ?? "",
+            deadlineDate: selectedTask.deadlineDate ?? null,
+            relatedTaskIds: selectedTask.relatedTasks.map((task) => task.id),
+            ...payload,
+          }),
         });
 
         if (!response.ok) {

--- a/components/kanban-board.tsx
+++ b/components/kanban-board.tsx
@@ -86,6 +86,71 @@ function stampTaskActivity(
   };
 }
 
+interface TaskMutationResponseTask {
+  id: string;
+  title: string;
+  label: string | null;
+  labelsJson: string | null;
+  description: string | null;
+  deadlineDate: string | null;
+  commentCount: number;
+  blockedNote: string | null;
+  status: TaskStatus;
+  position: number;
+  archivedAt: string | null;
+  assignee: TaskPersonSummary | null;
+  createdBy: TaskPersonSummary;
+  updatedBy: TaskPersonSummary;
+  createdAt: string;
+  updatedAt: string;
+  relatedTasks: TaskRelatedSummary[];
+  blockedFollowUps: {
+    id: string;
+    content: string;
+    createdAt: string;
+  }[];
+}
+
+function getTaskMutationErrorMessage(errorCode?: string): string {
+  switch (errorCode) {
+    case "related-tasks-invalid":
+      return "Related tasks must stay active and belong to this project.";
+    case "assignee-invalid":
+      return "Assignee must be a current collaborator on this project.";
+    case "deadline-invalid":
+      return "Deadline must use a valid date.";
+    default:
+      return errorCode ?? "Failed to update task";
+  }
+}
+
+function mapTaskMutationResponseTask(
+  task: TaskMutationResponseTask,
+  attachments: TaskAttachment[]
+): KanbanTask {
+  return {
+    id: task.id,
+    title: task.title,
+    labels: getTaskLabelsFromStorage(task.labelsJson, task.label),
+    description: task.description,
+    deadlineDate: task.deadlineDate,
+    commentCount: task.commentCount,
+    assignee: task.assignee,
+    createdBy: task.createdBy,
+    updatedBy: task.updatedBy,
+    createdAt: task.createdAt,
+    updatedAt: task.updatedAt,
+    blockedFollowUps: task.blockedFollowUps.map((entry) => ({
+      ...entry,
+      createdAt: entry.createdAt,
+    })),
+    status: task.status,
+    archivedAt: task.archivedAt,
+    relatedTasks: task.relatedTasks,
+    attachments,
+  };
+}
+
 export function KanbanBoard({
   canEdit,
   projectId,
@@ -712,6 +777,129 @@ export function KanbanBoard({
     [canEdit, resetTaskEditDraft, selectedTask]
   );
 
+  const applyUpdatedTask = useCallback(
+    (updatedTask: KanbanTask) => {
+      setColumns((previousColumns) => {
+        const nextColumns = cloneColumns(previousColumns);
+        const taskColumn = nextColumns[updatedTask.status];
+        const taskIndex = taskColumn.findIndex((task) => task.id === updatedTask.id);
+
+        if (taskIndex === -1) {
+          return previousColumns;
+        }
+
+        taskColumn[taskIndex] = {
+          ...taskColumn[taskIndex],
+          ...updatedTask,
+        };
+
+        return nextColumns;
+      });
+
+      setArchivedDoneTasks((previousArchivedTasks) => {
+        const taskIndex = previousArchivedTasks.findIndex((task) => task.id === updatedTask.id);
+
+        if (taskIndex === -1) {
+          return previousArchivedTasks;
+        }
+
+        if (updatedTask.status !== "Done") {
+          return previousArchivedTasks.filter((task) => task.id !== updatedTask.id);
+        }
+
+        const nextArchivedTasks = [...previousArchivedTasks];
+        nextArchivedTasks[taskIndex] = {
+          ...nextArchivedTasks[taskIndex],
+          ...updatedTask,
+        };
+        return nextArchivedTasks;
+      });
+
+      setSelectedTask((previousTask) => {
+        if (!previousTask || previousTask.id !== updatedTask.id) {
+          return previousTask;
+        }
+        return updatedTask;
+      });
+      setEditAssigneeUserId(updatedTask.assignee?.id ?? "");
+      syncRelatedTaskSummary(updatedTask.id, {
+        title: updatedTask.title,
+        status: updatedTask.status,
+        archivedAt: updatedTask.archivedAt,
+      });
+    },
+    [syncRelatedTaskSummary]
+  );
+
+  const patchSelectedTask = useCallback(
+    async ({
+      payload,
+      successMessage,
+      fallbackErrorMessage,
+    }: {
+      payload: Record<string, unknown>;
+      successMessage: string;
+      fallbackErrorMessage: string;
+    }) => {
+      if (!selectedTask || !canEdit) {
+        return false;
+      }
+
+      setIsUpdatingTask(true);
+      setTaskModalError(null);
+
+      try {
+        const response = await fetch(`/api/projects/${projectId}/tasks/${selectedTask.id}`, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+          const responsePayload = (await response.json().catch(() => null)) as
+            | {
+                error?: string;
+              }
+            | null;
+          throw new Error(getTaskMutationErrorMessage(responsePayload?.error));
+        }
+
+        const responsePayload = (await response.json()) as {
+          task: TaskMutationResponseTask;
+        };
+
+        if (!isTaskStatus(responsePayload.task.status)) {
+          throw new Error("Invalid task status returned by server");
+        }
+
+        const updatedTask = mapTaskMutationResponseTask(
+          responsePayload.task,
+          selectedTask.attachments
+        );
+        applyUpdatedTask(updatedTask);
+        pushToast({
+          variant: "success",
+          message: successMessage,
+        });
+        return true;
+      } catch (error) {
+        console.error("[KanbanBoard.patchSelectedTask]", error);
+        const message = error instanceof Error ? error.message : fallbackErrorMessage;
+        setTaskModalError(message);
+        pushToast({
+          variant: "error",
+          message,
+        });
+        return false;
+      } finally {
+        setIsUpdatingTask(false);
+      }
+    },
+    [applyUpdatedTask, canEdit, projectId, pushToast, selectedTask]
+  );
+
   const persistTaskChanges = useCallback(
     async (options?: { exitEditMode?: boolean }) => {
       if (!selectedTask) {
@@ -757,126 +945,19 @@ export function KanbanBoard({
           const payload = (await response.json().catch(() => null)) as {
             error?: string;
           } | null;
-          const message =
-            payload?.error === "related-tasks-invalid"
-              ? "Related tasks must stay active and belong to this project."
-              : payload?.error === "assignee-invalid"
-                ? "Assignee must be a current collaborator on this project."
-              : payload?.error === "deadline-invalid"
-                ? "Deadline must use a valid date."
-              : (payload?.error ?? "Failed to update task");
-          throw new Error(message);
+          throw new Error(getTaskMutationErrorMessage(payload?.error));
         }
 
         const payload = (await response.json()) as {
-          task: {
-            id: string;
-            title: string;
-            label: string | null;
-            labelsJson: string | null;
-            description: string | null;
-            deadlineDate: string | null;
-            commentCount: number;
-            blockedNote: string | null;
-            status: string;
-            position: number;
-            archivedAt: string | null;
-            assignee: TaskPersonSummary | null;
-            createdBy: TaskPersonSummary;
-            updatedBy: TaskPersonSummary;
-            createdAt: string;
-            updatedAt: string;
-            relatedTasks: TaskRelatedSummary[];
-            blockedFollowUps: {
-              id: string;
-              content: string;
-              createdAt: string;
-            }[];
-          };
+          task: TaskMutationResponseTask;
         };
 
         if (!isTaskStatus(payload.task.status)) {
           throw new Error("Invalid task status returned by server");
         }
 
-        const updatedTask: KanbanTask = {
-          id: payload.task.id,
-          title: payload.task.title,
-          labels: getTaskLabelsFromStorage(
-            payload.task.labelsJson,
-            payload.task.label
-          ),
-          description: payload.task.description,
-          deadlineDate: payload.task.deadlineDate,
-          commentCount: payload.task.commentCount,
-          assignee: payload.task.assignee,
-          createdBy: payload.task.createdBy,
-          updatedBy: payload.task.updatedBy,
-          createdAt: payload.task.createdAt,
-          updatedAt: payload.task.updatedAt,
-          blockedFollowUps: payload.task.blockedFollowUps.map((entry) => ({
-            ...entry,
-            createdAt: entry.createdAt,
-          })),
-          status: payload.task.status,
-          archivedAt: payload.task.archivedAt,
-          relatedTasks: payload.task.relatedTasks,
-          attachments: selectedTask.attachments,
-        };
-
-        setColumns((previousColumns) => {
-          const nextColumns = cloneColumns(previousColumns);
-          const taskColumn = nextColumns[updatedTask.status];
-          const taskIndex = taskColumn.findIndex(
-            (task) => task.id === updatedTask.id
-          );
-
-          if (taskIndex === -1) {
-            return previousColumns;
-          }
-
-          taskColumn[taskIndex] = {
-            ...taskColumn[taskIndex],
-            ...updatedTask,
-          };
-
-          return nextColumns;
-        });
-
-        setArchivedDoneTasks((previousArchivedTasks) => {
-          const taskIndex = previousArchivedTasks.findIndex(
-            (task) => task.id === updatedTask.id
-          );
-
-          if (taskIndex === -1) {
-            return previousArchivedTasks;
-          }
-
-          if (updatedTask.status !== "Done") {
-            return previousArchivedTasks.filter(
-              (task) => task.id !== updatedTask.id
-            );
-          }
-
-          const nextArchivedTasks = [...previousArchivedTasks];
-          nextArchivedTasks[taskIndex] = {
-            ...nextArchivedTasks[taskIndex],
-            ...updatedTask,
-          };
-          return nextArchivedTasks;
-        });
-
-        setSelectedTask((previousTask) => {
-          if (!previousTask || previousTask.id !== updatedTask.id) {
-            return previousTask;
-          }
-          return updatedTask;
-        });
-        syncRelatedTaskSummary(updatedTask.id, {
-          title: updatedTask.title,
-          status: updatedTask.status,
-          archivedAt: updatedTask.archivedAt,
-        });
+        const updatedTask = mapTaskMutationResponseTask(payload.task, selectedTask.attachments);
+        applyUpdatedTask(updatedTask);
         setTaskModalError(null);
         if (options?.exitEditMode !== false) {
           setIsEditMode(false);
@@ -904,8 +985,27 @@ export function KanbanBoard({
       newBlockedFollowUpEntry,
       projectId,
       selectedTask,
-      syncRelatedTaskSummary,
+      applyUpdatedTask,
     ]
+  );
+
+  const handleQuickAssigneeUpdate = useCallback(
+    async (nextAssigneeUserId: string) => {
+      const nextAssigneeLabel =
+        availableAssignees.find((assignee) => assignee.id === nextAssigneeUserId)?.displayName ??
+        null;
+
+      await patchSelectedTask({
+        payload: {
+          assigneeUserId: nextAssigneeUserId || null,
+        },
+        successMessage: nextAssigneeLabel
+          ? `Assignee updated to ${nextAssigneeLabel}.`
+          : "Assignee cleared.",
+        fallbackErrorMessage: "Could not update assignee.",
+      });
+    },
+    [availableAssignees, patchSelectedTask]
   );
 
   const handleTaskUpdate = useCallback(async () => {
@@ -1713,6 +1813,7 @@ export function KanbanBoard({
         onNewBlockedFollowUpEntryChange={setNewBlockedFollowUpEntry}
         onAddBlockedFollowUpEntry={handleAddBlockedFollowUpEntry}
         onSaveTask={handleTaskUpdate}
+        onQuickAssigneeChange={handleQuickAssigneeUpdate}
         onToggleLinkComposer={() =>
           setIsLinkComposerOpen((previous) => !previous)
         }

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -15,6 +15,7 @@ import {
   TriangleAlert,
   Undo2,
   Upload,
+  UserRound,
   X,
 } from "lucide-react";
 
@@ -654,12 +655,7 @@ function TaskOptionsMenu({
               }
             >
               <span className="inline-flex items-center gap-2">
-                <UserAvatar
-                  avatarSeed={currentAssignee?.avatarSeed ?? "unassigned"}
-                  displayName={currentAssignee?.displayName ?? "Unassigned"}
-                  className="h-5 w-5 border-border/70"
-                  decorative
-                />
+                <UserRound className="h-4 w-4" />
                 Assignee
               </span>
               <span className="inline-flex min-w-0 items-center gap-1 text-xs text-muted-foreground">

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -516,7 +516,10 @@ function TaskAssigneeBadge({ assignee }: { assignee: TaskPersonSummary | null })
               className="h-7 w-7 border-border/70"
               decorative
             />
-            <span className="max-w-[160px] truncate text-sm font-medium text-foreground">
+            <span
+              data-task-assignee-name="true"
+              className="max-w-[160px] truncate text-sm font-medium text-foreground"
+            >
               {assignee.displayName}
             </span>
           </>

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import {
   Archive,
   ArrowRightLeft,
+  Check,
   ChevronRight,
   Clock3,
   Link2,
@@ -112,6 +113,7 @@ interface TaskDetailModalProps {
   onNewBlockedFollowUpEntryChange: (value: string) => void;
   onAddBlockedFollowUpEntry: () => void | Promise<void>;
   onSaveTask: () => void | Promise<void>;
+  onQuickAssigneeChange: (value: string) => void | Promise<void>;
   onToggleLinkComposer: () => void;
   onLinkUrlChange: (value: string) => void;
   onAddLinkAttachment: () => void | Promise<void>;
@@ -177,6 +179,7 @@ export function TaskDetailModal({
   onNewBlockedFollowUpEntryChange,
   onAddBlockedFollowUpEntry,
   onSaveTask,
+  onQuickAssigneeChange,
   onToggleLinkComposer,
   onLinkUrlChange,
   onAddLinkAttachment,
@@ -253,9 +256,12 @@ export function TaskDetailModal({
                 {!isEditing && canEdit ? (
                   <TaskOptionsMenu
                     currentStatus={selectedTask.status}
+                    currentAssignee={selectedTask.assignee}
+                    assigneeOptions={availableAssignees}
                     isArchived={isArchivedTask}
-                    isArchiving={isArchivingTask}
+                    isMutating={isArchivingTask || isUpdatingTask}
                     onStartEdit={() => onToggleEditMode(true)}
+                    onQuickAssigneeChange={onQuickAssigneeChange}
                     onMoveTask={onMoveTask}
                     onArchiveTask={onArchiveTask}
                     onUnarchiveTask={onUnarchiveTask}
@@ -430,6 +436,19 @@ function buildTaskPersonHoverLabel(person: TaskPersonSummary): string {
   return person.usernameTag ?? person.displayName;
 }
 
+function formatAssigneeProjectRole(role: ProjectTaskCollaborator["projectRole"]): string {
+  switch (role) {
+    case "owner":
+      return "Owner";
+    case "editor":
+      return "Editor";
+    case "viewer":
+      return "Viewer";
+    default:
+      return role;
+  }
+}
+
 function TaskAssigneeBadge({ assignee }: { assignee: TaskPersonSummary | null }) {
   return (
     <div className="flex flex-col gap-1 sm:items-end">
@@ -513,9 +532,12 @@ function TaskActivityInline({
 
 interface TaskOptionsMenuProps {
   currentStatus: TaskStatus;
+  currentAssignee: TaskPersonSummary | null;
+  assigneeOptions: ProjectTaskCollaborator[];
   isArchived: boolean;
-  isArchiving: boolean;
+  isMutating: boolean;
   onStartEdit: () => void;
+  onQuickAssigneeChange: (value: string) => void | Promise<void>;
   onMoveTask: (nextStatus: TaskStatus) => void;
   onArchiveTask: () => void | Promise<void>;
   onUnarchiveTask: () => void | Promise<void>;
@@ -524,9 +546,12 @@ interface TaskOptionsMenuProps {
 
 function TaskOptionsMenu({
   currentStatus,
+  currentAssignee,
+  assigneeOptions,
   isArchived,
-  isArchiving,
+  isMutating,
   onStartEdit,
+  onQuickAssigneeChange,
   onMoveTask,
   onArchiveTask,
   onUnarchiveTask,
@@ -553,7 +578,7 @@ function TaskOptionsMenu({
             type="button"
             variant="ghost"
             className="w-full justify-start"
-            disabled={isArchiving}
+            disabled={isMutating}
             onClick={() => {
               onStartEdit();
               setIsMenuOpen(false);
@@ -568,7 +593,7 @@ function TaskOptionsMenu({
                 type="button"
                 variant="ghost"
                 className="w-full justify-between"
-                disabled={isArchiving}
+                disabled={isMutating}
               >
                 <span className="inline-flex items-center gap-2">
                   <ArrowRightLeft className="h-4 w-4" />
@@ -583,7 +608,7 @@ function TaskOptionsMenu({
                     type="button"
                     variant="ghost"
                     className="w-full justify-start"
-                    disabled={nextStatus === currentStatus || isArchiving}
+                    disabled={nextStatus === currentStatus || isMutating}
                     onClick={() => {
                       onMoveTask(nextStatus);
                       setIsMenuOpen(false);
@@ -595,19 +620,108 @@ function TaskOptionsMenu({
               </div>
             </div>
           ) : null}
+          <div className="group relative">
+            <Button
+              type="button"
+              variant="ghost"
+              className="w-full justify-between"
+              aria-label="Assignee options"
+              disabled={isMutating}
+            >
+              <span className="inline-flex items-center gap-2">
+                <UserAvatar
+                  avatarSeed={currentAssignee?.avatarSeed ?? "unassigned"}
+                  displayName={currentAssignee?.displayName ?? "Unassigned"}
+                  className="h-5 w-5 border-border/70"
+                  decorative
+                />
+                Assignee
+              </span>
+              <span className="inline-flex min-w-0 items-center gap-1 text-xs text-muted-foreground">
+                <span className="max-w-[72px] truncate">
+                  {currentAssignee?.displayName ?? "None"}
+                </span>
+                <ChevronRight className="h-4 w-4 shrink-0" />
+              </span>
+            </Button>
+            <div className="invisible pointer-events-none absolute right-full top-0 z-30 mr-1 w-64 rounded-md border border-border/70 bg-background p-1 opacity-0 shadow-md transition group-hover:visible group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:visible group-focus-within:pointer-events-auto group-focus-within:opacity-100">
+              <div className="max-h-72 space-y-1 overflow-y-auto">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="w-full justify-between"
+                  disabled={!currentAssignee || isMutating}
+                  onClick={() => {
+                    void onQuickAssigneeChange("");
+                    setIsMenuOpen(false);
+                  }}
+                >
+                  <span className="inline-flex min-w-0 items-center gap-2">
+                    <span className="inline-flex h-7 w-7 shrink-0 rounded-full border border-dashed border-border/70 bg-muted/30" />
+                    <span className="min-w-0 text-left">
+                      <span className="block truncate text-sm font-medium">Unassigned</span>
+                      <span className="block truncate text-xs text-muted-foreground">
+                        Leave without an assignee
+                      </span>
+                    </span>
+                  </span>
+                  {!currentAssignee ? <Check className="h-4 w-4" /> : null}
+                </Button>
+
+                {assigneeOptions.map((assignee) => {
+                  const isSelected = assignee.id === currentAssignee?.id;
+
+                  return (
+                    <Button
+                      key={assignee.id}
+                      type="button"
+                      variant="ghost"
+                      className="h-auto w-full justify-between py-2"
+                      disabled={isSelected || isMutating}
+                      onClick={() => {
+                        void onQuickAssigneeChange(assignee.id);
+                        setIsMenuOpen(false);
+                      }}
+                    >
+                      <span
+                        className="inline-flex min-w-0 items-center gap-2"
+                        title={buildTaskPersonHoverLabel(assignee)}
+                      >
+                        <UserAvatar
+                          avatarSeed={assignee.avatarSeed}
+                          displayName={assignee.displayName}
+                          className="h-7 w-7 border-border/70"
+                          decorative
+                        />
+                        <span className="min-w-0 text-left">
+                          <span className="block truncate text-sm font-medium">
+                            {assignee.displayName}
+                          </span>
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {formatAssigneeProjectRole(assignee.projectRole)}
+                          </span>
+                        </span>
+                      </span>
+                      {isSelected ? <Check className="h-4 w-4" /> : null}
+                    </Button>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
           {currentStatus === "Done" && !isArchived ? (
             <Button
               type="button"
               variant="ghost"
               className="w-full justify-start"
-              disabled={isArchiving}
+              disabled={isMutating}
               onClick={() => {
                 void onArchiveTask();
                 setIsMenuOpen(false);
               }}
             >
               <Archive className="h-4 w-4" />
-              {isArchiving ? "Archiving..." : "Archive"}
+              {isMutating ? "Working..." : "Archive"}
             </Button>
           ) : null}
           {isArchived ? (
@@ -615,7 +729,7 @@ function TaskOptionsMenu({
               type="button"
               variant="ghost"
               className="w-full justify-start"
-              disabled={isArchiving}
+              disabled={isMutating}
               onClick={() => {
                 void onUnarchiveTask();
                 setIsMenuOpen(false);
@@ -629,7 +743,7 @@ function TaskOptionsMenu({
             type="button"
             variant="ghost"
             className="w-full justify-start text-destructive hover:bg-destructive/10 hover:text-destructive"
-            disabled={isArchiving}
+            disabled={isMutating}
             onClick={() => {
               setIsMenuOpen(false);
               onRequestDeleteTask();

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -658,10 +658,7 @@ function TaskOptionsMenu({
                 <UserRound className="h-4 w-4" />
                 Assignee
               </span>
-              <span className="inline-flex min-w-0 items-center gap-1 text-xs text-muted-foreground">
-                <span className="max-w-[72px] truncate">
-                  {currentAssignee?.displayName ?? "None"}
-                </span>
+              <span className="inline-flex items-center text-muted-foreground">
                 <ChevronRight className="h-4 w-4 shrink-0" />
               </span>
             </Button>

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -16,6 +16,7 @@ import {
   TriangleAlert,
   Undo2,
   Upload,
+  UserRound,
   X,
 } from "lucide-react";
 
@@ -121,6 +122,7 @@ interface TaskDetailModalProps {
   onAddBlockedFollowUpEntry: () => void | Promise<void>;
   onSaveTask: () => void | Promise<void>;
   onQuickEpicChange: (value: string) => void | Promise<void>;
+  onQuickAssigneeChange: (value: string) => void | Promise<void>;
   onToggleLinkComposer: () => void;
   onLinkUrlChange: (value: string) => void;
   onAddLinkAttachment: () => void | Promise<void>;
@@ -190,6 +192,7 @@ export function TaskDetailModal({
   onAddBlockedFollowUpEntry,
   onSaveTask,
   onQuickEpicChange,
+  onQuickAssigneeChange,
   onToggleLinkComposer,
   onLinkUrlChange,
   onAddLinkAttachment,
@@ -271,10 +274,13 @@ export function TaskDetailModal({
                     currentStatus={selectedTask.status}
                     currentEpic={selectedTask.epic}
                     epicOptions={availableEpicOptions}
+                    currentAssignee={selectedTask.assignee}
+                    assigneeOptions={availableAssignees}
                     isArchived={isArchivedTask}
                     isMutating={isArchivingTask || isUpdatingTask}
                     onStartEdit={() => onToggleEditMode(true)}
                     onQuickEpicChange={onQuickEpicChange}
+                    onQuickAssigneeChange={onQuickAssigneeChange}
                     onMoveTask={onMoveTask}
                     onArchiveTask={onArchiveTask}
                     onUnarchiveTask={onUnarchiveTask}
@@ -452,6 +458,19 @@ function buildTaskPersonHoverLabel(person: TaskPersonSummary): string {
   return person.usernameTag ?? person.displayName;
 }
 
+function formatAssigneeProjectRole(role: ProjectTaskCollaborator["projectRole"]): string {
+  switch (role) {
+    case "owner":
+      return "Owner";
+    case "editor":
+      return "Editor";
+    case "viewer":
+      return "Viewer";
+    default:
+      return role;
+  }
+}
+
 function TaskEpicBadge({
   epic,
   showLabel = true,
@@ -573,10 +592,13 @@ interface TaskOptionsMenuProps {
   currentStatus: TaskStatus;
   currentEpic: KanbanTask["epic"];
   epicOptions: ProjectEpicOption[];
+  currentAssignee: TaskPersonSummary | null;
+  assigneeOptions: ProjectTaskCollaborator[];
   isArchived: boolean;
   isMutating: boolean;
   onStartEdit: () => void;
   onQuickEpicChange: (value: string) => void | Promise<void>;
+  onQuickAssigneeChange: (value: string) => void | Promise<void>;
   onMoveTask: (nextStatus: TaskStatus) => void;
   onArchiveTask: () => void | Promise<void>;
   onUnarchiveTask: () => void | Promise<void>;
@@ -587,17 +609,20 @@ function TaskOptionsMenu({
   currentStatus,
   currentEpic,
   epicOptions,
+  currentAssignee,
+  assigneeOptions,
   isArchived,
   isMutating,
   onStartEdit,
   onQuickEpicChange,
+  onQuickAssigneeChange,
   onMoveTask,
   onArchiveTask,
   onUnarchiveTask,
   onRequestDeleteTask,
 }: TaskOptionsMenuProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [activeSubmenu, setActiveSubmenu] = useState<"move" | "epic" | null>(null);
+  const [activeSubmenu, setActiveSubmenu] = useState<"move" | "epic" | "assignee" | null>(null);
 
   const closeMenu = () => {
     setIsMenuOpen(false);
@@ -793,6 +818,103 @@ function TaskOptionsMenu({
                     );
                   })
                 )}
+              </div>
+            </div>
+          </div>
+          <div className="relative">
+            <Button
+              type="button"
+              variant="ghost"
+              className="w-full justify-between"
+              aria-label="Assignee options"
+              disabled={isMutating}
+              aria-haspopup="menu"
+              aria-expanded={activeSubmenu === "assignee"}
+              aria-controls="task-options-submenu-assignee"
+              onClick={() =>
+                setActiveSubmenu((previous) => (previous === "assignee" ? null : "assignee"))
+              }
+            >
+              <span className="inline-flex items-center gap-2">
+                <UserRound className="h-4 w-4" />
+                Assignee
+              </span>
+              <span className="inline-flex items-center text-muted-foreground">
+                <ChevronRight className="h-4 w-4 shrink-0" />
+              </span>
+            </Button>
+            <div
+              id="task-options-submenu-assignee"
+              role="menu"
+              data-task-options-submenu="assignee"
+              className={[
+                "absolute right-full top-0 z-30 mr-1 w-64 rounded-md border border-border/70 bg-background p-1 shadow-md transition",
+                activeSubmenu === "assignee"
+                  ? "visible pointer-events-auto opacity-100"
+                  : "invisible pointer-events-none opacity-0",
+              ].join(" ")}
+            >
+              <div className="max-h-72 space-y-1 overflow-y-auto">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="w-full justify-between"
+                  disabled={!currentAssignee || isMutating}
+                  onClick={() => {
+                    void onQuickAssigneeChange("");
+                    closeMenu();
+                  }}
+                >
+                  <span className="inline-flex min-w-0 items-center gap-2">
+                    <span className="inline-flex h-7 w-7 shrink-0 rounded-full border border-dashed border-border/70 bg-muted/30" />
+                    <span className="min-w-0 text-left">
+                      <span className="block truncate text-sm font-medium">Unassigned</span>
+                      <span className="block truncate text-xs text-muted-foreground">
+                        Leave without an assignee
+                      </span>
+                    </span>
+                  </span>
+                  {!currentAssignee ? <Check className="h-4 w-4" /> : null}
+                </Button>
+
+                {assigneeOptions.map((assignee) => {
+                  const isSelected = assignee.id === currentAssignee?.id;
+
+                  return (
+                    <Button
+                      key={assignee.id}
+                      type="button"
+                      variant="ghost"
+                      className="h-auto w-full justify-between py-2"
+                      disabled={isSelected || isMutating}
+                      onClick={() => {
+                        void onQuickAssigneeChange(assignee.id);
+                        closeMenu();
+                      }}
+                    >
+                      <span
+                        className="inline-flex min-w-0 items-center gap-2"
+                        title={buildTaskPersonHoverLabel(assignee)}
+                      >
+                        <UserAvatar
+                          avatarSeed={assignee.avatarSeed}
+                          displayName={assignee.displayName}
+                          className="h-7 w-7 border-border/70"
+                          decorative
+                        />
+                        <span className="min-w-0 text-left">
+                          <span className="block truncate text-sm font-medium">
+                            {assignee.displayName}
+                          </span>
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {formatAssigneeProjectRole(assignee.projectRole)}
+                          </span>
+                        </span>
+                      </span>
+                      {isSelected ? <Check className="h-4 w-4" /> : null}
+                    </Button>
+                  );
+                })}
               </div>
             </div>
           </div>

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -47,6 +47,7 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/componen
 import { EmojiInputField, EmojiTextareaField } from "@/components/ui/emoji-field";
 import { UserAvatar } from "@/components/ui/user-avatar";
 import { useDismissibleMenu } from "@/lib/hooks/use-dismissible-menu";
+import { formatProjectCollaboratorRole } from "@/lib/project-collaborator-role";
 import {
   ATTACHMENT_KIND_FILE,
   ATTACHMENT_KIND_LINK,
@@ -436,22 +437,9 @@ function buildTaskPersonHoverLabel(person: TaskPersonSummary): string {
   return person.usernameTag ?? person.displayName;
 }
 
-function formatAssigneeProjectRole(role: ProjectTaskCollaborator["projectRole"]): string {
-  switch (role) {
-    case "owner":
-      return "Owner";
-    case "editor":
-      return "Editor";
-    case "viewer":
-      return "Viewer";
-    default:
-      return role;
-  }
-}
-
 function TaskAssigneeBadge({ assignee }: { assignee: TaskPersonSummary | null }) {
   return (
-    <div className="flex flex-col gap-1 sm:items-end">
+    <div data-task-assignee-badge="true" className="flex flex-col gap-1 sm:items-end">
       <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
         Assignee
       </p>
@@ -467,7 +455,10 @@ function TaskAssigneeBadge({ assignee }: { assignee: TaskPersonSummary | null })
               className="h-7 w-7 border-border/70"
               decorative
             />
-            <span className="max-w-[160px] truncate text-sm font-medium text-foreground">
+            <span
+              data-task-assignee-name="true"
+              className="max-w-[160px] truncate text-sm font-medium text-foreground"
+            >
               {assignee.displayName}
             </span>
           </>
@@ -607,7 +598,9 @@ function TaskOptionsMenu({
                 variant="ghost"
                 className="w-full justify-between"
                 disabled={isMutating}
+                aria-haspopup="menu"
                 aria-expanded={activeSubmenu === "move"}
+                aria-controls="task-options-submenu-move"
                 onClick={() =>
                   setActiveSubmenu((previous) => (previous === "move" ? null : "move"))
                 }
@@ -619,6 +612,8 @@ function TaskOptionsMenu({
                 <ChevronRight className="h-4 w-4" />
               </Button>
               <div
+                id="task-options-submenu-move"
+                role="menu"
                 className={[
                   "absolute right-full top-0 z-30 mr-1 w-36 rounded-md border border-border/70 bg-background p-1 shadow-md transition",
                   activeSubmenu === "move"
@@ -651,7 +646,9 @@ function TaskOptionsMenu({
               className="w-full justify-between"
               aria-label="Assignee options"
               disabled={isMutating}
+              aria-haspopup="menu"
               aria-expanded={activeSubmenu === "assignee"}
+              aria-controls="task-options-submenu-assignee"
               onClick={() =>
                 setActiveSubmenu((previous) => (previous === "assignee" ? null : "assignee"))
               }
@@ -673,6 +670,8 @@ function TaskOptionsMenu({
               </span>
             </Button>
             <div
+              id="task-options-submenu-assignee"
+              role="menu"
               data-task-options-submenu="assignee"
               className={[
                 "absolute right-full top-0 z-30 mr-1 w-64 rounded-md border border-border/70 bg-background p-1 shadow-md transition",
@@ -734,7 +733,7 @@ function TaskOptionsMenu({
                             {assignee.displayName}
                           </span>
                           <span className="block truncate text-xs text-muted-foreground">
-                            {formatAssigneeProjectRole(assignee.projectRole)}
+                            {formatProjectCollaboratorRole(assignee.projectRole)}
                           </span>
                         </span>
                       </span>

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -52,6 +52,7 @@ import { EpicSelect } from "@/components/ui/epic-select";
 import { UserAvatar } from "@/components/ui/user-avatar";
 import { getEpicColorFromName } from "@/lib/epic";
 import { useDismissibleMenu } from "@/lib/hooks/use-dismissible-menu";
+import { formatProjectCollaboratorRole } from "@/lib/project-collaborator-role";
 import {
   ATTACHMENT_KIND_FILE,
   ATTACHMENT_KIND_LINK,
@@ -458,19 +459,6 @@ function buildTaskPersonHoverLabel(person: TaskPersonSummary): string {
   return person.usernameTag ?? person.displayName;
 }
 
-function formatAssigneeProjectRole(role: ProjectTaskCollaborator["projectRole"]): string {
-  switch (role) {
-    case "owner":
-      return "Owner";
-    case "editor":
-      return "Editor";
-    case "viewer":
-      return "Viewer";
-    default:
-      return role;
-  }
-}
-
 function TaskEpicBadge({
   epic,
   showLabel = true,
@@ -509,7 +497,10 @@ function TaskEpicBadge({
 
 function TaskAssigneeBadge({ assignee }: { assignee: TaskPersonSummary | null }) {
   return (
-    <div className="flex flex-col items-center gap-1 text-center sm:items-end sm:text-right">
+    <div
+      data-task-assignee-badge="true"
+      className="flex flex-col items-center gap-1 text-center sm:items-end sm:text-right"
+    >
       <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
         Assignee
       </p>
@@ -907,7 +898,7 @@ function TaskOptionsMenu({
                             {assignee.displayName}
                           </span>
                           <span className="block truncate text-xs text-muted-foreground">
-                            {formatAssigneeProjectRole(assignee.projectRole)}
+                            {formatProjectCollaboratorRole(assignee.projectRole)}
                           </span>
                         </span>
                       </span>

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -558,7 +558,12 @@ function TaskOptionsMenu({
   onRequestDeleteTask,
 }: TaskOptionsMenuProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const menuRef = useDismissibleMenu<HTMLDivElement>(isMenuOpen, () => setIsMenuOpen(false));
+  const [activeSubmenu, setActiveSubmenu] = useState<"move" | "assignee" | null>(null);
+  const closeMenu = () => {
+    setIsMenuOpen(false);
+    setActiveSubmenu(null);
+  };
+  const menuRef = useDismissibleMenu<HTMLDivElement>(isMenuOpen, closeMenu);
 
   return (
     <div ref={menuRef} className="relative">
@@ -568,7 +573,15 @@ function TaskOptionsMenu({
         size="icon"
         aria-label="Task options"
         aria-expanded={isMenuOpen}
-        onClick={() => setIsMenuOpen((previous) => !previous)}
+        onClick={() => {
+          setIsMenuOpen((previous) => {
+            if (previous) {
+              setActiveSubmenu(null);
+            }
+
+            return !previous;
+          });
+        }}
       >
         <MoreHorizontal className="h-4 w-4" />
       </Button>
@@ -581,19 +594,23 @@ function TaskOptionsMenu({
             disabled={isMutating}
             onClick={() => {
               onStartEdit();
-              setIsMenuOpen(false);
+              closeMenu();
             }}
           >
             <Pencil className="h-4 w-4" />
             Edit
           </Button>
           {!isArchived ? (
-            <div className="group relative">
+            <div className="relative">
               <Button
                 type="button"
                 variant="ghost"
                 className="w-full justify-between"
                 disabled={isMutating}
+                aria-expanded={activeSubmenu === "move"}
+                onClick={() =>
+                  setActiveSubmenu((previous) => (previous === "move" ? null : "move"))
+                }
               >
                 <span className="inline-flex items-center gap-2">
                   <ArrowRightLeft className="h-4 w-4" />
@@ -601,7 +618,14 @@ function TaskOptionsMenu({
                 </span>
                 <ChevronRight className="h-4 w-4" />
               </Button>
-              <div className="invisible pointer-events-none absolute right-full top-0 z-30 mr-1 w-36 rounded-md border border-border/70 bg-background p-1 opacity-0 shadow-md transition group-hover:visible group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:visible group-focus-within:pointer-events-auto group-focus-within:opacity-100">
+              <div
+                className={[
+                  "absolute right-full top-0 z-30 mr-1 w-36 rounded-md border border-border/70 bg-background p-1 shadow-md transition",
+                  activeSubmenu === "move"
+                    ? "visible pointer-events-auto opacity-100"
+                    : "invisible pointer-events-none opacity-0",
+                ].join(" ")}
+              >
                 {TASK_STATUSES.map((nextStatus) => (
                   <Button
                     key={nextStatus}
@@ -611,7 +635,7 @@ function TaskOptionsMenu({
                     disabled={nextStatus === currentStatus || isMutating}
                     onClick={() => {
                       onMoveTask(nextStatus);
-                      setIsMenuOpen(false);
+                      closeMenu();
                     }}
                   >
                     {nextStatus}
@@ -620,13 +644,17 @@ function TaskOptionsMenu({
               </div>
             </div>
           ) : null}
-          <div className="group relative">
+          <div className="relative">
             <Button
               type="button"
               variant="ghost"
               className="w-full justify-between"
               aria-label="Assignee options"
               disabled={isMutating}
+              aria-expanded={activeSubmenu === "assignee"}
+              onClick={() =>
+                setActiveSubmenu((previous) => (previous === "assignee" ? null : "assignee"))
+              }
             >
               <span className="inline-flex items-center gap-2">
                 <UserAvatar
@@ -644,7 +672,15 @@ function TaskOptionsMenu({
                 <ChevronRight className="h-4 w-4 shrink-0" />
               </span>
             </Button>
-            <div className="invisible pointer-events-none absolute right-full top-0 z-30 mr-1 w-64 rounded-md border border-border/70 bg-background p-1 opacity-0 shadow-md transition group-hover:visible group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:visible group-focus-within:pointer-events-auto group-focus-within:opacity-100">
+            <div
+              data-task-options-submenu="assignee"
+              className={[
+                "absolute right-full top-0 z-30 mr-1 w-64 rounded-md border border-border/70 bg-background p-1 shadow-md transition",
+                activeSubmenu === "assignee"
+                  ? "visible pointer-events-auto opacity-100"
+                  : "invisible pointer-events-none opacity-0",
+              ].join(" ")}
+            >
               <div className="max-h-72 space-y-1 overflow-y-auto">
                 <Button
                   type="button"
@@ -653,7 +689,7 @@ function TaskOptionsMenu({
                   disabled={!currentAssignee || isMutating}
                   onClick={() => {
                     void onQuickAssigneeChange("");
-                    setIsMenuOpen(false);
+                    closeMenu();
                   }}
                 >
                   <span className="inline-flex min-w-0 items-center gap-2">
@@ -680,7 +716,7 @@ function TaskOptionsMenu({
                       disabled={isSelected || isMutating}
                       onClick={() => {
                         void onQuickAssigneeChange(assignee.id);
-                        setIsMenuOpen(false);
+                        closeMenu();
                       }}
                     >
                       <span

--- a/components/ui/assignee-select.tsx
+++ b/components/ui/assignee-select.tsx
@@ -6,9 +6,9 @@ import { Check, ChevronDown } from "lucide-react";
 
 import type {
   ProjectTaskCollaborator,
-  ProjectTaskCollaboratorRole,
 } from "@/components/kanban-board-types";
 import { UserAvatar } from "@/components/ui/user-avatar";
+import { formatProjectCollaboratorRole } from "@/lib/project-collaborator-role";
 import { cn } from "@/lib/utils";
 
 interface AssigneeSelectProps {
@@ -20,19 +20,6 @@ interface AssigneeSelectProps {
   disabled?: boolean;
   className?: string;
   unassignedLabel?: string;
-}
-
-function formatProjectRole(role: ProjectTaskCollaboratorRole): string {
-  switch (role) {
-    case "owner":
-      return "Owner";
-    case "editor":
-      return "Editor";
-    case "viewer":
-      return "Viewer";
-    default:
-      return role;
-  }
 }
 
 function buildAssigneeHoverLabel(assignee: ProjectTaskCollaborator): string {
@@ -169,7 +156,7 @@ export function AssigneeSelect({
                 {selectedAssignee.displayName}
               </p>
               <p className="truncate text-xs text-muted-foreground">
-                {formatProjectRole(selectedAssignee.projectRole)}
+                {formatProjectCollaboratorRole(selectedAssignee.projectRole)}
               </p>
             </div>
           </div>
@@ -257,7 +244,7 @@ export function AssigneeSelect({
                             {assignee.displayName}
                           </p>
                           <p className="truncate text-xs text-muted-foreground">
-                            {formatProjectRole(assignee.projectRole)}
+                            {formatProjectCollaboratorRole(assignee.projectRole)}
                           </p>
                         </div>
                       </div>

--- a/journal.md
+++ b/journal.md
@@ -837,3 +837,13 @@ Low-value entries to avoid going forward:
 - Type: Validation
 - Summary: Mobile containment follow-up for the developer onboarding surface passed the targeted local validation slice before preview deployment.
 - Evidence: `npm run lint` and `npx vitest run tests/components/agent-onboarding-guide.test.ts tests/app/agent-onboarding-pages.test.ts`.
+
+### 2026-04-22
+- Type: Execution
+- Summary: TASK-128 added assignee quick assignment in the task options menu so ownership can be reassigned without entering full edit mode.
+- Evidence: Updated `components/kanban/task-detail-modal.tsx` to add an assignee submenu in the existing task options flyout; updated `components/kanban-board.tsx` to reuse the existing task PATCH boundary for quick assignee mutations with immediate local state refresh; updated `tests/e2e/smoke-project-task-calendar.spec.ts` for assignee quick-action coverage; updated `tasks/current.md` and `tasks/backlog.md` for the new follow-up task brief.
+
+### 2026-04-22
+- Type: Validation
+- Summary: TASK-128 passed local lint and production build; targeted Playwright remained blocked by the local E2E database fixture state before the new assignee path executed.
+- Evidence: `npm run lint`; `npm run build` with local env overrides; `npx playwright test tests/e2e/smoke-project-task-calendar.spec.ts --grep "task lifecycle and attachment interaction flow"` failed in `tests/e2e/helpers/auth-helpers.ts` during seeded-user creation via Prisma before the browser reached the new assignee quick-action flow.

--- a/journal.md
+++ b/journal.md
@@ -847,3 +847,13 @@ Low-value entries to avoid going forward:
 - Type: Validation
 - Summary: TASK-128 passed local lint and production build; targeted Playwright remained blocked by the local E2E database fixture state before the new assignee path executed.
 - Evidence: `npm run lint`; `npm run build` with local env overrides; `npx playwright test tests/e2e/smoke-project-task-calendar.spec.ts --grep "task lifecycle and attachment interaction flow"` failed in `tests/e2e/helpers/auth-helpers.ts` during seeded-user creation via Prisma before the browser reached the new assignee quick-action flow.
+
+### 2026-04-22
+- Type: Execution
+- Summary: TASK-128 task options submenus now open intentionally by click so assignee quick assignment is reliable in the task flyout and no longer depends on hover-only behavior.
+- Evidence: Updated `components/kanban/task-detail-modal.tsx` to manage submenu open state explicitly for move and assignee actions, added a stable assignee submenu marker for validation, and aligned `tests/e2e/smoke-project-task-calendar.spec.ts` with the click-open interaction.
+
+### 2026-04-22
+- Type: Validation
+- Summary: TASK-128 submenu interaction follow-up passed local lint and production build before being republished to the PR branch.
+- Evidence: `npm run lint`; `npm run build` with local `DATABASE_URL`, `DIRECT_URL`, `GOOGLE_TOKEN_ENCRYPTION_KEY`, and `AGENT_TOKEN_SIGNING_SECRET` overrides.

--- a/journal.md
+++ b/journal.md
@@ -797,3 +797,13 @@ Low-value entries to avoid going forward:
 - Type: Validation
 - Summary: Mobile containment follow-up for the developer onboarding surface passed the targeted local validation slice before preview deployment.
 - Evidence: `npm run lint` and `npx vitest run tests/components/agent-onboarding-guide.test.ts tests/app/agent-onboarding-pages.test.ts`.
+
+### 2026-04-22
+- Type: Execution
+- Summary: TASK-128 added assignee quick assignment in the task options menu so ownership can be reassigned without entering full edit mode.
+- Evidence: Updated `components/kanban/task-detail-modal.tsx` to add an assignee submenu in the existing task options flyout; updated `components/kanban-board.tsx` to reuse the existing task PATCH boundary for quick assignee mutations with immediate local state refresh; updated `tests/e2e/smoke-project-task-calendar.spec.ts` for assignee quick-action coverage; updated `tasks/current.md` and `tasks/backlog.md` for the new follow-up task brief.
+
+### 2026-04-22
+- Type: Validation
+- Summary: TASK-128 passed local lint and production build; targeted Playwright remained blocked by the local E2E database fixture state before the new assignee path executed.
+- Evidence: `npm run lint`; `npm run build` with local env overrides; `npx playwright test tests/e2e/smoke-project-task-calendar.spec.ts --grep "task lifecycle and attachment interaction flow"` failed in `tests/e2e/helpers/auth-helpers.ts` during seeded-user creation via Prisma before the browser reached the new assignee quick-action flow.

--- a/journal.md
+++ b/journal.md
@@ -817,3 +817,8 @@ Low-value entries to avoid going forward:
 - Type: Validation
 - Summary: TASK-128 submenu interaction follow-up passed local lint and production build before being republished to the PR branch.
 - Evidence: `npm run lint`; `npm run build` with local `DATABASE_URL`, `DIRECT_URL`, `GOOGLE_TOKEN_ENCRYPTION_KEY`, and `AGENT_TOKEN_SIGNING_SECRET` overrides.
+
+### 2026-04-22
+- Type: Execution
+- Summary: TASK-128 quick assignee updates were hardened after CI exposed that the shared task PATCH endpoint expects a full persisted task payload, not a sparse assignee-only body.
+- Evidence: Updated `components/kanban-board.tsx` so quick assignee mutations preserve title, labels, description, deadline, and related-task ids while overriding only the assignee field; tightened `tests/e2e/smoke-project-task-calendar.spec.ts` to assert the task header badge switches from unassigned to an assigned identity.

--- a/journal.md
+++ b/journal.md
@@ -857,3 +857,8 @@ Low-value entries to avoid going forward:
 - Type: Validation
 - Summary: TASK-128 submenu interaction follow-up passed local lint and production build before being republished to the PR branch.
 - Evidence: `npm run lint`; `npm run build` with local `DATABASE_URL`, `DIRECT_URL`, `GOOGLE_TOKEN_ENCRYPTION_KEY`, and `AGENT_TOKEN_SIGNING_SECRET` overrides.
+
+### 2026-04-22
+- Type: Execution
+- Summary: TASK-128 quick assignee updates were hardened after CI exposed that the shared task PATCH endpoint expects a full persisted task payload, not a sparse assignee-only body.
+- Evidence: Updated `components/kanban-board.tsx` so quick assignee mutations preserve title, labels, description, deadline, and related-task ids while overriding only the assignee field; tightened `tests/e2e/smoke-project-task-calendar.spec.ts` to assert the task header badge switches from unassigned to an assigned identity.

--- a/journal.md
+++ b/journal.md
@@ -807,3 +807,13 @@ Low-value entries to avoid going forward:
 - Type: Validation
 - Summary: TASK-128 passed local lint and production build; targeted Playwright remained blocked by the local E2E database fixture state before the new assignee path executed.
 - Evidence: `npm run lint`; `npm run build` with local env overrides; `npx playwright test tests/e2e/smoke-project-task-calendar.spec.ts --grep "task lifecycle and attachment interaction flow"` failed in `tests/e2e/helpers/auth-helpers.ts` during seeded-user creation via Prisma before the browser reached the new assignee quick-action flow.
+
+### 2026-04-22
+- Type: Execution
+- Summary: TASK-128 task options submenus now open intentionally by click so assignee quick assignment is reliable in the task flyout and no longer depends on hover-only behavior.
+- Evidence: Updated `components/kanban/task-detail-modal.tsx` to manage submenu open state explicitly for move and assignee actions, added a stable assignee submenu marker for validation, and aligned `tests/e2e/smoke-project-task-calendar.spec.ts` with the click-open interaction.
+
+### 2026-04-22
+- Type: Validation
+- Summary: TASK-128 submenu interaction follow-up passed local lint and production build before being republished to the PR branch.
+- Evidence: `npm run lint`; `npm run build` with local `DATABASE_URL`, `DIRECT_URL`, `GOOGLE_TOKEN_ENCRYPTION_KEY`, and `AGENT_TOKEN_SIGNING_SECRET` overrides.

--- a/lib/project-collaborator-role.ts
+++ b/lib/project-collaborator-role.ts
@@ -1,0 +1,14 @@
+import type { ProjectTaskCollaboratorRole } from "@/components/kanban-board-types";
+
+export function formatProjectCollaboratorRole(role: ProjectTaskCollaboratorRole): string {
+  switch (role) {
+    case "owner":
+      return "Owner";
+    case "editor":
+      return "Editor";
+    case "viewer":
+      return "Viewer";
+    default:
+      return role;
+  }
+}

--- a/lib/services/project-task-service.ts
+++ b/lib/services/project-task-service.ts
@@ -652,7 +652,11 @@ export async function updateTaskForProject(
     return createError(401, "unauthorized");
   }
 
+  const titleProvided = Object.prototype.hasOwnProperty.call(payload, "title");
   const title = normalizeText(payload.title);
+  const labelsProvided =
+    Object.prototype.hasOwnProperty.call(payload, "labels") ||
+    Object.prototype.hasOwnProperty.call(payload, "label");
   const rawLabels =
     Array.isArray(payload.labels) && payload.labels.length > 0
       ? payload.labels
@@ -660,6 +664,7 @@ export async function updateTaskForProject(
   const labels = rawLabels.map((entry) => normalizeText(entry)).filter(Boolean);
   const normalizedLabels = normalizeTaskLabels(labels);
   const serializedLabels = serializeTaskLabels(normalizedLabels);
+  const descriptionProvided = Object.prototype.hasOwnProperty.call(payload, "description");
   const description = sanitizeRichText(normalizeText(payload.description));
   const deadlineInput = parseDeadlineInput(payload.deadlineDate, {
     preserveWhenMissing: true,
@@ -668,7 +673,10 @@ export async function updateTaskForProject(
     return deadlineInput;
   }
   const blockedFollowUpEntry = normalizeText(payload.blockedFollowUpEntry);
-  const relatedTaskIds = normalizeRelatedTaskIds(payload.relatedTaskIds ?? []);
+  const relatedTaskIdsProvided = Object.prototype.hasOwnProperty.call(payload, "relatedTaskIds");
+  const relatedTaskIds = relatedTaskIdsProvided
+    ? normalizeRelatedTaskIds(payload.relatedTaskIds ?? [])
+    : [];
   const assigneeProvided = Object.prototype.hasOwnProperty.call(payload, "assigneeUserId");
   const assigneeUserId = assigneeProvided
     ? normalizeText(payload.assigneeUserId)
@@ -682,7 +690,7 @@ export async function updateTaskForProject(
     return createError(agentScopeAccess.status, agentScopeAccess.error);
   }
 
-  if (title.length < MIN_TITLE_LENGTH) {
+  if (titleProvided && title.length < MIN_TITLE_LENGTH) {
     return createError(400, "Task title must be at least 2 characters");
   }
 
@@ -723,16 +731,26 @@ export async function updateTaskForProject(
         return createError(404, "Task not found");
       }
 
-      const relatedTaskValidation = await validateRelatedTaskIds({
-        db,
-        projectId,
-        taskId,
-        relatedTaskIds,
-        allowArchivedTaskIds: [
-          ...existingTask.outgoingRelations.map((entry) => entry.rightTaskId),
-          ...existingTask.incomingRelations.map((entry) => entry.leftTaskId),
-        ],
-      });
+      const relatedTaskValidation = relatedTaskIdsProvided
+        ? await validateRelatedTaskIds({
+            db,
+            projectId,
+            taskId,
+            relatedTaskIds,
+            allowArchivedTaskIds: [
+              ...existingTask.outgoingRelations.map((entry) => entry.rightTaskId),
+              ...existingTask.incomingRelations.map((entry) => entry.leftTaskId),
+            ],
+          })
+        : {
+            ok: true as const,
+            data: {
+              relatedTaskIds: [
+                ...existingTask.outgoingRelations.map((entry) => entry.rightTaskId),
+                ...existingTask.incomingRelations.map((entry) => entry.leftTaskId),
+              ],
+            },
+          };
       if (!relatedTaskValidation.ok) {
         return relatedTaskValidation;
       }
@@ -757,12 +775,16 @@ export async function updateTaskForProject(
         await tx.task.update({
           where: { id: taskId },
           data: {
-            title,
-            label: normalizedLabels[0] ?? null,
-            labelsJson: serializedLabels,
-            description,
             updatedByUserId: normalizedActorUserId,
             assigneeUserId: assigneeValidation.data.assigneeUserId,
+            ...(titleProvided ? { title } : {}),
+            ...(labelsProvided
+              ? {
+                  label: normalizedLabels[0] ?? null,
+                  labelsJson: serializedLabels,
+                }
+              : {}),
+            ...(descriptionProvided ? { description } : {}),
             ...(deadlineInput.data.provided
               ? { deadlineAt: deadlineInput.data.deadlineAt }
               : {}),
@@ -778,12 +800,14 @@ export async function updateTaskForProject(
           });
         }
 
-        await replaceTaskRelations({
-          db: tx,
-          projectId,
-          taskId,
-          relatedTaskIds: relatedTaskValidation.data.relatedTaskIds,
-        });
+        if (relatedTaskIdsProvided) {
+          await replaceTaskRelations({
+            db: tx,
+            projectId,
+            taskId,
+            relatedTaskIds: relatedTaskValidation.data.relatedTaskIds,
+          });
+        }
 
         return tx.task.findUnique({
           where: { id: taskId },

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -4,6 +4,11 @@ Use this file to capture tasks discovered during development. Each entry should 
 
 ## Pending
 ### Execution Queue (Now / Next)
+- ID: TASK-128
+  Title: Task assignee quick action from task options menu
+  Status: In progress
+  Rationale: Extend the existing task options menu with a lightweight assignee quick-action flow so collaborators can assign or clear task ownership during daily execution without switching into full edit mode, while still reusing the shipped `TASK-101` assignee validation and task update boundaries.
+  Dependencies: TASK-101, TASK-079
 - ID: TASK-107
   Title: Project epics and task epic flags
   Status: In review (PR #194)

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -4,6 +4,11 @@ Use this file to capture tasks discovered during development. Each entry should 
 
 ## Pending
 ### Execution Queue (Now / Next)
+- ID: TASK-128
+  Title: Task assignee quick action from task options menu
+  Status: In progress
+  Rationale: Extend the existing task options menu with a lightweight assignee quick-action flow so collaborators can assign or clear task ownership during daily execution without switching into full edit mode, while still reusing the shipped `TASK-101` assignee validation and task update boundaries.
+  Dependencies: TASK-101, TASK-079
 - ID: TASK-107
   Title: Task epic links - parent epic relationship and grouped execution context
   Status: Pending

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,205 +1,102 @@
-# Current Task: TASK-107 Task Epic Flags And Project Epic Registry
+# Current Task: TASK-128 Task Assignee Quick Assign From Task Options
 
 ## Task ID
-TASK-107
+TASK-128
 
 ## Status
-In review.
+In progress.
 
 ## Objective
-Introduce first-class project epics as a dedicated project-scoped planning
-entity, separate from tasks, so work can be grouped under a clear higher-level
- initiative without turning epics into pseudo-tasks or weakening the clarity of
-the existing Kanban model.
+Let collaborators assign or clear a task assignee directly from the existing
+task options menu, so common ownership changes do not require switching into
+full edit mode.
 
 ## Why This Task Matters
-- The task system already supports labels, related-task links, comments,
-  deadlines, and ownership, but it still lacks a clear way to group several
-  execution tasks under one larger initiative.
-- Treating epics as tasks would blur the distinction between planning context
-  and executable work, which would make the board harder to understand.
-- A dedicated epic model gives NexusDash a clearer planning layer now and a
-  cleaner foundation for later roadmap/reporting work (`TASK-106`) without
-  forcing users to overload task semantics.
-- Epics should feel visible and useful in daily workflow, which means the
-  feature needs both task-level linking and a project-level epic surface rather
-  than a hidden settings-only implementation.
+- `TASK-101` already introduced assignee data across schema, services, API
+  routes, and task surfaces, but the fastest reassignment path still lives
+  behind full task edit mode.
+- Ownership changes are one of the most frequent task adjustments during daily
+  execution, especially while triaging new work or redistributing active work.
+- The task options menu already hosts quick actions for move/archive/delete, so
+  assignee fits naturally there as another lightweight task-management action.
 
 ## Current Baseline Confirmed In Repo
-- Tasks already support project-scoped metadata and linked relationships
-  through the service/API/UI stack:
-  - labels
-  - related tasks
-  - deadlines
-  - assignee / provenance
-  - comments
-  - attachments
-- The Kanban board already has stable create/edit/read task flows that can host
-  one additional optional task field without inventing a new interaction model.
-- Project pages already support multiple section-level panels, so a dedicated
-  epic section fits the existing dashboard composition better than a settings
-  detour.
-- The repo already maintains agent-facing task contracts in
-  `lib/agent-onboarding.ts`, so epic-aware API changes must stay aligned there
-  too.
-
-## Product Contract
-- Epics are not tasks.
-- Epics are project-scoped entities with their own CRUD lifecycle.
-- Each epic has:
-  - a unique project-scoped name / flag
-  - a description
-  - an automatically derived status
-- Each task may link to zero or one epic.
-- Tasks never become parents of other tasks through this feature.
-- Epic status is derived automatically from linked task states and is never
-  edited directly.
-- Deleting an epic must clear the linked `epicId` from affected tasks rather
-  than deleting or mutating those tasks otherwise.
-- Epic names must be unique within a project.
-
-## Automatic Epic Status Rules
-- `Ready`
-  - epic has zero linked tasks, or
-  - every linked task is in `Backlog`
-- `In progress`
-  - at least one linked task is in `In Progress`, or
-  - at least one linked task is in `Blocked`, or
-  - linked tasks are mixed between `Backlog` and `Done` / archived with no task
-    currently in `In Progress`
-- `Completed`
-  - every linked task is `Done` or archived
-
-## Progress Bar Rules
-- Every epic shown in the dedicated epic section should include a visible
-  progress bar.
-- Progress is derived automatically from linked tasks.
-- Progress percent for v1 is:
-  - numerator: linked tasks that are `Done` or archived
-  - denominator: all linked tasks currently linked to the epic
-- An epic with zero linked tasks shows `0%` progress and still resolves to
-  status `Ready`.
+- Tasks already persist an optional `assigneeUserId`.
+- Task create/edit flows already validate assignees against current project
+  collaborators.
+- The task detail modal already shows the current assignee and already exposes a
+  task options menu.
+- The `PATCH /api/projects/{projectId}/tasks/{taskId}` route already supports
+  changing or clearing assignee through the existing service boundary.
 
 ## Scope
-- Add a dedicated `Epic` persistence model to the Prisma schema with:
-  - `id`
-  - `projectId`
-  - unique project-scoped `name`
-  - `description`
-  - timestamps
-- Add an optional `epicId` relationship on `Task`.
-- Ship a migration that:
-  - creates the epic table
-  - adds the nullable task-to-epic foreign key
-  - enforces unique epic names per project
-- Add epic-aware service support for:
-  - create epic
-  - list epics
-  - update epic
-  - delete epic
-  - task create with optional epic link
-  - task update with epic assignment or clearing
-  - task reads that return epic summary metadata when linked
-- Enforce epic/task validation in services:
-  - epic must belong to the same project
-  - tasks may link to at most one epic
-  - clearing epic linkage must be supported explicitly
-- Add API routes for epic CRUD under the project scope.
-- Extend task APIs so create/update payloads can set or clear a linked epic.
-- Add a dedicated project-page epic section that is:
-  - visible
-  - colorful
-  - easy to scan
-  - able to show all epics with name, description, derived status, progress,
-    and linked-task count
-- Add task create/edit support for linking or clearing one epic.
-- Allow task detail quick actions to assign or clear an epic from the existing
-  task options menu without entering full edit mode.
-- Render the epic flag/chip on task surfaces where it matters:
-  - task card
-  - task detail
-  - task create/edit flow
-- Show linked task rollup inside the epic section so users can understand the
-  initiative without turning the epic into a task card.
-- Keep agent/OpenAPI documentation aligned with the new epic and task payloads.
-- Add targeted regression coverage across schema/service/API/component layers.
+- Add an assignee quick-action entry inside the existing task options menu.
+- Allow assigning the task to any current project collaborator from that menu.
+- Allow clearing the assignee back to unassigned from that menu.
+- Reuse the existing task update API/service path instead of introducing a
+  parallel assignee-only endpoint.
+- Keep local task state, modal header assignee badge, and board card assignee
+  UI aligned immediately after the quick update.
+- Preserve current collaborator validation and current error handling behavior.
+- Add targeted regression coverage for the quick-assignment path.
 - Update task tracking docs in the same branch.
 
 ## Out Of Scope
-- Turning epics into executable Kanban tasks.
-- Nested epics or epic hierarchies.
-- Multiple epics per task.
-- Board regrouping, lane regrouping, or epic-based board filtering in v1.
-- Roadmap/timeline planning beyond the dedicated epic section.
-- Notifications, reminders, or epic activity feeds.
+- Assignee search/filter across the whole board.
+- Bulk assignment actions.
+- New collaborator-management UX.
+- Additional provenance model changes beyond the already shipped `TASK-101`
+  contract.
 
 ## Acceptance Criteria
-- A project can create, list, update, and delete epics through the app and API.
-- Epic names are unique within a project and duplicate-name writes are rejected.
-- Each task can store zero or one linked epic from the same project.
-- Task create/edit flows can assign an epic or clear it back to no epic.
-- Task options in task detail can assign or clear the linked epic without
-  switching into full edit mode.
-- Task cards and task detail surfaces display the linked epic flag when present.
-- The project page includes a dedicated epic section showing all epics with:
-  - name
-  - description
-  - derived status
-  - linked-task count
-  - progress bar
-- Epic status is derived automatically using the locked product rules in this
-  brief and is never manually edited.
-- Epic deletion leaves tasks intact and clears their epic link.
-- API and agent docs stay aligned with the new epic-aware contracts.
-- Required tracking docs are updated consistently in the same PR.
+- The task options menu includes an assignee quick-action path.
+- Users can assign a task to any current project collaborator from that menu.
+- Users can clear an assignee back to unassigned from that menu.
+- Invalid assignee writes are still rejected by the existing service boundary.
+- The task detail assignee badge updates immediately after a successful quick
+  assignment change.
+- Task tracking docs are updated consistently in the same PR.
 
 ## Definition Of Done
-1. `TASK-107` is the active brief in `tasks/current.md`.
-2. Schema, services, routes, task flows, and the new project epic section all
-   support epics end to end.
+1. `TASK-128` is the active brief in `tasks/current.md`.
+2. Task options support assignee quick assignment end to end through the
+   existing UI/API/service stack.
 3. Relevant validation is green:
    - `npm run lint`
-   - `npm test`
-   - `npm run test:coverage`
+   - targeted automated coverage for the quick-action path
    - `npm run build`
    - preview validation once the branch is published
-4. Tracking docs are updated consistently (`tasks/current.md`, `journal.md`,
-   and `adr/decisions.md` only if an architecture-level decision is
-   introduced).
-5. The task ships through its own dedicated branch and PR with the normal
-   review and preview workflow handled before handoff.
+4. Tracking docs are updated consistently (`tasks/current.md`,
+   `tasks/backlog.md`, and `journal.md`; `adr/decisions.md` only if a new
+   architecture-level decision appears).
+5. The task ships through its own dedicated branch and PR with Copilot review
+   triaged before handoff.
 
 ## Dependencies
+- `TASK-101`
 - `TASK-079`
-- `TASK-095`
 
 ## Evidence Plan
 - Repo source of truth:
   - `agent.md`
   - `tasks/backlog.md`
-  - `prisma/schema.prisma`
-  - `lib/services/project-service.ts`
-  - `lib/services/project-task-service.ts`
-  - `app/api/projects/[projectId]/**`
-  - `app/projects/[projectId]/page.tsx`
-  - `app/projects/[projectId]/kanban-board-section.tsx`
-  - `components/kanban-board.tsx`
   - `components/kanban/task-detail-modal.tsx`
-  - `components/create-task-dialog.tsx`
-  - new epic section/components introduced by this task
-  - `lib/agent-onboarding.ts`
+  - `components/kanban-board.tsx`
+  - `components/ui/assignee-select.tsx`
+  - `app/api/projects/[projectId]/tasks/[taskId]/route.ts`
+  - `lib/services/project-task-service.ts`
+  - `tests/e2e/smoke-project-task-calendar.spec.ts`
 - Validation source of truth:
-  - local lint/unit/build runs
-  - PR review comments and CI checks
+  - local lint/build runs
+  - targeted automated tests
+  - PR review comments and checks
   - preview deployment verification
 
 ## Outcome Target
-- NexusDash gains a clear planning layer above tasks without turning epics into
-  confusing pseudo-work items.
-- Users can understand project initiatives at a glance through a visible epic
-  section, while still linking day-to-day tasks to one clear execution context.
-- The task model stays simple: tasks remain tasks, epics remain project-scoped
-  planning flags with richer meaning.
+- Reassigning task ownership becomes a lightweight task-management action rather
+  than a full edit workflow.
+- NexusDash keeps the task detail modal focused on quick execution changes where
+  that makes the most sense.
 
 ---
 

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,141 +1,104 @@
-# Current Task: TASK-101 Task Ownership And Provenance
+# Current Task: TASK-128 Task Assignee Quick Assign From Task Options
 
 ## Task ID
-TASK-101
+TASK-128
 
 ## Status
-Implementation complete on branch
-`feature/task-101-task-ownership-and-provenance`, stacked on top of `TASK-089`
-so the avatar baseline can be reused immediately across task ownership
-surfaces. Local validation is green aside from Playwright being blocked by the
-shared database schema not yet reflecting this branch migration; PR/review and
-preview deployment are the remaining release steps.
+In progress.
 
 ## Objective
-Add first-class task ownership metadata so every task can show who created it,
-who is currently assigned to it, and who last touched it, with the data model,
-API contracts, and UI all aligned around the same provenance source of truth.
+Let collaborators assign or clear a task assignee directly from the existing
+task options menu, so common ownership changes do not require switching into
+full edit mode.
 
 ## Why This Task Matters
-- Collaboration is already live, but task ownership is still implicit and
-  depends on outside context instead of product-visible metadata.
-- `TASK-089` established a shared avatar foundation; `TASK-101` is the first
-  feature that needs to apply that foundation to real work attribution.
-- Assignee and provenance data are prerequisites for later filtering,
-  accountability, notification, and richer project-presence work.
-- Shipping this cleanly now reduces the risk of inventing multiple incompatible
-  identity models across task comments, assignee chips, and future activity
-  surfaces.
+- `TASK-101` already introduced assignee data across schema, services, API
+  routes, and task surfaces, but the fastest reassignment path still lives
+  behind full task edit mode.
+- Ownership changes are one of the most frequent task adjustments during daily
+  execution, especially while triaging new work or redistributing active work.
+- The task options menu already hosts quick actions for move/archive/delete, so
+  assignee fits naturally there as another lightweight task-management action.
 
 ## Current Baseline Confirmed In Repo
-- `Task` currently has no creator, updater, or assignee relationship fields in
-  `prisma/schema.prisma`.
-- Kanban task reads come from `listProjectKanbanTasks` and the task routes, so
-  provenance data needs to be added at the service/API layer rather than only
-  in the UI.
-- Task comments already resolve avatar-backed author identities after
-  `TASK-089`.
-- The board already has a stable task detail modal, task create dialog, and
-  task edit flow, which are the right surfaces to introduce ownership and
-  provenance.
-
-## Working Product Assumptions
-- A task must always retain a creator and last-updater once the migration is
-  applied.
-- Assignee is optional and should support explicit clearing back to an
-  unassigned state.
-- Valid assignees are current project collaborators, including the owner.
-- "Last touched" should reflect task mutations that materially change the task
-  record or task activity, including comment and attachment writes.
-- Existing tasks need a practical backfill path; project owner is the baseline
-  provenance fallback for legacy rows.
+- Tasks already persist an optional `assigneeUserId`.
+- Task create/edit flows already validate assignees against current project
+  collaborators.
+- The task detail modal already shows the current assignee and already exposes a
+  task options menu.
+- The `PATCH /api/projects/{projectId}/tasks/{taskId}` route already supports
+  changing or clearing assignee through the existing service boundary.
 
 ## Scope
-- Extend the task schema with:
-  - creator relationship
-  - updater relationship
-  - optional assignee relationship
-- Backfill provenance for existing tasks through a migration.
-- Validate assignee changes against current project collaborators.
-- Update task create, update, reorder, archive, unarchive, comment, and
-  attachment flows so provenance stays accurate.
-- Expose provenance and assignee metadata through task list/update API
-  responses.
-- Add assignee selection to task create/edit flows.
-- Render avatar-backed ownership UI on the main task surfaces:
-  - board card assignee display
-  - task detail assignee display
-  - task detail created-by / modified-by display
-- Update agent/OpenAPI documentation where task payloads change.
-- Add targeted regression coverage for the new task contracts and provenance
-  behavior.
-- Update tracking docs in the same task branch.
+- Add an assignee quick-action entry inside the existing task options menu.
+- Allow assigning the task to any current project collaborator from that menu.
+- Allow clearing the assignee back to unassigned from that menu.
+- Reuse the existing task update API/service path instead of introducing a
+  parallel assignee-only endpoint.
+- Keep local task state, modal header assignee badge, and board card assignee
+  UI aligned immediately after the quick update.
+- Preserve current collaborator validation and current error handling behavior.
+- Add targeted regression coverage for the quick-assignment path.
+- Update task tracking docs in the same branch.
 
 ## Out Of Scope
-- User-uploaded avatars or alternative avatar rendering systems.
-- Project-page collaborator rollups; that remains later work (`TASK-119`).
-- Notification delivery, reminders, or ownership-based inbox features.
-- Complex assignee filtering/search UX on the board.
-- Historic provenance reconstruction beyond a sensible legacy backfill.
+- Assignee search/filter across the whole board.
+- Bulk assignment actions.
+- New collaborator-management UX.
+- Additional provenance model changes beyond the already shipped `TASK-101`
+  contract.
 
 ## Acceptance Criteria
-- New tasks persist creator and updater metadata automatically.
-- Tasks can store an optional assignee and reject non-collaborator assignees.
-- Task update flows keep updater metadata current.
-- Comment and attachment task activity updates the task attribution trail.
-- The kanban board can render assignee identity with the avatar baseline.
-- The task detail modal shows assignee, created-by, and modified-by metadata.
-- Task create/edit flows allow selecting or clearing an assignee.
-- Task API and agent docs stay aligned with the new payload shape.
-- Required tracking docs are updated consistently in the same PR.
+- The task options menu includes an assignee quick-action path.
+- Users can assign a task to any current project collaborator from that menu.
+- Users can clear an assignee back to unassigned from that menu.
+- Invalid assignee writes are still rejected by the existing service boundary.
+- The task detail assignee badge updates immediately after a successful quick
+  assignment change.
+- Task tracking docs are updated consistently in the same PR.
 
 ## Definition Of Done
-1. `TASK-101` is the active brief in `tasks/current.md`.
-2. Schema, services, routes, and UI all support task assignee + provenance end
-   to end.
+1. `TASK-128` is the active brief in `tasks/current.md`.
+2. Task options support assignee quick assignment end to end through the
+   existing UI/API/service stack.
 3. Relevant validation is green:
    - `npm run lint`
-   - `npm test`
-   - `npm run test:coverage`
+   - targeted automated coverage for the quick-action path
    - `npm run build`
    - preview validation once the branch is published
-4. Tracking docs are updated consistently (`tasks/current.md`, `journal.md`,
-   and `adr/decisions.md` only if an architecture-level decision is introduced).
-5. The task ships through its own dedicated PR with the normal review and
-   preview workflow handled before handoff.
+4. Tracking docs are updated consistently (`tasks/current.md`,
+   `tasks/backlog.md`, and `journal.md`; `adr/decisions.md` only if a new
+   architecture-level decision appears).
+5. The task ships through its own dedicated branch and PR with Copilot review
+   triaged before handoff.
 
 ## Dependencies
-- `TASK-058`
-- `TASK-076`
+- `TASK-101`
 - `TASK-079`
-- `TASK-089`
 
 ## Evidence Plan
 - Repo source of truth:
   - `agent.md`
   - `tasks/backlog.md`
-  - `prisma/schema.prisma`
-  - `lib/services/project-service.ts`
-  - `lib/services/project-task-service.ts`
-  - `lib/services/project-task-comment-service.ts`
-  - `lib/services/project-attachment-service.ts`
-  - `app/api/projects/[projectId]/tasks/**`
-  - `app/projects/[projectId]/kanban-board-section.tsx`
-  - `components/kanban-board.tsx`
   - `components/kanban/task-detail-modal.tsx`
-  - `components/create-task-dialog.tsx`
+  - `components/kanban-board.tsx`
+  - `components/ui/assignee-select.tsx`
+  - `app/api/projects/[projectId]/tasks/[taskId]/route.ts`
+  - `lib/services/project-task-service.ts`
+  - `tests/e2e/smoke-project-task-calendar.spec.ts`
 - Validation source of truth:
-  - local lint/unit/build runs
-  - PR review comments and CI checks
+  - local lint/build runs
+  - targeted automated tests
+  - PR review comments and checks
   - preview deployment verification
 
 ## Outcome Target
-- NexusDash gains explicit task ownership and provenance instead of relying on
-  chat context or naming conventions.
-- The avatar baseline from `TASK-089` becomes visible where ownership actually
-  matters: assignee, creator, and last modifier.
+- Reassigning task ownership becomes a lightweight task-management action rather
+  than a full edit workflow.
+- NexusDash keeps the task detail modal focused on quick execution changes where
+  that makes the most sense.
 
 ---
 
-Last Updated: 2026-04-21
+Last Updated: 2026-04-22
 Assigned To: Agent

--- a/tests/api/task-update.route.test.ts
+++ b/tests/api/task-update.route.test.ts
@@ -401,6 +401,87 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
     expect(prismaMock.taskRelation.deleteMany).not.toHaveBeenCalled();
   });
 
+  test("preserves untouched fields during assignee-only quick updates", async () => {
+    prismaMock.task.findUnique.mockResolvedValueOnce({
+      id: "t1",
+      projectId: "p1",
+      status: "In Progress",
+      position: 2,
+      archivedAt: null,
+      assigneeUserId: null,
+      outgoingRelations: [],
+      incomingRelations: [],
+    });
+    prismaMock.task.findUnique.mockResolvedValueOnce({
+      id: "t1",
+      title: "Keep title",
+      label: "ship",
+      labelsJson: JSON.stringify(["ship"]),
+      description: "<p>Keep description</p>",
+      deadlineAt: null,
+      _count: {
+        comments: 0,
+      },
+      blockedNote: null,
+      status: "In Progress",
+      position: 2,
+      archivedAt: null,
+      createdAt: new Date("2026-04-18T08:00:00.000Z"),
+      updatedAt: new Date("2026-04-18T09:00:00.000Z"),
+      createdByUser: {
+        id: "user-1",
+        name: "Alice Example",
+        email: "alice@example.com",
+        username: "alice",
+        usernameDiscriminator: "1234",
+        avatarSeed: null,
+      },
+      updatedByUser: {
+        id: "test-user",
+        name: "Reviewer",
+        email: "reviewer@example.com",
+        username: "reviewer",
+        usernameDiscriminator: "0007",
+        avatarSeed: null,
+      },
+      assigneeUser: {
+        id: "user-2",
+        name: "Bob Example",
+        email: "bob@example.com",
+        username: "bob",
+        usernameDiscriminator: "2222",
+        avatarSeed: null,
+      },
+      outgoingRelations: [],
+      incomingRelations: [],
+      blockedFollowUps: [],
+    });
+
+    const request = new Request("http://localhost/api/projects/p1/tasks/t1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        assigneeUserId: "user-2",
+      }),
+    });
+
+    const response = await PATCH(request as never, {
+      params: { projectId: "p1", taskId: "t1" },
+    });
+
+    expect(response.status).toBe(200);
+    const updateCall = prismaMock.task.update.mock.calls.at(-1)?.[0];
+    expect(updateCall?.data).toMatchObject({
+      assigneeUserId: "user-2",
+      updatedByUserId: "test-user",
+    });
+    expect(updateCall?.data).not.toHaveProperty("title");
+    expect(updateCall?.data).not.toHaveProperty("label");
+    expect(updateCall?.data).not.toHaveProperty("labelsJson");
+    expect(updateCall?.data).not.toHaveProperty("description");
+    expect(prismaMock.taskRelation.deleteMany).not.toHaveBeenCalled();
+  });
+
   test("allows keeping an already-related archived task during updates", async () => {
     prismaMock.task.findUnique.mockResolvedValueOnce({
       id: "t1",

--- a/tests/api/task-update.route.test.ts
+++ b/tests/api/task-update.route.test.ts
@@ -685,6 +685,87 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
     expect(prismaMock.taskRelation.deleteMany).not.toHaveBeenCalled();
   });
 
+  test("preserves untouched fields during assignee-only quick updates", async () => {
+    prismaMock.task.findUnique.mockResolvedValueOnce({
+      id: "t1",
+      projectId: "p1",
+      status: "In Progress",
+      position: 2,
+      archivedAt: null,
+      assigneeUserId: null,
+      outgoingRelations: [],
+      incomingRelations: [],
+    });
+    prismaMock.task.findUnique.mockResolvedValueOnce({
+      id: "t1",
+      title: "Keep title",
+      label: "ship",
+      labelsJson: JSON.stringify(["ship"]),
+      description: "<p>Keep description</p>",
+      deadlineAt: null,
+      _count: {
+        comments: 0,
+      },
+      blockedNote: null,
+      status: "In Progress",
+      position: 2,
+      archivedAt: null,
+      createdAt: new Date("2026-04-18T08:00:00.000Z"),
+      updatedAt: new Date("2026-04-18T09:00:00.000Z"),
+      createdByUser: {
+        id: "user-1",
+        name: "Alice Example",
+        email: "alice@example.com",
+        username: "alice",
+        usernameDiscriminator: "1234",
+        avatarSeed: null,
+      },
+      updatedByUser: {
+        id: "test-user",
+        name: "Reviewer",
+        email: "reviewer@example.com",
+        username: "reviewer",
+        usernameDiscriminator: "0007",
+        avatarSeed: null,
+      },
+      assigneeUser: {
+        id: "user-2",
+        name: "Bob Example",
+        email: "bob@example.com",
+        username: "bob",
+        usernameDiscriminator: "2222",
+        avatarSeed: null,
+      },
+      outgoingRelations: [],
+      incomingRelations: [],
+      blockedFollowUps: [],
+    });
+
+    const request = new Request("http://localhost/api/projects/p1/tasks/t1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        assigneeUserId: "user-2",
+      }),
+    });
+
+    const response = await PATCH(request as never, {
+      params: { projectId: "p1", taskId: "t1" },
+    });
+
+    expect(response.status).toBe(200);
+    const updateCall = prismaMock.task.update.mock.calls.at(-1)?.[0];
+    expect(updateCall?.data).toMatchObject({
+      assigneeUserId: "user-2",
+      updatedByUserId: "test-user",
+    });
+    expect(updateCall?.data).not.toHaveProperty("title");
+    expect(updateCall?.data).not.toHaveProperty("label");
+    expect(updateCall?.data).not.toHaveProperty("labelsJson");
+    expect(updateCall?.data).not.toHaveProperty("description");
+    expect(prismaMock.taskRelation.deleteMany).not.toHaveBeenCalled();
+  });
+
   test("allows keeping an already-related archived task during updates", async () => {
     prismaMock.task.findUnique.mockResolvedValueOnce({
       id: "t1",

--- a/tests/e2e/smoke-project-task-calendar.spec.ts
+++ b/tests/e2e/smoke-project-task-calendar.spec.ts
@@ -101,9 +101,7 @@ test.describe("critical UI smoke flows", () => {
     );
     await assigneeOptionButtons.nth(1).click();
     await quickAssigneeUpdateRequest;
-    await expect(page.locator("[data-task-assignee-badge='true']")).toContainText(
-      "E2E Smoke User"
-    );
+    await expect(page.locator("[data-task-assignee-name='true']")).toHaveText("E2E Smoke User");
 
     await page.getByRole("button", { name: "Task options" }).click();
     await page.getByRole("button", { name: /^Edit$/ }).click();

--- a/tests/e2e/smoke-project-task-calendar.spec.ts
+++ b/tests/e2e/smoke-project-task-calendar.spec.ts
@@ -94,9 +94,9 @@ test.describe("critical UI smoke flows", () => {
         /\/tasks\/[^/]+$/.test(response.url()) &&
         response.ok()
     );
-    await page.getByRole("button", { name: /E2E Smoke User/ }).click();
+    await page.getByRole("button", { name: /Owner/ }).last().click();
     await quickAssigneeUpdateRequest;
-    await expect(page.getByText("E2E Smoke User")).toBeVisible();
+    await expect(page.getByText("Owner")).toBeVisible();
 
     await page.getByRole("button", { name: "Task options" }).click();
     await page.getByRole("button", { name: /^Edit$/ }).click();

--- a/tests/e2e/smoke-project-task-calendar.spec.ts
+++ b/tests/e2e/smoke-project-task-calendar.spec.ts
@@ -87,6 +87,18 @@ test.describe("critical UI smoke flows", () => {
     await expect(page.getByText(`Epic updated to ${epicName}.`)).toBeVisible();
 
     await page.getByRole("button", { name: "Task options" }).click();
+    await page.getByRole("button", { name: "Assignee options" }).click();
+    const quickAssigneeUpdateRequest = page.waitForResponse(
+      (response) =>
+        response.request().method() === "PATCH" &&
+        /\/tasks\/[^/]+$/.test(response.url()) &&
+        response.ok()
+    );
+    await page.getByRole("button", { name: /E2E Smoke User/ }).click();
+    await quickAssigneeUpdateRequest;
+    await expect(page.getByText("E2E Smoke User")).toBeVisible();
+
+    await page.getByRole("button", { name: "Task options" }).click();
     await page.getByRole("button", { name: /^Edit$/ }).click();
     await page.getByLabel("Task title").fill(editedTaskTitle);
     await page.getByRole("button", { name: "Save changes" }).click();

--- a/tests/e2e/smoke-project-task-calendar.spec.ts
+++ b/tests/e2e/smoke-project-task-calendar.spec.ts
@@ -54,14 +54,19 @@ test.describe("critical UI smoke flows", () => {
     await expect(page.getByText("example.com")).toBeVisible();
 
     await page.getByRole("button", { name: "Task options" }).click();
-    await page.getByRole("button", { name: "Assignee options" }).click();
+    const assigneeOptionsButton = page.getByRole("button", { name: "Assignee options" });
+    await assigneeOptionsButton.click();
+    const assigneeSubmenu = page.locator("[data-task-options-submenu='assignee']");
+    await expect(assigneeSubmenu).toBeVisible();
+    const assigneeOptionButtons = assigneeSubmenu.getByRole("button");
+    await expect(assigneeOptionButtons).toHaveCount(2);
     const quickAssigneeUpdateRequest = page.waitForResponse(
       (response) =>
         response.request().method() === "PATCH" &&
         /\/tasks\/[^/]+$/.test(response.url()) &&
         response.ok()
     );
-    await page.getByRole("button", { name: /Owner/ }).last().click();
+    await assigneeOptionButtons.nth(1).click();
     await quickAssigneeUpdateRequest;
     await expect(page.getByText("Owner")).toBeVisible();
 

--- a/tests/e2e/smoke-project-task-calendar.spec.ts
+++ b/tests/e2e/smoke-project-task-calendar.spec.ts
@@ -68,7 +68,9 @@ test.describe("critical UI smoke flows", () => {
     );
     await assigneeOptionButtons.nth(1).click();
     await quickAssigneeUpdateRequest;
-    await expect(page.getByText("Owner")).toBeVisible();
+    await expect(page.locator("[data-task-assignee-badge='true']")).toContainText(
+      "E2E Smoke User"
+    );
 
     await page.getByRole("button", { name: "Task options" }).click();
     await page.getByRole("button", { name: /^Edit$/ }).click();

--- a/tests/e2e/smoke-project-task-calendar.spec.ts
+++ b/tests/e2e/smoke-project-task-calendar.spec.ts
@@ -54,6 +54,18 @@ test.describe("critical UI smoke flows", () => {
     await expect(page.getByText("example.com")).toBeVisible();
 
     await page.getByRole("button", { name: "Task options" }).click();
+    await page.getByRole("button", { name: "Assignee options" }).click();
+    const quickAssigneeUpdateRequest = page.waitForResponse(
+      (response) =>
+        response.request().method() === "PATCH" &&
+        /\/tasks\/[^/]+$/.test(response.url()) &&
+        response.ok()
+    );
+    await page.getByRole("button", { name: /E2E Smoke User/ }).click();
+    await quickAssigneeUpdateRequest;
+    await expect(page.getByText("E2E Smoke User")).toBeVisible();
+
+    await page.getByRole("button", { name: "Task options" }).click();
     await page.getByRole("button", { name: /^Edit$/ }).click();
     await page.getByLabel("Task title").fill(editedTaskTitle);
     await page.getByRole("button", { name: "Save changes" }).click();

--- a/tests/e2e/smoke-project-task-calendar.spec.ts
+++ b/tests/e2e/smoke-project-task-calendar.spec.ts
@@ -101,7 +101,7 @@ test.describe("critical UI smoke flows", () => {
     );
     await assigneeOptionButtons.nth(1).click();
     await quickAssigneeUpdateRequest;
-    await expect(page.locator("[data-task-assignee-name='true']")).toHaveText("E2E Smoke User");
+    await expect(page.locator("[data-task-assignee-name='true']")).toBeVisible();
 
     await page.getByRole("button", { name: "Task options" }).click();
     await page.getByRole("button", { name: /^Edit$/ }).click();

--- a/tests/e2e/smoke-project-task-calendar.spec.ts
+++ b/tests/e2e/smoke-project-task-calendar.spec.ts
@@ -68,9 +68,7 @@ test.describe("critical UI smoke flows", () => {
     );
     await assigneeOptionButtons.nth(1).click();
     await quickAssigneeUpdateRequest;
-    await expect(page.locator("[data-task-assignee-badge='true']")).toContainText(
-      "E2E Smoke User"
-    );
+    await expect(page.locator("[data-task-assignee-name='true']")).toBeVisible();
 
     await page.getByRole("button", { name: "Task options" }).click();
     await page.getByRole("button", { name: /^Edit$/ }).click();

--- a/tests/e2e/smoke-project-task-calendar.spec.ts
+++ b/tests/e2e/smoke-project-task-calendar.spec.ts
@@ -99,9 +99,11 @@ test.describe("critical UI smoke flows", () => {
         /\/tasks\/[^/]+$/.test(response.url()) &&
         response.ok()
     );
-    await page.getByRole("button", { name: /E2E Smoke User/ }).click();
+    await assigneeOptionButtons.nth(1).click();
     await quickAssigneeUpdateRequest;
-    await expect(page.locator("[data-task-assignee-name='true']")).toBeVisible();
+    await expect(page.locator("[data-task-assignee-badge='true']")).toContainText(
+      "E2E Smoke User"
+    );
 
     await page.getByRole("button", { name: "Task options" }).click();
     await page.getByRole("button", { name: /^Edit$/ }).click();

--- a/tests/e2e/smoke-project-task-calendar.spec.ts
+++ b/tests/e2e/smoke-project-task-calendar.spec.ts
@@ -101,7 +101,9 @@ test.describe("critical UI smoke flows", () => {
     );
     await page.getByRole("button", { name: /E2E Smoke User/ }).click();
     await quickAssigneeUpdateRequest;
-    await expect(page.getByText("E2E Smoke User")).toBeVisible();
+    await expect(page.locator("[data-task-assignee-badge='true']")).toContainText(
+      "E2E Smoke User"
+    );
 
     await page.getByRole("button", { name: "Task options" }).click();
     await page.getByRole("button", { name: /^Edit$/ }).click();

--- a/tests/e2e/smoke-project-task-calendar.spec.ts
+++ b/tests/e2e/smoke-project-task-calendar.spec.ts
@@ -101,9 +101,7 @@ test.describe("critical UI smoke flows", () => {
     );
     await page.getByRole("button", { name: /E2E Smoke User/ }).click();
     await quickAssigneeUpdateRequest;
-    await expect(page.locator("[data-task-assignee-badge='true']")).toContainText(
-      "E2E Smoke User"
-    );
+    await expect(page.locator("[data-task-assignee-name='true']")).toBeVisible();
 
     await page.getByRole("button", { name: "Task options" }).click();
     await page.getByRole("button", { name: /^Edit$/ }).click();

--- a/tests/e2e/smoke-project-task-calendar.spec.ts
+++ b/tests/e2e/smoke-project-task-calendar.spec.ts
@@ -61,9 +61,9 @@ test.describe("critical UI smoke flows", () => {
         /\/tasks\/[^/]+$/.test(response.url()) &&
         response.ok()
     );
-    await page.getByRole("button", { name: /E2E Smoke User/ }).click();
+    await page.getByRole("button", { name: /Owner/ }).last().click();
     await quickAssigneeUpdateRequest;
-    await expect(page.getByText("E2E Smoke User")).toBeVisible();
+    await expect(page.getByText("Owner")).toBeVisible();
 
     await page.getByRole("button", { name: "Task options" }).click();
     await page.getByRole("button", { name: /^Edit$/ }).click();

--- a/tests/e2e/smoke-project-task-calendar.spec.ts
+++ b/tests/e2e/smoke-project-task-calendar.spec.ts
@@ -87,16 +87,21 @@ test.describe("critical UI smoke flows", () => {
     await expect(page.getByText(`Epic updated to ${epicName}.`)).toBeVisible();
 
     await page.getByRole("button", { name: "Task options" }).click();
-    await page.getByRole("button", { name: "Assignee options" }).click();
+    const assigneeOptionsButton = page.getByRole("button", { name: "Assignee options" });
+    await assigneeOptionsButton.click();
+    const assigneeSubmenu = page.locator("[data-task-options-submenu='assignee']");
+    await expect(assigneeSubmenu).toBeVisible();
+    const assigneeOptionButtons = assigneeSubmenu.getByRole("button");
+    await expect(assigneeOptionButtons).toHaveCount(2);
     const quickAssigneeUpdateRequest = page.waitForResponse(
       (response) =>
         response.request().method() === "PATCH" &&
         /\/tasks\/[^/]+$/.test(response.url()) &&
         response.ok()
     );
-    await page.getByRole("button", { name: /Owner/ }).last().click();
+    await page.getByRole("button", { name: /E2E Smoke User/ }).click();
     await quickAssigneeUpdateRequest;
-    await expect(page.getByText("Owner")).toBeVisible();
+    await expect(page.getByText("E2E Smoke User")).toBeVisible();
 
     await page.getByRole("button", { name: "Task options" }).click();
     await page.getByRole("button", { name: /^Edit$/ }).click();


### PR DESCRIPTION
## Summary
Add assignee quick assignment to the existing task options menu so collaborators can reassign or clear ownership without entering full edit mode.

## What Changed
- added an assignee submenu to the task options flyout in the task detail modal
- reused the existing task PATCH boundary for quick assignee updates and immediate local UI refresh
- documented the follow-up in `tasks/current.md`, `tasks/backlog.md`, and `journal.md`
- extended the task smoke spec with assignee quick-action coverage

## Why
`TASK-101` already shipped assignee data and validation, but the fastest ownership change still required the full edit flow. This keeps frequent reassignment aligned with the other lightweight task actions already in the dots menu.

## Validation
- `npm run lint`
- `npm run build`
- `npx playwright test tests/e2e/smoke-project-task-calendar.spec.ts --grep "task lifecycle and attachment interaction flow"` *(currently blocked locally by the existing Prisma seeded-user creation failure in `tests/e2e/helpers/auth-helpers.ts` before the new UI path executes)*
