### PR TITLE
fix: retry deploy migrations

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -129,7 +129,21 @@ jobs:
 
       - name: Apply Prisma migrations
         run: |
-          DATABASE_URL="$MIGRATION_DATABASE_URL" DIRECT_URL="$MIGRATION_DATABASE_URL" npx prisma migrate deploy
+          for attempt in 1 2 3; do
+            echo "Running Prisma migrations (attempt ${attempt}/3)..."
+            if DATABASE_URL="$MIGRATION_DATABASE_URL" DIRECT_URL="$MIGRATION_DATABASE_URL" npx prisma migrate deploy; then
+              exit 0
+            fi
+
+            if [ "$attempt" -lt 3 ]; then
+              delay=$((attempt * 15))
+              echo "::warning::Prisma migrations failed; retrying in ${delay}s."
+              sleep "$delay"
+            fi
+          done
+
+          echo "::error::Prisma migrations failed after 3 attempts."
+          exit 1
 
       - name: Pull Vercel environment (production)
         run: npx vercel@${VERCEL_CLI_VERSION} pull --yes --environment=production --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN"
@@ -271,7 +285,21 @@ jobs:
       - name: Apply Prisma migrations
         if: ${{ inputs.action == 'deploy-preview' || inputs.action == 'deploy-production-staged' }}
         run: |
-          DATABASE_URL="$MIGRATION_DATABASE_URL" DIRECT_URL="$MIGRATION_DATABASE_URL" npx prisma migrate deploy
+          for attempt in 1 2 3; do
+            echo "Running Prisma migrations (attempt ${attempt}/3)..."
+            if DATABASE_URL="$MIGRATION_DATABASE_URL" DIRECT_URL="$MIGRATION_DATABASE_URL" npx prisma migrate deploy; then
+              exit 0
+            fi
+
+            if [ "$attempt" -lt 3 ]; then
+              delay=$((attempt * 15))
+              echo "::warning::Prisma migrations failed; retrying in ${delay}s."
+              sleep "$delay"
+            fi
+          done
+
+          echo "::error::Prisma migrations failed after 3 attempts."
+          exit 1
 
       - name: Deploy preview
         if: inputs.action == 'deploy-preview'


### PR DESCRIPTION
## Summary

Adds bounded retry/backoff around `npx prisma migrate deploy` in the Vercel deploy workflow.

## Root cause

The last auto deploy on `main` failed in `Deploy Vercel (CD + Rollback)` run `25339983104` before build/deploy. The failing step was `Apply Prisma migrations`, where Prisma returned `P1001: Can't reach database server at aws-1-eu-west-1.pooler.supabase.com:5432`.

The same workflow succeeded earlier on May 4, 2026, and local TCP/DNS checks for the Supabase pooler host succeeded, so this appears to be a transient network/database reachability failure. Retrying this network-sensitive step should avoid failing the whole deploy on a short-lived connection blip while still surfacing persistent DB or configuration problems.

## Changes

- Retries Prisma migrations up to 3 times in automatic production staged deploys.
- Applies the same retry behavior to manual preview/production staged deploys.
- Uses 15s/30s backoff and preserves a final nonzero failure after all attempts.

## Validation

- `git diff --check`
- Bash syntax check of the retry block
- Inspected failed GitHub Actions run logs with `gh run view 25339983104 --log-failed`

## Notes

The failed run URL was https://github.com/dorianagaesse/nexus_dash/actions/runs/25339983104.