### PR TITLE
[codex] Add backlog task for local validation environment repair

### DIFF
--- a/journal.md
+++ b/journal.md
@@ -957,3 +957,8 @@ Low-value entries to avoid going forward:
 - Type: Validation
 - Summary: TASK-130 roadmap modal follow-up passed focused lint and a production build before preview redeploy.
 - Evidence: `npm run lint -- components/project-roadmap-panel.tsx`; `npm run build` with local `DATABASE_URL`, `DIRECT_URL`, `GOOGLE_TOKEN_ENCRYPTION_KEY`, and `AGENT_TOKEN_SIGNING_SECRET` overrides.
+
+### 2026-04-27
+- Type: Governance
+- Summary: Added TASK-131 to track the local validation environment repair work across container bootstrap, database availability, and required toolchain/version alignment.
+- Evidence: Updated `tasks/backlog.md` and `journal.md` on branch `docs/add-local-testing-backlog-task`.

--- a/journal.md
+++ b/journal.md
@@ -961,4 +961,4 @@ Low-value entries to avoid going forward:
 ### 2026-04-27
 - Type: Governance
 - Summary: Added TASK-131 to track the local validation environment repair work across container bootstrap, database availability, and required toolchain/version alignment.
-- Evidence: Updated `tasks/backlog.md` and `journal.md` on branch `docs/add-local-testing-backlog-task`.
+- Evidence: Updated `tasks/backlog.md` and `journal.md`; PR title: `TASK-131 add local testing backlog task`.

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -4,6 +4,11 @@ Use this file to capture tasks discovered during development. Each entry should 
 
 ## Pending
 ### Execution Queue (Now / Next)
+- ID: TASK-131
+  Title: Local validation baseline repair - reproducible container, database, and toolchain setup
+  Status: Pending
+  Rationale: Restore a dependable local validation path by aligning the repo-required Node/npm/Prisma toolchain, making the containerized database/app bootstrap reproducible, and documenting one reliable workflow for `npm ci`, Prisma generate/migrate, Vitest, build, and Playwright smoke runs so routine development stops getting blocked by environment drift.
+  Dependencies: TASK-041, TASK-067
 - ID: TASK-123
   Title: Notification center - unified in-app inbox for invitations, mentions, and future activity
   Status: Pending


### PR DESCRIPTION
## Summary
- add `TASK-131` to the execution queue for repairing the local validation baseline
- scope the task around reproducible container bootstrap, database availability, and required Node/npm/Prisma version alignment
- record the backlog/journal update in `journal.md`

## Why
Local validation is currently too fragile because container startup, database access, and runtime/toolchain requirements drift out of sync. Capturing this as an explicit near-term task makes the repair work visible and prioritizable instead of leaving it as scattered blocker notes.

## Impact
This does not change product behavior. It adds planning/documentation so the local developer workflow fix has a tracked home in the backlog.

## Validation
- No code/runtime checks run; docs-only change (`tasks/backlog.md`, `journal.md`).