### PR TITLE
TASK-217 Fix mention notification open route

### DIFF
--- a/app/projects/[projectId]/kanban-board-section.tsx
+++ b/app/projects/[projectId]/kanban-board-section.tsx
@@ -35,6 +35,7 @@ interface KanbanBoardSectionProps {
   actorUserId: string;
   canEdit: boolean;
   storageProvider: "local" | "r2";
+  initialTaskId?: string | null;
 }
 
 export async function KanbanBoardSection({
@@ -42,6 +43,7 @@ export async function KanbanBoardSection({
   actorUserId,
   canEdit,
   storageProvider,
+  initialTaskId,
 }: KanbanBoardSectionProps) {
   const [tasks, collaborators, epics] = await Promise.all([
     listProjectKanbanTasks(projectId, actorUserId),
@@ -123,6 +125,7 @@ export async function KanbanBoardSection({
       epics={epicOptions}
       collaborators={collaborators}
       actorUserId={actorUserId}
+      initialTaskId={initialTaskId}
     />
   );
 }

--- a/app/projects/[projectId]/page.tsx
+++ b/app/projects/[projectId]/page.tsx
@@ -112,6 +112,7 @@ export default async function ProjectDashboardPage({
   const storageProvider = getStorageRuntimeConfig().provider;
   const status = readQueryValue(resolvedSearchParams?.status);
   const error = readQueryValue(resolvedSearchParams?.error);
+  const initialTaskId = readQueryValue(resolvedSearchParams?.taskId);
   const actorRole =
     project.ownerId === actorUserId ? "owner" : (project.memberships[0]?.role ?? "viewer");
   const canEditProjectContent = actorRole === "owner" || actorRole === "editor";
@@ -238,6 +239,7 @@ export default async function ProjectDashboardPage({
           actorUserId={actorUserId}
           canEdit={canEditProjectContent}
           storageProvider={storageProvider}
+          initialTaskId={initialTaskId}
         />
       </Suspense>
 

--- a/app/projects/[projectId]/tasks/[taskId]/page.tsx
+++ b/app/projects/[projectId]/tasks/[taskId]/page.tsx
@@ -1,0 +1,15 @@
+import { redirect } from "next/navigation";
+
+export default async function ProjectTaskRedirectPage({
+  params,
+}: {
+  params: Promise<{ projectId: string; taskId: string }>;
+}) {
+  const { projectId, taskId } = await params;
+
+  redirect(
+    `/projects/${encodeURIComponent(projectId)}?taskId=${encodeURIComponent(
+      taskId
+    )}`
+  );
+}

--- a/components/kanban-board.tsx
+++ b/components/kanban-board.tsx
@@ -70,6 +70,7 @@ interface KanbanBoardProps {
   archivedDoneTasks?: KanbanTask[];
   epics: ProjectEpicOption[];
   collaborators: ProjectTaskCollaborator[];
+  initialTaskId?: string | null;
 }
 
 function createLocalUploadId(): string {
@@ -169,6 +170,7 @@ export function KanbanBoard({
   archivedDoneTasks: initialArchivedDoneTasks = [],
   epics,
   collaborators,
+  initialTaskId,
 }: KanbanBoardProps) {
   const router = useRouter();
   const initialColumns = useMemo(
@@ -189,6 +191,7 @@ export function KanbanBoard({
   const [isArchivingTask, setIsArchivingTask] = useState(false);
   const shouldOpenTaskInEditModeRef = useRef(false);
   const previousSelectedTaskIdRef = useRef<string | null>(null);
+  const openedInitialTaskIdRef = useRef<string | null>(null);
   const { pushToast } = useToast();
   const { isExpanded, setIsExpanded } = useProjectSectionExpanded({
     projectId,
@@ -446,6 +449,28 @@ export function KanbanBoard({
     () => new Map(allTasks.map((task) => [task.id, task])),
     [allTasks]
   );
+
+  const normalizedInitialTaskId =
+    typeof initialTaskId === "string" ? initialTaskId.trim() : "";
+
+  useEffect(() => {
+    if (
+      !normalizedInitialTaskId ||
+      openedInitialTaskIdRef.current === normalizedInitialTaskId
+    ) {
+      return;
+    }
+
+    const initialTask = taskById.get(normalizedInitialTaskId);
+    openedInitialTaskIdRef.current = normalizedInitialTaskId;
+    if (!initialTask) {
+      return;
+    }
+
+    shouldOpenTaskInEditModeRef.current = false;
+    setSelectedTask(initialTask);
+    setIsExpanded(true);
+  }, [normalizedInitialTaskId, setIsExpanded, taskById]);
 
   const relatedTaskGraph = useMemo(() => createRelatedTaskMap(allTasks), [allTasks]);
 

--- a/journal.md
+++ b/journal.md
@@ -1103,6 +1103,21 @@ Low-value entries to avoid going forward:
 - Summary: TASK-124 mention regression follow-up fixed task-description tooltip dismissal, comment composer caret alignment, and post-edit description mention highlighting.
 - Evidence: Rich-text description hover now clears the tooltip when pointer coordinates leave the actual mention span; the comment textarea highlight mirror can preserve full discriminated mention text so the visible text aligns with the transparent textarea caret; `RichTextContent` now enhances mounted content updates synchronously so a saved plain-text description with `@username#tag` is immediately highlighted.
 
+### 2026-05-06
+- Type: Investigation
+- Summary: TASK-217 started from scratch in dedicated worktree `../nexus_dash_task217` on branch `fix/task-217-mention-notification-open`.
+- Evidence: GitHub issue #217 reports mention notification `Open` links landing on 404 pages. The old `../nexus_dash_issue217` worktree and old `fix/issue-217-*` branches were intentionally left untouched. Initial investigation found task comment mention notifications storing `/projects/:projectId/tasks/:taskId`, while the app only has a dashboard route at `/projects/:projectId` and task APIs under `/api/projects/:projectId/tasks/:taskId`.
+
+### 2026-05-06
+- Type: Execution
+- Summary: TASK-217 fixed mention notification navigation at the generated target and added stale-link compatibility.
+- Evidence: Task comment mention notifications now target `/projects/:projectId?taskId=:taskId&commentId=:commentId`; the project dashboard passes `taskId` into the Kanban board and opens the matching task modal once board data is loaded; `/projects/:projectId/tasks/:taskId` now redirects to the dashboard task target for existing notifications that already stored the stale nested route.
+
+### 2026-05-06
+- Type: Validation
+- Summary: TASK-217 passed focused regression tests, lint, full unit/API tests, coverage, build, migrations, and Playwright smoke validation.
+- Evidence: Passed: `npx vitest run tests/api/task-comments.route.test.ts tests/app/project-task-redirect-page.test.ts`; `npm run lint`; placeholder-env `npm test` (93 files passed, 1 skipped; 719 passed, 1 skipped); placeholder-env `npm run test:coverage` (91.23% statements, 81.2% branches, 93.42% functions, 91.75% lines); placeholder-env `npm run build`; Compose Postgres `npm run db:local:up`; `npm run db:migrate` after using the documented local `postgres:postgres` connection; `NODE_ENV=test` `npm run test:e2e` (7 passed). A first plain `npm test` failed because the clean worktree had no `DATABASE_URL`; a first E2E retry without `NODE_ENV=test` failed because local password-reset smoke attempted real Resend delivery with a placeholder key.
+
 ### 2026-05-03
 - Type: Validation
 - Summary: TASK-124 mention regression follow-up passed focused mention/comment/rich-text validation, lint, and production build.

--- a/lib/services/project-task-comment-service.ts
+++ b/lib/services/project-task-comment-service.ts
@@ -290,7 +290,10 @@ function buildPendingMentionNotifications(input: {
   projectName: string;
   mentionedUsers: MentionedProjectMember[];
 }): PendingMentionNotification[] {
-  const taskPath = `/projects/${input.projectId}/tasks/${input.taskId}`;
+  const taskPath =
+    `/projects/${encodeURIComponent(input.projectId)}` +
+    `?taskId=${encodeURIComponent(input.taskId)}` +
+    `&commentId=${encodeURIComponent(input.commentId)}`;
 
   return input.mentionedUsers
     .filter((mentionedUser) => mentionedUser.userId !== input.actorUserId)

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -4,6 +4,11 @@ Use this file to capture tasks discovered during development. Each entry should 
 
 ## Pending
 ### Execution Queue (Now / Next)
+- ID: TASK-217
+  Title: Mention notification open route - fix stale task URL 404
+  Status: In Progress (GitHub issue #217)
+  Rationale: Mention notifications currently generate or retain `/projects/:projectId/tasks/:taskId` links even though task detail is a dashboard modal, so the notification center `Open` action can navigate recipients to a 404. The fix should generate a canonical dashboard task target, open the task context when available, and preserve stale notification compatibility.
+  Dependencies: TASK-123, TASK-124
 - ID: TASK-131
   Title: Local validation baseline repair - reproducible container, database, and toolchain setup
   Status: Pending

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,94 +1,32 @@
-# Current Task: TASK-131 Local Validation Baseline Repair
+# Current Task: TASK-217 Mention Notification Open Route
 
 ## Task ID
-TASK-131
+TASK-217
 
 ## Status
-Local validation baseline green on `feature/task-131-local-validation-baseline`.
+Validation green for GitHub issue #217 on branch `fix/task-217-mention-notification-open`.
 
 ## Objective
-Restore a reproducible local validation path for NexusDash so a contributor can
-start from a clean checkout and run the full baseline through install, Prisma
-client generation, migrations, unit/API tests, coverage, production build, and
-Playwright smoke tests without relying on undocumented machine state.
+Fix the `Open` action for task comment mention notifications so recipients land on the relevant project dashboard task context instead of a 404 route.
 
-## Current Scope
-- Align the repository toolchain contract around a supported Node/npm baseline
-  for the current Next.js, Prisma, Vitest, jsdom, and Playwright dependencies.
-- Make local database bootstrap explicit and reproducible, preferably through a
-  Docker Compose Postgres service that matches the CI E2E database contract.
-- Ensure Prisma generate/migrate commands use the intended local connection
-  strings and do not require production-only secrets.
-- Define a single documented local validation workflow that covers:
-  - clean dependency install with `npm ci`
-  - `npx prisma generate`
-  - `npm run db:migrate`
-  - `npm run lint`
-  - `npm test`
-  - `npm run test:coverage`
-  - `npm run build`
-  - `npm run test:e2e`
-- Keep the app container path reproducible without assuming an external
-  database URL is already present in the developer shell.
-- Record validation evidence and any remaining local environment constraints in
-  `journal.md`.
-
-## Initial Findings
-- The current shell is on Node `v20.17.0`; `npm ci` fails at Prisma preinstall
-  because the current dependency tree requires Node `20.19+`, `22.13+`, or
-  `24+`.
-- `docker compose config` fails without shell-provided `DATABASE_URL` and
-  `DIRECT_URL`, and the current compose file has no Postgres service.
-- CI E2E already defines the desired local-style Postgres contract:
-  `postgres:16-alpine` with
-  `postgresql://postgres:postgres@127.0.0.1:5432/nexusdash?schema=public`.
-- `npm run test:e2e` builds and launches `next start`, while Playwright helper
-  code seeds test users directly through Prisma. That means E2E needs a
-  migrated database and generated Prisma client before the browser run begins.
+## Scope
+- Generate task comment mention notification targets using an app route that exists.
+- Open the referenced task from the project dashboard when a notification target includes a task id.
+- Preserve compatibility for existing mention notifications that already store the stale nested task path.
+- Keep other notification types and invitation actions unchanged.
 
 ## Acceptance Criteria
-1. A clean checkout exposes an explicit supported Node version contract through
-   repo-owned configuration or documentation.
-2. `npm ci` succeeds on the supported local Node baseline.
-3. A developer can start a local PostgreSQL database for validation using a
-   documented repo-owned command or compose profile.
-4. Local `DATABASE_URL` and `DIRECT_URL` values for validation are documented
-   and line up with the local database service.
-5. `npx prisma generate` and `npm run db:migrate` succeed against the documented
-   local validation database.
-6. `npm run lint`, `npm test`, `npm run test:coverage`, and `npm run build`
-   succeed after the documented bootstrap.
-7. `npm run test:e2e` succeeds locally against the documented local database and
-   app startup path.
-8. Docker Compose can render its config and start the app/database baseline
-   without requiring undocumented external database variables.
-9. README or runbook documentation contains one copy-pasteable local validation
-   sequence and describes cleanup/reset behavior for the local database.
-10. `journal.md` records the commands run, observed failures, fixes, and final
-    validation evidence.
+1. Clicking `Open` on a task comment mention notification no longer lands on a 404.
+2. Mention notification targets route to the relevant project dashboard and open the mentioned task when it is present in the board data.
+3. Existing stale mention notification paths of the form `/projects/:projectId/tasks/:taskId` are handled when reasonably possible.
+4. Project invitation notifications and other existing notification actions keep their current behavior.
+5. Focused regression coverage proves the generated mention target and stale-path compatibility behavior.
+6. Required lint, test, coverage, and build checks pass or any environment blocker is recorded in `journal.md`.
 
 ## Definition Of Done
-- TASK-131 has a dedicated worktree and branch.
-- Toolchain, database, Docker/Compose, and test documentation changes are
-  committed in the TASK-131 branch.
-- The full local validation baseline has been run, or any remaining blocker is
-  documented with exact command output and next action.
-- `tasks/current.md`, `journal.md`, and any touched runbooks/README sections
-  agree on the final local validation workflow.
-- A PR is opened for TASK-131 once the branch is reviewable.
-
-## Out Of Scope
-- Reworking production deploy secrets or Vercel preview workflows beyond keeping
-  local validation documentation consistent with existing runbooks.
-- Expanding Playwright coverage beyond the existing smoke suite unless required
-  to make the current suite reliable.
-
-## Validation Evidence
-- `npm run validate:local` passed on 2026-05-04 with Node `v24.15.0` and Docker
-  Desktop running.
-- The validation run started Docker Compose Postgres, ran `npm ci`, generated
-  Prisma Client, applied migrations, ran lint, unit/API tests, coverage,
-  production build, installed Playwright Chromium, and passed all Playwright E2E
-  tests.
-- `APP_PORT=3131 docker compose up --build -d app` started the app container,
-  and `/api/health/live` plus `/api/health/ready` both returned HTTP 200.
+- The root cause is fixed at mention notification target generation rather than only in notification list rendering.
+- The project dashboard supports opening the task modal from the canonical mention target.
+- Existing stale mention paths redirect to the canonical project task target.
+- Relevant tests are updated.
+- `journal.md` records implementation and validation evidence.
+- A PR is opened for issue #217 from `fix/task-217-mention-notification-open`.

--- a/tests/api/task-comments.route.test.ts
+++ b/tests/api/task-comments.route.test.ts
@@ -351,7 +351,8 @@ describe("task comments route", () => {
           recipientUserId: "owner-1",
           sourceType: "task_comment_mention",
           sourceId: "comment-mention",
-          targetPath: "/projects/project-1/tasks/task-1",
+          targetPath:
+            "/projects/project-1?taskId=task-1&commentId=comment-mention",
         }),
       ],
       skipDuplicates: true,
@@ -497,7 +498,8 @@ describe("task comments route", () => {
           recipientUserId: "member-1",
           sourceType: "task_comment_mention",
           sourceId: "comment-selected",
-          targetPath: "/projects/project-1/tasks/task-1",
+          targetPath:
+            "/projects/project-1?taskId=task-1&commentId=comment-selected",
         }),
       ],
       skipDuplicates: true,

--- a/tests/app/project-task-redirect-page.test.ts
+++ b/tests/app/project-task-redirect-page.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test, vi } from "vitest";
+
+const redirectMock = vi.hoisted(() => vi.fn());
+
+vi.mock("next/navigation", () => ({
+  redirect: redirectMock,
+}));
+
+import ProjectTaskRedirectPage from "@/app/projects/[projectId]/tasks/[taskId]/page";
+
+describe("project task redirect page", () => {
+  test("redirects stale task detail links to the dashboard task target", async () => {
+    redirectMock.mockImplementationOnce((path: string) => {
+      throw new Error(`NEXT_REDIRECT:${path}`);
+    });
+
+    await expect(
+      ProjectTaskRedirectPage({
+        params: Promise.resolve({
+          projectId: "project 1",
+          taskId: "task/1",
+        }),
+      })
+    ).rejects.toThrow(
+      "NEXT_REDIRECT:/projects/project%201?taskId=task%2F1"
+    );
+
+    expect(redirectMock).toHaveBeenCalledWith(
+      "/projects/project%201?taskId=task%2F1"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Generate task comment mention notification targets as dashboard task links (`/projects/:projectId?taskId=:taskId&commentId=:commentId`) instead of the nonexistent nested task page.
- Open the referenced Kanban task modal when the project dashboard receives a `taskId` query parameter.
- Add a compatibility redirect from stale `/projects/:projectId/tasks/:taskId` links to the canonical dashboard task target.

## Root Cause
Mention notifications were storing `/projects/:projectId/tasks/:taskId`, but that path only existed as an API shape under `/api`; the user-facing task detail lives inside the project dashboard modal. The notification `Open` action therefore navigated to an app route that did not exist.

Closes #217.

## Validation
- `npx vitest run tests/api/task-comments.route.test.ts tests/app/project-task-redirect-page.test.ts`
- `npm run lint`
- `npm test` with local placeholder env (93 passed, 1 skipped; 719 passed, 1 skipped)
- `npm run test:coverage` with local placeholder env (91.23% statements, 81.2% branches, 93.42% functions, 91.75% lines)
- `npm run build` with local placeholder env
- `npm run db:local:up`
- `npm run db:migrate` against local Compose Postgres
- `NODE_ENV=test npm run test:e2e` against local Compose Postgres (7 passed)