### PR TITLE
fix: show user avatars in project invitation search results

### DIFF
--- a/components/project-dashboard/project-dashboard-owner-sharing-panel.tsx
+++ b/components/project-dashboard/project-dashboard-owner-sharing-panel.tsx
@@ -5,6 +5,7 @@ import { Check, Copy, Search, UserPlus } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { UserAvatar } from "@/components/ui/user-avatar";
 
 import {
   formatIdentity,
@@ -209,13 +210,21 @@ export function ProjectDashboardOwnerSharingPanel({
                 key={user.id}
                 className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-border/60 bg-card p-3"
               >
-                <div className="space-y-1">
-                  <p className="text-sm font-medium">{user.displayName}</p>
-                  {getSecondaryIdentity(user.displayName, formatIdentity(user)) ? (
-                    <p className="text-xs text-muted-foreground">
-                      {getSecondaryIdentity(user.displayName, formatIdentity(user))}
-                    </p>
-                  ) : null}
+                <div className="flex items-center gap-3">
+                  <UserAvatar
+                    avatarSeed={user.avatarSeed}
+                    displayName={user.displayName}
+                    className="h-10 w-10 border-border/70"
+                    decorative
+                  />
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium">{user.displayName}</p>
+                    {getSecondaryIdentity(user.displayName, formatIdentity(user)) ? (
+                      <p className="text-xs text-muted-foreground">
+                        {getSecondaryIdentity(user.displayName, formatIdentity(user))}
+                      </p>
+                    ) : null}
+                  </div>
                 </div>
                 <Button
                   type="button"

--- a/tests/components/project-dashboard-owner-sharing-panel.test.tsx
+++ b/tests/components/project-dashboard-owner-sharing-panel.test.tsx
@@ -63,6 +63,7 @@ describe("project-dashboard-owner-sharing-panel", () => {
             displayName: "Person Example",
             usernameTag: "person#1234",
             email: "person@example.com",
+            avatarSeed: "user-1",
           },
         ],
         generatedInvitationLink: null,


### PR DESCRIPTION
## Summary
- Add `UserAvatar` component to project invitation search results to match the avatar rendering used in the contributors list
- Use `avatarSeed` from `CollaboratorIdentitySummary` with the same size (`h-10 w-10`) and styling (`border-border/70`) as the access panel
- Mark avatars as `decorative` since the name is already announced by screen readers
- Include `avatarSeed` in test fixtures so existing tests pass

## Test plan
- [x] Lint passes
- [x] Sharing search API tests pass

Issue: #216