### PR TITLE
fix: open task modal when navigating via mention notification (#217)

### DIFF
--- a/app/projects/[projectId]/kanban-board-section.tsx
+++ b/app/projects/[projectId]/kanban-board-section.tsx
@@ -35,6 +35,7 @@ interface KanbanBoardSectionProps {
   actorUserId: string;
   canEdit: boolean;
   storageProvider: "local" | "r2";
+  initialSelectedTaskId?: string | null;
 }
 
 export async function KanbanBoardSection({
@@ -42,6 +43,7 @@ export async function KanbanBoardSection({
   actorUserId,
   canEdit,
   storageProvider,
+  initialSelectedTaskId,
 }: KanbanBoardSectionProps) {
   const [tasks, collaborators, epics] = await Promise.all([
     listProjectKanbanTasks(projectId, actorUserId),
@@ -123,6 +125,7 @@ export async function KanbanBoardSection({
       epics={epicOptions}
       collaborators={collaborators}
       actorUserId={actorUserId}
+      initialSelectedTaskId={initialSelectedTaskId}
     />
   );
 }

--- a/app/projects/[projectId]/page.tsx
+++ b/app/projects/[projectId]/page.tsx
@@ -238,6 +238,7 @@ export default async function ProjectDashboardPage({
           actorUserId={actorUserId}
           canEdit={canEditProjectContent}
           storageProvider={storageProvider}
+          initialSelectedTaskId={readQueryValue(resolvedSearchParams?.taskId)}
         />
       </Suspense>
 

--- a/components/account/notification-center-list.tsx
+++ b/components/account/notification-center-list.tsx
@@ -3,7 +3,10 @@ import { Bell, Check, ExternalLink, MailPlus, RotateCcw } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import type { NotificationSummary } from "@/lib/services/notification-service";
+import type {
+  NotificationSummary,
+  TaskCommentMentionNotificationMetadata,
+} from "@/lib/services/notification-service";
 
 interface NotificationCenterListProps {
   notifications: NotificationSummary[];
@@ -33,6 +36,22 @@ function getNotificationTypeLabel(notification: NotificationSummary): string {
   }
 
   return "Notification";
+}
+
+function isTaskCommentMentionMetadata(
+  metadata: unknown,
+): metadata is TaskCommentMentionNotificationMetadata {
+  return (
+    typeof metadata === "object" &&
+    metadata !== null &&
+    "taskId" in metadata
+  );
+}
+
+function buildMentionNotificationOpenPath(
+  metadata: TaskCommentMentionNotificationMetadata,
+): string {
+  return `/projects/${metadata.projectId}?taskId=${encodeURIComponent(metadata.taskId)}`;
 }
 
 function isProjectInvitationMetadata(
@@ -176,9 +195,16 @@ export function NotificationCenterList({
                       </>
                     ) : null}
 
-                    {notification.targetPath ? (
+                    {notification.targetPath || isTaskCommentMentionMetadata(notification.metadata) ? (
                       <Button asChild variant="ghost">
-                        <Link href={notification.targetPath}>
+                        <Link
+                          href={
+                            notification.type === "task_comment_mention" &&
+                            isTaskCommentMentionMetadata(notification.metadata)
+                              ? buildMentionNotificationOpenPath(notification.metadata)
+                              : notification.targetPath!
+                          }
+                        >
                           <ExternalLink className="h-4 w-4" />
                           Open
                         </Link>

--- a/components/kanban-board.tsx
+++ b/components/kanban-board.tsx
@@ -170,6 +170,7 @@ export function KanbanBoard({
   archivedDoneTasks: initialArchivedDoneTasks = [],
   epics,
   collaborators,
+  initialSelectedTaskId,
 }: KanbanBoardProps) {
   const router = useRouter();
   const initialColumns = useMemo(

--- a/components/kanban-board.tsx
+++ b/components/kanban-board.tsx
@@ -70,6 +70,7 @@ interface KanbanBoardProps {
   archivedDoneTasks?: KanbanTask[];
   epics: ProjectEpicOption[];
   collaborators: ProjectTaskCollaborator[];
+  initialSelectedTaskId?: string | null;
 }
 
 function createLocalUploadId(): string {
@@ -328,6 +329,18 @@ export function KanbanBoard({
   useEffect(() => {
     setIsClient(true);
   }, []);
+
+  useEffect(() => {
+    if (!initialSelectedTaskId || selectedTask) {
+      return;
+    }
+
+    const allTasks = TASK_STATUSES.flatMap((status) => columns[status]).concat(archivedDoneTasks);
+    const taskToSelect = allTasks.find((task) => task.id === initialSelectedTaskId) ?? null;
+    if (taskToSelect) {
+      setSelectedTask(taskToSelect);
+    }
+  }, [archivedDoneTasks, columns, selectedTask]);
 
   const selectedTaskId = selectedTask?.id ?? null;
   const selectedTaskCommentCount = selectedTask?.commentCount ?? 0;


### PR DESCRIPTION
## Summary

- Mention notifications store a `targetPath` like `/projects/{projectId}/tasks/{taskId}` but there was no route to handle it — the task detail is shown in a modal overlay on the project dashboard, not a separate page.
- This change passes `?taskId=<taskId>` as a query parameter when navigating to the project dashboard. The KanbanBoard component now accepts an `initialSelectedTaskId` prop and auto-opens the task modal when that ID matches a task in the board.

## Changes

- `KanbanBoardProps`: added `initialSelectedTaskId?: string | null`
- `KanbanBoard`: added `useEffect` to find and select the task by ID on mount when `initialSelectedTaskId` is set and no task is yet selected
- `KanbanBoardSectionProps`: added `initialSelectedTaskId`
- `KanbanBoardSection`: passes `initialSelectedTaskId` through to KanbanBoard
- `page.tsx`: reads `taskId` from `searchParams` and passes it to KanbanBoardSection

## Test plan

- [x] Unit tests pass
- [x] Lint passes
- [x] Waiting for CI

Closes #217