### PR TITLE
TASK-106 Add project roadmap milestones

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Implemented today:
 - Project-scoped agent access with owner-managed API credentials, short-lived bearer-token exchange, and audit trail
 - Project dashboard with:
   - Context cards (CRUD + attachments)
+  - Roadmap milestones (manual visual sequencing + target dates)
   - Kanban board (`Backlog`, `In Progress`, `Blocked`, `Done`)
   - Calendar panel (Google Calendar list/create/update/delete)
 - Per-user Google Calendar connection and calendar target setting (`/account/settings`)
@@ -32,7 +33,7 @@ Implemented today:
 
 ## Tech Stack
 
-- Next.js 14 (App Router)
+- Next.js 16 (App Router)
 - TypeScript (strict)
 - Tailwind CSS + Shadcn UI
 - Prisma + PostgreSQL

--- a/app/api/projects/[projectId]/roadmap-milestones/[milestoneId]/route.ts
+++ b/app/api/projects/[projectId]/roadmap-milestones/[milestoneId]/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireAuthenticatedApiUser } from "@/lib/auth/api-guard";
+import { logServerWarning } from "@/lib/observability/logger";
+import {
+  deleteProjectRoadmapMilestone,
+  updateProjectRoadmapMilestone,
+} from "@/lib/services/project-roadmap-service";
+
+interface RoadmapMilestoneRequestBody {
+  title?: unknown;
+  description?: unknown;
+  targetDate?: unknown;
+  status?: unknown;
+}
+
+export async function PATCH(
+  request: NextRequest,
+  props: { params: Promise<{ projectId: string; milestoneId: string }> }
+) {
+  const params = await props.params;
+  const authenticatedUser = await requireAuthenticatedApiUser(request);
+  if (!authenticatedUser.ok) {
+    return authenticatedUser.response;
+  }
+
+  let payload: RoadmapMilestoneRequestBody;
+  try {
+    payload = (await request.json()) as RoadmapMilestoneRequestBody;
+  } catch (error) {
+    logServerWarning(
+      "PATCH /api/projects/:projectId/roadmap-milestones/:milestoneId.invalidJson",
+      "Invalid JSON payload",
+      { error }
+    );
+    return NextResponse.json({ error: "invalid-json" }, { status: 400 });
+  }
+
+  const result = await updateProjectRoadmapMilestone({
+    actorUserId: authenticatedUser.userId,
+    projectId: params.projectId,
+    milestoneId: params.milestoneId,
+    ...(Object.prototype.hasOwnProperty.call(payload, "title")
+      ? { title: typeof payload.title === "string" ? payload.title : "" }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(payload, "description")
+      ? {
+          description:
+            typeof payload.description === "string" ? payload.description : null,
+        }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(payload, "targetDate")
+      ? {
+          targetDate:
+            typeof payload.targetDate === "string" ? payload.targetDate : null,
+        }
+      : {}),
+    ...(Object.prototype.hasOwnProperty.call(payload, "status")
+      ? {
+          status: typeof payload.status === "string" ? payload.status : null,
+        }
+      : {}),
+  });
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json({
+    milestone: result.data.milestone,
+  });
+}
+
+export async function DELETE(
+  request: NextRequest,
+  props: { params: Promise<{ projectId: string; milestoneId: string }> }
+) {
+  const params = await props.params;
+  const authenticatedUser = await requireAuthenticatedApiUser(request);
+  if (!authenticatedUser.ok) {
+    return authenticatedUser.response;
+  }
+
+  const result = await deleteProjectRoadmapMilestone({
+    actorUserId: authenticatedUser.userId,
+    projectId: params.projectId,
+    milestoneId: params.milestoneId,
+  });
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/projects/[projectId]/roadmap-milestones/[milestoneId]/route.ts
+++ b/app/api/projects/[projectId]/roadmap-milestones/[milestoneId]/route.ts
@@ -14,6 +14,10 @@ interface RoadmapMilestoneRequestBody {
   status?: unknown;
 }
 
+function hasOwn(payload: RoadmapMilestoneRequestBody, key: keyof RoadmapMilestoneRequestBody) {
+  return Object.prototype.hasOwnProperty.call(payload, key);
+}
+
 export async function PATCH(
   request: NextRequest,
   props: { params: Promise<{ projectId: string; milestoneId: string }> }
@@ -36,29 +40,46 @@ export async function PATCH(
     return NextResponse.json({ error: "invalid-json" }, { status: 400 });
   }
 
+  if (hasOwn(payload, "title") && typeof payload.title !== "string") {
+    return NextResponse.json({ error: "invalid-payload" }, { status: 400 });
+  }
+  if (
+    hasOwn(payload, "description") &&
+    payload.description !== null &&
+    typeof payload.description !== "string"
+  ) {
+    return NextResponse.json({ error: "invalid-payload" }, { status: 400 });
+  }
+  if (
+    hasOwn(payload, "targetDate") &&
+    payload.targetDate !== null &&
+    typeof payload.targetDate !== "string"
+  ) {
+    return NextResponse.json({ error: "invalid-payload" }, { status: 400 });
+  }
+  if (
+    hasOwn(payload, "status") &&
+    payload.status !== null &&
+    typeof payload.status !== "string"
+  ) {
+    return NextResponse.json({ error: "invalid-payload" }, { status: 400 });
+  }
+
   const result = await updateProjectRoadmapMilestone({
     actorUserId: authenticatedUser.userId,
     projectId: params.projectId,
     milestoneId: params.milestoneId,
-    ...(Object.prototype.hasOwnProperty.call(payload, "title")
-      ? { title: typeof payload.title === "string" ? payload.title : "" }
+    ...(hasOwn(payload, "title")
+      ? { title: payload.title as string }
       : {}),
-    ...(Object.prototype.hasOwnProperty.call(payload, "description")
-      ? {
-          description:
-            typeof payload.description === "string" ? payload.description : null,
-        }
+    ...(hasOwn(payload, "description")
+      ? { description: (payload.description ?? null) as string | null }
       : {}),
-    ...(Object.prototype.hasOwnProperty.call(payload, "targetDate")
-      ? {
-          targetDate:
-            typeof payload.targetDate === "string" ? payload.targetDate : null,
-        }
+    ...(hasOwn(payload, "targetDate")
+      ? { targetDate: (payload.targetDate ?? null) as string | null }
       : {}),
-    ...(Object.prototype.hasOwnProperty.call(payload, "status")
-      ? {
-          status: typeof payload.status === "string" ? payload.status : null,
-        }
+    ...(hasOwn(payload, "status")
+      ? { status: (payload.status ?? null) as string | null }
       : {}),
   });
 

--- a/app/api/projects/[projectId]/roadmap-milestones/reorder/route.ts
+++ b/app/api/projects/[projectId]/roadmap-milestones/reorder/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireAuthenticatedApiUser } from "@/lib/auth/api-guard";
+import { logServerWarning } from "@/lib/observability/logger";
+import {
+  isValidRoadmapReorderPayload,
+  reorderProjectRoadmapMilestones,
+} from "@/lib/services/project-roadmap-service";
+
+export async function POST(
+  request: NextRequest,
+  props: { params: Promise<{ projectId: string }> }
+) {
+  const params = await props.params;
+  const authenticatedUser = await requireAuthenticatedApiUser(request);
+  if (!authenticatedUser.ok) {
+    return authenticatedUser.response;
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch (error) {
+    logServerWarning(
+      "POST /api/projects/:projectId/roadmap-milestones/reorder.invalidJson",
+      "Invalid JSON payload",
+      { error }
+    );
+    return NextResponse.json({ error: "invalid-json" }, { status: 400 });
+  }
+
+  if (!isValidRoadmapReorderPayload(payload)) {
+    return NextResponse.json({ error: "invalid-payload" }, { status: 400 });
+  }
+
+  const result = await reorderProjectRoadmapMilestones({
+    actorUserId: authenticatedUser.userId,
+    projectId: params.projectId,
+    milestoneIds: payload.milestoneIds,
+  });
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/projects/[projectId]/roadmap-milestones/route.ts
+++ b/app/api/projects/[projectId]/roadmap-milestones/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireAuthenticatedApiUser } from "@/lib/auth/api-guard";
+import { logServerWarning } from "@/lib/observability/logger";
+import {
+  createProjectRoadmapMilestone,
+  listProjectRoadmapMilestones,
+} from "@/lib/services/project-roadmap-service";
+
+interface RoadmapMilestoneRequestBody {
+  title?: unknown;
+  description?: unknown;
+  targetDate?: unknown;
+  status?: unknown;
+}
+
+export async function GET(
+  request: NextRequest,
+  props: { params: Promise<{ projectId: string }> }
+) {
+  const params = await props.params;
+  const authenticatedUser = await requireAuthenticatedApiUser(request);
+  if (!authenticatedUser.ok) {
+    return authenticatedUser.response;
+  }
+
+  const milestones = await listProjectRoadmapMilestones(
+    params.projectId,
+    authenticatedUser.userId
+  );
+
+  return NextResponse.json({
+    milestones,
+  });
+}
+
+export async function POST(
+  request: NextRequest,
+  props: { params: Promise<{ projectId: string }> }
+) {
+  const params = await props.params;
+  const authenticatedUser = await requireAuthenticatedApiUser(request);
+  if (!authenticatedUser.ok) {
+    return authenticatedUser.response;
+  }
+
+  let payload: RoadmapMilestoneRequestBody;
+  try {
+    payload = (await request.json()) as RoadmapMilestoneRequestBody;
+  } catch (error) {
+    logServerWarning(
+      "POST /api/projects/:projectId/roadmap-milestones.invalidJson",
+      "Invalid JSON payload",
+      { error }
+    );
+    return NextResponse.json({ error: "invalid-json" }, { status: 400 });
+  }
+
+  const result = await createProjectRoadmapMilestone({
+    actorUserId: authenticatedUser.userId,
+    projectId: params.projectId,
+    title: typeof payload.title === "string" ? payload.title : "",
+    description: typeof payload.description === "string" ? payload.description : null,
+    targetDate: typeof payload.targetDate === "string" ? payload.targetDate : null,
+    status: typeof payload.status === "string" ? payload.status : null,
+  });
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json(
+    {
+      milestone: result.data.milestone,
+    },
+    { status: 201 }
+  );
+}

--- a/app/projects/[projectId]/page.tsx
+++ b/app/projects/[projectId]/page.tsx
@@ -33,6 +33,10 @@ import {
   ProjectEpicPanelSection,
   ProjectEpicPanelSkeleton,
 } from "./project-epic-panel-section";
+import {
+  ProjectRoadmapPanelSection,
+  ProjectRoadmapPanelSkeleton,
+} from "./project-roadmap-panel-section";
 
 type SearchParams = Record<string, string | string[] | undefined>;
 
@@ -217,6 +221,14 @@ export default async function ProjectDashboardPage({
           actorUserId={actorUserId}
           canEdit={canEditProjectContent}
           storageProvider={storageProvider}
+        />
+      </Suspense>
+
+      <Suspense fallback={<ProjectRoadmapPanelSkeleton />}>
+        <ProjectRoadmapPanelSection
+          projectId={project.id}
+          actorUserId={actorUserId}
+          canEdit={canEditProjectContent}
         />
       </Suspense>
 

--- a/app/projects/[projectId]/project-roadmap-panel-section.tsx
+++ b/app/projects/[projectId]/project-roadmap-panel-section.tsx
@@ -1,0 +1,68 @@
+import { Map } from "lucide-react";
+
+import {
+  PROJECT_SECTION_CARD_CLASS,
+  PROJECT_SECTION_CONTENT_CLASS,
+  PROJECT_SECTION_HEADER_CLASS,
+} from "@/components/project-dashboard/project-section-chrome";
+import {
+  ProjectRoadmapPanel,
+  type ProjectRoadmapPanelMilestone,
+} from "@/components/project-roadmap-panel";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { logServerError } from "@/lib/observability/logger";
+import { listProjectRoadmapMilestones } from "@/lib/services/project-roadmap-service";
+
+interface ProjectRoadmapPanelSectionProps {
+  projectId: string;
+  actorUserId: string;
+  canEdit: boolean;
+}
+
+export async function ProjectRoadmapPanelSection({
+  projectId,
+  actorUserId,
+  canEdit,
+}: ProjectRoadmapPanelSectionProps) {
+  let milestones: ProjectRoadmapPanelMilestone[] = [];
+  let loadError: string | null = null;
+
+  try {
+    milestones = await listProjectRoadmapMilestones(projectId, actorUserId);
+  } catch (error) {
+    logServerError("ProjectRoadmapPanelSection", error, {
+      actorUserId,
+      projectId,
+    });
+    loadError = "Roadmap is temporarily unavailable. Reload to try again.";
+  }
+
+  return (
+    <ProjectRoadmapPanel
+      projectId={projectId}
+      canEdit={canEdit}
+      milestones={milestones}
+      loadError={loadError}
+    />
+  );
+}
+
+export function ProjectRoadmapPanelSkeleton() {
+  return (
+    <Card className={PROJECT_SECTION_CARD_CLASS}>
+      <CardHeader className={PROJECT_SECTION_HEADER_CLASS}>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Map className="h-4 w-4" />
+          Roadmap
+        </CardTitle>
+      </CardHeader>
+      <CardContent className={`space-y-4 ${PROJECT_SECTION_CONTENT_CLASS}`}>
+        <div className="hidden h-52 animate-pulse rounded-3xl bg-muted/70 lg:block" />
+        <div className="grid gap-3 lg:hidden">
+          <div className="h-32 animate-pulse rounded-2xl bg-muted/70" />
+          <div className="h-32 animate-pulse rounded-2xl bg-muted/70" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/project-roadmap-panel.tsx
+++ b/components/project-roadmap-panel.tsx
@@ -1,0 +1,1048 @@
+"use client";
+
+import { startTransition, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  ArrowLeft,
+  ArrowRight,
+  CalendarDays,
+  ChevronDown,
+  ChevronUp,
+  Map,
+  Pencil,
+  PlusSquare,
+  Trash2,
+} from "lucide-react";
+
+import { CalendarDateTimeField } from "@/components/calendar-date-time-field";
+import {
+  PROJECT_SECTION_CARD_CLASS,
+  PROJECT_SECTION_CONTENT_CLASS,
+  PROJECT_SECTION_HEADER_CLASS,
+} from "@/components/project-dashboard/project-section-chrome";
+import { useToast } from "@/components/toast-provider";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { EmojiInputField, EmojiTextareaField } from "@/components/ui/emoji-field";
+import {
+  formatRoadmapTargetDateForDisplay,
+  getRoadmapMilestoneStatusLabel,
+  ROADMAP_MILESTONE_STATUSES,
+  type ProjectRoadmapMilestone,
+  type RoadmapMilestoneStatus,
+} from "@/lib/roadmap-milestone";
+import { useProjectSectionExpanded } from "@/lib/hooks/use-project-section-expanded";
+import { cn } from "@/lib/utils";
+
+export type ProjectRoadmapPanelMilestone = ProjectRoadmapMilestone;
+
+interface ProjectRoadmapPanelProps {
+  projectId: string;
+  canEdit: boolean;
+  milestones: ProjectRoadmapPanelMilestone[];
+  loadError?: string | null;
+}
+
+interface RoadmapDraftState {
+  title: string;
+  description: string;
+  targetDate: string;
+  status: RoadmapMilestoneStatus;
+}
+
+const DEFAULT_DRAFT_STATE: RoadmapDraftState = {
+  title: "",
+  description: "",
+  targetDate: "",
+  status: "planned",
+};
+
+function cloneDraftState(
+  milestone?: ProjectRoadmapPanelMilestone | null
+): RoadmapDraftState {
+  if (!milestone) {
+    return { ...DEFAULT_DRAFT_STATE };
+  }
+
+  return {
+    title: milestone.title,
+    description: milestone.description ?? "",
+    targetDate: milestone.targetDate ?? "",
+    status: milestone.status,
+  };
+}
+
+function mapRoadmapMutationError(errorCode: string): string {
+  switch (errorCode) {
+    case "roadmap-title-too-short":
+      return "Milestone title must be at least 2 characters.";
+    case "roadmap-title-too-long":
+      return "Milestone title must be 100 characters or fewer.";
+    case "roadmap-description-too-long":
+      return "Milestone description must be 400 characters or fewer.";
+    case "roadmap-target-date-invalid":
+      return "Target date must be a valid calendar date.";
+    case "roadmap-status-invalid":
+      return "Milestone status is invalid.";
+    case "roadmap-milestone-not-found":
+      return "Roadmap milestone not found.";
+    case "roadmap-milestones-invalid":
+      return "Roadmap order could not be saved because one or more milestones are invalid.";
+    case "roadmap-milestone-create-failed":
+      return "Could not create roadmap milestone. Please retry.";
+    case "roadmap-milestone-update-failed":
+      return "Could not update roadmap milestone. Please retry.";
+    case "roadmap-milestone-delete-failed":
+      return "Could not delete roadmap milestone. Please retry.";
+    case "roadmap-milestones-reorder-failed":
+      return "Could not save roadmap order. Please retry.";
+    default:
+      return "Could not save roadmap changes. Please retry.";
+  }
+}
+
+function getRoadmapStatusClasses(status: RoadmapMilestoneStatus) {
+  if (status === "reached") {
+    return {
+      accent: "text-emerald-700 dark:text-emerald-200",
+      badge: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200",
+      dot: "border-emerald-500/40 bg-emerald-500",
+      card:
+        "border-emerald-500/25 bg-[linear-gradient(160deg,rgba(16,185,129,0.12),rgba(255,255,255,0.72))] dark:bg-[linear-gradient(160deg,rgba(16,185,129,0.2),rgba(15,23,42,0.82))]",
+      glow: "from-emerald-500/30 via-emerald-400/10 to-transparent",
+    };
+  }
+
+  if (status === "active") {
+    return {
+      accent: "text-amber-700 dark:text-amber-200",
+      badge: "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-200",
+      dot: "border-amber-500/40 bg-amber-500",
+      card:
+        "border-amber-500/25 bg-[linear-gradient(160deg,rgba(245,158,11,0.12),rgba(255,255,255,0.72))] dark:bg-[linear-gradient(160deg,rgba(245,158,11,0.18),rgba(15,23,42,0.82))]",
+      glow: "from-amber-500/25 via-amber-400/10 to-transparent",
+    };
+  }
+
+  return {
+    accent: "text-sky-700 dark:text-sky-200",
+    badge: "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-200",
+    dot: "border-sky-500/40 bg-sky-500",
+    card:
+      "border-sky-500/25 bg-[linear-gradient(160deg,rgba(14,165,233,0.1),rgba(255,255,255,0.72))] dark:bg-[linear-gradient(160deg,rgba(14,165,233,0.16),rgba(15,23,42,0.82))]",
+    glow: "from-sky-500/25 via-sky-400/10 to-transparent",
+  };
+}
+
+function RoadmapStatusBadge({ status }: { status: RoadmapMilestoneStatus }) {
+  const tone = getRoadmapStatusClasses(status);
+
+  return (
+    <Badge variant="outline" className={tone.badge}>
+      {getRoadmapMilestoneStatusLabel(status)}
+    </Badge>
+  );
+}
+
+function RoadmapDraftForm({
+  draft,
+  onChange,
+  onSubmit,
+  onCancel,
+  submitLabel,
+  isSubmitting,
+  error,
+}: {
+  draft: RoadmapDraftState;
+  onChange: (nextDraft: RoadmapDraftState) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+  submitLabel: string;
+  isSubmitting: boolean;
+  error: string | null;
+}) {
+  return (
+    <section className="space-y-4 rounded-[1.75rem] border border-border/70 bg-background/75 p-4 shadow-[0_18px_48px_-40px_rgba(15,23,42,0.45)]">
+      <div className="space-y-1">
+        <h3 className="text-sm font-semibold text-foreground">{submitLabel}</h3>
+        <p className="text-xs text-muted-foreground">
+          Capture the milestone as a directional moment, not a task checklist.
+        </p>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div className="grid gap-2">
+          <label htmlFor="roadmap-title" className="text-sm font-medium">
+            Title
+          </label>
+          <EmojiInputField
+            id="roadmap-title"
+            value={draft.title}
+            onChange={(event) =>
+              onChange({
+                ...draft,
+                title: event.target.value,
+              })
+            }
+            className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+            placeholder="Private beta opens"
+            maxLength={100}
+          />
+        </div>
+
+        <div className="grid gap-2">
+          <div className="flex items-center justify-between gap-3">
+            <label htmlFor="roadmap-target-date" className="text-sm font-medium">
+              Target date
+            </label>
+            {draft.targetDate ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-auto px-2 py-1 text-xs"
+                onClick={() =>
+                  onChange({
+                    ...draft,
+                    targetDate: "",
+                  })
+                }
+                disabled={isSubmitting}
+              >
+                Clear
+              </Button>
+            ) : null}
+          </div>
+          <CalendarDateTimeField
+            id="roadmap-target-date"
+            value={draft.targetDate}
+            onChange={(nextValue) =>
+              onChange({
+                ...draft,
+                targetDate: nextValue,
+              })
+            }
+            includeTime={false}
+            disabled={isSubmitting}
+          />
+          <p className="text-xs text-muted-foreground">
+            Optional. Use this when the milestone has a meaningful target moment.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[1fr_200px]">
+        <div className="grid gap-2">
+          <label htmlFor="roadmap-description" className="text-sm font-medium">
+            Description
+          </label>
+          <EmojiTextareaField
+            id="roadmap-description"
+            value={draft.description}
+            onChange={(event) =>
+              onChange({
+                ...draft,
+                description: event.target.value,
+              })
+            }
+            className="min-h-28 rounded-md border border-input bg-background px-3 py-2 text-sm"
+            placeholder="Describe why this milestone matters and what it signals for the project."
+            maxLength={400}
+          />
+        </div>
+
+        <div className="grid gap-2">
+          <label htmlFor="roadmap-status" className="text-sm font-medium">
+            Visual state
+          </label>
+          <select
+            id="roadmap-status"
+            value={draft.status}
+            onChange={(event) =>
+              onChange({
+                ...draft,
+                status: event.target.value as RoadmapMilestoneStatus,
+              })
+            }
+            className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+            disabled={isSubmitting}
+          >
+            {ROADMAP_MILESTONE_STATUSES.map((status) => (
+              <option key={status} value={status}>
+                {getRoadmapMilestoneStatusLabel(status)}
+              </option>
+            ))}
+          </select>
+          <p className="text-xs text-muted-foreground">
+            This is manual for v1 and helps the roadmap read clearly.
+          </p>
+        </div>
+      </div>
+
+      {error ? (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="flex flex-col-reverse gap-2 sm:flex-row sm:items-center">
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={onCancel}
+          disabled={isSubmitting}
+          className="w-full sm:w-auto"
+        >
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          onClick={onSubmit}
+          disabled={isSubmitting}
+          className="w-full sm:w-auto"
+        >
+          {isSubmitting ? "Saving..." : submitLabel}
+        </Button>
+      </div>
+    </section>
+  );
+}
+
+function DesktopRoadmapTimeline({
+  milestones,
+  canEdit,
+  editingMilestoneId,
+  onStartEdit,
+  onDelete,
+  onMove,
+}: {
+  milestones: ProjectRoadmapPanelMilestone[];
+  canEdit: boolean;
+  editingMilestoneId: string | null;
+  onStartEdit: (milestone: ProjectRoadmapPanelMilestone) => void;
+  onDelete: (milestoneId: string) => void;
+  onMove: (milestoneId: string, direction: -1 | 1) => void;
+}) {
+  return (
+    <div className="hidden lg:block">
+      <div className="overflow-x-auto pb-4">
+        <div className="relative min-w-max px-2 py-5">
+          <div className="absolute left-10 right-10 top-[5.2rem] h-px bg-[linear-gradient(90deg,rgba(148,163,184,0.12),rgba(148,163,184,0.8),rgba(14,165,233,0.18),rgba(148,163,184,0.8),rgba(148,163,184,0.12))]" />
+          <div className="flex min-w-max items-start gap-5">
+            {milestones.map((milestone, index) => {
+              const tone = getRoadmapStatusClasses(milestone.status);
+              const isEditing = editingMilestoneId === milestone.id;
+
+              return (
+                <div
+                  key={milestone.id}
+                  className={cn(
+                    "relative w-[19rem] shrink-0",
+                    index % 2 === 0 ? "pt-0" : "pt-14"
+                  )}
+                >
+                  <div className="mb-4 flex items-center gap-3">
+                    <span
+                      className={cn(
+                        "relative flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-4 border-background shadow-sm",
+                        tone.dot
+                      )}
+                    >
+                      <span className="h-1.5 w-1.5 rounded-full bg-background/90" />
+                    </span>
+                    <div className="flex min-w-0 flex-wrap items-center gap-2">
+                      <RoadmapStatusBadge status={milestone.status} />
+                      <span className="rounded-full border border-border/60 bg-background/80 px-2.5 py-1 text-xs text-muted-foreground">
+                        {milestone.targetDate
+                          ? formatRoadmapTargetDateForDisplay(milestone.targetDate)
+                          : `Step ${index + 1}`}
+                      </span>
+                    </div>
+                  </div>
+
+                  <article
+                    className={cn(
+                      "relative overflow-hidden rounded-[1.8rem] border p-4 shadow-[0_24px_70px_-46px_rgba(15,23,42,0.55)] backdrop-blur-sm transition",
+                      tone.card,
+                      isEditing ? "ring-1 ring-primary/30" : ""
+                    )}
+                  >
+                    <div
+                      className={cn(
+                        "pointer-events-none absolute inset-0 bg-gradient-to-br opacity-80",
+                        tone.glow
+                      )}
+                    />
+                    <div className="relative space-y-4">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0 space-y-1">
+                          <p className={cn("text-xs font-medium uppercase tracking-[0.22em]", tone.accent)}>
+                            Milestone {index + 1}
+                          </p>
+                          <h3 className="text-lg font-semibold leading-6 text-foreground">
+                            {milestone.title}
+                          </h3>
+                        </div>
+                        {canEdit ? (
+                          <div className="flex items-center gap-1">
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8 rounded-full"
+                              onClick={() => onMove(milestone.id, -1)}
+                              disabled={index === 0}
+                              aria-label={`Move ${milestone.title} earlier`}
+                            >
+                              <ArrowLeft className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8 rounded-full"
+                              onClick={() => onMove(milestone.id, 1)}
+                              disabled={index === milestones.length - 1}
+                              aria-label={`Move ${milestone.title} later`}
+                            >
+                              <ArrowRight className="h-4 w-4" />
+                            </Button>
+                          </div>
+                        ) : null}
+                      </div>
+
+                      {milestone.description ? (
+                        <p className="text-sm leading-6 text-muted-foreground">
+                          {milestone.description}
+                        </p>
+                      ) : (
+                        <p className="text-sm italic text-muted-foreground">
+                          No extra note attached to this milestone yet.
+                        </p>
+                      )}
+
+                      <div className="flex flex-wrap items-center gap-2">
+                        {milestone.targetDate ? (
+                          <span className="inline-flex items-center gap-1.5 rounded-full border border-border/60 bg-background/75 px-3 py-1 text-xs text-muted-foreground">
+                            <CalendarDays className="h-3.5 w-3.5" />
+                            {formatRoadmapTargetDateForDisplay(milestone.targetDate)}
+                          </span>
+                        ) : (
+                          <span className="inline-flex items-center rounded-full border border-dashed border-border/60 bg-background/60 px-3 py-1 text-xs text-muted-foreground">
+                            No target date
+                          </span>
+                        )}
+                      </div>
+
+                      {canEdit ? (
+                        <div className="flex items-center justify-end gap-2 border-t border-border/40 pt-3">
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => onStartEdit(milestone)}
+                          >
+                            <Pencil className="h-4 w-4" />
+                            Edit
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => onDelete(milestone.id)}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                            Delete
+                          </Button>
+                        </div>
+                      ) : null}
+                    </div>
+                  </article>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MobileRoadmapTimeline({
+  milestones,
+  canEdit,
+  editingMilestoneId,
+  onStartEdit,
+  onDelete,
+  onMove,
+}: {
+  milestones: ProjectRoadmapPanelMilestone[];
+  canEdit: boolean;
+  editingMilestoneId: string | null;
+  onStartEdit: (milestone: ProjectRoadmapPanelMilestone) => void;
+  onDelete: (milestoneId: string) => void;
+  onMove: (milestoneId: string, direction: -1 | 1) => void;
+}) {
+  return (
+    <div className="grid gap-4 lg:hidden">
+      {milestones.map((milestone, index) => {
+        const tone = getRoadmapStatusClasses(milestone.status);
+        const isEditing = editingMilestoneId === milestone.id;
+
+        return (
+          <div key={milestone.id} className="relative pl-8">
+            {index < milestones.length - 1 ? (
+              <div className="absolute bottom-[-1.25rem] left-[0.55rem] top-7 w-px bg-[linear-gradient(180deg,rgba(148,163,184,0.7),rgba(148,163,184,0.18))]" />
+            ) : null}
+            <span
+              className={cn(
+                "absolute left-0 top-4 flex h-5 w-5 items-center justify-center rounded-full border-4 border-background shadow-sm",
+                tone.dot
+              )}
+            >
+              <span className="h-1.5 w-1.5 rounded-full bg-background/90" />
+            </span>
+
+            <article
+              className={cn(
+                "overflow-hidden rounded-[1.6rem] border p-4 shadow-[0_22px_60px_-46px_rgba(15,23,42,0.45)]",
+                tone.card,
+                isEditing ? "ring-1 ring-primary/30" : ""
+              )}
+            >
+              <div className="space-y-3">
+                <div className="flex flex-wrap items-center gap-2">
+                  <RoadmapStatusBadge status={milestone.status} />
+                  <span className="rounded-full border border-border/60 bg-background/75 px-2.5 py-1 text-[11px] text-muted-foreground">
+                    {milestone.targetDate
+                      ? formatRoadmapTargetDateForDisplay(milestone.targetDate)
+                      : `Step ${index + 1}`}
+                  </span>
+                </div>
+
+                <div className="space-y-1">
+                  <p className={cn("text-[11px] font-medium uppercase tracking-[0.22em]", tone.accent)}>
+                    Milestone {index + 1}
+                  </p>
+                  <h3 className="text-base font-semibold text-foreground">{milestone.title}</h3>
+                </div>
+
+                {milestone.description ? (
+                  <p className="text-sm leading-6 text-muted-foreground">
+                    {milestone.description}
+                  </p>
+                ) : (
+                  <p className="text-sm italic text-muted-foreground">
+                    No extra note attached to this milestone yet.
+                  </p>
+                )}
+
+                {canEdit ? (
+                  <div className="flex flex-wrap items-center gap-2 border-t border-border/40 pt-3">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => onMove(milestone.id, -1)}
+                      disabled={index === 0}
+                    >
+                      <ArrowLeft className="h-4 w-4" />
+                      Earlier
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => onMove(milestone.id, 1)}
+                      disabled={index === milestones.length - 1}
+                    >
+                      <ArrowRight className="h-4 w-4" />
+                      Later
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => onStartEdit(milestone)}
+                    >
+                      <Pencil className="h-4 w-4" />
+                      Edit
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => onDelete(milestone.id)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                      Delete
+                    </Button>
+                  </div>
+                ) : null}
+              </div>
+            </article>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function ProjectRoadmapPanel({
+  projectId,
+  canEdit,
+  milestones,
+  loadError = null,
+}: ProjectRoadmapPanelProps) {
+  const router = useRouter();
+  const { pushToast } = useToast();
+  const { isExpanded, setIsExpanded } = useProjectSectionExpanded({
+    projectId,
+    sectionKey: "roadmap",
+    defaultExpanded: true,
+    logLabel: "ProjectRoadmapPanel",
+  });
+  const [localMilestones, setLocalMilestones] = useState<ProjectRoadmapPanelMilestone[]>(
+    milestones
+  );
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [createDraft, setCreateDraft] = useState<RoadmapDraftState>({
+    ...DEFAULT_DRAFT_STATE,
+  });
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [editingMilestoneId, setEditingMilestoneId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState<RoadmapDraftState>({
+    ...DEFAULT_DRAFT_STATE,
+  });
+  const [editError, setEditError] = useState<string | null>(null);
+  const [isSavingEdit, setIsSavingEdit] = useState(false);
+  const [pendingDeleteMilestoneId, setPendingDeleteMilestoneId] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [reorderingMilestoneId, setReorderingMilestoneId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLocalMilestones(milestones);
+  }, [milestones]);
+
+  const pendingDeleteMilestone = useMemo(
+    () =>
+      localMilestones.find((milestone) => milestone.id === pendingDeleteMilestoneId) ?? null,
+    [localMilestones, pendingDeleteMilestoneId]
+  );
+
+  const refreshProjectData = () => {
+    startTransition(() => {
+      router.refresh();
+    });
+  };
+
+  const resetCreateDraft = () => {
+    setCreateDraft({ ...DEFAULT_DRAFT_STATE });
+    setCreateError(null);
+  };
+
+  const closeCreate = (force = false) => {
+    if (isCreating && !force) {
+      return;
+    }
+
+    setIsCreateOpen(false);
+    resetCreateDraft();
+  };
+
+  const startEdit = (milestone: ProjectRoadmapPanelMilestone) => {
+    setEditingMilestoneId(milestone.id);
+    setEditDraft(cloneDraftState(milestone));
+    setEditError(null);
+  };
+
+  const cancelEdit = (force = false) => {
+    if (isSavingEdit && !force) {
+      return;
+    }
+
+    setEditingMilestoneId(null);
+    setEditDraft({ ...DEFAULT_DRAFT_STATE });
+    setEditError(null);
+  };
+
+  const handleCreateMilestone = async () => {
+    const normalizedTitle = createDraft.title.trim();
+    if (!normalizedTitle) {
+      setCreateError("Milestone title is required.");
+      return;
+    }
+
+    setIsCreating(true);
+    setCreateError(null);
+
+    try {
+      const response = await fetch(`/api/projects/${projectId}/roadmap-milestones`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          title: normalizedTitle,
+          description: createDraft.description,
+          targetDate: createDraft.targetDate || null,
+          status: createDraft.status,
+        }),
+      });
+
+      const payload = (await response.json().catch(() => null)) as
+        | { error?: string; milestone?: ProjectRoadmapPanelMilestone }
+        | null;
+
+      if (!response.ok || !payload?.milestone) {
+        throw new Error(
+          mapRoadmapMutationError(payload?.error ?? "roadmap-milestone-create-failed")
+        );
+      }
+
+      setLocalMilestones((previousMilestones) => [
+        ...previousMilestones,
+        payload.milestone!,
+      ].sort((left, right) => left.position - right.position));
+      closeCreate(true);
+      refreshProjectData();
+      pushToast({
+        variant: "success",
+        message: "Roadmap milestone created.",
+      });
+    } catch (error) {
+      setCreateError(
+        error instanceof Error ? error.message : "Could not create roadmap milestone."
+      );
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleSaveMilestone = async () => {
+    if (!editingMilestoneId) {
+      return;
+    }
+
+    const normalizedTitle = editDraft.title.trim();
+    if (!normalizedTitle) {
+      setEditError("Milestone title is required.");
+      return;
+    }
+
+    setIsSavingEdit(true);
+    setEditError(null);
+
+    try {
+      const response = await fetch(
+        `/api/projects/${projectId}/roadmap-milestones/${editingMilestoneId}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            title: normalizedTitle,
+            description: editDraft.description,
+            targetDate: editDraft.targetDate || null,
+            status: editDraft.status,
+          }),
+        }
+      );
+
+      const payload = (await response.json().catch(() => null)) as
+        | { error?: string; milestone?: ProjectRoadmapPanelMilestone }
+        | null;
+
+      if (!response.ok || !payload?.milestone) {
+        throw new Error(
+          mapRoadmapMutationError(payload?.error ?? "roadmap-milestone-update-failed")
+        );
+      }
+
+      const updatedMilestone = payload.milestone;
+      setLocalMilestones((previousMilestones) =>
+        previousMilestones.map((milestone) =>
+          milestone.id === updatedMilestone.id ? updatedMilestone : milestone
+        )
+      );
+      cancelEdit(true);
+      refreshProjectData();
+      pushToast({
+        variant: "success",
+        message: "Roadmap milestone updated.",
+      });
+    } catch (error) {
+      setEditError(
+        error instanceof Error ? error.message : "Could not update roadmap milestone."
+      );
+    } finally {
+      setIsSavingEdit(false);
+    }
+  };
+
+  const handleDeleteMilestone = async () => {
+    if (!pendingDeleteMilestone || isDeleting) {
+      return;
+    }
+
+    setIsDeleting(true);
+
+    try {
+      const response = await fetch(
+        `/api/projects/${projectId}/roadmap-milestones/${pendingDeleteMilestone.id}`,
+        {
+          method: "DELETE",
+        }
+      );
+
+      const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+
+      if (!response.ok) {
+        throw new Error(
+          mapRoadmapMutationError(payload?.error ?? "roadmap-milestone-delete-failed")
+        );
+      }
+
+      setLocalMilestones((previousMilestones) =>
+        previousMilestones.filter((milestone) => milestone.id !== pendingDeleteMilestone.id)
+      );
+      setPendingDeleteMilestoneId(null);
+      refreshProjectData();
+      pushToast({
+        variant: "success",
+        message: "Roadmap milestone deleted.",
+      });
+    } catch (error) {
+      pushToast({
+        variant: "error",
+        message:
+          error instanceof Error ? error.message : "Could not delete roadmap milestone.",
+      });
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleMoveMilestone = async (milestoneId: string, direction: -1 | 1) => {
+    if (!canEdit || reorderingMilestoneId) {
+      return;
+    }
+
+    const currentIndex = localMilestones.findIndex((milestone) => milestone.id === milestoneId);
+    if (currentIndex === -1) {
+      return;
+    }
+
+    const nextIndex = currentIndex + direction;
+    if (nextIndex < 0 || nextIndex >= localMilestones.length) {
+      return;
+    }
+
+    const reorderedMilestones = localMilestones.slice();
+    const [movedMilestone] = reorderedMilestones.splice(currentIndex, 1);
+    if (!movedMilestone) {
+      return;
+    }
+    reorderedMilestones.splice(nextIndex, 0, movedMilestone);
+
+    const normalizedReorderedMilestones = reorderedMilestones.map((milestone, index) => ({
+      ...milestone,
+      position: index,
+    }));
+    const previousMilestones = localMilestones;
+    setLocalMilestones(normalizedReorderedMilestones);
+    setReorderingMilestoneId(milestoneId);
+
+    try {
+      const response = await fetch(
+        `/api/projects/${projectId}/roadmap-milestones/reorder`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            milestoneIds: normalizedReorderedMilestones.map((milestone) => milestone.id),
+          }),
+        }
+      );
+
+      const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+      if (!response.ok) {
+        throw new Error(
+          mapRoadmapMutationError(payload?.error ?? "roadmap-milestones-reorder-failed")
+        );
+      }
+
+      refreshProjectData();
+    } catch (error) {
+      setLocalMilestones(previousMilestones);
+      pushToast({
+        variant: "error",
+        message:
+          error instanceof Error ? error.message : "Could not save roadmap order.",
+      });
+    } finally {
+      setReorderingMilestoneId(null);
+    }
+  };
+
+  return (
+    <Card className={PROJECT_SECTION_CARD_CLASS}>
+      <CardHeader className={PROJECT_SECTION_HEADER_CLASS}>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <button
+            type="button"
+            onClick={() => setIsExpanded((previous) => !previous)}
+            aria-expanded={isExpanded}
+            className="flex min-w-0 flex-1 items-center gap-3 rounded-xl px-1 py-1 text-left transition hover:bg-muted/40"
+          >
+            {isExpanded ? (
+              <ChevronUp className="h-4 w-4 text-muted-foreground" />
+            ) : (
+              <ChevronDown className="h-4 w-4 text-muted-foreground" />
+            )}
+            <div className="min-w-0">
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Map className="h-4 w-4" />
+                Roadmap
+              </CardTitle>
+            </div>
+            <span className="rounded-full border border-border/60 bg-background/70 px-2.5 py-1 text-xs text-muted-foreground">
+              {localMilestones.length} milestone{localMilestones.length === 1 ? "" : "s"}
+            </span>
+          </button>
+
+          {canEdit ? (
+            <Button
+              type="button"
+              size="sm"
+              className="w-full sm:w-auto"
+              onClick={() => {
+                resetCreateDraft();
+                setIsExpanded(true);
+                setIsCreateOpen(true);
+              }}
+            >
+              <PlusSquare className="h-4 w-4" />
+              New milestone
+            </Button>
+          ) : null}
+        </div>
+      </CardHeader>
+
+      {isExpanded ? (
+        <CardContent className={cn("space-y-5", PROJECT_SECTION_CONTENT_CLASS)}>
+          <div className="rounded-[1.6rem] border border-border/70 bg-[linear-gradient(135deg,rgba(15,23,42,0.04),rgba(14,165,233,0.08),rgba(255,255,255,0.58))] px-4 py-4 dark:bg-[linear-gradient(135deg,rgba(15,23,42,0.78),rgba(14,165,233,0.16),rgba(15,23,42,0.72))]">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+              <div className="space-y-1.5">
+                <p className="text-xs font-medium uppercase tracking-[0.22em] text-muted-foreground">
+                  Direction View
+                </p>
+                <h3 className="text-lg font-semibold text-foreground">
+                  Show where the project is going before people dive into the work.
+                </h3>
+                <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
+                  The roadmap is intentionally lightweight in v1: manual milestones, visual
+                  sequencing, and enough narrative context to make the project feel oriented.
+                </p>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <RoadmapStatusBadge status="planned" />
+                <RoadmapStatusBadge status="active" />
+                <RoadmapStatusBadge status="reached" />
+              </div>
+            </div>
+          </div>
+
+          {loadError ? (
+            <div className="rounded-xl border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-200">
+              {loadError}
+            </div>
+          ) : null}
+
+          {isCreateOpen ? (
+            <RoadmapDraftForm
+              draft={createDraft}
+              onChange={setCreateDraft}
+              onSubmit={() => void handleCreateMilestone()}
+              onCancel={() => closeCreate()}
+              submitLabel="Create milestone"
+              isSubmitting={isCreating}
+              error={createError}
+            />
+          ) : null}
+
+          {editingMilestoneId ? (
+            <RoadmapDraftForm
+              draft={editDraft}
+              onChange={setEditDraft}
+              onSubmit={() => void handleSaveMilestone()}
+              onCancel={() => cancelEdit()}
+              submitLabel="Save milestone"
+              isSubmitting={isSavingEdit}
+              error={editError}
+            />
+          ) : null}
+
+          {localMilestones.length === 0 ? (
+            <div className="rounded-[1.8rem] border border-dashed border-border/70 bg-muted/20 px-5 py-10 text-center">
+              <p className="text-sm font-medium text-foreground">No roadmap milestones yet.</p>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                Add the major moments ahead so the project reads like a journey, not just a list
+                of tasks.
+              </p>
+            </div>
+          ) : (
+            <>
+              <DesktopRoadmapTimeline
+                milestones={localMilestones}
+                canEdit={canEdit}
+                editingMilestoneId={editingMilestoneId}
+                onStartEdit={startEdit}
+                onDelete={(milestoneId) => setPendingDeleteMilestoneId(milestoneId)}
+                onMove={(milestoneId, direction) =>
+                  void handleMoveMilestone(milestoneId, direction)
+                }
+              />
+              <MobileRoadmapTimeline
+                milestones={localMilestones}
+                canEdit={canEdit}
+                editingMilestoneId={editingMilestoneId}
+                onStartEdit={startEdit}
+                onDelete={(milestoneId) => setPendingDeleteMilestoneId(milestoneId)}
+                onMove={(milestoneId, direction) =>
+                  void handleMoveMilestone(milestoneId, direction)
+                }
+              />
+            </>
+          )}
+        </CardContent>
+      ) : null}
+
+      <ConfirmDialog
+        isOpen={Boolean(pendingDeleteMilestone)}
+        title="Delete roadmap milestone?"
+        description={
+          pendingDeleteMilestone
+            ? `Delete "${pendingDeleteMilestone.title}" from the roadmap? This removes the milestone from the project journey.`
+            : ""
+        }
+        confirmLabel={isDeleting ? "Deleting..." : "Delete milestone"}
+        onConfirm={() => void handleDeleteMilestone()}
+        onCancel={() => {
+          if (isDeleting) {
+            return;
+          }
+
+          setPendingDeleteMilestoneId(null);
+        }}
+        isConfirming={isDeleting}
+      />
+    </Card>
+  );
+}

--- a/components/project-roadmap-panel.tsx
+++ b/components/project-roadmap-panel.tsx
@@ -361,7 +361,7 @@ function DesktopRoadmapTimeline({
 }) {
   return (
     <div className="hidden lg:block">
-      <div className="overflow-x-auto pb-4">
+      <div className="overflow-x-auto pb-4 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         <div className="flex min-w-max items-stretch gap-4 px-2 py-3">
           {milestones.map((milestone, index) => {
             const tone = getRoadmapStatusClasses(milestone.status);
@@ -491,10 +491,8 @@ function DesktopRoadmapTimeline({
                 </div>
 
                 {index < milestones.length - 1 ? (
-                  <div className="flex h-[15.5rem] items-center">
-                    <div className="flex h-11 w-11 items-center justify-center rounded-full border border-border/60 bg-background/85 text-muted-foreground shadow-[0_14px_35px_-28px_rgba(15,23,42,0.55)]">
-                      <ArrowRight className="h-4 w-4" />
-                    </div>
+                  <div className="flex w-16 shrink-0 pt-7">
+                    <div className="h-px w-full bg-[linear-gradient(90deg,rgba(14,165,233,0.35),rgba(148,163,184,0.35),rgba(148,163,184,0.08))]" />
                   </div>
                 ) : null}
               </div>

--- a/components/project-roadmap-panel.tsx
+++ b/components/project-roadmap-panel.tsx
@@ -361,8 +361,8 @@ function DesktopRoadmapTimeline({
 }) {
   return (
     <div className="hidden lg:block">
-      <div className="overflow-x-auto pb-4 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-        <div className="flex min-w-max items-stretch gap-4 px-2 py-3">
+      <div className="overflow-x-auto pb-4 [scrollbar-color:rgba(148,163,184,0.52)_transparent] [scrollbar-width:thin] [&::-webkit-scrollbar]:h-2 [&::-webkit-scrollbar-track]:rounded-full [&::-webkit-scrollbar-track]:bg-[rgba(148,163,184,0.14)] [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-[rgba(148,163,184,0.52)]">
+        <div className="flex min-w-max items-stretch gap-2 px-2 py-3">
           {milestones.map((milestone, index) => {
             const tone = getRoadmapStatusClasses(milestone.status);
             const isEditing = editingMilestoneId === milestone.id;
@@ -491,8 +491,8 @@ function DesktopRoadmapTimeline({
                 </div>
 
                 {index < milestones.length - 1 ? (
-                  <div className="flex w-16 shrink-0 pt-7">
-                    <div className="h-px w-full bg-[linear-gradient(90deg,rgba(14,165,233,0.35),rgba(148,163,184,0.35),rgba(148,163,184,0.08))]" />
+                  <div className="flex w-12 shrink-0 pt-[1.15rem]">
+                    <div className="h-0.5 w-full rounded-full bg-border/75" />
                   </div>
                 ) : null}
               </div>

--- a/components/project-roadmap-panel.tsx
+++ b/components/project-roadmap-panel.tsx
@@ -368,8 +368,7 @@ function DesktopRoadmapTimeline({
             const isEditing = editingMilestoneId === milestone.id;
 
             return (
-              <div key={milestone.id} className="flex items-start gap-4">
-                <div className="w-[19rem] shrink-0 space-y-3">
+              <div key={milestone.id} className="w-[19rem] shrink-0 space-y-3">
                   <div className="flex items-center gap-3 pl-1">
                     <span
                       className={cn(
@@ -379,16 +378,22 @@ function DesktopRoadmapTimeline({
                     >
                       <span className="h-1.5 w-1.5 rounded-full bg-background/90" />
                     </span>
-                    <div className="min-w-0 space-y-1">
-                      <p
-                        className={cn(
-                          "text-[11px] font-medium uppercase tracking-[0.22em]",
-                          tone.accent
-                        )}
-                      >
-                        Milestone {index + 1}
-                      </p>
-                      <RoadmapStatusBadge status={milestone.status} />
+                    <div className="flex min-w-0 flex-1 items-center gap-3">
+                      <div className="min-w-0 space-y-1">
+                        <p
+                          className={cn(
+                            "text-[11px] font-medium uppercase tracking-[0.22em]",
+                            tone.accent
+                          )}
+                        >
+                          Milestone {index + 1}
+                        </p>
+                        <RoadmapStatusBadge status={milestone.status} />
+                      </div>
+
+                      {index < milestones.length - 1 ? (
+                        <div className="h-0.5 min-w-10 flex-1 rounded-full bg-border/75" />
+                      ) : null}
                     </div>
                   </div>
 
@@ -488,13 +493,6 @@ function DesktopRoadmapTimeline({
                       </div>
                     </div>
                   </article>
-                </div>
-
-                {index < milestones.length - 1 ? (
-                  <div className="flex w-12 shrink-0 pt-[1.15rem]">
-                    <div className="h-0.5 w-full rounded-full bg-border/75" />
-                  </div>
-                ) : null}
               </div>
             );
           })}

--- a/components/project-roadmap-panel.tsx
+++ b/components/project-roadmap-panel.tsx
@@ -156,7 +156,7 @@ function RoadmapStatusBadge({ status }: { status: RoadmapMilestoneStatus }) {
 }
 
 const ROADMAP_ACTION_BUTTON_CLASS =
-  "rounded-full border border-transparent bg-transparent text-foreground/90 hover:border-white/90 hover:bg-white hover:text-slate-950 dark:text-white/90 dark:hover:border-white dark:hover:bg-white dark:hover:text-slate-950";
+  "rounded-full border border-transparent bg-transparent text-foreground/90 hover:border-slate-950 hover:bg-slate-950 hover:text-white dark:text-white/90 dark:hover:border-white dark:hover:bg-white dark:hover:text-slate-950";
 
 function RoadmapMilestoneDescriptionPreview({
   description,

--- a/components/project-roadmap-panel.tsx
+++ b/components/project-roadmap-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { startTransition, useEffect, useMemo, useState } from "react";
+import { type CSSProperties, startTransition, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   ArrowLeft,
@@ -8,10 +8,12 @@ import {
   CalendarDays,
   ChevronDown,
   ChevronUp,
+  Eye,
   Map,
   Pencil,
   PlusSquare,
   Trash2,
+  X,
 } from "lucide-react";
 
 import { CalendarDateTimeField } from "@/components/calendar-date-time-field";
@@ -58,6 +60,13 @@ const DEFAULT_DRAFT_STATE: RoadmapDraftState = {
   targetDate: "",
   status: "planned",
 };
+
+const ROADMAP_DESCRIPTION_PREVIEW_STYLE = {
+  display: "-webkit-box",
+  WebkitBoxOrient: "vertical",
+  WebkitLineClamp: 4,
+  overflow: "hidden",
+} satisfies CSSProperties;
 
 function cloneDraftState(
   milestone?: ProjectRoadmapPanelMilestone | null
@@ -143,6 +152,29 @@ function RoadmapStatusBadge({ status }: { status: RoadmapMilestoneStatus }) {
     <Badge variant="outline" className={tone.badge}>
       {getRoadmapMilestoneStatusLabel(status)}
     </Badge>
+  );
+}
+
+function RoadmapMilestoneDescriptionPreview({
+  description,
+}: {
+  description: string | null;
+}) {
+  if (!description) {
+    return (
+      <p className="text-sm italic text-muted-foreground">
+        No extra note attached to this milestone yet.
+      </p>
+    );
+  }
+
+  return (
+    <p
+      className="break-words text-sm leading-6 text-muted-foreground"
+      style={ROADMAP_DESCRIPTION_PREVIEW_STYLE}
+    >
+      {description}
+    </p>
   );
 }
 
@@ -314,6 +346,7 @@ function DesktopRoadmapTimeline({
   milestones,
   canEdit,
   editingMilestoneId,
+  onView,
   onStartEdit,
   onDelete,
   onMove,
@@ -321,6 +354,7 @@ function DesktopRoadmapTimeline({
   milestones: ProjectRoadmapPanelMilestone[];
   canEdit: boolean;
   editingMilestoneId: string | null;
+  onView: (milestoneId: string) => void;
   onStartEdit: (milestone: ProjectRoadmapPanelMilestone) => void;
   onDelete: (milestoneId: string) => void;
   onMove: (milestoneId: string, direction: -1 | 1) => void;
@@ -328,22 +362,15 @@ function DesktopRoadmapTimeline({
   return (
     <div className="hidden lg:block">
       <div className="overflow-x-auto pb-4">
-        <div className="relative min-w-max px-2 py-5">
-          <div className="absolute left-10 right-10 top-[5.2rem] h-px bg-[linear-gradient(90deg,rgba(148,163,184,0.12),rgba(148,163,184,0.8),rgba(14,165,233,0.18),rgba(148,163,184,0.8),rgba(148,163,184,0.12))]" />
-          <div className="flex min-w-max items-start gap-5">
-            {milestones.map((milestone, index) => {
-              const tone = getRoadmapStatusClasses(milestone.status);
-              const isEditing = editingMilestoneId === milestone.id;
+        <div className="flex min-w-max items-stretch gap-4 px-2 py-3">
+          {milestones.map((milestone, index) => {
+            const tone = getRoadmapStatusClasses(milestone.status);
+            const isEditing = editingMilestoneId === milestone.id;
 
-              return (
-                <div
-                  key={milestone.id}
-                  className={cn(
-                    "relative w-[19rem] shrink-0",
-                    index % 2 === 0 ? "pt-0" : "pt-14"
-                  )}
-                >
-                  <div className="mb-4 flex items-center gap-3">
+            return (
+              <div key={milestone.id} className="flex items-start gap-4">
+                <div className="w-[19rem] shrink-0 space-y-3">
+                  <div className="flex items-center gap-3 pl-1">
                     <span
                       className={cn(
                         "relative flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-4 border-background shadow-sm",
@@ -352,13 +379,16 @@ function DesktopRoadmapTimeline({
                     >
                       <span className="h-1.5 w-1.5 rounded-full bg-background/90" />
                     </span>
-                    <div className="flex min-w-0 flex-wrap items-center gap-2">
+                    <div className="min-w-0 space-y-1">
+                      <p
+                        className={cn(
+                          "text-[11px] font-medium uppercase tracking-[0.22em]",
+                          tone.accent
+                        )}
+                      >
+                        Milestone {index + 1}
+                      </p>
                       <RoadmapStatusBadge status={milestone.status} />
-                      <span className="rounded-full border border-border/60 bg-background/80 px-2.5 py-1 text-xs text-muted-foreground">
-                        {milestone.targetDate
-                          ? formatRoadmapTargetDateForDisplay(milestone.targetDate)
-                          : `Step ${index + 1}`}
-                      </span>
                     </div>
                   </div>
 
@@ -377,13 +407,20 @@ function DesktopRoadmapTimeline({
                     />
                     <div className="relative space-y-4">
                       <div className="flex items-start justify-between gap-3">
-                        <div className="min-w-0 space-y-1">
-                          <p className={cn("text-xs font-medium uppercase tracking-[0.22em]", tone.accent)}>
-                            Milestone {index + 1}
-                          </p>
-                          <h3 className="text-lg font-semibold leading-6 text-foreground">
+                        <div className="min-w-0 space-y-2">
+                          <h3 className="break-words text-lg font-semibold leading-6 text-foreground">
                             {milestone.title}
                           </h3>
+                          {milestone.targetDate ? (
+                            <span className="inline-flex items-center gap-1.5 rounded-full border border-border/60 bg-background/75 px-3 py-1 text-xs text-muted-foreground">
+                              <CalendarDays className="h-3.5 w-3.5" />
+                              {formatRoadmapTargetDateForDisplay(milestone.targetDate)}
+                            </span>
+                          ) : (
+                            <span className="inline-flex items-center rounded-full border border-dashed border-border/60 bg-background/60 px-3 py-1 text-xs text-muted-foreground">
+                              No target date
+                            </span>
+                          )}
                         </div>
                         {canEdit ? (
                           <div className="flex items-center gap-1">
@@ -413,57 +450,56 @@ function DesktopRoadmapTimeline({
                         ) : null}
                       </div>
 
-                      {milestone.description ? (
-                        <p className="text-sm leading-6 text-muted-foreground">
-                          {milestone.description}
-                        </p>
-                      ) : (
-                        <p className="text-sm italic text-muted-foreground">
-                          No extra note attached to this milestone yet.
-                        </p>
-                      )}
+                      <RoadmapMilestoneDescriptionPreview description={milestone.description} />
 
-                      <div className="flex flex-wrap items-center gap-2">
-                        {milestone.targetDate ? (
-                          <span className="inline-flex items-center gap-1.5 rounded-full border border-border/60 bg-background/75 px-3 py-1 text-xs text-muted-foreground">
-                            <CalendarDays className="h-3.5 w-3.5" />
-                            {formatRoadmapTargetDateForDisplay(milestone.targetDate)}
-                          </span>
-                        ) : (
-                          <span className="inline-flex items-center rounded-full border border-dashed border-border/60 bg-background/60 px-3 py-1 text-xs text-muted-foreground">
-                            No target date
-                          </span>
-                        )}
+                      <div className="flex items-center justify-between gap-2 border-t border-border/40 pt-3">
+                        <Button
+                          type="button"
+                          variant="secondary"
+                          size="sm"
+                          onClick={() => onView(milestone.id)}
+                        >
+                          <Eye className="h-4 w-4" />
+                          View
+                        </Button>
+
+                        {canEdit ? (
+                          <div className="flex items-center gap-2">
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => onStartEdit(milestone)}
+                            >
+                              <Pencil className="h-4 w-4" />
+                              Edit
+                            </Button>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => onDelete(milestone.id)}
+                            >
+                              <Trash2 className="h-4 w-4" />
+                              Delete
+                            </Button>
+                          </div>
+                        ) : null}
                       </div>
-
-                      {canEdit ? (
-                        <div className="flex items-center justify-end gap-2 border-t border-border/40 pt-3">
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => onStartEdit(milestone)}
-                          >
-                            <Pencil className="h-4 w-4" />
-                            Edit
-                          </Button>
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => onDelete(milestone.id)}
-                          >
-                            <Trash2 className="h-4 w-4" />
-                            Delete
-                          </Button>
-                        </div>
-                      ) : null}
                     </div>
                   </article>
                 </div>
-              );
-            })}
-          </div>
+
+                {index < milestones.length - 1 ? (
+                  <div className="flex h-[15.5rem] items-center">
+                    <div className="flex h-11 w-11 items-center justify-center rounded-full border border-border/60 bg-background/85 text-muted-foreground shadow-[0_14px_35px_-28px_rgba(15,23,42,0.55)]">
+                      <ArrowRight className="h-4 w-4" />
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
         </div>
       </div>
     </div>
@@ -474,6 +510,7 @@ function MobileRoadmapTimeline({
   milestones,
   canEdit,
   editingMilestoneId,
+  onView,
   onStartEdit,
   onDelete,
   onMove,
@@ -481,6 +518,7 @@ function MobileRoadmapTimeline({
   milestones: ProjectRoadmapPanelMilestone[];
   canEdit: boolean;
   editingMilestoneId: string | null;
+  onView: (milestoneId: string) => void;
   onStartEdit: (milestone: ProjectRoadmapPanelMilestone) => void;
   onDelete: (milestoneId: string) => void;
   onMove: (milestoneId: string, direction: -1 | 1) => void;
@@ -513,79 +551,285 @@ function MobileRoadmapTimeline({
               )}
             >
               <div className="space-y-3">
-                <div className="flex flex-wrap items-center gap-2">
-                  <RoadmapStatusBadge status={milestone.status} />
-                  <span className="rounded-full border border-border/60 bg-background/75 px-2.5 py-1 text-[11px] text-muted-foreground">
-                    {milestone.targetDate
-                      ? formatRoadmapTargetDateForDisplay(milestone.targetDate)
-                      : `Step ${index + 1}`}
+                <div className="flex items-start justify-between gap-3">
+                  <div className="space-y-2">
+                    <p
+                      className={cn(
+                        "text-[11px] font-medium uppercase tracking-[0.22em]",
+                        tone.accent
+                      )}
+                    >
+                      Milestone {index + 1}
+                    </p>
+                    <RoadmapStatusBadge status={milestone.status} />
+                  </div>
+
+                  {canEdit ? (
+                    <div className="flex items-center gap-1">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 rounded-full"
+                        onClick={() => onMove(milestone.id, -1)}
+                        disabled={index === 0}
+                        aria-label={`Move ${milestone.title} earlier`}
+                      >
+                        <ArrowLeft className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 rounded-full"
+                        onClick={() => onMove(milestone.id, 1)}
+                        disabled={index === milestones.length - 1}
+                        aria-label={`Move ${milestone.title} later`}
+                      >
+                        <ArrowRight className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  ) : null}
+                </div>
+
+                <h3 className="break-words text-base font-semibold text-foreground">
+                  {milestone.title}
+                </h3>
+
+                {milestone.targetDate ? (
+                  <span className="inline-flex items-center gap-1.5 rounded-full border border-border/60 bg-background/75 px-3 py-1 text-xs text-muted-foreground">
+                    <CalendarDays className="h-3.5 w-3.5" />
+                    {formatRoadmapTargetDateForDisplay(milestone.targetDate)}
                   </span>
-                </div>
-
-                <div className="space-y-1">
-                  <p className={cn("text-[11px] font-medium uppercase tracking-[0.22em]", tone.accent)}>
-                    Milestone {index + 1}
-                  </p>
-                  <h3 className="text-base font-semibold text-foreground">{milestone.title}</h3>
-                </div>
-
-                {milestone.description ? (
-                  <p className="text-sm leading-6 text-muted-foreground">
-                    {milestone.description}
-                  </p>
                 ) : (
-                  <p className="text-sm italic text-muted-foreground">
-                    No extra note attached to this milestone yet.
-                  </p>
+                  <span className="inline-flex items-center rounded-full border border-dashed border-border/60 bg-background/60 px-3 py-1 text-xs text-muted-foreground">
+                    No target date
+                  </span>
                 )}
 
-                {canEdit ? (
-                  <div className="flex flex-wrap items-center gap-2 border-t border-border/40 pt-3">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => onMove(milestone.id, -1)}
-                      disabled={index === 0}
-                    >
-                      <ArrowLeft className="h-4 w-4" />
-                      Earlier
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => onMove(milestone.id, 1)}
-                      disabled={index === milestones.length - 1}
-                    >
-                      <ArrowRight className="h-4 w-4" />
-                      Later
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => onStartEdit(milestone)}
-                    >
-                      <Pencil className="h-4 w-4" />
-                      Edit
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => onDelete(milestone.id)}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                      Delete
-                    </Button>
-                  </div>
-                ) : null}
+                <RoadmapMilestoneDescriptionPreview description={milestone.description} />
+
+                <div className="flex flex-wrap items-center gap-2 border-t border-border/40 pt-3">
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => onView(milestone.id)}
+                  >
+                    <Eye className="h-4 w-4" />
+                    View
+                  </Button>
+
+                  {canEdit ? (
+                    <>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onStartEdit(milestone)}
+                      >
+                        <Pencil className="h-4 w-4" />
+                        Edit
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onDelete(milestone.id)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                        Delete
+                      </Button>
+                    </>
+                  ) : null}
+                </div>
               </div>
             </article>
           </div>
         );
       })}
+    </div>
+  );
+}
+
+function RoadmapMilestoneDetailModal({
+  milestone,
+  milestoneIndex,
+  milestonesCount,
+  canEdit,
+  isOpen,
+  onClose,
+  onStartEdit,
+  onDelete,
+  onMove,
+}: {
+  milestone: ProjectRoadmapPanelMilestone | null;
+  milestoneIndex: number;
+  milestonesCount: number;
+  canEdit: boolean;
+  isOpen: boolean;
+  onClose: () => void;
+  onStartEdit: (milestone: ProjectRoadmapPanelMilestone) => void;
+  onDelete: (milestoneId: string) => void;
+  onMove: (milestoneId: string, direction: -1 | 1) => void;
+}) {
+  if (!isOpen || !milestone) {
+    return null;
+  }
+
+  const tone = getRoadmapStatusClasses(milestone.status);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end bg-slate-950/55 p-3 sm:items-center sm:justify-center sm:p-6">
+      <button
+        type="button"
+        aria-label="Close milestone details"
+        className="absolute inset-0"
+        onClick={onClose}
+      />
+
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="roadmap-milestone-dialog-title"
+        className={cn(
+          "relative z-10 w-full max-w-2xl overflow-hidden rounded-[2rem] border border-border/70 bg-background shadow-[0_35px_100px_-40px_rgba(15,23,42,0.6)]",
+          tone.card
+        )}
+      >
+        <div
+          className={cn(
+            "pointer-events-none absolute inset-0 bg-gradient-to-br opacity-80",
+            tone.glow
+          )}
+        />
+
+        <div className="relative space-y-6 p-5 sm:p-6">
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0 space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <span
+                  className={cn(
+                    "rounded-full border border-border/60 bg-background/80 px-3 py-1 text-[11px] font-medium uppercase tracking-[0.22em]",
+                    tone.accent
+                  )}
+                >
+                  Milestone {milestoneIndex + 1}
+                </span>
+                <RoadmapStatusBadge status={milestone.status} />
+              </div>
+              <h3
+                id="roadmap-milestone-dialog-title"
+                className="break-words text-2xl font-semibold leading-tight text-foreground"
+              >
+                {milestone.title}
+              </h3>
+            </div>
+
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-9 w-9 rounded-full"
+              onClick={onClose}
+              aria-label="Close milestone details"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+            <div className="space-y-2">
+              <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                Target date
+              </p>
+              {milestone.targetDate ? (
+                <span className="inline-flex items-center gap-1.5 rounded-full border border-border/60 bg-background/80 px-3 py-1 text-sm text-muted-foreground">
+                  <CalendarDays className="h-4 w-4" />
+                  {formatRoadmapTargetDateForDisplay(milestone.targetDate)}
+                </span>
+              ) : (
+                <span className="inline-flex items-center rounded-full border border-dashed border-border/60 bg-background/65 px-3 py-1 text-sm text-muted-foreground">
+                  No target date
+                </span>
+              )}
+            </div>
+
+            {canEdit ? (
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onMove(milestone.id, -1)}
+                  disabled={milestoneIndex === 0}
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                  Earlier
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onMove(milestone.id, 1)}
+                  disabled={milestoneIndex === milestonesCount - 1}
+                >
+                  <ArrowRight className="h-4 w-4" />
+                  Later
+                </Button>
+              </div>
+            ) : null}
+          </div>
+
+          <div className="space-y-2 rounded-[1.4rem] border border-border/60 bg-background/70 p-4">
+            <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+              Description
+            </p>
+            {milestone.description ? (
+              <p className="whitespace-pre-wrap break-words text-sm leading-7 text-foreground/85">
+                {milestone.description}
+              </p>
+            ) : (
+              <p className="text-sm italic text-muted-foreground">
+                No extra note attached to this milestone yet.
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col-reverse gap-2 border-t border-border/40 pt-4 sm:flex-row sm:items-center sm:justify-between">
+            <Button type="button" variant="ghost" onClick={onClose}>
+              Close
+            </Button>
+
+            {canEdit ? (
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={() => {
+                    onStartEdit(milestone);
+                    onClose();
+                  }}
+                >
+                  <Pencil className="h-4 w-4" />
+                  Edit
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => {
+                    onDelete(milestone.id);
+                    onClose();
+                  }}
+                >
+                  <Trash2 className="h-4 w-4" />
+                  Delete
+                </Button>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }
@@ -620,6 +864,7 @@ export function ProjectRoadmapPanel({
   const [editError, setEditError] = useState<string | null>(null);
   const [isSavingEdit, setIsSavingEdit] = useState(false);
   const [pendingDeleteMilestoneId, setPendingDeleteMilestoneId] = useState<string | null>(null);
+  const [viewMilestoneId, setViewMilestoneId] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [reorderingMilestoneId, setReorderingMilestoneId] = useState<string | null>(null);
 
@@ -631,6 +876,19 @@ export function ProjectRoadmapPanel({
     () =>
       localMilestones.find((milestone) => milestone.id === pendingDeleteMilestoneId) ?? null,
     [localMilestones, pendingDeleteMilestoneId]
+  );
+
+  const viewedMilestone = useMemo(
+    () => localMilestones.find((milestone) => milestone.id === viewMilestoneId) ?? null,
+    [localMilestones, viewMilestoneId]
+  );
+
+  const viewedMilestoneIndex = useMemo(
+    () =>
+      viewedMilestone
+        ? localMilestones.findIndex((milestone) => milestone.id === viewedMilestone.id)
+        : -1,
+    [localMilestones, viewedMilestone]
   );
 
   const refreshProjectData = () => {
@@ -703,10 +961,11 @@ export function ProjectRoadmapPanel({
         );
       }
 
-      setLocalMilestones((previousMilestones) => [
-        ...previousMilestones,
-        payload.milestone!,
-      ].sort((left, right) => left.position - right.position));
+      setLocalMilestones((previousMilestones) =>
+        [...previousMilestones, payload.milestone!].sort(
+          (left, right) => left.position - right.position
+        )
+      );
       closeCreate(true);
       refreshProjectData();
       pushToast({
@@ -810,6 +1069,9 @@ export function ProjectRoadmapPanel({
       setLocalMilestones((previousMilestones) =>
         previousMilestones.filter((milestone) => milestone.id !== pendingDeleteMilestone.id)
       );
+      if (viewMilestoneId === pendingDeleteMilestone.id) {
+        setViewMilestoneId(null);
+      }
       setPendingDeleteMilestoneId(null);
       refreshProjectData();
       pushToast({
@@ -858,18 +1120,15 @@ export function ProjectRoadmapPanel({
     setReorderingMilestoneId(milestoneId);
 
     try {
-      const response = await fetch(
-        `/api/projects/${projectId}/roadmap-milestones/reorder`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            milestoneIds: normalizedReorderedMilestones.map((milestone) => milestone.id),
-          }),
-        }
-      );
+      const response = await fetch(`/api/projects/${projectId}/roadmap-milestones/reorder`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          milestoneIds: normalizedReorderedMilestones.map((milestone) => milestone.id),
+        }),
+      });
 
       const payload = (await response.json().catch(() => null)) as { error?: string } | null;
       if (!response.ok) {
@@ -883,8 +1142,7 @@ export function ProjectRoadmapPanel({
       setLocalMilestones(previousMilestones);
       pushToast({
         variant: "error",
-        message:
-          error instanceof Error ? error.message : "Could not save roadmap order.",
+        message: error instanceof Error ? error.message : "Could not save roadmap order.",
       });
     } finally {
       setReorderingMilestoneId(null);
@@ -937,28 +1195,6 @@ export function ProjectRoadmapPanel({
 
       {isExpanded ? (
         <CardContent className={cn("space-y-5", PROJECT_SECTION_CONTENT_CLASS)}>
-          <div className="rounded-[1.6rem] border border-border/70 bg-[linear-gradient(135deg,rgba(15,23,42,0.04),rgba(14,165,233,0.08),rgba(255,255,255,0.58))] px-4 py-4 dark:bg-[linear-gradient(135deg,rgba(15,23,42,0.78),rgba(14,165,233,0.16),rgba(15,23,42,0.72))]">
-            <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-              <div className="space-y-1.5">
-                <p className="text-xs font-medium uppercase tracking-[0.22em] text-muted-foreground">
-                  Direction View
-                </p>
-                <h3 className="text-lg font-semibold text-foreground">
-                  Show where the project is going before people dive into the work.
-                </h3>
-                <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
-                  The roadmap is intentionally lightweight in v1: manual milestones, visual
-                  sequencing, and enough narrative context to make the project feel oriented.
-                </p>
-              </div>
-              <div className="flex flex-wrap items-center gap-2">
-                <RoadmapStatusBadge status="planned" />
-                <RoadmapStatusBadge status="active" />
-                <RoadmapStatusBadge status="reached" />
-              </div>
-            </div>
-          </div>
-
           {loadError ? (
             <div className="rounded-xl border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-700 dark:text-amber-200">
               {loadError}
@@ -1003,6 +1239,7 @@ export function ProjectRoadmapPanel({
                 milestones={localMilestones}
                 canEdit={canEdit}
                 editingMilestoneId={editingMilestoneId}
+                onView={setViewMilestoneId}
                 onStartEdit={startEdit}
                 onDelete={(milestoneId) => setPendingDeleteMilestoneId(milestoneId)}
                 onMove={(milestoneId, direction) =>
@@ -1013,6 +1250,7 @@ export function ProjectRoadmapPanel({
                 milestones={localMilestones}
                 canEdit={canEdit}
                 editingMilestoneId={editingMilestoneId}
+                onView={setViewMilestoneId}
                 onStartEdit={startEdit}
                 onDelete={(milestoneId) => setPendingDeleteMilestoneId(milestoneId)}
                 onMove={(milestoneId, direction) =>
@@ -1023,6 +1261,18 @@ export function ProjectRoadmapPanel({
           )}
         </CardContent>
       ) : null}
+
+      <RoadmapMilestoneDetailModal
+        milestone={viewedMilestone}
+        milestoneIndex={viewedMilestoneIndex}
+        milestonesCount={localMilestones.length}
+        canEdit={canEdit}
+        isOpen={Boolean(viewedMilestone)}
+        onClose={() => setViewMilestoneId(null)}
+        onStartEdit={startEdit}
+        onDelete={(milestoneId) => setPendingDeleteMilestoneId(milestoneId)}
+        onMove={(milestoneId, direction) => void handleMoveMilestone(milestoneId, direction)}
+      />
 
       <ConfirmDialog
         isOpen={Boolean(pendingDeleteMilestone)}

--- a/components/project-roadmap-panel.tsx
+++ b/components/project-roadmap-panel.tsx
@@ -155,6 +155,18 @@ function RoadmapStatusBadge({ status }: { status: RoadmapMilestoneStatus }) {
   );
 }
 
+function getRoadmapActionButtonClasses(status: RoadmapMilestoneStatus) {
+  if (status === "reached") {
+    return "rounded-full border border-emerald-500/25 bg-emerald-500/10 text-emerald-700 hover:border-emerald-500 hover:bg-emerald-500 hover:text-slate-950 dark:text-emerald-200 dark:hover:text-slate-950";
+  }
+
+  if (status === "active") {
+    return "rounded-full border border-amber-500/25 bg-amber-500/10 text-amber-700 hover:border-amber-500 hover:bg-amber-500 hover:text-slate-950 dark:text-amber-200 dark:hover:text-slate-950";
+  }
+
+  return "rounded-full border border-sky-500/25 bg-sky-500/10 text-sky-700 hover:border-sky-500 hover:bg-sky-500 hover:text-slate-950 dark:text-sky-200 dark:hover:text-slate-950";
+}
+
 function RoadmapMilestoneDescriptionPreview({
   description,
 }: {
@@ -460,8 +472,9 @@ function DesktopRoadmapTimeline({
                       <div className="flex items-center justify-between gap-2 border-t border-border/40 pt-3">
                         <Button
                           type="button"
-                          variant="secondary"
+                          variant="ghost"
                           size="sm"
+                          className={getRoadmapActionButtonClasses(milestone.status)}
                           onClick={() => onView(milestone.id)}
                         >
                           <Eye className="h-4 w-4" />
@@ -474,6 +487,7 @@ function DesktopRoadmapTimeline({
                               type="button"
                               variant="ghost"
                               size="sm"
+                              className={getRoadmapActionButtonClasses(milestone.status)}
                               onClick={() => onStartEdit(milestone)}
                             >
                               <Pencil className="h-4 w-4" />
@@ -483,6 +497,7 @@ function DesktopRoadmapTimeline({
                               type="button"
                               variant="ghost"
                               size="sm"
+                              className={getRoadmapActionButtonClasses(milestone.status)}
                               onClick={() => onDelete(milestone.id)}
                             >
                               <Trash2 className="h-4 w-4" />
@@ -608,8 +623,9 @@ function MobileRoadmapTimeline({
                 <div className="flex flex-wrap items-center gap-2 border-t border-border/40 pt-3">
                   <Button
                     type="button"
-                    variant="secondary"
+                    variant="ghost"
                     size="sm"
+                    className={getRoadmapActionButtonClasses(milestone.status)}
                     onClick={() => onView(milestone.id)}
                   >
                     <Eye className="h-4 w-4" />
@@ -622,6 +638,7 @@ function MobileRoadmapTimeline({
                         type="button"
                         variant="ghost"
                         size="sm"
+                        className={getRoadmapActionButtonClasses(milestone.status)}
                         onClick={() => onStartEdit(milestone)}
                       >
                         <Pencil className="h-4 w-4" />
@@ -631,6 +648,7 @@ function MobileRoadmapTimeline({
                         type="button"
                         variant="ghost"
                         size="sm"
+                        className={getRoadmapActionButtonClasses(milestone.status)}
                         onClick={() => onDelete(milestone.id)}
                       >
                         <Trash2 className="h-4 w-4" />
@@ -801,7 +819,8 @@ function RoadmapMilestoneDetailModal({
               <div className="flex flex-wrap items-center gap-2">
                 <Button
                   type="button"
-                  variant="secondary"
+                  variant="ghost"
+                  className={getRoadmapActionButtonClasses(milestone.status)}
                   onClick={() => {
                     onStartEdit(milestone);
                     onClose();
@@ -813,6 +832,7 @@ function RoadmapMilestoneDetailModal({
                 <Button
                   type="button"
                   variant="ghost"
+                  className={getRoadmapActionButtonClasses(milestone.status)}
                   onClick={() => {
                     onDelete(milestone.id);
                     onClose();

--- a/components/project-roadmap-panel.tsx
+++ b/components/project-roadmap-panel.tsx
@@ -155,17 +155,8 @@ function RoadmapStatusBadge({ status }: { status: RoadmapMilestoneStatus }) {
   );
 }
 
-function getRoadmapActionButtonClasses(status: RoadmapMilestoneStatus) {
-  if (status === "reached") {
-    return "rounded-full border border-emerald-500/25 bg-emerald-500/10 text-emerald-700 hover:border-emerald-500 hover:bg-emerald-500 hover:text-slate-950 dark:text-emerald-200 dark:hover:text-slate-950";
-  }
-
-  if (status === "active") {
-    return "rounded-full border border-amber-500/25 bg-amber-500/10 text-amber-700 hover:border-amber-500 hover:bg-amber-500 hover:text-slate-950 dark:text-amber-200 dark:hover:text-slate-950";
-  }
-
-  return "rounded-full border border-sky-500/25 bg-sky-500/10 text-sky-700 hover:border-sky-500 hover:bg-sky-500 hover:text-slate-950 dark:text-sky-200 dark:hover:text-slate-950";
-}
+const ROADMAP_ACTION_BUTTON_CLASS =
+  "rounded-full border border-transparent bg-transparent text-foreground/90 hover:border-white/90 hover:bg-white hover:text-slate-950 dark:text-white/90 dark:hover:border-white dark:hover:bg-white dark:hover:text-slate-950";
 
 function RoadmapMilestoneDescriptionPreview({
   description,
@@ -474,7 +465,7 @@ function DesktopRoadmapTimeline({
                           type="button"
                           variant="ghost"
                           size="sm"
-                          className={getRoadmapActionButtonClasses(milestone.status)}
+                          className={ROADMAP_ACTION_BUTTON_CLASS}
                           onClick={() => onView(milestone.id)}
                         >
                           <Eye className="h-4 w-4" />
@@ -487,7 +478,7 @@ function DesktopRoadmapTimeline({
                               type="button"
                               variant="ghost"
                               size="sm"
-                              className={getRoadmapActionButtonClasses(milestone.status)}
+                              className={ROADMAP_ACTION_BUTTON_CLASS}
                               onClick={() => onStartEdit(milestone)}
                             >
                               <Pencil className="h-4 w-4" />
@@ -497,7 +488,7 @@ function DesktopRoadmapTimeline({
                               type="button"
                               variant="ghost"
                               size="sm"
-                              className={getRoadmapActionButtonClasses(milestone.status)}
+                              className={ROADMAP_ACTION_BUTTON_CLASS}
                               onClick={() => onDelete(milestone.id)}
                             >
                               <Trash2 className="h-4 w-4" />
@@ -625,7 +616,7 @@ function MobileRoadmapTimeline({
                     type="button"
                     variant="ghost"
                     size="sm"
-                    className={getRoadmapActionButtonClasses(milestone.status)}
+                    className={ROADMAP_ACTION_BUTTON_CLASS}
                     onClick={() => onView(milestone.id)}
                   >
                     <Eye className="h-4 w-4" />
@@ -638,7 +629,7 @@ function MobileRoadmapTimeline({
                         type="button"
                         variant="ghost"
                         size="sm"
-                        className={getRoadmapActionButtonClasses(milestone.status)}
+                        className={ROADMAP_ACTION_BUTTON_CLASS}
                         onClick={() => onStartEdit(milestone)}
                       >
                         <Pencil className="h-4 w-4" />
@@ -648,7 +639,7 @@ function MobileRoadmapTimeline({
                         type="button"
                         variant="ghost"
                         size="sm"
-                        className={getRoadmapActionButtonClasses(milestone.status)}
+                        className={ROADMAP_ACTION_BUTTON_CLASS}
                         onClick={() => onDelete(milestone.id)}
                       >
                         <Trash2 className="h-4 w-4" />
@@ -820,7 +811,7 @@ function RoadmapMilestoneDetailModal({
                 <Button
                   type="button"
                   variant="ghost"
-                  className={getRoadmapActionButtonClasses(milestone.status)}
+                  className={ROADMAP_ACTION_BUTTON_CLASS}
                   onClick={() => {
                     onStartEdit(milestone);
                     onClose();
@@ -832,7 +823,7 @@ function RoadmapMilestoneDetailModal({
                 <Button
                   type="button"
                   variant="ghost"
-                  className={getRoadmapActionButtonClasses(milestone.status)}
+                  className={ROADMAP_ACTION_BUTTON_CLASS}
                   onClick={() => {
                     onDelete(milestone.id);
                     onClose();

--- a/journal.md
+++ b/journal.md
@@ -862,3 +862,13 @@ Low-value entries to avoid going forward:
 - Type: Execution
 - Summary: TASK-128 quick assignee updates were hardened after CI exposed that the shared task PATCH endpoint expects a full persisted task payload, not a sparse assignee-only body.
 - Evidence: Updated `components/kanban-board.tsx` so quick assignee mutations preserve title, labels, description, deadline, and related-task ids while overriding only the assignee field; tightened `tests/e2e/smoke-project-task-calendar.spec.ts` to assert the task header badge switches from unassigned to an assigned identity.
+
+### 2026-04-23
+- Type: Execution
+- Summary: TASK-106 added a dedicated `Roadmap` dashboard section with standalone project milestones, new project-scoped roadmap persistence/routes, and distinct desktop/mobile timeline presentations.
+- Evidence: Added `RoadmapMilestone` schema + migration, implemented `lib/services/project-roadmap-service.ts` plus human-only roadmap API routes, wired `app/projects/[projectId]/project-roadmap-panel-section.tsx` into the project page, and built the visual milestone UI in `components/project-roadmap-panel.tsx`.
+
+### 2026-04-23
+- Type: Validation
+- Summary: TASK-106 passed local lint, targeted roadmap coverage, full Vitest coverage, and production build after pinning local validation to the repo-compatible Node `20.19.0` runtime and supplying placeholder env values expected by startup/build validation.
+- Evidence: `npx -y -p node@20.19.0 node .\\node_modules\\prisma\\build\\index.js generate`; `npx -y -p node@20.19.0 node .\\node_modules\\eslint\\bin\\eslint.js .`; `npx -y -p node@20.19.0 node .\\node_modules\\vitest\\vitest.mjs run tests\\lib\\project-roadmap-service.test.ts tests\\api\\project-roadmap.route.test.ts tests\\components\\project-roadmap-panel.test.tsx`; `DATABASE_URL=... DIRECT_URL=... AGENT_TOKEN_SIGNING_SECRET=... RESEND_API_KEY=... npx -y -p node@20.19.0 node .\\node_modules\\vitest\\vitest.mjs run`; `DATABASE_URL=... DIRECT_URL=... AGENT_TOKEN_SIGNING_SECRET=... RESEND_API_KEY=... GOOGLE_TOKEN_ENCRYPTION_KEY=... npx -y -p node@20.19.0 node .\\node_modules\\next\\dist\\bin\\next build`.

--- a/journal.md
+++ b/journal.md
@@ -12,6 +12,11 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ## Recent Entries (Most Relevant)
 
+### 2026-04-23
+- Type: Execution
+- Summary: TASK-106 roadmap follow-up refined the first milestone UI by removing the persistent explanatory hero copy, replacing the long desktop cross-rail with a card-to-card journey treatment, deduplicating deadline display, clamping card descriptions, and adding a dedicated milestone detail view triggered by a `View` action.
+- Evidence: Updated `components/project-roadmap-panel.tsx`, added roadmap detail-view regression coverage in `tests/components/project-roadmap-panel.test.tsx`, and recorded the future section-help affordance follow-up in `tasks/backlog.md` as `TASK-129`.
+
 ### 2026-04-22
 - Type: Execution
 - Summary: TASK-107 follow-up refined the epic registry UX to sit between project context and Kanban, removed the extra epic-header subtitle for better section consistency, made `New epic` expand the collapsed section before opening the form, and replaced the full-card light gradient treatment with a more consistent accent-strip/card treatment that stays readable in dark mode.

--- a/lib/roadmap-milestone.ts
+++ b/lib/roadmap-milestone.ts
@@ -1,0 +1,41 @@
+import { formatTaskDeadlineDate, formatTaskDeadlineForDisplay } from "@/lib/task-deadline";
+
+export const ROADMAP_MILESTONE_STATUSES = ["planned", "active", "reached"] as const;
+
+export type RoadmapMilestoneStatus = (typeof ROADMAP_MILESTONE_STATUSES)[number];
+
+export interface ProjectRoadmapMilestone {
+  id: string;
+  title: string;
+  description: string | null;
+  targetDate: string | null;
+  status: RoadmapMilestoneStatus;
+  position: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const ROADMAP_MILESTONE_STATUS_LABELS: Record<RoadmapMilestoneStatus, string> = {
+  planned: "Planned",
+  active: "Active",
+  reached: "Reached",
+};
+
+export function isRoadmapMilestoneStatus(value: unknown): value is RoadmapMilestoneStatus {
+  return (
+    typeof value === "string" &&
+    ROADMAP_MILESTONE_STATUSES.includes(value as RoadmapMilestoneStatus)
+  );
+}
+
+export function getRoadmapMilestoneStatusLabel(status: RoadmapMilestoneStatus): string {
+  return ROADMAP_MILESTONE_STATUS_LABELS[status];
+}
+
+export function formatRoadmapTargetDate(value: Date | string | null | undefined): string | null {
+  return formatTaskDeadlineDate(value);
+}
+
+export function formatRoadmapTargetDateForDisplay(value: string, locale?: string): string {
+  return formatTaskDeadlineForDisplay(value, locale);
+}

--- a/lib/services/project-roadmap-service.ts
+++ b/lib/services/project-roadmap-service.ts
@@ -212,15 +212,20 @@ export function isValidRoadmapReorderPayload(
 
   const seenMilestoneIds = new Set<string>();
   return milestoneIds.every((milestoneId) => {
-    if (typeof milestoneId !== "string" || milestoneId.trim().length === 0) {
+    if (typeof milestoneId !== "string") {
       return false;
     }
 
-    if (seenMilestoneIds.has(milestoneId)) {
+    const trimmedMilestoneId = milestoneId.trim();
+    if (trimmedMilestoneId.length === 0 || milestoneId !== trimmedMilestoneId) {
       return false;
     }
 
-    seenMilestoneIds.add(milestoneId);
+    if (seenMilestoneIds.has(trimmedMilestoneId)) {
+      return false;
+    }
+
+    seenMilestoneIds.add(trimmedMilestoneId);
     return true;
   });
 }

--- a/lib/services/project-roadmap-service.ts
+++ b/lib/services/project-roadmap-service.ts
@@ -1,0 +1,589 @@
+import { logServerError } from "@/lib/observability/logger";
+import {
+  formatRoadmapTargetDate,
+  isRoadmapMilestoneStatus,
+  type ProjectRoadmapMilestone,
+  type RoadmapMilestoneStatus,
+} from "@/lib/roadmap-milestone";
+import { requireProjectRole } from "@/lib/services/project-access-service";
+import { type DbClient, withActorRlsContext } from "@/lib/services/rls-context";
+import { parseTaskDeadlineDate } from "@/lib/task-deadline";
+
+const MIN_TITLE_LENGTH = 2;
+const MAX_TITLE_LENGTH = 100;
+const MAX_DESCRIPTION_LENGTH = 400;
+
+interface ServiceErrorResult {
+  ok: false;
+  status: number;
+  error: string;
+}
+
+interface ServiceSuccessResult<T> {
+  ok: true;
+  data: T;
+}
+
+type ServiceResult<T> = ServiceSuccessResult<T> | ServiceErrorResult;
+
+interface CreateRoadmapMilestoneInput {
+  actorUserId: string;
+  projectId: string;
+  title: string;
+  description?: string | null;
+  targetDate?: string | null;
+  status?: string | null;
+}
+
+interface UpdateRoadmapMilestoneInput {
+  actorUserId: string;
+  projectId: string;
+  milestoneId: string;
+  title?: string;
+  description?: string | null;
+  targetDate?: string | null;
+  status?: string | null;
+}
+
+interface ReorderRoadmapMilestonesInput {
+  actorUserId: string;
+  projectId: string;
+  milestoneIds: string[];
+}
+
+function createError(status: number, error: string): ServiceErrorResult {
+  return { ok: false, status, error };
+}
+
+function normalizeText(value: unknown): string {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  return value.trim();
+}
+
+function normalizeOptionalDescription(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalizedValue = value.trim();
+  return normalizedValue.length > 0 ? normalizedValue : null;
+}
+
+function parseRoadmapTargetDate(
+  value: unknown
+): ServiceResult<{ provided: boolean; targetDate: Date | null }> {
+  if (value === undefined) {
+    return {
+      ok: true,
+      data: {
+        provided: false,
+        targetDate: null,
+      },
+    };
+  }
+
+  if (value === null) {
+    return {
+      ok: true,
+      data: {
+        provided: true,
+        targetDate: null,
+      },
+    };
+  }
+
+  if (typeof value !== "string") {
+    return createError(400, "roadmap-target-date-invalid");
+  }
+
+  const normalizedValue = value.trim();
+  if (!normalizedValue) {
+    return {
+      ok: true,
+      data: {
+        provided: true,
+        targetDate: null,
+      },
+    };
+  }
+
+  const parsedDate = parseTaskDeadlineDate(normalizedValue);
+  if (!parsedDate) {
+    return createError(400, "roadmap-target-date-invalid");
+  }
+
+  return {
+    ok: true,
+    data: {
+      provided: true,
+      targetDate: parsedDate,
+    },
+  };
+}
+
+function parseRoadmapMilestoneStatus(
+  value: unknown,
+  options?: { fallback?: RoadmapMilestoneStatus }
+): ServiceResult<{ provided: boolean; status: RoadmapMilestoneStatus }> {
+  if (value === undefined || value === null) {
+    return {
+      ok: true,
+      data: {
+        provided: false,
+        status: options?.fallback ?? "planned",
+      },
+    };
+  }
+
+  if (!isRoadmapMilestoneStatus(value)) {
+    return createError(400, "roadmap-status-invalid");
+  }
+
+  return {
+    ok: true,
+    data: {
+      provided: true,
+      status: value,
+    },
+  };
+}
+
+function mapProjectRoadmapMilestone(record: {
+  id: string;
+  title: string;
+  description: string | null;
+  targetDate: Date | null;
+  status: RoadmapMilestoneStatus;
+  position: number;
+  createdAt: Date;
+  updatedAt: Date;
+}): ProjectRoadmapMilestone {
+  return {
+    id: record.id,
+    title: record.title,
+    description: record.description,
+    targetDate: formatRoadmapTargetDate(record.targetDate),
+    status: record.status,
+    position: record.position,
+    createdAt: record.createdAt.toISOString(),
+    updatedAt: record.updatedAt.toISOString(),
+  };
+}
+
+async function readRoadmapMilestoneById(input: {
+  db: DbClient;
+  projectId: string;
+  milestoneId: string;
+}): Promise<ProjectRoadmapMilestone | null> {
+  const milestone = await input.db.roadmapMilestone.findFirst({
+    where: {
+      id: input.milestoneId,
+      projectId: input.projectId,
+    },
+    select: {
+      id: true,
+      title: true,
+      description: true,
+      targetDate: true,
+      status: true,
+      position: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+
+  return milestone ? mapProjectRoadmapMilestone(milestone) : null;
+}
+
+export function isValidRoadmapReorderPayload(
+  payload: unknown
+): payload is { milestoneIds: string[] } {
+  if (!payload || typeof payload !== "object") {
+    return false;
+  }
+
+  const milestoneIds = (payload as { milestoneIds?: unknown }).milestoneIds;
+  if (!Array.isArray(milestoneIds)) {
+    return false;
+  }
+
+  const seenMilestoneIds = new Set<string>();
+  return milestoneIds.every((milestoneId) => {
+    if (typeof milestoneId !== "string" || milestoneId.trim().length === 0) {
+      return false;
+    }
+
+    if (seenMilestoneIds.has(milestoneId)) {
+      return false;
+    }
+
+    seenMilestoneIds.add(milestoneId);
+    return true;
+  });
+}
+
+export async function listProjectRoadmapMilestones(
+  projectId: string,
+  actorUserId: string
+): Promise<ProjectRoadmapMilestone[]> {
+  const normalizedActorUserId = normalizeText(actorUserId);
+  if (!normalizedActorUserId) {
+    return [];
+  }
+
+  return withActorRlsContext(normalizedActorUserId, async (db) => {
+    const access = await requireProjectRole({
+      actorUserId: normalizedActorUserId,
+      projectId,
+      minimumRole: "viewer",
+      db,
+    });
+    if (!access.ok) {
+      return [];
+    }
+
+    const milestones = await db.roadmapMilestone.findMany({
+      where: {
+        projectId,
+      },
+      orderBy: [{ position: "asc" }, { createdAt: "asc" }],
+      select: {
+        id: true,
+        title: true,
+        description: true,
+        targetDate: true,
+        status: true,
+        position: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    return milestones.map((milestone) => mapProjectRoadmapMilestone(milestone));
+  }) as Promise<ProjectRoadmapMilestone[]>;
+}
+
+export async function createProjectRoadmapMilestone(
+  input: CreateRoadmapMilestoneInput
+): Promise<ServiceResult<{ milestone: ProjectRoadmapMilestone }>> {
+  const actorUserId = normalizeText(input.actorUserId);
+  const title = normalizeText(input.title);
+  const description = normalizeOptionalDescription(input.description);
+  const targetDateInput = parseRoadmapTargetDate(input.targetDate);
+  const statusInput = parseRoadmapMilestoneStatus(input.status);
+
+  if (!actorUserId) {
+    return createError(401, "unauthorized");
+  }
+  if (title.length < MIN_TITLE_LENGTH) {
+    return createError(400, "roadmap-title-too-short");
+  }
+  if (title.length > MAX_TITLE_LENGTH) {
+    return createError(400, "roadmap-title-too-long");
+  }
+  if (description && description.length > MAX_DESCRIPTION_LENGTH) {
+    return createError(400, "roadmap-description-too-long");
+  }
+  if (!targetDateInput.ok) {
+    return targetDateInput;
+  }
+  if (!statusInput.ok) {
+    return statusInput;
+  }
+
+  return withActorRlsContext(actorUserId, async (db) => {
+    const access = await requireProjectRole({
+      actorUserId,
+      projectId: input.projectId,
+      minimumRole: "editor",
+      db,
+    });
+    if (!access.ok) {
+      return createError(access.status, access.error);
+    }
+
+    try {
+      const maxPosition = await db.roadmapMilestone.aggregate({
+        where: {
+          projectId: input.projectId,
+        },
+        _max: {
+          position: true,
+        },
+      });
+
+      const createdMilestone = await db.roadmapMilestone.create({
+        data: {
+          projectId: input.projectId,
+          title,
+          description,
+          targetDate: targetDateInput.data.targetDate,
+          status: statusInput.data.status,
+          position: (maxPosition._max.position ?? -1) + 1,
+        },
+        select: {
+          id: true,
+        },
+      });
+
+      const milestone = await readRoadmapMilestoneById({
+        db,
+        projectId: input.projectId,
+        milestoneId: createdMilestone.id,
+      });
+      if (!milestone) {
+        return createError(500, "roadmap-milestone-create-failed");
+      }
+
+      return {
+        ok: true,
+        data: {
+          milestone,
+        },
+      };
+    } catch (error) {
+      logServerError("createProjectRoadmapMilestone", error, {
+        actorUserId,
+        projectId: input.projectId,
+      });
+      return createError(500, "roadmap-milestone-create-failed");
+    }
+  });
+}
+
+export async function updateProjectRoadmapMilestone(
+  input: UpdateRoadmapMilestoneInput
+): Promise<ServiceResult<{ milestone: ProjectRoadmapMilestone }>> {
+  const actorUserId = normalizeText(input.actorUserId);
+  const milestoneId = normalizeText(input.milestoneId);
+  const titleProvided = Object.prototype.hasOwnProperty.call(input, "title");
+  const title = normalizeText(input.title);
+  const descriptionProvided = Object.prototype.hasOwnProperty.call(input, "description");
+  const description = normalizeOptionalDescription(input.description);
+  const targetDateInput = parseRoadmapTargetDate(input.targetDate);
+
+  if (!actorUserId) {
+    return createError(401, "unauthorized");
+  }
+  if (!milestoneId) {
+    return createError(400, "roadmap-milestone-not-found");
+  }
+  if (titleProvided && title.length < MIN_TITLE_LENGTH) {
+    return createError(400, "roadmap-title-too-short");
+  }
+  if (titleProvided && title.length > MAX_TITLE_LENGTH) {
+    return createError(400, "roadmap-title-too-long");
+  }
+  if (descriptionProvided && description && description.length > MAX_DESCRIPTION_LENGTH) {
+    return createError(400, "roadmap-description-too-long");
+  }
+  if (!targetDateInput.ok) {
+    return targetDateInput;
+  }
+
+  return withActorRlsContext(actorUserId, async (db) => {
+    const access = await requireProjectRole({
+      actorUserId,
+      projectId: input.projectId,
+      minimumRole: "editor",
+      db,
+    });
+    if (!access.ok) {
+      return createError(access.status, access.error);
+    }
+
+    try {
+      const existingMilestone = await db.roadmapMilestone.findFirst({
+        where: {
+          id: milestoneId,
+          projectId: input.projectId,
+        },
+        select: {
+          id: true,
+          status: true,
+        },
+      });
+      if (!existingMilestone) {
+        return createError(404, "roadmap-milestone-not-found");
+      }
+
+      const statusInput = parseRoadmapMilestoneStatus(input.status, {
+        fallback: existingMilestone.status as RoadmapMilestoneStatus,
+      });
+      if (!statusInput.ok) {
+        return statusInput;
+      }
+
+      await db.roadmapMilestone.update({
+        where: {
+          id: milestoneId,
+        },
+        data: {
+          ...(titleProvided ? { title } : {}),
+          ...(descriptionProvided ? { description } : {}),
+          ...(targetDateInput.data.provided
+            ? { targetDate: targetDateInput.data.targetDate }
+            : {}),
+          ...(statusInput.data.provided ? { status: statusInput.data.status } : {}),
+        },
+      });
+
+      const milestone = await readRoadmapMilestoneById({
+        db,
+        projectId: input.projectId,
+        milestoneId,
+      });
+      if (!milestone) {
+        return createError(404, "roadmap-milestone-not-found");
+      }
+
+      return {
+        ok: true,
+        data: {
+          milestone,
+        },
+      };
+    } catch (error) {
+      logServerError("updateProjectRoadmapMilestone", error, {
+        actorUserId,
+        projectId: input.projectId,
+        milestoneId,
+      });
+      return createError(500, "roadmap-milestone-update-failed");
+    }
+  });
+}
+
+export async function deleteProjectRoadmapMilestone(input: {
+  actorUserId: string;
+  projectId: string;
+  milestoneId: string;
+}): Promise<ServiceResult<{ ok: true }>> {
+  const actorUserId = normalizeText(input.actorUserId);
+  const milestoneId = normalizeText(input.milestoneId);
+  if (!actorUserId) {
+    return createError(401, "unauthorized");
+  }
+  if (!milestoneId) {
+    return createError(400, "roadmap-milestone-not-found");
+  }
+
+  return withActorRlsContext(actorUserId, async (db) => {
+    const access = await requireProjectRole({
+      actorUserId,
+      projectId: input.projectId,
+      minimumRole: "editor",
+      db,
+    });
+    if (!access.ok) {
+      return createError(access.status, access.error);
+    }
+
+    try {
+      const existingMilestone = await db.roadmapMilestone.findFirst({
+        where: {
+          id: milestoneId,
+          projectId: input.projectId,
+        },
+        select: {
+          id: true,
+        },
+      });
+      if (!existingMilestone) {
+        return createError(404, "roadmap-milestone-not-found");
+      }
+
+      await db.roadmapMilestone.delete({
+        where: {
+          id: milestoneId,
+        },
+      });
+
+      return {
+        ok: true,
+        data: {
+          ok: true,
+        },
+      };
+    } catch (error) {
+      logServerError("deleteProjectRoadmapMilestone", error, {
+        actorUserId,
+        projectId: input.projectId,
+        milestoneId,
+      });
+      return createError(500, "roadmap-milestone-delete-failed");
+    }
+  });
+}
+
+export async function reorderProjectRoadmapMilestones(
+  input: ReorderRoadmapMilestonesInput
+): Promise<ServiceResult<{ ok: true }>> {
+  const actorUserId = normalizeText(input.actorUserId);
+  if (!actorUserId) {
+    return createError(401, "unauthorized");
+  }
+
+  if (input.milestoneIds.length === 0) {
+    return {
+      ok: true,
+      data: { ok: true },
+    };
+  }
+
+  return withActorRlsContext(actorUserId, async (db) => {
+    const access = await requireProjectRole({
+      actorUserId,
+      projectId: input.projectId,
+      minimumRole: "editor",
+      db,
+    });
+    if (!access.ok) {
+      return createError(access.status, access.error);
+    }
+
+    try {
+      const milestones = await db.roadmapMilestone.findMany({
+        where: {
+          projectId: input.projectId,
+          id: {
+            in: input.milestoneIds,
+          },
+        },
+        select: {
+          id: true,
+        },
+      });
+      if (milestones.length !== input.milestoneIds.length) {
+        return createError(400, "roadmap-milestones-invalid");
+      }
+
+      await Promise.all(
+        input.milestoneIds.map((milestoneId, index) =>
+          db.roadmapMilestone.update({
+            where: {
+              id: milestoneId,
+            },
+            data: {
+              position: index,
+            },
+          })
+        )
+      );
+
+      return {
+        ok: true,
+        data: { ok: true },
+      };
+    } catch (error) {
+      logServerError("reorderProjectRoadmapMilestones", error, {
+        actorUserId,
+        projectId: input.projectId,
+      });
+      return createError(500, "roadmap-milestones-reorder-failed");
+    }
+  });
+}

--- a/prisma/migrations/20260423164000_task106_project_roadmap/migration.sql
+++ b/prisma/migrations/20260423164000_task106_project_roadmap/migration.sql
@@ -1,0 +1,119 @@
+CREATE TYPE "RoadmapMilestoneStatus" AS ENUM ('planned', 'active', 'reached');
+
+CREATE TABLE "RoadmapMilestone" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "title" VARCHAR(100) NOT NULL,
+    "description" TEXT,
+    "targetDate" DATE,
+    "status" "RoadmapMilestoneStatus" NOT NULL DEFAULT 'planned',
+    "position" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RoadmapMilestone_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "RoadmapMilestone_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX "RoadmapMilestone_projectId_idx" ON "RoadmapMilestone"("projectId");
+CREATE INDEX "RoadmapMilestone_projectId_position_idx" ON "RoadmapMilestone"("projectId", "position");
+CREATE INDEX "RoadmapMilestone_projectId_targetDate_idx" ON "RoadmapMilestone"("projectId", "targetDate");
+
+ALTER TABLE "RoadmapMilestone" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "RoadmapMilestone" FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY roadmap_milestone_select_policy ON "RoadmapMilestone"
+FOR SELECT
+USING (
+  EXISTS (
+    SELECT 1
+    FROM "Project" p
+    WHERE p.id = "RoadmapMilestone"."projectId"
+      AND (
+        p."ownerId" = app.current_user_id()
+        OR EXISTS (
+          SELECT 1
+          FROM "ProjectMembership" pm
+          WHERE pm."projectId" = p.id
+            AND pm."userId" = app.current_user_id()
+        )
+      )
+  )
+);
+
+CREATE POLICY roadmap_milestone_insert_policy ON "RoadmapMilestone"
+FOR INSERT
+WITH CHECK (
+  EXISTS (
+    SELECT 1
+    FROM "Project" p
+    WHERE p.id = "RoadmapMilestone"."projectId"
+      AND (
+        p."ownerId" = app.current_user_id()
+        OR EXISTS (
+          SELECT 1
+          FROM "ProjectMembership" pm
+          WHERE pm."projectId" = p.id
+            AND pm."userId" = app.current_user_id()
+            AND pm.role IN ('owner', 'editor')
+        )
+      )
+  )
+);
+
+CREATE POLICY roadmap_milestone_update_policy ON "RoadmapMilestone"
+FOR UPDATE
+USING (
+  EXISTS (
+    SELECT 1
+    FROM "Project" p
+    WHERE p.id = "RoadmapMilestone"."projectId"
+      AND (
+        p."ownerId" = app.current_user_id()
+        OR EXISTS (
+          SELECT 1
+          FROM "ProjectMembership" pm
+          WHERE pm."projectId" = p.id
+            AND pm."userId" = app.current_user_id()
+            AND pm.role IN ('owner', 'editor')
+        )
+      )
+  )
+)
+WITH CHECK (
+  EXISTS (
+    SELECT 1
+    FROM "Project" p
+    WHERE p.id = "RoadmapMilestone"."projectId"
+      AND (
+        p."ownerId" = app.current_user_id()
+        OR EXISTS (
+          SELECT 1
+          FROM "ProjectMembership" pm
+          WHERE pm."projectId" = p.id
+            AND pm."userId" = app.current_user_id()
+            AND pm.role IN ('owner', 'editor')
+        )
+      )
+  )
+);
+
+CREATE POLICY roadmap_milestone_delete_policy ON "RoadmapMilestone"
+FOR DELETE
+USING (
+  EXISTS (
+    SELECT 1
+    FROM "Project" p
+    WHERE p.id = "RoadmapMilestone"."projectId"
+      AND (
+        p."ownerId" = app.current_user_id()
+        OR EXISTS (
+          SELECT 1
+          FROM "ProjectMembership" pm
+          WHERE pm."projectId" = p.id
+            AND pm."userId" = app.current_user_id()
+            AND pm.role IN ('owner', 'editor')
+        )
+      )
+  )
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -130,6 +130,12 @@ enum ProjectMembershipRole {
   viewer
 }
 
+enum RoadmapMilestoneStatus {
+  planned
+  active
+  reached
+}
+
 model Project {
   id          String   @id @default(cuid())
   ownerId     String
@@ -141,6 +147,7 @@ model Project {
   owner          User                 @relation("ProjectOwner", fields: [ownerId], references: [id], onDelete: Cascade)
   tasks          Task[]
   epics          Epic[]
+  roadmapMilestones RoadmapMilestone[]
   resources      Resource[]
   memberships    ProjectMembership[]
   invitations    ProjectInvitation[]
@@ -199,6 +206,24 @@ model Epic {
   tasks   Task[]
 
   @@index([projectId, updatedAt])
+}
+
+model RoadmapMilestone {
+  id          String                 @id @default(cuid())
+  projectId   String
+  title       String                 @db.VarChar(100)
+  description String?
+  targetDate  DateTime?              @db.Date
+  status      RoadmapMilestoneStatus @default(planned)
+  position    Int                    @default(0)
+  createdAt   DateTime               @default(now())
+  updatedAt   DateTime               @updatedAt
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@index([projectId])
+  @@index([projectId, position])
+  @@index([projectId, targetDate])
 }
 
 model Task {

--- a/project.md
+++ b/project.md
@@ -1,6 +1,6 @@
 # NexusDash Project Blueprint (Current State)
 
-Last verified: 2026-04-22
+Last verified: 2026-04-23
 
 ## 1. Vision
 
@@ -13,8 +13,9 @@ NexusDash is a personal/team execution workspace that keeps project planning, de
 - DB-backed session authentication with protected app routes (`/projects/**`, `/account/**`).
 - Multi-project workspace with project CRUD.
 - Project sharing v2 with owner-managed invites, role-based membership, email-bound invitation flows, and resumable invite acceptance.
-- Project dashboard with three core panels:
+- Project dashboard with core panels:
   - Context cards (create/edit/delete + attachments)
+  - Roadmap milestones with manual visual sequencing and target-date planning
   - Kanban board (`Backlog`, `In Progress`, `Blocked`, `Done`) with reorder, deadline/comment visibility, task epic links, and task detail modal
   - Project epics registry with dedicated epic CRUD, automatic status/progress, and linked-task rollups
   - Google Calendar panel (read/create/update/delete events when connected)
@@ -40,9 +41,9 @@ NexusDash is a personal/team execution workspace that keeps project planning, de
 
 ## 3. Architecture and Stack
 
-- Framework: Next.js 14 App Router + TypeScript strict
+- Framework: Next.js 16 App Router + TypeScript strict
 - UI: Tailwind CSS + Shadcn UI + Lucide + `@hello-pangea/dnd`
-- Data: Prisma 5 + PostgreSQL
+- Data: Prisma 7 + PostgreSQL
 - Auth model (current):
   - Credentials onboarding + DB sessions for humans
   - Project-scoped agent API credentials exchanged into short-lived signed bearer tokens
@@ -58,7 +59,7 @@ Current schema includes:
 - Auth/session: `User`, `Account`, `Session`, `VerificationToken`
 - Authorization boundaries: `Project.ownerId`, `ProjectMembership` (`owner|editor|viewer`)
 - Agent auth: `ApiCredential`, `ApiCredentialScopeGrant`, `AuthAuditEvent`
-- Domain: `Project`, `Epic`, `Task`, `Resource` (context cards), `TaskBlockedFollowUp`
+- Domain: `Project`, `RoadmapMilestone`, `Epic`, `Task`, `Resource` (context cards), `TaskBlockedFollowUp`
 - Collaboration on tasks: `TaskComment`
 - Attachments: `TaskAttachment`, `ResourceAttachment` with `uploadedByUserId`
 - Calendar: `GoogleCalendarCredential` (one row per user)
@@ -89,10 +90,10 @@ Source of truth: [`prisma/schema.prisma`](./prisma/schema.prisma)
 
 From `tasks/current.md` + `tasks/backlog.md`:
 
-1. TASK-115: agent onboarding v1 - hosted docs, OpenAPI surface, and in-app setup UX
-2. TASK-048: authentication hardening + auth regression coverage
-3. TASK-061: dependency security baseline
-4. TASK-049/TASK-050/TASK-051: OWASP-focused security assessment, remediation, and verification
+1. TASK-123: notification center - unified in-app inbox for invitations, mentions, and future activity
+2. TASK-124: comment mentions - project-member @tagging with notification-center delivery
+3. TASK-126: comment reactions - lightweight emoji response system on task threads
+4. TASK-127: API capability audit - confirm every shipped feature remains fully manageable through the API
 
 ## 8. Source-of-Truth Docs
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -81,6 +81,11 @@ Use this file to capture tasks discovered during development. Each entry should 
   Status: Pending
   Rationale: Run a broader refinement pass across the entire app so pages, panels, forms, and feedback patterns feel cohesive, intentional, and production-grade instead of evolving as isolated local improvements.
   Dependencies: TASK-096, TASK-100
+- ID: TASK-129
+  Title: Section help affordances - opt-in question-mark guidance across dashboard modules
+  Status: Pending
+  Rationale: Replace persistent explanatory copy inside dashboard sections with lighter opt-in help affordances so users can click a question-mark entry point when they want extra context, keeping section layouts cleaner while creating a reusable explanation pattern for Roadmap and future modules.
+  Dependencies: TASK-096, TASK-108
 - ID: TASK-100
   Title: Mobile UI/UX refinement - touch ergonomics, compact layouts, and small-screen polish
   Status: Pending

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -4,11 +4,6 @@ Use this file to capture tasks discovered during development. Each entry should 
 
 ## Pending
 ### Execution Queue (Now / Next)
-- ID: TASK-106
-  Title: Project roadmap feature - milestone/timeline visibility for better execution sight
-  Status: Pending
-  Rationale: Add a roadmap-oriented project view so teams can see planned direction, upcoming milestones, and sequencing at a higher level than the current Kanban board, improving long-range visibility without losing the existing execution detail.
-  Dependencies: TASK-076, TASK-079, TASK-096
 - ID: TASK-123
   Title: Notification center - unified in-app inbox for invitations, mentions, and future activity
   Status: Pending
@@ -130,6 +125,11 @@ Use this file to capture tasks discovered during development. Each entry should 
   Dependencies: TASK-051
 
 ## Completed
+- ID: TASK-106
+  Title: Project roadmap feature - milestone/timeline visibility for better execution sight
+  Status: Done (2026-04-23)
+  Rationale: Added a dedicated project `Roadmap` section with standalone manual milestones, visual sequencing, and intentionally distinct desktop/mobile timeline treatments so teams can communicate project direction without coupling the first release to tasks or epics yet.
+  Dependencies: TASK-076, TASK-079, TASK-096
 - ID: TASK-128
   Title: Task assignee quick action from task options menu
   Status: Done (2026-04-23)

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,104 +1,170 @@
-# Current Task: TASK-128 Task Assignee Quick Assign From Task Options
+# Current Task: TASK-106 Project Roadmap
 
 ## Task ID
-TASK-128
+TASK-106
 
 ## Status
-In progress.
+Done.
 
 ## Objective
-Let collaborators assign or clear a task assignee directly from the existing
-task options menu, so common ownership changes do not require switching into
-full edit mode.
+Add a dedicated `Roadmap` section to each project dashboard where users can
+manually create and arrange visual milestones that communicate the intended
+direction of the project.
+
+This first version is intentionally a planning-communication surface, not a
+task-tracking surface. Milestones should help users see where the project is
+heading at a glance, without coupling roadmap items to Kanban tasks, task
+deadlines, or epics yet.
 
 ## Why This Task Matters
-- `TASK-101` already introduced assignee data across schema, services, API
-  routes, and task surfaces, but the fastest reassignment path still lives
-  behind full task edit mode.
-- Ownership changes are one of the most frequent task adjustments during daily
-  execution, especially while triaging new work or redistributing active work.
-- The task options menu already hosts quick actions for move/archive/delete, so
-  assignee fits naturally there as another lightweight task-management action.
+- NexusDash currently gives strong execution visibility through context cards,
+  epics, Kanban tasks, deadlines, comments, and calendar events, but it does
+  not yet provide a high-level visual story of project direction.
+- Teams need a lightweight way to express upcoming phases, target moments,
+  launch checkpoints, decision gates, or aspirational milestones without
+  forcing those ideas into task status columns.
+- A compelling roadmap section can make the project dashboard feel more
+  strategic and easier to scan before users dive into execution detail.
+- Keeping v1 independent from tasks preserves clarity now while leaving room
+  for a future v2 where epics or tasks can power milestone tracking.
 
 ## Current Baseline Confirmed In Repo
-- Tasks already persist an optional `assigneeUserId`.
-- Task create/edit flows already validate assignees against current project
-  collaborators.
-- The task detail modal already shows the current assignee and already exposes a
-  task options menu.
-- The `PATCH /api/projects/{projectId}/tasks/{taskId}` route already supports
-  changing or clearing assignee through the existing service boundary.
+- The project dashboard is composed from async server sections under
+  `app/projects/[projectId]`.
+- Existing sections use shared dashboard chrome from
+  `components/project-dashboard/project-section-chrome.ts`.
+- Project-scoped persistence and authorization belong in `lib/services/**`.
+- API routes are thin transport adapters that authenticate principals, parse
+  input, call services, and map service results.
+- Project roles are already available through the service layer:
+  - viewers can read project-scoped content
+  - editors and owners can mutate most project execution content
+  - owners keep project administration capabilities
+- The app already has a first-class `Epic` model, but roadmap v1 should not
+  depend on epics or tasks.
+
+## Product Direction
+- The section name is `Roadmap`.
+- The user experience should be creative, visual, and compelling rather than a
+  plain CRUD table.
+- Desktop should present milestones as a directional journey or timeline that
+  makes sequencing easy to understand at a glance.
+- Mobile should feel intentionally designed, likely as a vertical milestone
+  journey, stacked timeline, or card path rather than a cramped desktop layout.
+- Milestones should be standalone project artifacts in v1.
+- Future v2 may use epics as a tracking layer, but that is explicitly deferred.
 
 ## Scope
-- Add an assignee quick-action entry inside the existing task options menu.
-- Allow assigning the task to any current project collaborator from that menu.
-- Allow clearing the assignee back to unassigned from that menu.
-- Reuse the existing task update API/service path instead of introducing a
-  parallel assignee-only endpoint.
-- Keep local task state, modal header assignee badge, and board card assignee
-  UI aligned immediately after the quick update.
-- Preserve current collaborator validation and current error handling behavior.
-- Add targeted regression coverage for the quick-assignment path.
-- Update task tracking docs in the same branch.
+- Add a project-scoped roadmap milestone data model.
+- Add service-layer functions for listing, creating, updating, deleting, and
+  reordering roadmap milestones.
+- Add API routes for roadmap milestone reads and mutations.
+- Add a `Roadmap` dashboard section that matches the existing dashboard
+  architecture and visual quality bar.
+- Allow users with edit permission to create, edit, delete, and reorder
+  milestones.
+- Allow viewers to read roadmap milestones without mutation controls.
+- Support milestone fields that are expressive enough for visual planning:
+  - title
+  - optional description
+  - optional target date
+  - visual state or tone for manual planning communication
+  - explicit order/position
+- Preserve project-scoped authorization and RLS context in all service paths.
+- Add targeted unit/API/component coverage for the roadmap service, routes, and
+  core UI behavior.
+- Update task tracking documentation and the project blueprint after the
+  feature lands.
 
 ## Out Of Scope
-- Assignee search/filter across the whole board.
-- Bulk assignment actions.
-- New collaborator-management UX.
-- Additional provenance model changes beyond the already shipped `TASK-101`
-  contract.
+- Linking milestones to tasks.
+- Linking milestones to epics.
+- Automatic progress calculation.
+- Calendar synchronization.
+- Reminder or notification behavior.
+- Dependency graphs or critical-path planning.
+- Multi-project roadmap aggregation.
+- Dragging tasks onto roadmap milestones.
+- Agent/OpenAPI roadmap management unless intentionally added as a follow-up
+  after the human dashboard flow is stable.
 
 ## Acceptance Criteria
-- The task options menu includes an assignee quick-action path.
-- Users can assign a task to any current project collaborator from that menu.
-- Users can clear an assignee back to unassigned from that menu.
-- Invalid assignee writes are still rejected by the existing service boundary.
-- The task detail assignee badge updates immediately after a successful quick
-  assignment change.
-- Task tracking docs are updated consistently in the same PR.
+- A `Roadmap` section appears on the project dashboard.
+- Project members with viewer access can see roadmap milestones.
+- Editors and owners can create roadmap milestones.
+- Editors and owners can update roadmap milestone content and visual state.
+- Editors and owners can delete roadmap milestones with an intentional
+  confirmation flow.
+- Editors and owners can control milestone ordering or sequencing.
+- Milestones remain independent from tasks, deadlines, comments, and epics in
+  v1.
+- The desktop presentation communicates sequence/direction visually and is not
+  just a table or unstyled list.
+- The mobile presentation is intentionally adapted for narrow screens.
+- Service-layer authorization rejects unauthorized reads and mutations.
+- API routes remain thin adapters over the roadmap service.
+- Prisma access remains limited to `lib/services/**`.
+- Relevant automated tests cover service behavior, API contracts, and core UI
+  rendering/interactions.
+- Tracking docs are updated consistently in the same PR.
 
 ## Definition Of Done
-1. `TASK-128` is the active brief in `tasks/current.md`.
-2. Task options support assignee quick assignment end to end through the
-   existing UI/API/service stack.
-3. Relevant validation is green:
+1. `TASK-106` is the active brief in `tasks/current.md`.
+2. The roadmap milestone model, migration, service, API routes, and dashboard
+   section are implemented without coupling milestones to tasks or epics.
+3. The UI works intentionally on desktop and mobile.
+4. Relevant validation is green:
    - `npm run lint`
-   - targeted automated coverage for the quick-action path
+   - targeted roadmap service/API/component tests
+   - `npm test`
    - `npm run build`
-   - preview validation once the branch is published
-4. Tracking docs are updated consistently (`tasks/current.md`,
-   `tasks/backlog.md`, and `journal.md`; `adr/decisions.md` only if a new
-   architecture-level decision appears).
-5. The task ships through its own dedicated branch and PR with Copilot review
-   triaged before handoff.
+   - Playwright smoke coverage when the dashboard interaction flow is touched
+5. Tracking docs are updated consistently:
+   - `tasks/current.md`
+   - `tasks/backlog.md`
+   - `journal.md`
+   - `project.md`
+   - `adr/decisions.md` only if a new architecture-level decision appears
+6. The task ships through its own dedicated branch and PR with automated review
+   feedback triaged before handoff.
 
 ## Dependencies
-- `TASK-101`
+- `TASK-076`
 - `TASK-079`
+- `TASK-096`
 
 ## Evidence Plan
 - Repo source of truth:
   - `agent.md`
+  - `project.md`
+  - `README.md`
   - `tasks/backlog.md`
-  - `components/kanban/task-detail-modal.tsx`
-  - `components/kanban-board.tsx`
-  - `components/ui/assignee-select.tsx`
-  - `app/api/projects/[projectId]/tasks/[taskId]/route.ts`
-  - `lib/services/project-task-service.ts`
-  - `tests/e2e/smoke-project-task-calendar.spec.ts`
+  - `prisma/schema.prisma`
+  - `app/projects/[projectId]/page.tsx`
+  - `components/project-dashboard/project-section-chrome.ts`
+  - `lib/services/project-access-service.ts`
+  - `lib/services/rls-context.ts`
+- Likely implementation areas:
+  - `prisma/migrations/**`
+  - `lib/services/project-roadmap-service.ts`
+  - `app/api/projects/[projectId]/roadmap-milestones/**`
+  - `app/projects/[projectId]/project-roadmap-section.tsx`
+  - `components/project-roadmap-panel.tsx`
+  - focused tests under `tests/lib`, `tests/api`, and `tests/components`
 - Validation source of truth:
-  - local lint/build runs
-  - targeted automated tests
-  - PR review comments and checks
-  - preview deployment verification
+  - local lint/test/build runs
+  - targeted UI/API/service tests
+  - PR checks and review comments
+  - preview validation if the branch proceeds to full implementation handoff
 
 ## Outcome Target
-- Reassigning task ownership becomes a lightweight task-management action rather
-  than a full edit workflow.
-- NexusDash keeps the task detail modal focused on quick execution changes where
-  that makes the most sense.
+- Project dashboards gain a high-level visual roadmap that makes project
+  direction, sequencing, and upcoming milestones easy to understand.
+- Roadmap v1 remains simple, manual, and expressive, setting up a clean future
+  path for v2 tracking through epics or tasks without overloading the first
+  release.
 
 ---
 
-Last Updated: 2026-04-22
+Last Updated: 2026-04-23
 Assigned To: Agent

--- a/tests/api/project-roadmap.route.test.ts
+++ b/tests/api/project-roadmap.route.test.ts
@@ -210,6 +210,27 @@ describe("project roadmap routes", () => {
     });
   });
 
+  test("PATCH /api/projects/:projectId/roadmap-milestones/:milestoneId rejects invalid field types", async () => {
+    const response = await updateRoadmapMilestone(
+      new Request("http://localhost/api/projects/p1/roadmap-milestones/m1", {
+        method: "PATCH",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          description: 123,
+        }),
+      }) as never,
+      milestoneParams("p1", "m1")
+    );
+
+    expect(response.status).toBe(400);
+    await expect(readJson(response)).resolves.toEqual({
+      error: "invalid-payload",
+    });
+    expect(roadmapServiceMock.updateProjectRoadmapMilestone).not.toHaveBeenCalled();
+  });
+
   test("DELETE /api/projects/:projectId/roadmap-milestones/:milestoneId deletes a milestone", async () => {
     roadmapServiceMock.deleteProjectRoadmapMilestone.mockResolvedValueOnce({
       ok: true,

--- a/tests/api/project-roadmap.route.test.ts
+++ b/tests/api/project-roadmap.route.test.ts
@@ -1,0 +1,283 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const apiGuardMock = vi.hoisted(() => ({
+  requireAuthenticatedApiUser: vi.fn(),
+}));
+
+const roadmapServiceMock = vi.hoisted(() => ({
+  listProjectRoadmapMilestones: vi.fn(),
+  createProjectRoadmapMilestone: vi.fn(),
+  updateProjectRoadmapMilestone: vi.fn(),
+  deleteProjectRoadmapMilestone: vi.fn(),
+  reorderProjectRoadmapMilestones: vi.fn(),
+  isValidRoadmapReorderPayload: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/api-guard", () => ({
+  requireAuthenticatedApiUser: apiGuardMock.requireAuthenticatedApiUser,
+}));
+
+vi.mock("@/lib/services/project-roadmap-service", () => ({
+  listProjectRoadmapMilestones: roadmapServiceMock.listProjectRoadmapMilestones,
+  createProjectRoadmapMilestone: roadmapServiceMock.createProjectRoadmapMilestone,
+  updateProjectRoadmapMilestone: roadmapServiceMock.updateProjectRoadmapMilestone,
+  deleteProjectRoadmapMilestone: roadmapServiceMock.deleteProjectRoadmapMilestone,
+  reorderProjectRoadmapMilestones: roadmapServiceMock.reorderProjectRoadmapMilestones,
+  isValidRoadmapReorderPayload: roadmapServiceMock.isValidRoadmapReorderPayload,
+}));
+
+import {
+  GET as getRoadmapMilestones,
+  POST as createRoadmapMilestone,
+} from "@/app/api/projects/[projectId]/roadmap-milestones/route";
+import {
+  DELETE as deleteRoadmapMilestone,
+  PATCH as updateRoadmapMilestone,
+} from "@/app/api/projects/[projectId]/roadmap-milestones/[milestoneId]/route";
+import { POST as reorderRoadmapMilestones } from "@/app/api/projects/[projectId]/roadmap-milestones/reorder/route";
+
+async function readJson(response: Response): Promise<Record<string, unknown>> {
+  return (await response.json()) as Record<string, unknown>;
+}
+
+function projectParams(projectId: string) {
+  return { params: Promise.resolve({ projectId }) };
+}
+
+function milestoneParams(projectId: string, milestoneId: string) {
+  return { params: Promise.resolve({ projectId, milestoneId }) };
+}
+
+describe("project roadmap routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiGuardMock.requireAuthenticatedApiUser.mockResolvedValue({
+      ok: true,
+      userId: "user-1",
+    });
+    roadmapServiceMock.isValidRoadmapReorderPayload.mockReturnValue(true);
+  });
+
+  test("GET /api/projects/:projectId/roadmap-milestones returns serialized milestones", async () => {
+    roadmapServiceMock.listProjectRoadmapMilestones.mockResolvedValueOnce([
+      {
+        id: "milestone-1",
+        title: "Private beta",
+        description: "Open beta wave one.",
+        targetDate: "2026-05-02",
+        status: "active",
+        position: 0,
+        createdAt: "2026-04-23T08:00:00.000Z",
+        updatedAt: "2026-04-23T08:00:00.000Z",
+      },
+    ]);
+
+    const response = await getRoadmapMilestones(
+      new Request("http://localhost/api/projects/p1/roadmap-milestones") as never,
+      projectParams("p1")
+    );
+
+    expect(response.status).toBe(200);
+    await expect(readJson(response)).resolves.toEqual({
+      milestones: [
+        {
+          id: "milestone-1",
+          title: "Private beta",
+          description: "Open beta wave one.",
+          targetDate: "2026-05-02",
+          status: "active",
+          position: 0,
+          createdAt: "2026-04-23T08:00:00.000Z",
+          updatedAt: "2026-04-23T08:00:00.000Z",
+        },
+      ],
+    });
+    expect(roadmapServiceMock.listProjectRoadmapMilestones).toHaveBeenCalledWith(
+      "p1",
+      "user-1"
+    );
+  });
+
+  test("POST /api/projects/:projectId/roadmap-milestones returns 400 for invalid json", async () => {
+    const response = await createRoadmapMilestone(
+      new Request("http://localhost/api/projects/p1/roadmap-milestones", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: "{",
+      }) as never,
+      projectParams("p1")
+    );
+
+    expect(response.status).toBe(400);
+    await expect(readJson(response)).resolves.toEqual({
+      error: "invalid-json",
+    });
+  });
+
+  test("POST /api/projects/:projectId/roadmap-milestones creates a milestone", async () => {
+    roadmapServiceMock.createProjectRoadmapMilestone.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        milestone: {
+          id: "milestone-1",
+          title: "Launch",
+          description: null,
+          targetDate: "2026-06-14",
+          status: "planned",
+          position: 0,
+          createdAt: "2026-04-23T08:00:00.000Z",
+          updatedAt: "2026-04-23T08:00:00.000Z",
+        },
+      },
+    });
+
+    const response = await createRoadmapMilestone(
+      new Request("http://localhost/api/projects/p1/roadmap-milestones", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          title: "Launch",
+          targetDate: "2026-06-14",
+          status: "planned",
+        }),
+      }) as never,
+      projectParams("p1")
+    );
+
+    expect(response.status).toBe(201);
+    await expect(readJson(response)).resolves.toEqual({
+      milestone: {
+        id: "milestone-1",
+        title: "Launch",
+        description: null,
+        targetDate: "2026-06-14",
+        status: "planned",
+        position: 0,
+        createdAt: "2026-04-23T08:00:00.000Z",
+        updatedAt: "2026-04-23T08:00:00.000Z",
+      },
+    });
+  });
+
+  test("PATCH /api/projects/:projectId/roadmap-milestones/:milestoneId updates a milestone", async () => {
+    roadmapServiceMock.updateProjectRoadmapMilestone.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        milestone: {
+          id: "milestone-1",
+          title: "Launch",
+          description: "Refined note",
+          targetDate: "2026-06-14",
+          status: "active",
+          position: 0,
+          createdAt: "2026-04-23T08:00:00.000Z",
+          updatedAt: "2026-04-23T09:00:00.000Z",
+        },
+      },
+    });
+
+    const response = await updateRoadmapMilestone(
+      new Request("http://localhost/api/projects/p1/roadmap-milestones/m1", {
+        method: "PATCH",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          title: "Launch",
+          description: "Refined note",
+          status: "active",
+        }),
+      }) as never,
+      milestoneParams("p1", "m1")
+    );
+
+    expect(response.status).toBe(200);
+    await expect(readJson(response)).resolves.toEqual({
+      milestone: {
+        id: "milestone-1",
+        title: "Launch",
+        description: "Refined note",
+        targetDate: "2026-06-14",
+        status: "active",
+        position: 0,
+        createdAt: "2026-04-23T08:00:00.000Z",
+        updatedAt: "2026-04-23T09:00:00.000Z",
+      },
+    });
+  });
+
+  test("DELETE /api/projects/:projectId/roadmap-milestones/:milestoneId deletes a milestone", async () => {
+    roadmapServiceMock.deleteProjectRoadmapMilestone.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        ok: true,
+      },
+    });
+
+    const response = await deleteRoadmapMilestone(
+      new Request("http://localhost/api/projects/p1/roadmap-milestones/m1", {
+        method: "DELETE",
+      }) as never,
+      milestoneParams("p1", "m1")
+    );
+
+    expect(response.status).toBe(200);
+    await expect(readJson(response)).resolves.toEqual({ ok: true });
+  });
+
+  test("POST /api/projects/:projectId/roadmap-milestones/reorder returns 400 for invalid payload", async () => {
+    roadmapServiceMock.isValidRoadmapReorderPayload.mockReturnValueOnce(false);
+
+    const response = await reorderRoadmapMilestones(
+      new Request("http://localhost/api/projects/p1/roadmap-milestones/reorder", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          milestoneIds: ["m1", "m1"],
+        }),
+      }) as never,
+      projectParams("p1")
+    );
+
+    expect(response.status).toBe(400);
+    await expect(readJson(response)).resolves.toEqual({
+      error: "invalid-payload",
+    });
+  });
+
+  test("POST /api/projects/:projectId/roadmap-milestones/reorder saves ordering", async () => {
+    roadmapServiceMock.reorderProjectRoadmapMilestones.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        ok: true,
+      },
+    });
+
+    const response = await reorderRoadmapMilestones(
+      new Request("http://localhost/api/projects/p1/roadmap-milestones/reorder", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          milestoneIds: ["m1", "m2"],
+        }),
+      }) as never,
+      projectParams("p1")
+    );
+
+    expect(response.status).toBe(200);
+    await expect(readJson(response)).resolves.toEqual({ ok: true });
+    expect(roadmapServiceMock.reorderProjectRoadmapMilestones).toHaveBeenCalledWith({
+      actorUserId: "user-1",
+      projectId: "p1",
+      milestoneIds: ["m1", "m2"],
+    });
+  });
+});

--- a/tests/components/project-roadmap-panel.test.tsx
+++ b/tests/components/project-roadmap-panel.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const routerRefreshMock = vi.hoisted(() => vi.fn());
+const pushToastMock = vi.hoisted(() => vi.fn());
+const setIsExpandedMock = vi.hoisted(() => vi.fn());
+const projectSectionExpandedMock = vi.hoisted(() => ({
+  isExpanded: false,
+  setIsExpanded: setIsExpandedMock,
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: routerRefreshMock,
+  }),
+}));
+
+vi.mock("@/components/toast-provider", () => ({
+  useToast: () => ({
+    pushToast: pushToastMock,
+  }),
+}));
+
+vi.mock("@/lib/hooks/use-project-section-expanded", () => ({
+  useProjectSectionExpanded: () => projectSectionExpandedMock,
+}));
+
+import { ProjectRoadmapPanel } from "@/components/project-roadmap-panel";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function createTestRenderer() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  return {
+    container,
+    root,
+  };
+}
+
+async function renderWithRoot(root: Root, ui: React.ReactElement) {
+  await act(async () => {
+    root.render(ui);
+  });
+}
+
+describe("project-roadmap-panel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    projectSectionExpandedMock.isExpanded = false;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("expands the section before opening the create flow", async () => {
+    const { container, root } = createTestRenderer();
+
+    await renderWithRoot(
+      root,
+      React.createElement(ProjectRoadmapPanel, {
+        projectId: "project-1",
+        canEdit: true,
+        milestones: [],
+      })
+    );
+
+    const newMilestoneButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("New milestone")
+    );
+
+    expect(newMilestoneButton).not.toBeUndefined();
+
+    await act(async () => {
+      newMilestoneButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(setIsExpandedMock).toHaveBeenCalledWith(true);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  test("renders milestone content when expanded", async () => {
+    projectSectionExpandedMock.isExpanded = true;
+    const { container, root } = createTestRenderer();
+
+    await renderWithRoot(
+      root,
+      React.createElement(ProjectRoadmapPanel, {
+        projectId: "project-1",
+        canEdit: false,
+        milestones: [
+          {
+            id: "milestone-1",
+            title: "Private beta",
+            description: "Open the first customer wave.",
+            targetDate: "2026-05-02",
+            status: "active",
+            position: 0,
+            createdAt: "2026-04-23T08:00:00.000Z",
+            updatedAt: "2026-04-23T08:00:00.000Z",
+          },
+        ],
+      })
+    );
+
+    expect(container.textContent).toContain("Roadmap");
+    expect(container.textContent).toContain("Private beta");
+    expect(container.textContent).toContain("Open the first customer wave.");
+    expect(container.textContent).toContain("Active");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/tests/components/project-roadmap-panel.test.tsx
+++ b/tests/components/project-roadmap-panel.test.tsx
@@ -117,6 +117,55 @@ describe("project-roadmap-panel", () => {
     expect(container.textContent).toContain("Private beta");
     expect(container.textContent).toContain("Open the first customer wave.");
     expect(container.textContent).toContain("Active");
+    expect(container.textContent).not.toContain(
+      "Show where the project is going before people dive into the work."
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  test("opens milestone detail view from the view button", async () => {
+    projectSectionExpandedMock.isExpanded = true;
+    const { container, root } = createTestRenderer();
+    const fullDescription =
+      "A much longer milestone note that should remain available in the dedicated detail view even when the card preview is compact.";
+
+    await renderWithRoot(
+      root,
+      React.createElement(ProjectRoadmapPanel, {
+        projectId: "project-1",
+        canEdit: true,
+        milestones: [
+          {
+            id: "milestone-1",
+            title: "Private beta",
+            description: fullDescription,
+            targetDate: "2026-05-02",
+            status: "active",
+            position: 0,
+            createdAt: "2026-04-23T08:00:00.000Z",
+            updatedAt: "2026-04-23T08:00:00.000Z",
+          },
+        ],
+      })
+    );
+
+    const viewButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("View")
+    );
+
+    expect(viewButton).not.toBeUndefined();
+
+    await act(async () => {
+      viewButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const detailDialog = container.querySelector("[role='dialog']");
+    expect(detailDialog?.textContent).toContain("Private beta");
+    expect(detailDialog?.textContent).toContain(fullDescription);
+    expect(detailDialog?.textContent).toContain("Target date");
 
     await act(async () => {
       root.unmount();

--- a/tests/lib/project-roadmap-service.test.ts
+++ b/tests/lib/project-roadmap-service.test.ts
@@ -191,6 +191,14 @@ describe("project-roadmap-service", () => {
     ).toBe(false);
   });
 
+  test("reorder validation rejects ids with surrounding whitespace", () => {
+    expect(
+      isValidRoadmapReorderPayload({
+        milestoneIds: ["m1", " m2 "],
+      })
+    ).toBe(false);
+  });
+
   test("returns 400 when reorder payload includes ids outside the project", async () => {
     dbMock.roadmapMilestone.findMany.mockResolvedValueOnce([{ id: "milestone-1" }]);
 

--- a/tests/lib/project-roadmap-service.test.ts
+++ b/tests/lib/project-roadmap-service.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const projectAccessServiceMock = vi.hoisted(() => ({
+  requireProjectRole: vi.fn(),
+}));
+
+const rlsContextMock = vi.hoisted(() => ({
+  withActorRlsContext: vi.fn(),
+}));
+
+const loggerMock = vi.hoisted(() => ({
+  logServerError: vi.fn(),
+}));
+
+const dbMock = vi.hoisted(() => ({
+  roadmapMilestone: {
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    aggregate: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/services/project-access-service", () => ({
+  requireProjectRole: projectAccessServiceMock.requireProjectRole,
+}));
+
+vi.mock("@/lib/services/rls-context", () => ({
+  withActorRlsContext: rlsContextMock.withActorRlsContext,
+}));
+
+vi.mock("@/lib/observability/logger", () => ({
+  logServerError: loggerMock.logServerError,
+}));
+
+import {
+  createProjectRoadmapMilestone,
+  isValidRoadmapReorderPayload,
+  listProjectRoadmapMilestones,
+  reorderProjectRoadmapMilestones,
+} from "@/lib/services/project-roadmap-service";
+
+describe("project-roadmap-service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    projectAccessServiceMock.requireProjectRole.mockResolvedValue({
+      ok: true,
+      role: "owner",
+    });
+    rlsContextMock.withActorRlsContext.mockImplementation(
+      async (_actorUserId: string, operation: (db: typeof dbMock) => unknown) =>
+        operation(dbMock)
+    );
+  });
+
+  test("lists roadmap milestones ordered and serialized for viewers", async () => {
+    dbMock.roadmapMilestone.findMany.mockResolvedValueOnce([
+      {
+        id: "milestone-1",
+        title: "Private beta",
+        description: "Open the first external wave.",
+        targetDate: new Date("2026-05-02T00:00:00.000Z"),
+        status: "active",
+        position: 0,
+        createdAt: new Date("2026-04-20T08:00:00.000Z"),
+        updatedAt: new Date("2026-04-21T09:30:00.000Z"),
+      },
+    ]);
+
+    const result = await listProjectRoadmapMilestones("project-1", "user-1");
+
+    expect(result).toEqual([
+      {
+        id: "milestone-1",
+        title: "Private beta",
+        description: "Open the first external wave.",
+        targetDate: "2026-05-02",
+        status: "active",
+        position: 0,
+        createdAt: "2026-04-20T08:00:00.000Z",
+        updatedAt: "2026-04-21T09:30:00.000Z",
+      },
+    ]);
+    expect(projectAccessServiceMock.requireProjectRole).toHaveBeenCalledWith({
+      actorUserId: "user-1",
+      projectId: "project-1",
+      minimumRole: "viewer",
+      db: dbMock,
+    });
+    expect(dbMock.roadmapMilestone.findMany).toHaveBeenCalledWith({
+      where: {
+        projectId: "project-1",
+      },
+      orderBy: [{ position: "asc" }, { createdAt: "asc" }],
+      select: {
+        id: true,
+        title: true,
+        description: true,
+        targetDate: true,
+        status: true,
+        position: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+  });
+
+  test("creates roadmap milestone with sequential position and serialized target date", async () => {
+    dbMock.roadmapMilestone.aggregate.mockResolvedValueOnce({
+      _max: {
+        position: 2,
+      },
+    });
+    dbMock.roadmapMilestone.create.mockResolvedValueOnce({
+      id: "milestone-3",
+    });
+    dbMock.roadmapMilestone.findFirst.mockResolvedValueOnce({
+      id: "milestone-3",
+      title: "Public launch",
+      description: "Make the roadmap public.",
+      targetDate: new Date("2026-06-14T00:00:00.000Z"),
+      status: "planned",
+      position: 3,
+      createdAt: new Date("2026-04-23T08:00:00.000Z"),
+      updatedAt: new Date("2026-04-23T08:00:00.000Z"),
+    });
+
+    const result = await createProjectRoadmapMilestone({
+      actorUserId: "user-1",
+      projectId: "project-1",
+      title: "Public launch",
+      description: "Make the roadmap public.",
+      targetDate: "2026-06-14",
+      status: "planned",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        milestone: {
+          id: "milestone-3",
+          title: "Public launch",
+          description: "Make the roadmap public.",
+          targetDate: "2026-06-14",
+          status: "planned",
+          position: 3,
+          createdAt: "2026-04-23T08:00:00.000Z",
+          updatedAt: "2026-04-23T08:00:00.000Z",
+        },
+      },
+    });
+    expect(dbMock.roadmapMilestone.create).toHaveBeenCalledWith({
+      data: {
+        projectId: "project-1",
+        title: "Public launch",
+        description: "Make the roadmap public.",
+        targetDate: new Date("2026-06-14T00:00:00.000Z"),
+        status: "planned",
+        position: 3,
+      },
+      select: {
+        id: true,
+      },
+    });
+  });
+
+  test("rejects invalid roadmap milestone status input", async () => {
+    const result = await createProjectRoadmapMilestone({
+      actorUserId: "user-1",
+      projectId: "project-1",
+      title: "Roadmap item",
+      status: "unknown",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 400,
+      error: "roadmap-status-invalid",
+    });
+    expect(dbMock.roadmapMilestone.create).not.toHaveBeenCalled();
+  });
+
+  test("reorder validation rejects duplicate ids", () => {
+    expect(
+      isValidRoadmapReorderPayload({
+        milestoneIds: ["m1", "m1"],
+      })
+    ).toBe(false);
+  });
+
+  test("returns 400 when reorder payload includes ids outside the project", async () => {
+    dbMock.roadmapMilestone.findMany.mockResolvedValueOnce([{ id: "milestone-1" }]);
+
+    const result = await reorderProjectRoadmapMilestones({
+      actorUserId: "user-1",
+      projectId: "project-1",
+      milestoneIds: ["milestone-1", "milestone-2"],
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 400,
+      error: "roadmap-milestones-invalid",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated `Roadmap` section with standalone project milestones and creative desktop/mobile timeline layouts
- add roadmap milestone schema, migration, service layer, and human-only project API routes including ordering
- cover the rollout with roadmap service, API, and component tests and update project tracking/docs

## Validation
- `npx -y -p node@20.19.0 node .\\node_modules\\prisma\\build\\index.js generate`
- `npx -y -p node@20.19.0 node .\\node_modules\\eslint\\bin\\eslint.js .`
- `npx -y -p node@20.19.0 node .\\node_modules\\vitest\\vitest.mjs run tests\\lib\\project-roadmap-service.test.ts tests\\api\\project-roadmap.route.test.ts tests\\components\\project-roadmap-panel.test.tsx`
- `DATABASE_URL=... DIRECT_URL=... AGENT_TOKEN_SIGNING_SECRET=... RESEND_API_KEY=... npx -y -p node@20.19.0 node .\\node_modules\\vitest\\vitest.mjs run`
- `DATABASE_URL=... DIRECT_URL=... AGENT_TOKEN_SIGNING_SECRET=... RESEND_API_KEY=... GOOGLE_TOKEN_ENCRYPTION_KEY=... npx -y -p node@20.19.0 node .\\node_modules\\next\\dist\\bin\\next build`