### PR TITLE
docs: clarify agent workflow contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,10 @@
 
 ## Workflow Rules
 
-- **One task per branch/PR.** Branch: `feature/*`, `fix/*`, `refactor/*`, `docs/*`, or `chore/*`.
-- **PR is mandatory** for any product code change — not optional.
+- **One task per worktree/branch/PR.** Use `npm run worktree:create -- TASK-XXX slug` for task worktrees when a task ID exists; otherwise create a dedicated worktree manually.
+- **Branch by work type.** Use `feature/*` for planned product work, `fix/*` for GitHub issues/bugs/remediations, `docs/*` for docs-only changes, `refactor/*` for behavior-preserving restructuring, and `chore/*` for maintenance.
+- **PR is mandatory** for any task or GitHub issue that changes repository contents, including docs-only changes.
+- **Remote stays current.** Push the active branch after meaningful progress and again before handoff so the remote branch matches local completed work.
 - **Startup:** read `tasks/current.md` before implementing. Ensure it has `Acceptance Criteria` and `Definition Of Done`; add/tighten if missing.
 - **Architecture:** persistence only in `lib/services/**`; API routes are thin transport adapters.
 - **Secrets:** server env only via `lib/env.server.ts`; never commit secrets.

--- a/agent.md
+++ b/agent.md
@@ -56,15 +56,29 @@ npm run worktree:create -- TASK-124 comment-mentions
   remote branch when present, and keeps the root checkout free for coordination.
 - Start each task on its dedicated branch before implementation work begins.
 - Branch name must match CI rule: `feature/*`, `fix/*`, `refactor/*`, `docs/*`, or `chore/*`.
+- Choose the branch prefix by work type:
+  - `feature/*` for planned product backlog tasks
+  - `fix/*` for GitHub issue work, regressions, bugs, and remediations
+  - `docs/*` for documentation-only changes
+  - `refactor/*` for behavior-preserving code restructuring
+  - `chore/*` for maintenance that is neither product behavior nor docs
 - Dependabot-authored PRs are the one exception and may use `dependabot/*`.
 - Keep PRs single-purpose; do not mix unrelated backlog tasks.
 - PR titles must follow repository convention rather than generic agent branding:
   - when the PR implements or closes a backlog task, include the primary task
     ID in the title
   - do not use generic prefixes like `[codex]`
-- Push the active branch remotely after meaningful implementation/validation progress and before handoff.
-- If the current task does not already have an open PR, create one once the branch is reviewable; continue updating the same PR for that task.
-- Do not treat PR creation as optional. A coding task that changes product code is not ready for handoff until its dedicated branch has an open PR, unless the user explicitly says not to open one.
+- Push the active branch remotely after meaningful implementation/validation progress.
+- Push again before completion handoff whenever local commits changed after the
+  previous push. The remote branch must be up to date with the local branch at
+  handoff; do not leave completed local work only on disk.
+- If the current task or GitHub issue does not already have an open PR, create
+  one once the branch is reviewable; continue updating the same PR for that
+  task or issue.
+- Do not treat PR creation as optional. Any task or GitHub issue that changes
+  repository contents, including docs-only work, is not ready for handoff until
+  its dedicated branch has an open PR, unless the user explicitly says not to
+  open one.
 - Open PRs in a ready-for-review state once they are reviewable so automatic
   Copilot review can start immediately.
 - Use draft PRs only when the user explicitly asks for a draft or when the work

--- a/journal.md
+++ b/journal.md
@@ -13,6 +13,16 @@ Use it for important implementation milestones, blockers, validation runs, and r
 ## Recent Entries (Most Relevant)
 
 ### 2026-05-04
+- Type: Governance
+- Summary: Tightened the repository agent workflow contract for worktrees, branch prefixes, mandatory PRs, and final push parity.
+- Evidence: Updated `agent.md` and `CLAUDE.md` so GitHub issue work maps to `fix/*`, docs-only repository changes still require PRs, task worktree creation points to `npm run worktree:create -- TASK-XXX slug`, and completed local work must be pushed so the remote branch matches the handoff state.
+
+### 2026-05-04
+- Type: Validation
+- Summary: Agent workflow contract documentation cleanup passed whitespace and lint validation.
+- Evidence: `git diff --check`; `npm ci` in the docs worktree to provide ignored local dependencies; `npm run lint`.
+
+### 2026-05-04
 - Type: Execution
 - Summary: TASK-124 PR #211 follow-up fixed the remaining mention display regressions reported from task comments and edited task descriptions.
 - Evidence: Comment composer mention mirrors now hide discriminator text without extending the visible `@name` highlight or leaving a blank tail; task-description view rendering normalizes split text nodes before mention highlighting so earlier mentions remain highlighted after later edits add more mentions. Updated `lib/content-with-mentions.tsx`, `components/kanban/task-detail-modal.tsx`, `components/rich-text-content.tsx`, `tests/components/rich-text-content.test.ts`, `tests/components/rich-text-editor.test.ts`, and `tasks/current.md`.


### PR DESCRIPTION
## Summary
- Clarify that task work should use a dedicated worktree, branch, and PR, with the task worktree helper called out in the short agent context.
- Map GitHub issue work, bugs, regressions, and remediations to `fix/*` branches while preserving `docs/*`, `feature/*`, `refactor/*`, and `chore/*` guidance.
- Make PR creation mandatory for any task or issue that changes repository contents, including docs-only work, and require the remote branch to match local completed work before handoff.
- Record the governance update and validation in `journal.md`.

## Validation
- `git diff --check`
- `npm ci`
- `npm run lint`