### PR TITLE
TASK-214 Fix task and card focus borders

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -69,7 +69,7 @@
   }
 }
 
-.task-create-focus-field {
+.form-focus-border-field {
   outline: none;
   transition-property:
     color,
@@ -81,12 +81,12 @@
   transition-duration: 150ms;
 }
 
-.task-create-focus-field:focus,
-.task-create-focus-field:focus-visible {
+.form-focus-border-field:focus,
+.form-focus-border-field:focus-visible {
   border-color: hsl(var(--ring) / 0.6) !important;
 }
 
-.task-create-focus-shell {
+.form-focus-border-shell {
   transition-property:
     color,
     background-color,
@@ -97,10 +97,10 @@
   transition-duration: 150ms;
 }
 
-.task-create-focus-shell:focus-within {
+.form-focus-border-shell:focus-within {
   border-color: hsl(var(--ring) / 0.6) !important;
 }
 
-.task-create-focus-shell:has(:focus) {
+.form-focus-border-shell:has(:focus) {
   border-color: hsl(var(--ring) / 0.6) !important;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -68,3 +68,39 @@
     display: none;
   }
 }
+
+.task-create-focus-field {
+  outline: none;
+  transition-property:
+    color,
+    background-color,
+    border-color,
+    text-decoration-color,
+    fill,
+    stroke;
+  transition-duration: 150ms;
+}
+
+.task-create-focus-field:focus,
+.task-create-focus-field:focus-visible {
+  border-color: hsl(var(--ring) / 0.6) !important;
+}
+
+.task-create-focus-shell {
+  transition-property:
+    color,
+    background-color,
+    border-color,
+    text-decoration-color,
+    fill,
+    stroke;
+  transition-duration: 150ms;
+}
+
+.task-create-focus-shell:focus-within {
+  border-color: hsl(var(--ring) / 0.6) !important;
+}
+
+.task-create-focus-shell:has(:focus) {
+  border-color: hsl(var(--ring) / 0.6) !important;
+}

--- a/components/calendar-date-time-field.tsx
+++ b/components/calendar-date-time-field.tsx
@@ -36,6 +36,7 @@ export interface CalendarDateTimeFieldProps {
   onChange: (nextValue: string) => void;
   includeTime: boolean;
   disabled: boolean;
+  triggerClassName?: string;
 }
 
 export function CalendarDateTimeField({
@@ -44,6 +45,7 @@ export function CalendarDateTimeField({
   onChange,
   includeTime,
   disabled,
+  triggerClassName,
 }: CalendarDateTimeFieldProps) {
   const [isBrowserReady, setIsBrowserReady] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
@@ -332,7 +334,10 @@ export function CalendarDateTimeField({
         id={id}
         ref={triggerRef}
         type="button"
-        className="flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 text-left text-sm transition hover:bg-muted/40"
+        className={cn(
+          "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 text-left text-sm transition hover:bg-muted/40",
+          triggerClassName
+        )}
         disabled={disabled}
         onClick={() => setIsOpen((previous) => !previous)}
       >

--- a/components/context-panel/context-create-modal.tsx
+++ b/components/context-panel/context-create-modal.tsx
@@ -8,6 +8,10 @@ import { RichTextEditor } from "@/components/rich-text-editor";
 import { AttachmentLinkComposer } from "@/components/ui/attachment-link-composer";
 import { Button } from "@/components/ui/button";
 import { EmojiInputField } from "@/components/ui/emoji-field";
+import {
+  FORM_FOCUS_BORDER_CLASS,
+  FORM_FOCUS_BORDER_SHELL_CLASS,
+} from "@/components/ui/focus-border-styles";
 
 interface ContextCreateModalProps {
   isOpen: boolean;
@@ -78,7 +82,8 @@ export function ContextCreateModal({
             required
             minLength={2}
             maxLength={120}
-            className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+            wrapperClassName={`rounded-md border border-input bg-background ${FORM_FOCUS_BORDER_SHELL_CLASS}`}
+            className="h-10 rounded-md border-0 bg-transparent px-3 text-sm outline-none"
             placeholder="Sprint notes"
           />
         </div>
@@ -93,6 +98,7 @@ export function ContextCreateModal({
             onChange={onCreateContentChange}
             placeholder="Anything useful for this project..."
             ariaLabelledBy="context-create-content-label"
+            editorClassName={FORM_FOCUS_BORDER_CLASS}
           />
           <input type="hidden" name="content" value={createContent} />
         </div>
@@ -141,6 +147,8 @@ export function ContextCreateModal({
               onValueChange={onCreateLinkUrlChange}
               onSubmit={onStageCreateLink}
               isSubmitDisabled={!createLinkUrl.trim()}
+              className={`rounded-md border border-input bg-background ring-0 ${FORM_FOCUS_BORDER_SHELL_CLASS}`}
+              inputClassName="text-sm"
             />
           ) : null}
 

--- a/components/context-panel/context-edit-modal.tsx
+++ b/components/context-panel/context-edit-modal.tsx
@@ -13,6 +13,10 @@ import { AttachmentLinkComposer } from "@/components/ui/attachment-link-composer
 import { Button } from "@/components/ui/button";
 import { EmojiInputField } from "@/components/ui/emoji-field";
 import {
+  FORM_FOCUS_BORDER_CLASS,
+  FORM_FOCUS_BORDER_SHELL_CLASS,
+} from "@/components/ui/focus-border-styles";
+import {
   ATTACHMENT_KIND_FILE,
   ATTACHMENT_KIND_LINK,
   formatAttachmentFileSize,
@@ -85,7 +89,8 @@ export function ContextEditModal({
             minLength={2}
             maxLength={120}
             defaultValue={editingCard.title}
-            className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+            wrapperClassName={`rounded-md border border-input bg-background ${FORM_FOCUS_BORDER_SHELL_CLASS}`}
+            className="h-10 rounded-md border-0 bg-transparent px-3 text-sm outline-none"
           />
         </div>
 
@@ -98,6 +103,7 @@ export function ContextEditModal({
             value={editContent}
             onChange={onEditContentChange}
             ariaLabelledBy="context-edit-content-label"
+            editorClassName={FORM_FOCUS_BORDER_CLASS}
           />
           <input type="hidden" name="content" value={editContent} />
         </div>
@@ -204,6 +210,8 @@ export function ContextEditModal({
               onValueChange={onEditLinkUrlChange}
               onSubmit={onAddLinkAttachment}
               isSubmitDisabled={isSubmittingAttachment || !editLinkUrl.trim()}
+              className={`rounded-md border border-input bg-background ring-0 ${FORM_FOCUS_BORDER_SHELL_CLASS}`}
+              inputClassName="text-sm"
             />
           ) : null}
 

--- a/components/create-task-dialog.tsx
+++ b/components/create-task-dialog.tsx
@@ -18,6 +18,10 @@ import { AttachmentLinkComposer } from "@/components/ui/attachment-link-composer
 import { AssigneeSelect } from "@/components/ui/assignee-select";
 import { Button } from "@/components/ui/button";
 import { EpicSelect } from "@/components/ui/epic-select";
+import {
+  FORM_FOCUS_BORDER_CLASS,
+  FORM_FOCUS_BORDER_SHELL_CLASS,
+} from "@/components/ui/focus-border-styles";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { EmojiInputField } from "@/components/ui/emoji-field";
 import {
@@ -50,10 +54,6 @@ interface PendingAttachmentLink {
 function createLocalId(): string {
   return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
-
-const TASK_CREATE_FOCUS_BORDER_CLASS =
-  "task-create-focus-field focus-visible:ring-0";
-const TASK_CREATE_FOCUS_WITHIN_BORDER_CLASS = "task-create-focus-shell";
 
 export function CreateTaskDialog({
   projectId,
@@ -399,7 +399,7 @@ export function CreateTaskDialog({
                           minLength={2}
                           maxLength={120}
                           wrapperClassName={`rounded-md border border-input bg-background ${
-                            TASK_CREATE_FOCUS_WITHIN_BORDER_CLASS
+                            FORM_FOCUS_BORDER_SHELL_CLASS
                           }`}
                           className="h-10 rounded-md border-0 bg-transparent px-3 text-sm outline-none"
                           placeholder="Implement drag sorting"
@@ -412,7 +412,7 @@ export function CreateTaskDialog({
                         </label>
                         <div
                           className={`rounded-md border border-input bg-background p-2 ${
-                            TASK_CREATE_FOCUS_WITHIN_BORDER_CLASS
+                            FORM_FOCUS_BORDER_SHELL_CLASS
                           }`}
                         >
                           <div className="flex flex-wrap gap-2">
@@ -482,7 +482,7 @@ export function CreateTaskDialog({
                           onChange={setDescription}
                           placeholder="Optional implementation notes..."
                           mentionProjectId={projectId}
-                          editorClassName={TASK_CREATE_FOCUS_BORDER_CLASS}
+                          editorClassName={FORM_FOCUS_BORDER_CLASS}
                         />
                         <input type="hidden" name="description" value={description} />
                       </div>
@@ -495,7 +495,7 @@ export function CreateTaskDialog({
                         onChange={setDeadlineDate}
                         disabled={isSubmitting}
                         helperText="Optional. Near deadlines are highlighted automatically on the board."
-                        triggerClassName={TASK_CREATE_FOCUS_BORDER_CLASS}
+                        triggerClassName={FORM_FOCUS_BORDER_CLASS}
                       />
 
                       <div className="grid gap-2">
@@ -508,7 +508,7 @@ export function CreateTaskDialog({
                           value={epicId}
                           onChange={setEpicId}
                           options={availableEpics}
-                          className={TASK_CREATE_FOCUS_BORDER_CLASS}
+                          className={FORM_FOCUS_BORDER_CLASS}
                         />
                         <p className="text-xs text-muted-foreground">
                           Optional. Link this task to a broader initiative without turning the
@@ -526,7 +526,7 @@ export function CreateTaskDialog({
                           value={assigneeUserId}
                           onChange={setAssigneeUserId}
                           options={availableAssignees}
-                          className={TASK_CREATE_FOCUS_BORDER_CLASS}
+                          className={FORM_FOCUS_BORDER_CLASS}
                         />
                         <p className="text-xs text-muted-foreground">
                           Optional. Leave unassigned until ownership is clear.
@@ -551,7 +551,7 @@ export function CreateTaskDialog({
                               previous.filter((entry) => entry !== taskId)
                             );
                           }}
-                          inputClassName={TASK_CREATE_FOCUS_BORDER_CLASS}
+                          inputClassName={FORM_FOCUS_BORDER_CLASS}
                         />
                         <input
                           type="hidden"
@@ -613,7 +613,7 @@ export function CreateTaskDialog({
                             onSubmit={handleAddLink}
                             isSubmitDisabled={!linkUrl.trim()}
                             className={`rounded-md border border-input bg-background ring-0 ${
-                              TASK_CREATE_FOCUS_WITHIN_BORDER_CLASS
+                              FORM_FOCUS_BORDER_SHELL_CLASS
                             }`}
                             inputClassName="text-sm"
                           />

--- a/components/create-task-dialog.tsx
+++ b/components/create-task-dialog.tsx
@@ -51,6 +51,10 @@ function createLocalId(): string {
   return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
 
+const TASK_CREATE_FOCUS_BORDER_CLASS =
+  "task-create-focus-field focus-visible:ring-0";
+const TASK_CREATE_FOCUS_WITHIN_BORDER_CLASS = "task-create-focus-shell";
+
 export function CreateTaskDialog({
   projectId,
   storageProvider,
@@ -394,7 +398,10 @@ export function CreateTaskDialog({
                           required
                           minLength={2}
                           maxLength={120}
-                          className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+                          wrapperClassName={`rounded-md border border-input bg-background ${
+                            TASK_CREATE_FOCUS_WITHIN_BORDER_CLASS
+                          }`}
+                          className="h-10 rounded-md border-0 bg-transparent px-3 text-sm outline-none"
                           placeholder="Implement drag sorting"
                         />
                       </div>
@@ -403,7 +410,11 @@ export function CreateTaskDialog({
                         <label htmlFor="task-label-input" className="text-sm font-medium">
                           Labels
                         </label>
-                        <div className="rounded-md border border-input bg-background p-2">
+                        <div
+                          className={`rounded-md border border-input bg-background p-2 ${
+                            TASK_CREATE_FOCUS_WITHIN_BORDER_CLASS
+                          }`}
+                        >
                           <div className="flex flex-wrap gap-2">
                             {labels.map((label) => (
                               <span
@@ -471,6 +482,7 @@ export function CreateTaskDialog({
                           onChange={setDescription}
                           placeholder="Optional implementation notes..."
                           mentionProjectId={projectId}
+                          editorClassName={TASK_CREATE_FOCUS_BORDER_CLASS}
                         />
                         <input type="hidden" name="description" value={description} />
                       </div>
@@ -483,6 +495,7 @@ export function CreateTaskDialog({
                         onChange={setDeadlineDate}
                         disabled={isSubmitting}
                         helperText="Optional. Near deadlines are highlighted automatically on the board."
+                        triggerClassName={TASK_CREATE_FOCUS_BORDER_CLASS}
                       />
 
                       <div className="grid gap-2">
@@ -495,6 +508,7 @@ export function CreateTaskDialog({
                           value={epicId}
                           onChange={setEpicId}
                           options={availableEpics}
+                          className={TASK_CREATE_FOCUS_BORDER_CLASS}
                         />
                         <p className="text-xs text-muted-foreground">
                           Optional. Link this task to a broader initiative without turning the
@@ -512,6 +526,7 @@ export function CreateTaskDialog({
                           value={assigneeUserId}
                           onChange={setAssigneeUserId}
                           options={availableAssignees}
+                          className={TASK_CREATE_FOCUS_BORDER_CLASS}
                         />
                         <p className="text-xs text-muted-foreground">
                           Optional. Leave unassigned until ownership is clear.
@@ -536,6 +551,7 @@ export function CreateTaskDialog({
                               previous.filter((entry) => entry !== taskId)
                             );
                           }}
+                          inputClassName={TASK_CREATE_FOCUS_BORDER_CLASS}
                         />
                         <input
                           type="hidden"
@@ -596,6 +612,10 @@ export function CreateTaskDialog({
                             onValueChange={setLinkUrl}
                             onSubmit={handleAddLink}
                             isSubmitDisabled={!linkUrl.trim()}
+                            className={`rounded-md border border-input bg-background ring-0 ${
+                              TASK_CREATE_FOCUS_WITHIN_BORDER_CLASS
+                            }`}
+                            inputClassName="text-sm"
                           />
                         ) : null}
 

--- a/components/kanban/related-task-field.tsx
+++ b/components/kanban/related-task-field.tsx
@@ -29,6 +29,8 @@ interface RelatedTaskSelectorProps {
   onAddTask: (taskId: string) => void;
   onRemoveTask: (taskId: string) => void;
   disabled?: boolean;
+  className?: string;
+  inputClassName?: string;
 }
 
 export function RelatedTaskSelector({
@@ -39,6 +41,8 @@ export function RelatedTaskSelector({
   onAddTask,
   onRemoveTask,
   disabled = false,
+  className,
+  inputClassName,
 }: RelatedTaskSelectorProps) {
   const [isSearchFocused, setIsSearchFocused] = useState(false);
   const [dropdownPosition, setDropdownPosition] = useState<{
@@ -108,7 +112,12 @@ export function RelatedTaskSelector({
   }, [shouldShowSuggestions, suggestions.length]);
 
   return (
-    <div className="grid gap-2 rounded-md border border-border/60 bg-muted/10 p-2.5">
+    <div
+      className={cn(
+        "grid gap-2 rounded-md border border-border/60 bg-muted/10 p-2.5",
+        className
+      )}
+    >
       {selectedTasks.length > 0 ? (
         <div className="flex flex-wrap gap-1.5">
           {selectedTasks.map((task) => (
@@ -132,7 +141,10 @@ export function RelatedTaskSelector({
             window.setTimeout(() => setIsSearchFocused(false), 120);
           }}
           placeholder="Search active tasks"
-          className="h-9 w-full rounded-md border border-input bg-background pl-9 pr-3 text-sm"
+          className={cn(
+            "h-9 w-full rounded-md border border-input bg-background pl-9 pr-3 text-sm",
+            inputClassName
+          )}
           disabled={disabled}
         />
       </div>

--- a/components/kanban/task-deadline-field.tsx
+++ b/components/kanban/task-deadline-field.tsx
@@ -11,6 +11,7 @@ interface TaskDeadlineFieldProps {
   disabled?: boolean;
   name?: string;
   helperText?: string;
+  triggerClassName?: string;
 }
 
 export function TaskDeadlineField({
@@ -21,6 +22,7 @@ export function TaskDeadlineField({
   disabled = false,
   name,
   helperText = "Optional. Close deadlines are highlighted automatically on the board.",
+  triggerClassName,
 }: TaskDeadlineFieldProps) {
   return (
     <div className="grid gap-2">
@@ -47,6 +49,7 @@ export function TaskDeadlineField({
         onChange={onChange}
         includeTime={false}
         disabled={disabled}
+        triggerClassName={triggerClassName}
       />
       {name ? <input type="hidden" name={name} value={value} /> : null}
       <p className="text-xs text-muted-foreground">{helperText}</p>

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -54,6 +54,10 @@ import { EmojiInputField, EmojiTextareaField } from "@/components/ui/emoji-field
 import { EmojiPickerButton } from "@/components/ui/emoji-picker-button";
 import { EpicSelect } from "@/components/ui/epic-select";
 import {
+  FORM_FOCUS_BORDER_CLASS,
+  FORM_FOCUS_BORDER_SHELL_CLASS,
+} from "@/components/ui/focus-border-styles";
+import {
   MentionAutocomplete,
   buildMentionAutocompleteDisplayValue,
   buildMentionAutocompleteValue,
@@ -371,7 +375,11 @@ export function TaskDetailModal({
                     aria-label="Task title"
                     value={editTitle}
                     onChange={(event) => onEditTitleChange(event.target.value)}
-                    className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                    wrapperClassName={cn(
+                      "rounded-md border border-input bg-background",
+                      FORM_FOCUS_BORDER_SHELL_CLASS
+                    )}
+                    className="h-10 w-full rounded-md border-0 bg-transparent px-3 text-sm outline-none"
                   />
                 )}
               </div>
@@ -1724,7 +1732,12 @@ function TaskEditContent({
           <label htmlFor="task-edit-label-input" className="text-sm font-medium">
             Labels
           </label>
-          <div className="rounded-md border border-input bg-background p-2">
+          <div
+            className={cn(
+              "rounded-md border border-input bg-background p-2",
+              FORM_FOCUS_BORDER_SHELL_CLASS
+            )}
+          >
             <div className="flex flex-wrap gap-2">
               {editLabels.map((label) => (
                 <span
@@ -1790,6 +1803,7 @@ function TaskEditContent({
             onChange={onEditDescriptionChange}
             placeholder="Task details..."
             mentionProjectId={projectId}
+            editorClassName={FORM_FOCUS_BORDER_CLASS}
           />
         </div>
 
@@ -1799,6 +1813,7 @@ function TaskEditContent({
           value={editDeadlineDate}
           onChange={onEditDeadlineDateChange}
           disabled={isUpdatingTask}
+          triggerClassName={FORM_FOCUS_BORDER_CLASS}
         />
 
         <div className="grid gap-2">
@@ -1811,6 +1826,7 @@ function TaskEditContent({
             onChange={onEditEpicIdChange}
             disabled={isUpdatingTask}
             options={availableEpicOptions}
+            className={FORM_FOCUS_BORDER_CLASS}
           />
         </div>
 
@@ -1824,6 +1840,7 @@ function TaskEditContent({
             onChange={onEditAssigneeUserIdChange}
             disabled={isUpdatingTask}
             options={availableAssignees}
+            className={FORM_FOCUS_BORDER_CLASS}
           />
         </div>
 
@@ -1868,7 +1885,10 @@ function TaskEditContent({
                 maxLength={1200}
                 placeholder="Add follow-up and press Enter"
                 wrapperClassName="flex-1"
-                className="h-9 flex-1 rounded-md border border-input bg-background px-3 text-sm"
+                className={cn(
+                  "h-9 flex-1 rounded-md border border-input bg-background px-3 text-sm",
+                  FORM_FOCUS_BORDER_CLASS
+                )}
                 disabled={isUpdatingTask}
               />
               <Button
@@ -2003,6 +2023,11 @@ function TaskEditContent({
               isSubmitDisabled={
                 isSubmittingAttachment || hasPendingAttachmentUploads || !linkUrl.trim()
               }
+              className={cn(
+                "rounded-md border border-input bg-background ring-0",
+                FORM_FOCUS_BORDER_SHELL_CLASS
+              )}
+              inputClassName="text-sm"
             />
           ) : null}
 
@@ -2022,6 +2047,7 @@ function TaskEditContent({
             onSearchChange={onRelatedTaskSearchChange}
             onAddTask={onAddRelatedTask}
             onRemoveTask={onRemoveRelatedTask}
+            inputClassName={FORM_FOCUS_BORDER_CLASS}
           />
         </div>
       </div>

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -339,8 +339,15 @@ export function TaskDetailModal({
             className="flex max-h-[100dvh] w-full max-w-2xl flex-col sm:max-h-[calc(100vh-2rem)] sm:rounded-2xl"
             onMouseDown={(event) => event.stopPropagation()}
           >
-            <CardHeader className="flex shrink-0 flex-col gap-3 space-y-0 sm:flex-row sm:items-start sm:justify-between">
-              <div className="min-w-0 flex-1 space-y-2">
+            <CardHeader
+              className={cn(
+                "flex shrink-0 flex-col gap-3 space-y-0",
+                isEditing
+                  ? "relative"
+                  : "sm:flex-row sm:items-start sm:justify-between"
+              )}
+            >
+              <div className={cn("min-w-0 flex-1 space-y-2", isEditing && "w-full pr-1")}>
                 <Badge
                   variant="outline"
                   className={
@@ -383,7 +390,12 @@ export function TaskDetailModal({
                   />
                 )}
               </div>
-              <div className="flex items-center gap-1 self-end sm:self-auto">
+              <div
+                className={cn(
+                  "flex items-center gap-1 self-end",
+                  isEditing ? "absolute right-4 top-4" : "sm:self-auto"
+                )}
+              >
                 {!isEditing && canEdit ? (
                   <TaskOptionsMenu
                     currentStatus={selectedTask.status}

--- a/components/rich-text-editor.tsx
+++ b/components/rich-text-editor.tsx
@@ -46,6 +46,7 @@ interface RichTextEditorProps {
   onChange: (value: string) => void;
   placeholder?: string;
   className?: string;
+  editorClassName?: string;
   ariaLabel?: string;
   ariaLabelledBy?: string;
   mentionProjectId?: string;
@@ -2113,6 +2114,7 @@ export function RichTextEditor({
   onChange,
   placeholder,
   className,
+  editorClassName,
   ariaLabel,
   ariaLabelledBy,
   mentionProjectId,
@@ -2945,7 +2947,8 @@ export function RichTextEditor({
             "[&_pre[data-rich-block='code']_code]:[font-family:Consolas,Monaco,'Liberation_Mono',Menlo,monospace]",
             "[&_div[data-rich-block='token']]:w-full [&_div[data-rich-block='token']]:min-w-0 [&_div[data-rich-block='token']]:max-w-full [&_div[data-rich-block='token']_code]:w-full [&_div[data-rich-block='token']_code]:max-w-full [&_div[data-rich-block='token']_code]:[font-family:Consolas,Monaco,'Liberation_Mono',Menlo,monospace]",
             "[&_div[data-rich-block='token']_code]:selection:bg-foreground/20 [&_h1]:mb-3 [&_h1]:text-xl [&_h1]:font-bold",
-            "[&_h2]:mb-2 [&_h2]:text-lg [&_h2]:font-semibold [&_ol]:list-decimal [&_ol]:pl-5 [&_ul]:list-disc [&_ul]:pl-5"
+            "[&_h2]:mb-2 [&_h2]:text-lg [&_h2]:font-semibold [&_ol]:list-decimal [&_ol]:pl-5 [&_ul]:list-disc [&_ul]:pl-5",
+            editorClassName
           )}
           onMouseDown={handleEditorMouseDown}
           onClick={(event) => {

--- a/components/ui/focus-border-styles.ts
+++ b/components/ui/focus-border-styles.ts
@@ -1,0 +1,4 @@
+export const FORM_FOCUS_BORDER_CLASS =
+  "form-focus-border-field focus-visible:ring-0";
+
+export const FORM_FOCUS_BORDER_SHELL_CLASS = "form-focus-border-shell";

--- a/journal.md
+++ b/journal.md
@@ -1192,3 +1192,13 @@ Low-value entries to avoid going forward:
 - Type: Validation
 - Summary: TASK-214 passed local lint, unit/API tests, coverage, production build, and Playwright smoke validation.
 - Evidence: Node `v24.15.0`; `npm ci`; `npx prisma generate`; `npm run db:local:up`; `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/nexusdash?schema=public DIRECT_URL=... npm run db:migrate`; `npm run lint`; same DB env `npm test` (92 files passed, 1 skipped; 718 passed, 1 skipped); same DB env `npm run test:coverage` (91.23% statements, 81.2% branches, 93.42% functions, 91.75% lines); preview-style build env (`VERCEL_ENV=preview`, local `AGENT_TOKEN_SIGNING_SECRET`, `TRUSTED_ORIGINS`, `NEXTAUTH_URL`, `NEXTAUTH_SECRET`) `npm run build`; same env `npm run test:e2e` passed all 7 Playwright tests.
+
+### 2026-05-06
+- Type: Execution
+- Summary: TASK-214 follow-up generalized the focus-border treatment across task edit and context-card create/edit authoring surfaces.
+- Evidence: Replaced the task-create-only CSS hooks with shared opt-in `form-focus-border-*` hooks and reused them for task edit title, labels, description, deadline, epic, assignee, blocked follow-up entry, related-task search, and attachment-link entry. Context-card create/edit title, rich content, and attachment-link entry now use the same border-focused treatment.
+
+### 2026-05-06
+- Type: Validation
+- Summary: TASK-214 follow-up passed lint, unit/API tests, coverage, production build, and Playwright smoke validation.
+- Evidence: `npm run lint`; local DB env `npm test` (92 files passed, 1 skipped; 718 passed, 1 skipped); local DB env `npm run test:coverage` (91.23% statements, 81.2% branches, 93.42% functions, 91.75% lines); preview-style env `npm run build`; preview-style env `npm run test:e2e` passed all 7 Playwright tests.

--- a/journal.md
+++ b/journal.md
@@ -1222,3 +1222,13 @@ Low-value entries to avoid going forward:
 - Type: Validation
 - Summary: TASK-214 branch merged current `origin/main` without force-pushing and passed the full local validation suite again.
 - Evidence: Merged over `b60c983` (`TASK-217 Fix mention notification open route (#238)`) because branch rules disallow force-push. Passed `npm run lint`; local DB env `npm test` (93 files passed, 1 skipped; 719 passed, 1 skipped); local DB env `npm run test:coverage` (91.23% statements, 81.2% branches, 93.42% functions, 91.75% lines); preview-style env `npm run build`; preview-style env `npm run test:e2e` passed all 7 Playwright tests.
+
+### 2026-05-06
+- Type: Execution
+- Summary: TASK-214 edit task modal follow-up restored full-width title input alignment.
+- Evidence: Root cause was edit mode rendering the title input in the horizontal modal header beside the close/action area, while Labels renders in the full-width modal body. Edit mode now uses a stacked full-width header layout with the close action positioned independently, so the title input receives the same content width as Labels.
+
+### 2026-05-06
+- Type: Validation
+- Summary: TASK-214 edit title alignment follow-up passed lint, unit/API tests, coverage, and production build; task lifecycle E2E passed, while the unrelated roadmap drag smoke timed out locally.
+- Evidence: `npm run lint`; local DB env `npm test` (93 files passed, 1 skipped; 719 passed, 1 skipped); local DB env `npm run test:coverage` (91.23% statements, 81.2% branches, 93.42% functions, 91.75% lines); preview-style env `npm run build`; preview-style env `npm run test:e2e` passed 6 of 7 tests including `task lifecycle and attachment interaction flow`, then failed in `roadmap event-first milestone flow` waiting for `/roadmap/events/move` after Playwright dropped the roadmap card outside the drop area. Targeted rerun of that roadmap smoke reproduced the same drag/drop timeout; no task modal regression was observed.

--- a/journal.md
+++ b/journal.md
@@ -1182,3 +1182,13 @@ Low-value entries to avoid going forward:
 - Type: Validation
 - Summary: TASK-131 Copilot follow-up passed DB reset and full local validation from a fresh database volume.
 - Evidence: `node scripts/local-db-reset.mjs` removed only `nexus_dash_task131_postgres_data` and started a fresh healthy Postgres service. `npm run validate:local` then passed end to end, including reapplying all 31 migrations, lint, `npm test` (92 files passed, 1 skipped; 718 passed, 1 skipped), coverage (91.23% statements, 81.2% branches, 93.42% functions, 91.75% lines), production build, and all 7 Playwright E2E tests.
+
+### 2026-05-06
+- Type: Execution
+- Summary: TASK-214 fixed task creation focus-border inconsistency from a fresh worktree and branch.
+- Evidence: Created fresh worktree `../nexus_dash_issue214_codex` on `fix/issue-214-task-creation-focus-border` from `origin/main`, leaving the prior TASK-214 worktree/branch untouched. Root cause was the task creation form mixing native input focus paint, border-only rich text focus, ring-based custom selects, and mostly unstyled picker/search inputs inside overflow-constrained modal content. The title field now uses an internal wrapper border instead of native external focus paint, and the task creation fields share the scoped `task-create-focus-*` border treatment so focused borders stay inside the field box in light and dark themes.
+
+### 2026-05-06
+- Type: Validation
+- Summary: TASK-214 passed local lint, unit/API tests, coverage, production build, and Playwright smoke validation.
+- Evidence: Node `v24.15.0`; `npm ci`; `npx prisma generate`; `npm run db:local:up`; `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/nexusdash?schema=public DIRECT_URL=... npm run db:migrate`; `npm run lint`; same DB env `npm test` (92 files passed, 1 skipped; 718 passed, 1 skipped); same DB env `npm run test:coverage` (91.23% statements, 81.2% branches, 93.42% functions, 91.75% lines); preview-style build env (`VERCEL_ENV=preview`, local `AGENT_TOKEN_SIGNING_SECRET`, `TRUSTED_ORIGINS`, `NEXTAUTH_URL`, `NEXTAUTH_SECRET`) `npm run build`; same env `npm run test:e2e` passed all 7 Playwright tests.

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -4,6 +4,13 @@ Use this file to capture tasks discovered during development. Each entry should 
 
 ## Pending
 ### Execution Queue (Now / Next)
+- ID: TASK-214
+  Title: Task creation focus border consistency
+  Status: Ready for PR (issue #214)
+  Rationale: Align task creation form focus borders around the title input's
+    intended visual treatment, including the dark-theme left-edge clipping fix,
+    without changing task creation layout or behavior.
+  Dependencies: TASK-010, TASK-011
 - ID: TASK-131
   Title: Local validation baseline repair - reproducible container, database, and toolchain setup
   Status: Pending

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -5,11 +5,11 @@ Use this file to capture tasks discovered during development. Each entry should 
 ## Pending
 ### Execution Queue (Now / Next)
 - ID: TASK-214
-  Title: Task creation focus border consistency
-  Status: Ready for PR (issue #214)
-  Rationale: Align task creation form focus borders around the title input's
-    intended visual treatment, including the dark-theme left-edge clipping fix,
-    without changing task creation layout or behavior.
+  Title: Task and card focus border consistency
+  Status: PR update ready (issue #214)
+  Rationale: Align task and context-card create/edit form focus borders around
+    the title input's intended visual treatment, including the dark-theme
+    left-edge clipping fix, without changing authoring layout or behavior.
   Dependencies: TASK-010, TASK-011
 - ID: TASK-131
   Title: Local validation baseline repair - reproducible container, database, and toolchain setup

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,94 +1,55 @@
-# Current Task: TASK-131 Local Validation Baseline Repair
+# Current Task: TASK-214 Task Creation Focus Border Consistency
 
 ## Task ID
-TASK-131
+TASK-214
 
 ## Status
-Local validation baseline green on `feature/task-131-local-validation-baseline`.
+Implementation and local validation complete on
+`fix/issue-214-task-creation-focus-border`; ready for PR.
 
 ## Objective
-Restore a reproducible local validation path for NexusDash so a contributor can
-start from a clean checkout and run the full baseline through install, Prisma
-client generation, migrations, unit/API tests, coverage, production build, and
-Playwright smoke tests without relying on undocumented machine state.
+Resolve GitHub issue #214 by making the task creation form inputs use a
+consistent focused border treatment, using the title input as the visual
+reference, and fixing the dark-theme title focus border clipping on the left
+edge.
 
 ## Current Scope
-- Align the repository toolchain contract around a supported Node/npm baseline
-  for the current Next.js, Prisma, Vitest, jsdom, and Playwright dependencies.
-- Make local database bootstrap explicit and reproducible, preferably through a
-  Docker Compose Postgres service that matches the CI E2E database contract.
-- Ensure Prisma generate/migrate commands use the intended local connection
-  strings and do not require production-only secrets.
-- Define a single documented local validation workflow that covers:
-  - clean dependency install with `npm ci`
-  - `npx prisma generate`
-  - `npm run db:migrate`
-  - `npm run lint`
-  - `npm test`
-  - `npm run test:coverage`
-  - `npm run build`
-  - `npm run test:e2e`
-- Keep the app container path reproducible without assuming an external
-  database URL is already present in the developer shell.
-- Record validation evidence and any remaining local environment constraints in
-  `journal.md`.
-
-## Initial Findings
-- The current shell is on Node `v20.17.0`; `npm ci` fails at Prisma preinstall
-  because the current dependency tree requires Node `20.19+`, `22.13+`, or
-  `24+`.
-- `docker compose config` fails without shell-provided `DATABASE_URL` and
-  `DIRECT_URL`, and the current compose file has no Postgres service.
-- CI E2E already defines the desired local-style Postgres contract:
-  `postgres:16-alpine` with
-  `postgresql://postgres:postgres@127.0.0.1:5432/nexusdash?schema=public`.
-- `npm run test:e2e` builds and launches `next start`, while Playwright helper
-  code seeds test users directly through Prisma. That means E2E needs a
-  migrated database and generated Prisma client before the browser run begins.
+- Keep changes limited to the task creation form focus styling.
+- Align title, label entry, description, deadline, epic, assignee, related-task
+  search, and attachment-link entry focus states around the same border-color
+  treatment.
+- Avoid layout, validation, or task creation behavior changes.
+- Preserve existing design system tokens and component conventions.
 
 ## Acceptance Criteria
-1. A clean checkout exposes an explicit supported Node version contract through
-   repo-owned configuration or documentation.
-2. `npm ci` succeeds on the supported local Node baseline.
-3. A developer can start a local PostgreSQL database for validation using a
-   documented repo-owned command or compose profile.
-4. Local `DATABASE_URL` and `DIRECT_URL` values for validation are documented
-   and line up with the local database service.
-5. `npx prisma generate` and `npm run db:migrate` succeed against the documented
-   local validation database.
-6. `npm run lint`, `npm test`, `npm run test:coverage`, and `npm run build`
-   succeed after the documented bootstrap.
-7. `npm run test:e2e` succeeds locally against the documented local database and
-   app startup path.
-8. Docker Compose can render its config and start the app/database baseline
-   without requiring undocumented external database variables.
-9. README or runbook documentation contains one copy-pasteable local validation
-   sequence and describes cleanup/reset behavior for the local database.
-10. `journal.md` records the commands run, observed failures, fixes, and final
-    validation evidence.
+1. All visible task creation form input fields use the same focused border
+   style.
+2. The title input remains the visual reference for the focused state.
+3. Focused borders render correctly in light and dark themes.
+4. The dark-theme focused title input no longer appears cropped on the left
+   side.
+5. The task creation form layout and input behavior are unchanged.
+6. Relevant lint, test, build, and UI validation checks pass or any environment
+   blocker is recorded.
 
 ## Definition Of Done
-- TASK-131 has a dedicated worktree and branch.
-- Toolchain, database, Docker/Compose, and test documentation changes are
-  committed in the TASK-131 branch.
-- The full local validation baseline has been run, or any remaining blocker is
-  documented with exact command output and next action.
-- `tasks/current.md`, `journal.md`, and any touched runbooks/README sections
-  agree on the final local validation workflow.
-- A PR is opened for TASK-131 once the branch is reviewable.
+- TASK-214 has a dedicated branch and fresh worktree separate from the prior
+  closed PR/worktree attempt.
+- Focus styling fixes are implemented with minimal task creation form scope.
+- Local validation evidence and any environment blockers are recorded in
+  `journal.md`.
+- A PR is opened for issue #214 once the branch is reviewable.
 
 ## Out Of Scope
-- Reworking production deploy secrets or Vercel preview workflows beyond keeping
-  local validation documentation consistent with existing runbooks.
-- Expanding Playwright coverage beyond the existing smoke suite unless required
-  to make the current suite reliable.
+- Redesigning the task creation form.
+- Changing input validation, submission, upload, or task creation behavior.
+- Refactoring unrelated form components or global form styling.
 
 ## Validation Evidence
-- `npm run validate:local` passed on 2026-05-04 with Node `v24.15.0` and Docker
-  Desktop running.
-- The validation run started Docker Compose Postgres, ran `npm ci`, generated
-  Prisma Client, applied migrations, ran lint, unit/API tests, coverage,
-  production build, installed Playwright Chromium, and passed all Playwright E2E
-  tests.
-- `APP_PORT=3131 docker compose up --build -d app` started the app container,
-  and `/api/health/live` plus `/api/health/ready` both returned HTTP 200.
+- `npm run lint` passed on 2026-05-06.
+- `npm test` passed on 2026-05-06 with 92 files passed, 1 skipped; 718 tests
+  passed, 1 skipped.
+- `npm run test:coverage` passed on 2026-05-06 with 91.23% statements,
+  81.2% branches, 93.42% functions, and 91.75% lines.
+- `npm run build` passed on 2026-05-06 with local preview validation env vars.
+- `npm run test:e2e` passed on 2026-05-06 with all 7 Playwright tests passing.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,48 +1,48 @@
-# Current Task: TASK-214 Task Creation Focus Border Consistency
+# Current Task: TASK-214 Task And Card Focus Border Consistency
 
 ## Task ID
 TASK-214
 
 ## Status
 Implementation and local validation complete on
-`fix/issue-214-task-creation-focus-border`; ready for PR.
+`fix/issue-214-task-creation-focus-border`; PR update ready.
 
 ## Objective
-Resolve GitHub issue #214 by making the task creation form inputs use a
-consistent focused border treatment, using the title input as the visual
-reference, and fixing the dark-theme title focus border clipping on the left
-edge.
+Resolve GitHub issue #214 by making task and context-card authoring inputs use
+a consistent focused border treatment, using the title input as the visual
+reference, and fixing dark-theme title focus border clipping.
 
 ## Current Scope
-- Keep changes limited to the task creation form focus styling.
+- Keep changes limited to task and context-card create/edit form focus styling.
 - Align title, label entry, description, deadline, epic, assignee, related-task
-  search, and attachment-link entry focus states around the same border-color
-  treatment.
-- Avoid layout, validation, or task creation behavior changes.
+  search, follow-up entry, and attachment-link entry focus states around the
+  same border-color treatment.
+- Avoid layout, validation, or authoring behavior changes.
 - Preserve existing design system tokens and component conventions.
 
 ## Acceptance Criteria
-1. All visible task creation form input fields use the same focused border
-   style.
+1. All visible task create/edit and context-card create/edit form input fields
+   use the same focused border style.
 2. The title input remains the visual reference for the focused state.
 3. Focused borders render correctly in light and dark themes.
 4. The dark-theme focused title input no longer appears cropped on the left
    side.
-5. The task creation form layout and input behavior are unchanged.
+5. Task and context-card form layouts and input behavior are unchanged.
 6. Relevant lint, test, build, and UI validation checks pass or any environment
    blocker is recorded.
 
 ## Definition Of Done
 - TASK-214 has a dedicated branch and fresh worktree separate from the prior
   closed PR/worktree attempt.
-- Focus styling fixes are implemented with minimal task creation form scope.
+- Focus styling fixes are implemented with minimal task and context-card form
+  scope.
 - Local validation evidence and any environment blockers are recorded in
   `journal.md`.
 - A PR is opened for issue #214 once the branch is reviewable.
 
 ## Out Of Scope
-- Redesigning the task creation form.
-- Changing input validation, submission, upload, or task creation behavior.
+- Redesigning task or context-card forms.
+- Changing input validation, submission, upload, or authoring behavior.
 - Refactoring unrelated form components or global form styling.
 
 ## Validation Evidence


### PR DESCRIPTION
## Summary

- Fixes #214.
- Aligns task creation and task edit form focus borders around the title-field visual treatment.
- Applies the same border-focused treatment to context-card creation/editing title, content, and attachment-link inputs.
- Keeps focus paint inside the field border box so title focus borders are not clipped in dark mode.
- Uses shared opt-in class hooks for picker/search/editor controls so the styling remains scoped to these authoring forms.

## Root Cause

The authoring forms mixed several focus implementations: native input focus paint on title fields, border-only rich text editor focus states, ring-based custom select triggers, and mostly unstyled date/search/link fields. In overflow-constrained modal bodies, external focus paint could be clipped, which made the dark-theme title focus border look cropped on the left edge.

## Validation

- `npm run lint`
- `npm test` with `DATABASE_URL`/`DIRECT_URL` set to the documented local Postgres URL
- `npm run test:coverage` with the same DB env
- `npm run build` with local preview validation env vars
- `npm run test:e2e` with local preview validation env vars: 7 passed