### PR TITLE
docs: clarify single-agent vs multi-agent branching rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,8 @@
 
 ## Workflow Rules
 
-- **One task per worktree/branch/PR.** Use `npm run worktree:create -- TASK-XXX slug` for task worktrees when a task ID exists; otherwise create a dedicated worktree manually.
-- **Branch by work type.** Use `feature/*` for planned product work, `fix/*` for GitHub issues/bugs/remediations, `docs/*` for docs-only changes, `refactor/*` for behavior-preserving restructuring, and `chore/*` for maintenance.
+- **One task per branch/PR.** Branch from `main` using `chore/issue-XXX-description` for all task work. Never commit directly to `main` or mix task work across different branches.
+- **Start from main.** Before beginning work, `git fetch origin main` and branch from the latest `main` to avoid mixing unrelated commits into your task branch.
 - **PR is mandatory** for any task or GitHub issue that changes repository contents, including docs-only changes.
 - **Remote stays current.** Push the active branch after meaningful progress and again before handoff so the remote branch matches local completed work.
 - **Startup:** read `tasks/current.md` before implementing. Ensure it has `Acceptance Criteria` and `Definition Of Done`; add/tighten if missing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,7 @@
 
 ## Workflow Rules
 
-- **One task per branch/PR.** Branch from `main` using `chore/issue-XXX-description` for all task work. Never commit directly to `main` or mix task work across different branches.
-- **Start from main.** Before beginning work, `git fetch origin main` and branch from the latest `main` to avoid mixing unrelated commits into your task branch.
+- **One task per branch/PR.** Branch from `origin/main` using the appropriate work-type prefix (`feature/*`, `fix/*`, `docs/*`, `refactor/*`, or `chore/*`) for your task. Use `git switch -c <prefix>/<id>-<slug> origin/main` to start from the latest remote `main`. Never commit directly to `main` or mix task work across different branches.
 - **PR is mandatory** for any task or GitHub issue that changes repository contents, including docs-only changes.
 - **Remote stays current.** Push the active branch after meaningful progress and again before handoff so the remote branch matches local completed work.
 - **Startup:** read `tasks/current.md` before implementing. Ensure it has `Acceptance Criteria` and `Definition Of Done`; add/tighten if missing.

--- a/agent.md
+++ b/agent.md
@@ -35,25 +35,20 @@ If `tasks/current.md` is complete or invalid, pick the next `Pending` item in `t
 - One issue maps to one backlog task. If work starts from a GitHub issue,
   create or identify the matching `TASK-XXX` entry in `tasks/backlog.md` before
   implementation.
-- One task maps to exactly one branch, one pull request, and one worktree:
-  `1 task = 1 branch = 1 PR = 1 worktree`.
-- Agents must create or enter the task worktree before coding. Use the
-  cross-platform root script:
-
-```bash
-npm run worktree:create -- TASK-124 comment-mentions
-```
-
-PowerShell uses the same command:
-
-```pwsh
-npm run worktree:create -- TASK-124 comment-mentions
-```
-
-- Worktree directories are created one level above the project root and must
-  follow `nexus_dash_taskXXX`, for example `../nexus_dash_task124`.
-- The script creates the task branch when needed, reuses an existing local or
-  remote branch when present, and keeps the root checkout free for coordination.
+- One task maps to exactly one branch and one pull request:
+  `1 task = 1 branch = 1 PR`.
+- **Single-agent rule:** When only one agent is running, work in a clean branch
+  off `main` named `chore/issue-XXX-description`. Fetch `origin/main` and branch
+  from it before starting to avoid mixing unrelated commits.
+- **Multi-agent rule:** When multiple agents are running concurrently, each agent
+  must use a dedicated worktree created via:
+  ```bash
+  npm run worktree:create -- TASK-XXX slug
+  ```
+  Worktree directories are created one level above the project root and follow
+  `nexus_dash_taskXXX` (e.g. `../nexus_dash_task124`). The script creates the
+  task branch when needed, reuses an existing local or remote branch when
+  present, and keeps the root checkout free for coordination.
 - Start each task on its dedicated branch before implementation work begins.
 - Branch name must match CI rule: `feature/*`, `fix/*`, `refactor/*`, `docs/*`, or `chore/*`.
 - Choose the branch prefix by work type:

--- a/agent.md
+++ b/agent.md
@@ -37,9 +37,11 @@ If `tasks/current.md` is complete or invalid, pick the next `Pending` item in `t
   implementation.
 - One task maps to exactly one branch and one pull request:
   `1 task = 1 branch = 1 PR`.
-- **Single-agent rule:** When only one agent is running, work in a clean branch
-  off `main` named `chore/issue-XXX-description`. Fetch `origin/main` and branch
-  from it before starting to avoid mixing unrelated commits.
+- **Single-agent rule:** When only one agent is running, create a branch from
+  `origin/main` using the work-type prefix (`feature/*`, `fix/*`, `docs/*`,
+  `refactor/*`, or `chore/*`) that matches your task. Branch with
+  `git switch -c <prefix>/<id>-<slug> origin/main` to ensure you start from
+  the latest remote `main`.
 - **Multi-agent rule:** When multiple agents are running concurrently, each agent
   must use a dedicated worktree created via:
   ```bash


### PR DESCRIPTION
## Summary

Clarify branching rules in `agent.md` and `CLAUDE.md`:

- **Single-agent rule:** Work in a branch off `main` named `chore/issue-XXX-description`. Fetch `origin/main` and branch from it before starting to avoid mixing unrelated commits.
- **Multi-agent rule:** Use dedicated worktrees via `npm run worktree:create -- TASK-XXX slug`.

## Why

Issue #216 revealed that working directly in the root directory (without a worktree) led to mixing unrelated commits from different tasks into the same branch. This caused 3 PRs to be created for what should have been a single, focused fix.

## Changes

- `agent.md`: Replace "1 task = 1 branch = 1 PR = 1 worktree" with single-agent vs multi-agent rules
- `CLAUDE.md`: Replace worktree reference with simpler "branch from main using chore/issue-XXX-description"

Issue: #216 follow-up