### PR TITLE
fix(#223): unify mention highlighting and keyboard navigation

### DIFF
--- a/components/kanban/kanban-columns-grid.tsx
+++ b/components/kanban/kanban-columns-grid.tsx
@@ -192,8 +192,6 @@ function KanbanColumn({
                     <p className="mt-1 text-xs text-muted-foreground">
                       {renderContentWithMentions(getDescriptionPreview(task.description, 90), {
                         mentionUsers,
-                        mentionHighlightClassName:
-                          "rounded-sm bg-primary/10 px-1 py-0.5 font-medium text-primary",
                       })}
                     </p>
                   ) : null}
@@ -292,8 +290,6 @@ function KanbanColumn({
                           <p className="break-words text-xs text-muted-foreground">
                             {renderContentWithMentions(getDescriptionPreview(task.description), {
                               mentionUsers,
-                              mentionHighlightClassName:
-                                "rounded-sm bg-primary/10 px-1 py-0.5 font-medium text-primary",
                             })}
                           </p>
                         ) : null}

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -65,7 +65,7 @@ import { UserAvatar } from "@/components/ui/user-avatar";
 import { getEpicColorFromName } from "@/lib/epic";
 import { cn } from "@/lib/utils";
 import { useDismissibleMenu } from "@/lib/hooks/use-dismissible-menu";
-import { renderContentWithMentions } from "@/lib/content-with-mentions";
+import { renderContentWithMentions, MENTION_HIGHLIGHT_CLASS } from "@/lib/content-with-mentions";
 import {
   parseMentions,
   removeMentionBeforeCursor,
@@ -1438,8 +1438,7 @@ function TaskReadOnlyContent({
                         mentionUsers,
                         hideMentionDiscriminator: true,
                         resolveDisplayUsers: false,
-                        mentionHighlightClassName:
-                          "inline-block rounded-md bg-primary/15 px-1 py-0.5 align-baseline font-medium text-primary not-italic",
+                        mentionHighlightClassName: MENTION_HIGHLIGHT_CLASS,
                       })
                     : null}
                 </div>

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -1439,7 +1439,7 @@ function TaskReadOnlyContent({
                         hideMentionDiscriminator: true,
                         resolveDisplayUsers: false,
                         mentionHighlightClassName:
-                          "rounded-sm bg-primary/10 px-0 py-0 font-normal text-primary",
+                          "inline-block rounded-md bg-primary/15 px-1 py-0.5 align-baseline font-medium text-primary not-italic",
                       })
                     : null}
                 </div>

--- a/components/rich-text-content.tsx
+++ b/components/rich-text-content.tsx
@@ -8,6 +8,7 @@ import {
   type MentionDisplayUser,
 } from "@/components/ui/mention-hover-card";
 import { parseMentions, type ParsedMention } from "@/lib/mention";
+import { MENTION_HIGHLIGHT_CLASS } from "@/lib/content-with-mentions";
 import { coerceRichTextHtml } from "@/lib/rich-text";
 import { cn } from "@/lib/utils";
 
@@ -31,8 +32,6 @@ const TOKEN_BLOCK_MARKERS = [
   "data-rich-block='token'",
 ];
 const HIDDEN_TOKEN_VALUE_MASK = "********";
-const RICH_TEXT_MENTION_CLASS =
-  "inline-block rounded-md bg-primary/15 px-1 py-0.5 align-baseline font-medium text-primary not-italic";
 const RICH_TEXT_MENTION_SELECTOR = "[data-rich-mention='true']";
 const COPY_ICON_SVG =
   '<svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" class="h-4 w-4"><rect x="9" y="9" width="13" height="13" rx="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>';
@@ -300,7 +299,7 @@ function highlightMentionTextNodes(
       }
 
       const mentionElement = document.createElement("span");
-      mentionElement.className = RICH_TEXT_MENTION_CLASS;
+      mentionElement.className = MENTION_HIGHLIGHT_CLASS;
       mentionElement.dataset.richMention = "true";
       mentionElement.dataset.mentionUsername = mention.username;
       if (mention.discriminator) {

--- a/components/rich-text-editor.tsx
+++ b/components/rich-text-editor.tsx
@@ -2558,17 +2558,21 @@ export function RichTextEditor({
       if (isArrowLeftKey(event)) {
         event.preventDefault();
 
-        // Let the browser handle word-jump (Ctrl/Meta+ArrowLeft) naturally at
-        // mention boundaries - it correctly moves before the mention.
+        // When modifier keys are active, jump to before the mention element
+        // (same as comment inputs: Ctrl+Left from after @mention lands before @)
         if (
           (event.ctrlKey || event.metaKey || event.altKey) &&
           mentionBeforeCaret.trailingTextNode &&
           mentionBeforeCaret.trailingTextOffset > 0
         ) {
+          moveCaretBefore(mentionBeforeCaret.mentionElement);
           return;
         }
 
         if (
+          !event.ctrlKey &&
+          !event.metaKey &&
+          !event.altKey &&
           mentionBeforeCaret.trailingTextNode &&
           mentionBeforeCaret.trailingTextOffset > 0
         ) {
@@ -2576,8 +2580,9 @@ export function RichTextEditor({
           return;
         }
 
-        // Ctrl/Meta/Alt+ArrowLeft: move to before the mention (same as comment input behavior)
         moveCaretBefore(mentionBeforeCaret.mentionElement);
+        return;
+      }
         return;
       }
 

--- a/components/rich-text-editor.tsx
+++ b/components/rich-text-editor.tsx
@@ -2583,8 +2583,6 @@ export function RichTextEditor({
         moveCaretBefore(mentionBeforeCaret.mentionElement);
         return;
       }
-        return;
-      }
 
       if (isEnterKey(event)) {
         event.preventDefault();

--- a/components/rich-text-editor.tsx
+++ b/components/rich-text-editor.tsx
@@ -2557,10 +2557,18 @@ export function RichTextEditor({
 
       if (isArrowLeftKey(event)) {
         event.preventDefault();
+
+        // Let the browser handle word-jump (Ctrl/Meta+ArrowLeft) naturally at
+        // mention boundaries - it correctly moves before the mention.
         if (
-          !event.ctrlKey &&
-          !event.metaKey &&
-          !event.altKey &&
+          (event.ctrlKey || event.metaKey || event.altKey) &&
+          mentionBeforeCaret.trailingTextNode &&
+          mentionBeforeCaret.trailingTextOffset > 0
+        ) {
+          return;
+        }
+
+        if (
           mentionBeforeCaret.trailingTextNode &&
           mentionBeforeCaret.trailingTextOffset > 0
         ) {
@@ -2568,6 +2576,7 @@ export function RichTextEditor({
           return;
         }
 
+        // Ctrl/Meta/Alt+ArrowLeft: move to before the mention (same as comment input behavior)
         moveCaretBefore(mentionBeforeCaret.mentionElement);
         return;
       }

--- a/lib/content-with-mentions.tsx
+++ b/lib/content-with-mentions.tsx
@@ -9,6 +9,13 @@ import {
 import { parseMentions } from "@/lib/mention";
 
 /**
+ * Canonical highlight class for @username mentions.
+ * Used consistently across task descriptions, kanban cards, and comments.
+ */
+export const MENTION_HIGHLIGHT_CLASS =
+  "inline-block rounded-md bg-primary/15 px-1 py-0.5 align-baseline font-medium text-primary not-italic";
+
+/**
  * Renders content with @username mentions highlighted.
  * Splits content into segments and wraps mention patterns in styled spans.
  */
@@ -31,11 +38,8 @@ export function renderContentWithMentions(
   const segments: React.ReactNode[] = [];
   let lastIndex = 0;
 
-  const highlightClass = options?.mentionHighlightClassName ?? [
-    "rounded-md bg-primary/15 px-1 py-0.5",
-    "font-medium text-primary",
-    "not-italic",
-  ].join(" ");
+  const highlightClass =
+    options?.mentionHighlightClassName ?? MENTION_HIGHLIGHT_CLASS;
   const mentionUsers = options?.resolveDisplayUsers === false ? undefined : options?.mentionUsers;
 
   for (const mention of mentions) {


### PR DESCRIPTION
## Summary

Fixes two inconsistencies between comment inputs and task description edit mode for mention handling:

1. **Highlight styling mismatch**: Comment composer was using a different (smaller) mention highlight class than task descriptions. Aligned the comment composer to use the same `inline-block rounded-md bg-primary/15 px-1 py-0.5 align-baseline font-medium text-primary not-italic` class.

2. **Ctrl+ArrowLeft keyboard navigation**: In task description edit mode, pressing Ctrl+ArrowLeft from right after a mention (e.g., `@example|`) was placing the cursor after the `@` instead of before it. The editor was overriding the browser's behavior and jumping to after the `@`. Changed the handler to explicitly move before the mention when modifier keys are active.

## Changes

- `components/rich-text-editor.tsx`: Modified the ArrowLeft key handler to explicitly move the cursor before the mention element when Ctrl/Meta/Alt modifier keys are active, making behavior consistent with comment inputs.
- `components/kanban/task-detail-modal.tsx`: Updated comment composer `mentionHighlightClassName` to match task description mention styling.

## Test plan

- [x] Lint passes on changed files
- [ ] CI passes
- [ ] Manual verification of mention highlighting consistency between comments and task descriptions
- [ ] Manual verification of Ctrl+ArrowLeft behavior in comment inputs and task description edit mode

🤖 Generated with [Claude Code](https://claude.ai/code)