### PR TITLE
TASK-104 Invite email delivery

### DIFF
--- a/app/api/projects/[projectId]/sharing/invitations/[invitationId]/email/route.ts
+++ b/app/api/projects/[projectId]/sharing/invitations/[invitationId]/email/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireAuthenticatedApiUser } from "@/lib/auth/api-guard";
+import { resolveRequestOriginFromHeaders } from "@/lib/http/request-origin";
+import { sendProjectInvitationEmailForOwner } from "@/lib/services/project-collaboration-service";
+
+export async function POST(
+  request: NextRequest,
+  props: {
+    params: Promise<{ projectId: string; invitationId: string }>;
+  }
+) {
+  const params = await props.params;
+  const authenticatedUser = await requireAuthenticatedApiUser(request);
+  if (!authenticatedUser.ok) {
+    return authenticatedUser.response;
+  }
+
+  const result = await sendProjectInvitationEmailForOwner({
+    actorUserId: authenticatedUser.userId,
+    projectId: params.projectId,
+    invitationId: params.invitationId,
+    appOrigin: resolveRequestOriginFromHeaders(request.headers),
+  });
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json(result.data);
+}

--- a/app/api/projects/[projectId]/sharing/route.ts
+++ b/app/api/projects/[projectId]/sharing/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 
 import { requireAuthenticatedApiUser } from "@/lib/auth/api-guard";
+import { resolveRequestOriginFromHeaders } from "@/lib/http/request-origin";
 import { logServerWarning } from "@/lib/observability/logger";
 import {
   getProjectSharingSummary,
@@ -56,6 +57,7 @@ export async function POST(request: NextRequest, props: { params: Promise<{ proj
     invitedEmail:
       typeof payload.invitedEmail === "string" ? payload.invitedEmail : "",
     role: typeof payload.role === "string" ? payload.role : "",
+    appOrigin: resolveRequestOriginFromHeaders(request.headers),
   });
 
   if (!result.ok) {

--- a/components/project-dashboard/project-dashboard-owner-access-panel.tsx
+++ b/components/project-dashboard/project-dashboard-owner-access-panel.tsx
@@ -67,14 +67,6 @@ export function ProjectDashboardOwnerAccessPanel({
     return () => window.clearTimeout(timeoutId);
   }, [copiedInvitationId]);
 
-  const buildInvitationLink = (invitation: ProjectInvitationSummary) => {
-    if (typeof window === "undefined") {
-      return invitation.inviteLinkPath;
-    }
-
-    return new URL(invitation.inviteLinkPath, window.location.origin).toString();
-  };
-
   const handleCopyInvitation = async (invitation: ProjectInvitationSummary) => {
     const didCopy = await onCopyInvitationLink(invitation);
     if (didCopy) {
@@ -192,7 +184,6 @@ export function ProjectDashboardOwnerAccessPanel({
                   invitationLabel,
                   invitationIdentity
                 );
-                const isEmailOnlyInvitation = !invitation.invitedUserDisplayName;
                 const isCopied = copiedInvitationId === invitation.invitationId;
                 const emailDeliveryMessage = formatInvitationEmailDelivery(
                   invitationEmailDeliveries[invitation.invitationId]
@@ -231,39 +222,19 @@ export function ProjectDashboardOwnerAccessPanel({
                       ) : null}
                     </div>
                     <div className="flex flex-wrap items-center gap-2">
-                      {isEmailOnlyInvitation ? (
-                        <div className="flex max-w-full items-center gap-2 md:max-w-[28rem]">
-                          <input
-                            readOnly
-                            value={buildInvitationLink(invitation)}
-                            aria-label={`Invite link for ${invitation.invitedEmail}`}
-                            className="h-9 min-w-0 flex-1 rounded-md border border-input bg-background px-2.5 text-xs text-muted-foreground outline-none sm:text-sm"
-                          />
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="icon"
-                            aria-label={`Copy invite link for ${invitation.invitedEmail}`}
-                            className="h-9 w-9 shrink-0"
-                            onClick={() => void handleCopyInvitation(invitation)}
-                          >
-                            {isCopied ? (
-                              <Check className="h-4 w-4" />
-                            ) : (
-                              <Copy className="h-4 w-4" />
-                            )}
-                          </Button>
-                        </div>
-                      ) : (
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          onClick={() => void handleCopyInvitation(invitation)}
-                        >
-                          Copy link
-                        </Button>
-                      )}
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => void handleCopyInvitation(invitation)}
+                      >
+                        {isCopied ? (
+                          <Check className="h-4 w-4" />
+                        ) : (
+                          <Copy className="h-4 w-4" />
+                        )}
+                        Copy link
+                      </Button>
                       <Button
                         type="button"
                         variant="outline"

--- a/components/project-dashboard/project-dashboard-owner-access-panel.tsx
+++ b/components/project-dashboard/project-dashboard-owner-access-panel.tsx
@@ -1,14 +1,16 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Check, Copy } from "lucide-react";
+import { Check, Copy, Mail } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { UserAvatar } from "@/components/ui/user-avatar";
 
 import {
+  formatInvitationEmailDelivery,
   formatIdentity,
+  type ProjectInvitationEmailDeliverySummary,
   type ProjectCollaboratorRole,
   type ProjectInvitationSummary,
   type ProjectMemberSummary,
@@ -21,9 +23,15 @@ interface ProjectDashboardOwnerAccessPanelProps {
   sharingSummary: ProjectSharingSummary | null;
   isMutatingMemberId: string | null;
   isMutatingInvitationId: string | null;
+  sendingInvitationEmailId: string | null;
+  invitationEmailDeliveries: Record<
+    string,
+    ProjectInvitationEmailDeliverySummary | undefined
+  >;
   onRoleChange: (member: ProjectMemberSummary, nextRole: ProjectCollaboratorRole) => void;
   onRemoveMember: (member: ProjectMemberSummary) => void;
   onCopyInvitationLink: (invitation: ProjectInvitationSummary) => Promise<boolean> | boolean;
+  onSendInvitationEmail: (invitation: ProjectInvitationSummary) => void;
   onRevokeInvitation: (invitation: ProjectInvitationSummary) => void;
 }
 
@@ -37,9 +45,12 @@ export function ProjectDashboardOwnerAccessPanel({
   sharingSummary,
   isMutatingMemberId,
   isMutatingInvitationId,
+  sendingInvitationEmailId,
+  invitationEmailDeliveries,
   onRoleChange,
   onRemoveMember,
   onCopyInvitationLink,
+  onSendInvitationEmail,
   onRevokeInvitation,
 }: ProjectDashboardOwnerAccessPanelProps) {
   const [copiedInvitationId, setCopiedInvitationId] = useState<string | null>(null);
@@ -183,6 +194,11 @@ export function ProjectDashboardOwnerAccessPanel({
                 );
                 const isEmailOnlyInvitation = !invitation.invitedUserDisplayName;
                 const isCopied = copiedInvitationId === invitation.invitationId;
+                const emailDeliveryMessage = formatInvitationEmailDelivery(
+                  invitationEmailDeliveries[invitation.invitationId]
+                );
+                const isSendingEmail =
+                  sendingInvitationEmailId === invitation.invitationId;
 
                 return (
                   <div
@@ -208,6 +224,11 @@ export function ProjectDashboardOwnerAccessPanel({
                       <p className="text-xs text-muted-foreground">
                         Expires {new Date(invitation.expiresAt).toLocaleDateString()}.
                       </p>
+                      {emailDeliveryMessage ? (
+                        <p className="text-xs text-muted-foreground">
+                          {emailDeliveryMessage}
+                        </p>
+                      ) : null}
                     </div>
                     <div className="flex flex-wrap items-center gap-2">
                       {isEmailOnlyInvitation ? (
@@ -243,6 +264,16 @@ export function ProjectDashboardOwnerAccessPanel({
                           Copy link
                         </Button>
                       )}
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => onSendInvitationEmail(invitation)}
+                        disabled={isSendingEmail}
+                      >
+                        <Mail className="h-4 w-4" />
+                        {isSendingEmail ? "Sending..." : "Resend email"}
+                      </Button>
                       <Button
                         type="button"
                         variant="ghost"

--- a/components/project-dashboard/project-dashboard-owner-actions.shared.ts
+++ b/components/project-dashboard/project-dashboard-owner-actions.shared.ts
@@ -43,6 +43,21 @@ export interface ProjectInvitationSummary {
   inviteLinkPath: string;
 }
 
+export interface ProjectInvitationEmailDeliverySummary {
+  status: "sent" | "skipped" | "failed";
+  deliveryId: string | null;
+  provider: "resend";
+  providerMessageId: string | null;
+  providerStatus: number | null;
+  error:
+    | "invalid-recipient"
+    | "delivery-record-failed"
+    | "provider-unavailable"
+    | "provider-rejected"
+    | "invite-url-unavailable"
+    | null;
+}
+
 export interface ProjectSharingSummary {
   projectId: string;
   members: ProjectMemberSummary[];
@@ -93,6 +108,7 @@ export interface ProjectAgentCredentialIssuedSecret {
 export interface GeneratedProjectInvitationLink {
   invitation: ProjectInvitationSummary;
   url: string;
+  emailDelivery: ProjectInvitationEmailDeliverySummary | null;
 }
 
 export const ROLE_COPY: Record<ProjectCollaboratorRole, string> = {
@@ -135,10 +151,41 @@ export function mapSharingError(errorCode: string): string {
       return "The owner cannot be removed from the project.";
     case "invitation-not-found":
       return "Invitation not found.";
+    case "invitation-not-active":
+      return "That invitation is no longer active.";
     case "forbidden":
       return "Only the project owner can manage sharing.";
     default:
       return "Could not update project sharing. Please retry.";
+  }
+}
+
+export function formatInvitationEmailDelivery(
+  delivery: ProjectInvitationEmailDeliverySummary | null | undefined
+): string | null {
+  if (!delivery) {
+    return null;
+  }
+
+  if (delivery.status === "sent") {
+    return "Invitation email sent.";
+  }
+
+  if (delivery.status === "skipped") {
+    return "Email delivery skipped in this environment.";
+  }
+
+  switch (delivery.error) {
+    case "provider-unavailable":
+      return "Email provider unavailable. Copy the invite link instead.";
+    case "provider-rejected":
+      return "Email provider rejected the invite. Copy the invite link instead.";
+    case "invalid-recipient":
+      return "Recipient email could not be used for delivery.";
+    case "invite-url-unavailable":
+      return "Could not build the invite email link. Copy the invite link instead.";
+    default:
+      return "Invitation email could not be sent. Copy the invite link instead.";
   }
 }
 

--- a/components/project-dashboard/project-dashboard-owner-actions.tsx
+++ b/components/project-dashboard/project-dashboard-owner-actions.tsx
@@ -253,7 +253,7 @@ export function ProjectDashboardOwnerActions({
           setSearchMessage(
             users.length === 0
               ? inviteEmailCandidate
-                ? "No verified account found yet. Create a link below."
+                ? "No verified account found yet. Send an invitation below."
                 : "No matching verified users found."
               : null
           );
@@ -453,7 +453,7 @@ export function ProjectDashboardOwnerActions({
           variant: emailDelivery?.status === "failed" ? "error" : "success",
           message: buildInvitationEmailDeliveryToast(
             emailDelivery,
-            `Invite link ready for ${invitedEmail}.`
+            `Invitation created for ${invitedEmail}.`
           ),
         });
       } else {

--- a/components/project-dashboard/project-dashboard-owner-actions.tsx
+++ b/components/project-dashboard/project-dashboard-owner-actions.tsx
@@ -17,10 +17,12 @@ import { ProjectDashboardOwnerGeneralPanel } from "@/components/project-dashboar
 import { ProjectDashboardOwnerSharingPanel } from "@/components/project-dashboard/project-dashboard-owner-sharing-panel";
 import {
   type GeneratedProjectInvitationLink,
+  formatInvitationEmailDelivery,
   mapAgentAccessError,
   mapProjectMutationError,
   mapSharingError,
   type CollaboratorIdentitySummary,
+  type ProjectInvitationEmailDeliverySummary,
   type ProjectAgentAccessSummary,
   type ProjectAgentCredentialIssuedSecret,
   type ProjectAgentCredentialSummary,
@@ -88,6 +90,11 @@ export function ProjectDashboardOwnerActions({
   const [isInvitingUserId, setIsInvitingUserId] = useState<string | null>(null);
   const [isMutatingMemberId, setIsMutatingMemberId] = useState<string | null>(null);
   const [isMutatingInvitationId, setIsMutatingInvitationId] = useState<string | null>(null);
+  const [sendingInvitationEmailId, setSendingInvitationEmailId] =
+    useState<string | null>(null);
+  const [invitationEmailDeliveries, setInvitationEmailDeliveries] = useState<
+    Record<string, ProjectInvitationEmailDeliverySummary | undefined>
+  >({});
   const [searchMessage, setSearchMessage] = useState<string | null>(null);
   const [generatedInvitationLink, setGeneratedInvitationLink] =
     useState<GeneratedProjectInvitationLink | null>(null);
@@ -116,7 +123,8 @@ export function ProjectDashboardOwnerActions({
       isSavingProject ||
       isDeletingProject ||
       isCreatingAgentCredential ||
-      mutatingAgentCredentialId
+      mutatingAgentCredentialId ||
+      sendingInvitationEmailId
     ) {
       return;
     }
@@ -365,6 +373,36 @@ export function ProjectDashboardOwnerActions({
     }
   };
 
+  const rememberInvitationEmailDelivery = (
+    invitationId: string,
+    delivery: ProjectInvitationEmailDeliverySummary | null | undefined
+  ) => {
+    if (!delivery) {
+      return;
+    }
+
+    setInvitationEmailDeliveries((current) => ({
+      ...current,
+      [invitationId]: delivery,
+    }));
+  };
+
+  const buildInvitationEmailDeliveryToast = (
+    delivery: ProjectInvitationEmailDeliverySummary | null | undefined,
+    fallback: string
+  ) => {
+    const message = formatInvitationEmailDelivery(delivery);
+    if (!message) {
+      return fallback;
+    }
+
+    if (delivery?.status === "sent") {
+      return message;
+    }
+
+    return `${fallback} ${message}`;
+  };
+
   const handleInviteEmail = async (
     invitedEmail: string,
     label: string,
@@ -392,6 +430,7 @@ export function ProjectDashboardOwnerActions({
         | {
             error?: string;
             invitation?: ProjectInvitationSummary;
+            emailDelivery?: ProjectInvitationEmailDeliverySummary;
           }
         | null;
 
@@ -400,25 +439,37 @@ export function ProjectDashboardOwnerActions({
       }
 
       const invitation = payload?.invitation ?? null;
+      const emailDelivery = payload?.emailDelivery ?? null;
 
       if (source === "email" && invitation) {
+        rememberInvitationEmailDelivery(invitation.invitationId, emailDelivery);
         setGeneratedInvitationLink({
           invitation,
           url: buildAbsoluteInvitationLink(invitation.inviteLinkPath, window.location.origin),
+          emailDelivery,
         });
         setSearchMessage(null);
         pushToast({
-          variant: "success",
-          message: `Invite link ready for ${invitedEmail}.`,
+          variant: emailDelivery?.status === "failed" ? "error" : "success",
+          message: buildInvitationEmailDeliveryToast(
+            emailDelivery,
+            `Invite link ready for ${invitedEmail}.`
+          ),
         });
       } else {
+        if (invitation) {
+          rememberInvitationEmailDelivery(invitation.invitationId, emailDelivery);
+        }
         setGeneratedInvitationLink(null);
         setInviteQuery("");
         setInviteResults([]);
         setSearchMessage(null);
         pushToast({
-          variant: "success",
-          message: `${label} invited as ${inviteRole}.`,
+          variant: emailDelivery?.status === "failed" ? "error" : "success",
+          message: buildInvitationEmailDeliveryToast(
+            emailDelivery,
+            `${label} invited as ${inviteRole}.`
+          ),
         });
       }
 
@@ -446,6 +497,58 @@ export function ProjectDashboardOwnerActions({
     }
 
     await handleInviteEmail(user.email, user.displayName, user.id, "user");
+  };
+
+  const handleSendInvitationEmail = async (
+    invitation: ProjectInvitationSummary
+  ) => {
+    if (sendingInvitationEmailId) {
+      return;
+    }
+
+    setSendingInvitationEmailId(invitation.invitationId);
+
+    try {
+      const response = await fetch(
+        `/api/projects/${projectId}/sharing/invitations/${invitation.invitationId}/email`,
+        {
+          method: "POST",
+        }
+      );
+      const payload = (await response.json().catch(() => null)) as
+        | {
+            invitation?: ProjectInvitationSummary;
+            emailDelivery?: ProjectInvitationEmailDeliverySummary;
+            error?: string;
+          }
+        | null;
+
+      if (!response.ok || !payload?.emailDelivery) {
+        throw new Error(mapSharingError(payload?.error ?? "invite-email-failed"));
+      }
+
+      rememberInvitationEmailDelivery(
+        invitation.invitationId,
+        payload.emailDelivery
+      );
+      pushToast({
+        variant: payload.emailDelivery.status === "failed" ? "error" : "success",
+        message: buildInvitationEmailDeliveryToast(
+          payload.emailDelivery,
+          `Invite link remains ready for ${invitation.invitedEmail}.`
+        ),
+      });
+    } catch (error) {
+      pushToast({
+        variant: "error",
+        message:
+          error instanceof Error
+            ? error.message
+            : "Could not send the invitation email. Please retry.",
+      });
+    } finally {
+      setSendingInvitationEmailId(null);
+    }
   };
 
   const handleRoleChange = async (
@@ -947,11 +1050,16 @@ export function ProjectDashboardOwnerActions({
                       sharingSummary={sharingSummary}
                       isMutatingMemberId={isMutatingMemberId}
                       isMutatingInvitationId={isMutatingInvitationId}
+                      sendingInvitationEmailId={sendingInvitationEmailId}
+                      invitationEmailDeliveries={invitationEmailDeliveries}
                       onRoleChange={(member, nextRole) =>
                         void handleRoleChange(member, nextRole)
                       }
                       onRemoveMember={(member) => void handleRemoveMember(member)}
                       onCopyInvitationLink={handleCopyInvitationLink}
+                      onSendInvitationEmail={(invitation) =>
+                        void handleSendInvitationEmail(invitation)
+                      }
                       onRevokeInvitation={(invitation) =>
                         void handleRevokeInvitation(invitation)
                       }

--- a/components/project-dashboard/project-dashboard-owner-sharing-panel.tsx
+++ b/components/project-dashboard/project-dashboard-owner-sharing-panel.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { UserAvatar } from "@/components/ui/user-avatar";
 
 import {
+  formatInvitationEmailDelivery,
   formatIdentity,
   type CollaboratorIdentitySummary,
   type GeneratedProjectInvitationLink,
@@ -61,6 +62,9 @@ export function ProjectDashboardOwnerSharingPanel({
     generatedInvitationLink?.invitation.invitedEmail === inviteEmailCandidate;
   const isGeneratedInvitationCopied =
     copiedInvitationId === generatedInvitationLink?.invitation.invitationId;
+  const generatedEmailDeliveryMessage = formatInvitationEmailDelivery(
+    generatedInvitationLink?.emailDelivery
+  );
 
   useEffect(() => {
     if (!copiedInvitationId) {
@@ -154,6 +158,11 @@ export function ProjectDashboardOwnerSharingPanel({
               <p className="text-xs text-muted-foreground">
                 Bound to {generatedInvitationLink.invitation.invitedEmail}.
               </p>
+              {generatedEmailDeliveryMessage ? (
+                <p className="text-xs text-muted-foreground">
+                  {generatedEmailDeliveryMessage}
+                </p>
+              ) : null}
               <div className="flex max-w-full items-center gap-2 md:max-w-[28rem]">
                 <input
                   readOnly

--- a/components/project-dashboard/project-dashboard-owner-sharing-panel.tsx
+++ b/components/project-dashboard/project-dashboard-owner-sharing-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Check, Copy, Search, UserPlus } from "lucide-react";
+import { Check, Copy, Mail, Search, UserPlus } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -65,6 +65,10 @@ export function ProjectDashboardOwnerSharingPanel({
   const generatedEmailDeliveryMessage = formatInvitationEmailDelivery(
     generatedInvitationLink?.emailDelivery
   );
+  const isGeneratedInvitationEmailSent =
+    generatedInvitationLink?.emailDelivery?.status === "sent";
+  const shouldShowGeneratedInvitationLinkFallback =
+    Boolean(generatedInvitationLink) && !isGeneratedInvitationEmailSent;
 
   useEffect(() => {
     if (!copiedInvitationId) {
@@ -150,41 +154,49 @@ export function ProjectDashboardOwnerSharingPanel({
           <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-border/60 bg-card p-3">
             <div className="min-w-0 flex-1 space-y-1.5">
               <div className="flex flex-wrap items-center gap-2">
-                <p className="text-sm font-medium">Invite link ready</p>
+                <p className="text-sm font-medium">
+                  {isGeneratedInvitationEmailSent
+                    ? "Invitation sent"
+                    : "Invitation ready"}
+                </p>
                 <Badge variant="secondary" className="capitalize">
                   {generatedInvitationLink.invitation.role}
                 </Badge>
               </div>
               <p className="text-xs text-muted-foreground">
-                Bound to {generatedInvitationLink.invitation.invitedEmail}.
+                {isGeneratedInvitationEmailSent
+                  ? `Sent to ${generatedInvitationLink.invitation.invitedEmail} with a link that expires in 24 hours.`
+                  : `Bound to ${generatedInvitationLink.invitation.invitedEmail}.`}
               </p>
               {generatedEmailDeliveryMessage ? (
                 <p className="text-xs text-muted-foreground">
                   {generatedEmailDeliveryMessage}
                 </p>
               ) : null}
-              <div className="flex max-w-full items-center gap-2 md:max-w-[28rem]">
-                <input
-                  readOnly
-                  value={generatedInvitationLink.url}
-                  aria-label={`Invite link for ${generatedInvitationLink.invitation.invitedEmail}`}
-                  className="h-9 min-w-0 flex-1 rounded-md border border-input bg-background px-2.5 text-xs text-muted-foreground outline-none sm:text-sm"
-                />
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="icon"
-                  aria-label={`Copy invite link for ${generatedInvitationLink.invitation.invitedEmail}`}
-                  className="h-9 w-9 shrink-0"
-                  onClick={() => void handleCopyGeneratedInvitationLink()}
-                >
-                  {isGeneratedInvitationCopied ? (
-                    <Check className="h-4 w-4" />
-                  ) : (
-                    <Copy className="h-4 w-4" />
-                  )}
-                </Button>
-              </div>
+              {shouldShowGeneratedInvitationLinkFallback ? (
+                <div className="flex max-w-full items-center gap-2 md:max-w-[28rem]">
+                  <input
+                    readOnly
+                    value={generatedInvitationLink.url}
+                    aria-label={`Invite link for ${generatedInvitationLink.invitation.invitedEmail}`}
+                    className="h-9 min-w-0 flex-1 rounded-md border border-input bg-background px-2.5 text-xs text-muted-foreground outline-none sm:text-sm"
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    aria-label={`Copy invite link for ${generatedInvitationLink.invitation.invitedEmail}`}
+                    className="h-9 w-9 shrink-0"
+                    onClick={() => void handleCopyGeneratedInvitationLink()}
+                  >
+                    {isGeneratedInvitationCopied ? (
+                      <Check className="h-4 w-4" />
+                    ) : (
+                      <Copy className="h-4 w-4" />
+                    )}
+                  </Button>
+                </div>
+              ) : null}
             </div>
           </div>
         ) : null}
@@ -194,7 +206,7 @@ export function ProjectDashboardOwnerSharingPanel({
             <div className="space-y-1">
               <p className="text-sm font-medium">{inviteEmailCandidate}</p>
               <p className="text-xs text-muted-foreground">
-                Create a link and share it when you are ready.
+                Send an invitation email with a 24-hour link.
               </p>
             </div>
             <Button
@@ -203,7 +215,14 @@ export function ProjectDashboardOwnerSharingPanel({
               onClick={() => onInviteByEmail(inviteEmailCandidate)}
               disabled={isInvitingUserId === inviteEmailCandidate}
             >
-              {isInvitingUserId === inviteEmailCandidate ? "Creating..." : "Create link"}
+              {isInvitingUserId === inviteEmailCandidate ? (
+                "Sending..."
+              ) : (
+                <>
+                  <Mail className="h-4 w-4" />
+                  Send invitation
+                </>
+              )}
             </Button>
           </div>
         ) : null}

--- a/docs/runbooks/vercel-env-contract-and-secrets.md
+++ b/docs/runbooks/vercel-env-contract-and-secrets.md
@@ -48,9 +48,12 @@ Delivery modes:
   only for explicit smoke tests or controlled diagnostics.
 
 TASK-125 records each delivery attempt in `OutboundEmailDelivery` before
-contacting the provider. The current foundation does not run background retry
-workers, bounce webhooks, suppression handling, or notification preferences;
-failed sends are recorded and returned to the caller synchronously.
+contacting the provider. TASK-104 routes project invitation email sends through
+that same foundation, using absolute invite URLs derived from the trusted app
+origin and preserving copy-link fallback behavior when delivery is skipped or
+fails. The current foundation does not run background retry workers, bounce
+webhooks, suppression handling, or notification preferences; failed sends are
+recorded and returned to the caller synchronously.
 
 If Google OAuth is enabled:
 

--- a/journal.md
+++ b/journal.md
@@ -12,6 +12,11 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ## Recent Entries (Most Relevant)
 
+### 2026-05-08
+- Type: Execution
+- Summary: TASK-104 follow-up made email-only project invites email-first in the owner UI.
+- Evidence: Updated the sharing composer to show `Send invitation` for unmatched email addresses, show an invitation-sent state without exposing the raw link after successful delivery, keep copy-link fallback only for failed/skipped delivery and pending invitations, and reword owner feedback away from link creation. Focused validation passed with `npm test -- tests/components/project-dashboard-owner-sharing-panel.test.tsx tests/components/project-dashboard-owner-access-panel.test.tsx` and `npm run lint`.
+
 ### 2026-05-07
 - Type: Execution
 - Summary: TASK-104 implemented app-managed project invitation email delivery.

--- a/journal.md
+++ b/journal.md
@@ -29,6 +29,11 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ### 2026-05-07
 - Type: Execution
+- Summary: TASK-104 follow-up changed project invitation expiry to 24 hours.
+- Evidence: Replaced the previous project invitation TTL constant with a 24-hour policy in `lib/services/project-collaboration-service.ts` and pinned service coverage to assert new invitations are created with `now + 24h`. Focused validation passed with `npm test -- tests/lib/project-collaboration-service.test.ts`.
+
+### 2026-05-07
+- Type: Execution
 - Summary: TASK-125 implemented the outbound email foundation with durable provider-aware delivery records.
 - Evidence: Added `OutboundEmailDelivery` schema/migration, `sendOutboundEmail`, typed auth/project-invitation/smoke template keys, Resend delivery-mode config through `lib/env.server.ts`, provider-safe structured logging, and refactored email verification/password reset sends onto the shared foundation while leaving owner-triggered invite email delivery for TASK-104.
 

--- a/journal.md
+++ b/journal.md
@@ -14,6 +14,16 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ### 2026-05-07
 - Type: Execution
+- Summary: TASK-104 implemented app-managed project invitation email delivery.
+- Evidence: Added trusted-origin invite email sending for owner-created invitations, a resend endpoint at `/api/projects/[projectId]/sharing/invitations/[invitationId]/email`, owner UI delivery feedback and resend controls, safe outbound metadata, and copy-link fallback preservation. Updated `lib/services/project-collaboration-service.ts`, sharing API routes, owner sharing/access panels, component/API/service tests, and the outbound email runbook.
+
+### 2026-05-07
+- Type: Validation
+- Summary: TASK-104 passed local validation and live invitation-email smoke testing.
+- Evidence: `npm ci`; `npx prisma generate`; local migration deploy against the existing `127.0.0.1:5432` PostgreSQL service; focused invite-email tests passed (5 files, 23 tests); `npm run lint`; local DB `NODE_ENV=test npm test` passed (105 files passed, 2 skipped; 778 tests passed, 2 skipped); local DB `NODE_ENV=test npm run test:coverage` passed with 91.23% statements, 81.2% branches, 93.42% functions, and 91.75% lines; production-guarded `OUTBOUND_EMAIL_DELIVERY_MODE=disabled npm run build` passed after an initial expected local build guard failure without `RESEND_API_KEY`; `npm run test:e2e` passed all 8 Playwright tests. Manual live smoke created local project `cmovu31nw0000swsz9nhd1q80`, invited `galo.guccy@gmail.com` as an email-only recipient and `dorian.agaesse@gmail.com` as a matched verified local account, and recorded two sent `project_invitation` outbound delivery rows with provider message ids present.
+
+### 2026-05-07
+- Type: Execution
 - Summary: TASK-125 implemented the outbound email foundation with durable provider-aware delivery records.
 - Evidence: Added `OutboundEmailDelivery` schema/migration, `sendOutboundEmail`, typed auth/project-invitation/smoke template keys, Resend delivery-mode config through `lib/env.server.ts`, provider-safe structured logging, and refactored email verification/password reset sends onto the shared foundation while leaving owner-triggered invite email delivery for TASK-104.
 

--- a/journal.md
+++ b/journal.md
@@ -23,6 +23,11 @@ Use it for important implementation milestones, blockers, validation runs, and r
 - Evidence: `npm ci`; `npx prisma generate`; local migration deploy against the existing `127.0.0.1:5432` PostgreSQL service; focused invite-email tests passed (5 files, 23 tests); `npm run lint`; local DB `NODE_ENV=test npm test` passed (105 files passed, 2 skipped; 778 tests passed, 2 skipped); local DB `NODE_ENV=test npm run test:coverage` passed with 91.23% statements, 81.2% branches, 93.42% functions, and 91.75% lines; production-guarded `OUTBOUND_EMAIL_DELIVERY_MODE=disabled npm run build` passed after an initial expected local build guard failure without `RESEND_API_KEY`; `npm run test:e2e` passed all 8 Playwright tests. Manual live smoke created local project `cmovu31nw0000swsz9nhd1q80`, invited `galo.guccy@gmail.com` as an email-only recipient and `dorian.agaesse@gmail.com` as a matched verified local account, and recorded two sent `project_invitation` outbound delivery rows with provider message ids present.
 
 ### 2026-05-07
+- Type: Governance
+- Summary: TASK-104 PR #245 passed required checks and Copilot review follow-up.
+- Evidence: PR #245 was opened from `feature/task-104-invite-email-delivery`. Copilot's three actionable threads were addressed in commit `49ea2e4` by validating invite URL origins, separating original inviter metadata from resend actor metadata, and restoring jsdom globals in roadmap component tests. Post-review focused validation passed with `npm test -- tests/lib/project-collaboration-service.test.ts tests/components/project-roadmap-panel.test.tsx`, `npm run lint`, and production-guarded `OUTBOUND_EMAIL_DELIVERY_MODE=disabled npm run build`; GitHub checks passed for `check-name`, `Quality Core`, `E2E Smoke`, and `Container Image`.
+
+### 2026-05-07
 - Type: Execution
 - Summary: TASK-125 implemented the outbound email foundation with durable provider-aware delivery records.
 - Evidence: Added `OutboundEmailDelivery` schema/migration, `sendOutboundEmail`, typed auth/project-invitation/smoke template keys, Resend delivery-mode config through `lib/env.server.ts`, provider-safe structured logging, and refactored email verification/password reset sends onto the shared foundation while leaving owner-triggered invite email delivery for TASK-104.

--- a/lib/services/project-collaboration-service.ts
+++ b/lib/services/project-collaboration-service.ts
@@ -323,11 +323,21 @@ function buildAbsoluteProjectInvitationUrl(
     return null;
   }
 
+  let safeOrigin: string;
   try {
-    return new URL(invitation.inviteLinkPath, appOrigin).toString();
+    const parsedOrigin = new URL(appOrigin);
+    if (
+      (parsedOrigin.protocol !== "http:" && parsedOrigin.protocol !== "https:") ||
+      parsedOrigin.origin === "null"
+    ) {
+      return null;
+    }
+    safeOrigin = parsedOrigin.origin;
   } catch {
     return null;
   }
+
+  return new URL(invitation.inviteLinkPath, safeOrigin).toString();
 }
 
 export function buildProjectInvitationReturnToPath(
@@ -517,6 +527,7 @@ function buildProjectInvitationSummary(input: {
 
 async function sendProjectInvitationEmail(input: {
   actorUserId: string;
+  invitedByUserId: string;
   appOrigin: string | null | undefined;
   invitation: ProjectInvitationSummary;
 }): Promise<ProjectInvitationEmailDeliverySummary> {
@@ -561,7 +572,8 @@ async function sendProjectInvitationEmail(input: {
     metadata: {
       invitationId: input.invitation.invitationId,
       projectId: input.invitation.projectId,
-      invitedByUserId: input.actorUserId,
+      invitedByUserId: input.invitedByUserId,
+      triggeredByUserId: input.actorUserId,
       role: input.invitation.role,
     },
   });
@@ -987,6 +999,7 @@ export async function inviteUserToProject(input: {
 
       return createSuccess(201, {
         invitation: invitationSummary,
+        invitedByUserId: invitation.invitedByUser.id,
       });
     } catch (error) {
       if (isUniqueConstraintError(error)) {
@@ -1003,6 +1016,7 @@ export async function inviteUserToProject(input: {
 
   const emailDelivery = await sendProjectInvitationEmail({
     actorUserId,
+    invitedByUserId: invitationResult.data.invitedByUserId,
     appOrigin: input.appOrigin,
     invitation: invitationResult.data.invitation,
   });
@@ -1101,6 +1115,7 @@ export async function sendProjectInvitationEmailForOwner(input: {
           matchedInvitees.get(normalizeInvitationEmail(invitation.invitedEmail)) ??
           null,
       }),
+      invitedByUserId: invitation.invitedByUser.id,
     });
   });
 
@@ -1110,6 +1125,7 @@ export async function sendProjectInvitationEmailForOwner(input: {
 
   const emailDelivery = await sendProjectInvitationEmail({
     actorUserId,
+    invitedByUserId: invitationResult.data.invitedByUserId,
     appOrigin: input.appOrigin,
     invitation: invitationResult.data.invitation,
   });

--- a/lib/services/project-collaboration-service.ts
+++ b/lib/services/project-collaboration-service.ts
@@ -18,7 +18,10 @@ import {
   createProjectInvitationNotification,
   resolveProjectInvitationNotifications,
 } from "@/lib/services/notification-service";
+import { sendOutboundEmail } from "@/lib/services/outbound-email-service";
+import { buildProjectInvitationEmail } from "@/lib/services/outbound-email-templates";
 import { withActorRlsContext, type DbClient } from "@/lib/services/rls-context";
+import { logServerWarning } from "@/lib/observability/logger";
 
 const PROJECT_INVITATION_TTL_DAYS = 14;
 const INVITABLE_USER_SEARCH_LIMIT = 8;
@@ -70,6 +73,22 @@ export interface ProjectInvitationSummary {
   createdAt: string;
   expiresAt: string;
   inviteLinkPath: string;
+}
+
+export type ProjectInvitationEmailDeliveryError =
+  | "invalid-recipient"
+  | "delivery-record-failed"
+  | "provider-unavailable"
+  | "provider-rejected"
+  | "invite-url-unavailable";
+
+export interface ProjectInvitationEmailDeliverySummary {
+  status: "sent" | "skipped" | "failed";
+  deliveryId: string | null;
+  provider: "resend";
+  providerMessageId: string | null;
+  providerStatus: number | null;
+  error: ProjectInvitationEmailDeliveryError | null;
 }
 
 export interface ProjectSharingSummary {
@@ -296,6 +315,21 @@ function buildProjectInvitationPath(invitationId: string): string {
   return `${PROJECT_INVITATION_PATH_PREFIX}/${encodeURIComponent(normalizedInvitationId)}`;
 }
 
+function buildAbsoluteProjectInvitationUrl(
+  appOrigin: string | null | undefined,
+  invitation: ProjectInvitationSummary
+): string | null {
+  if (typeof appOrigin !== "string" || !appOrigin.trim()) {
+    return null;
+  }
+
+  try {
+    return new URL(invitation.inviteLinkPath, appOrigin).toString();
+  } catch {
+    return null;
+  }
+}
+
 export function buildProjectInvitationReturnToPath(
   invitationId: string
 ): string {
@@ -479,6 +513,78 @@ function buildProjectInvitationSummary(input: {
     expiresAt: input.invitation.expiresAt.toISOString(),
     inviteLinkPath: buildProjectInvitationPath(invitationId),
   } satisfies ProjectInvitationSummary;
+}
+
+async function sendProjectInvitationEmail(input: {
+  actorUserId: string;
+  appOrigin: string | null | undefined;
+  invitation: ProjectInvitationSummary;
+}): Promise<ProjectInvitationEmailDeliverySummary> {
+  const inviteUrl = buildAbsoluteProjectInvitationUrl(
+    input.appOrigin,
+    input.invitation
+  );
+  if (!inviteUrl) {
+    logServerWarning(
+      "sendProjectInvitationEmail",
+      "Could not resolve an absolute project invitation URL for email delivery.",
+      {
+        invitationId: input.invitation.invitationId,
+        projectId: input.invitation.projectId,
+      }
+    );
+
+    return {
+      status: "failed",
+      deliveryId: null,
+      provider: "resend",
+      providerMessageId: null,
+      providerStatus: null,
+      error: "invite-url-unavailable",
+    };
+  }
+
+  const message = buildProjectInvitationEmail({
+    inviteUrl,
+    projectName: input.invitation.projectName,
+    invitedByDisplayName: input.invitation.invitedByDisplayName,
+    role: input.invitation.role,
+    expiresAt: new Date(input.invitation.expiresAt),
+  });
+
+  const result = await sendOutboundEmail({
+    templateKey: "project_invitation",
+    to: input.invitation.invitedEmail,
+    subject: message.subject,
+    text: message.text,
+    html: message.html,
+    metadata: {
+      invitationId: input.invitation.invitationId,
+      projectId: input.invitation.projectId,
+      invitedByUserId: input.actorUserId,
+      role: input.invitation.role,
+    },
+  });
+
+  if (!result.ok) {
+    return {
+      status: "failed",
+      deliveryId: result.deliveryId,
+      provider: result.provider,
+      providerMessageId: null,
+      providerStatus: result.providerStatus ?? null,
+      error: result.error,
+    };
+  }
+
+  return {
+    status: result.delivery,
+    deliveryId: result.deliveryId,
+    provider: result.provider,
+    providerMessageId: result.providerMessageId,
+    providerStatus: null,
+    error: null,
+  };
 }
 
 async function findInvitationById(
@@ -682,7 +788,13 @@ export async function inviteUserToProject(input: {
   projectId: string;
   invitedEmail: string;
   role: string;
-}): Promise<ServiceResult<{ invitation: ProjectInvitationSummary }>> {
+  appOrigin?: string | null;
+}): Promise<
+  ServiceResult<{
+    invitation: ProjectInvitationSummary;
+    emailDelivery: ProjectInvitationEmailDeliverySummary;
+  }>
+> {
   const actorUserId = normalizeActorUserId(input.actorUserId);
   const invitedEmail = normalizeInvitationEmail(input.invitedEmail);
   if (!actorUserId) {
@@ -700,7 +812,7 @@ export async function inviteUserToProject(input: {
 
   const now = new Date();
 
-  return withActorRlsContext(actorUserId, async (db) => {
+  const invitationResult = await withActorRlsContext(actorUserId, async (db) => {
     const access = await requireProjectRole({
       actorUserId,
       projectId: input.projectId,
@@ -883,6 +995,128 @@ export async function inviteUserToProject(input: {
 
       throw error;
     }
+  });
+
+  if (!invitationResult.ok) {
+    return invitationResult;
+  }
+
+  const emailDelivery = await sendProjectInvitationEmail({
+    actorUserId,
+    appOrigin: input.appOrigin,
+    invitation: invitationResult.data.invitation,
+  });
+
+  return createSuccess(invitationResult.status, {
+    invitation: invitationResult.data.invitation,
+    emailDelivery,
+  });
+}
+
+export async function sendProjectInvitationEmailForOwner(input: {
+  actorUserId: string;
+  projectId: string;
+  invitationId: string;
+  appOrigin?: string | null;
+}): Promise<
+  ServiceResult<{
+    invitation: ProjectInvitationSummary;
+    emailDelivery: ProjectInvitationEmailDeliverySummary;
+  }>
+> {
+  const actorUserId = normalizeActorUserId(input.actorUserId);
+  const invitationId = normalizeInvitationId(input.invitationId);
+  if (!actorUserId) {
+    return createError(401, "unauthorized");
+  }
+
+  if (!invitationId) {
+    return createError(400, "invitation-required");
+  }
+
+  const now = new Date();
+
+  const invitationResult = await withActorRlsContext(actorUserId, async (db) => {
+    const access = await requireProjectRole({
+      actorUserId,
+      projectId: input.projectId,
+      minimumRole: "owner",
+      db,
+    });
+    if (!access.ok) {
+      return createError(access.status, access.error);
+    }
+
+    const invitation = await db.projectInvitation.findUnique({
+      where: { id: invitationId },
+      select: {
+        id: true,
+        projectId: true,
+        invitedEmail: true,
+        role: true,
+        createdAt: true,
+        expiresAt: true,
+        acceptedAt: true,
+        revokedAt: true,
+        replacedAt: true,
+        project: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+        invitedByUser: {
+          select: {
+            id: true,
+            email: true,
+            name: true,
+            username: true,
+            usernameDiscriminator: true,
+          },
+        },
+      },
+    });
+
+    if (!invitation || invitation.projectId !== input.projectId) {
+      return createError(404, "invitation-not-found");
+    }
+
+    if (
+      invitation.acceptedAt ||
+      invitation.revokedAt ||
+      invitation.replacedAt ||
+      invitation.expiresAt.getTime() <= now.getTime()
+    ) {
+      return createError(409, "invitation-not-active");
+    }
+
+    const matchedInvitees = await getVerifiedUsersByEmail(db, [
+      invitation.invitedEmail,
+    ]);
+    return createSuccess(200, {
+      invitation: buildProjectInvitationSummary({
+        invitation,
+        invitedBy: invitation.invitedByUser,
+        matchedInvitee:
+          matchedInvitees.get(normalizeInvitationEmail(invitation.invitedEmail)) ??
+          null,
+      }),
+    });
+  });
+
+  if (!invitationResult.ok) {
+    return invitationResult;
+  }
+
+  const emailDelivery = await sendProjectInvitationEmail({
+    actorUserId,
+    appOrigin: input.appOrigin,
+    invitation: invitationResult.data.invitation,
+  });
+
+  return createSuccess(200, {
+    invitation: invitationResult.data.invitation,
+    emailDelivery,
   });
 }
 

--- a/lib/services/project-collaboration-service.ts
+++ b/lib/services/project-collaboration-service.ts
@@ -23,7 +23,7 @@ import { buildProjectInvitationEmail } from "@/lib/services/outbound-email-templ
 import { withActorRlsContext, type DbClient } from "@/lib/services/rls-context";
 import { logServerWarning } from "@/lib/observability/logger";
 
-const PROJECT_INVITATION_TTL_DAYS = 14;
+const PROJECT_INVITATION_TTL_HOURS = 24;
 const INVITABLE_USER_SEARCH_LIMIT = 8;
 const PROJECT_INVITATION_PATH_PREFIX = "/invite/project";
 
@@ -306,7 +306,7 @@ function buildIdentitySummary(input: {
 
 function buildInvitationExpiry(): Date {
   return new Date(
-    Date.now() + PROJECT_INVITATION_TTL_DAYS * 24 * 60 * 60 * 1000
+    Date.now() + PROJECT_INVITATION_TTL_HOURS * 60 * 60 * 1000
   );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,6 @@
     "": {
       "name": "nexusdash",
       "version": "0.1.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24.0.0",
-        "npm": ">=10"
-      },
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1041.0",
         "@aws-sdk/s3-request-presigner": "^3.1041.0",
@@ -48,6 +44,10 @@
         "tailwindcss": "^4.2.2",
         "typescript": "^6.0.3",
         "vitest": "^4.1.5"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0",
+        "npm": ">=10"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1104,7 +1104,7 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1112,7 +1112,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1140,7 +1140,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -1191,7 +1191,7 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -4161,7 +4161,7 @@
     },
     "node_modules/@types/react-dom": {
       "version": "19.2.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -8088,7 +8088,7 @@
     },
     "node_modules/magicast": {
       "version": "0.5.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -8781,6 +8781,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -4,11 +4,6 @@ Use this file to capture tasks discovered during development. Each entry should 
 
 ## Pending
 ### Execution Queue (Now / Next)
-- ID: TASK-104
-  Title: Invite email delivery - app-managed sending for project collaboration invites
-  Status: Pending (promoted after TASK-125 merged via PR #243)
-  Rationale: Add first-party email sending for collaboration invites so owners can trigger invite delivery directly from the app, building on the reusable outbound-email foundation instead of coupling provider/deliverability concerns into the project-sharing service.
-  Dependencies: TASK-103, TASK-083, TASK-125
 - ID: TASK-225
   Title: Project notification email digests - grouped, rate-limited outbound summaries
   Status: Pending (promoted after TASK-125 merged via PR #243)
@@ -129,6 +124,11 @@ Use this file to capture tasks discovered during development. Each entry should 
   Dependencies: TASK-051
 
 ## Completed
+- ID: TASK-104
+  Title: Invite email delivery - app-managed sending for project collaboration invites
+  Status: Done (2026-05-07, PR #245 open)
+  Rationale: Added app-managed project invitation email delivery on top of the reusable outbound email foundation, with owner-visible delivery feedback, active-invitation resend, copy-link fallback preservation, safe outbound metadata, trusted-origin invite URLs, live smoke validation for email-only and matched-account recipients, green PR checks, and resolved Copilot feedback.
+  Dependencies: TASK-103, TASK-083, TASK-125
 - ID: TASK-125
   Title: Outbound email foundation - reusable app-owned email delivery for invites and future notifications
   Status: Done (2026-05-07, merged via PR #243)

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -125,6 +125,9 @@ and outbound-email observability foundation.
 - PR #245 required checks passed on 2026-05-07: `check-name`,
   `Quality Core (lint, test, coverage, build)`, `E2E Smoke (Playwright)`, and
   `Container Image (build + metadata artifact)`.
+- Follow-up requested on 2026-05-07 changed project invitation expiry to 24
+  hours. Focused validation passed:
+  `npm test -- tests/lib/project-collaboration-service.test.ts`.
 
 ## Out Of Scope
 - Background retry workers, bounce webhooks, suppression lists, digesting, and

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,108 +1,124 @@
-# Current Task: TASK-125 Outbound Email Foundation
+# Current Task: TASK-104 Invite Email Delivery
 
 ## Task ID
-TASK-125
+TASK-104
 
 ## Status
-Complete on `feature/task-125-outbound-email-foundation`; PR #243 is open,
-Copilot review threads are resolved, and required checks are green.
+Implemented locally on `feature/task-104-invite-email-delivery`; PR workflow
+pending.
 
 ## Objective
-Establish a reusable NexusDash-owned outbound email foundation so transactional
-emails can be sent through one provider-aware service with explicit sender
-identity, template identity, durable delivery observability, and consistent
-failure handling.
+Add app-managed email delivery for project collaboration invitations so project
+owners can send invite links directly from NexusDash while preserving the
+identity-bound invite model, copy-link fallback, notification-center behavior,
+and outbound-email observability foundation.
+
+## Context
+- TASK-103 shipped email-bound project invitations whose links are delivery
+  mechanisms only; acceptance still requires a verified signed-in account whose
+  email matches the invited address.
+- TASK-123 sends in-app notifications for verified invitees.
+- TASK-125 shipped `sendOutboundEmail`, durable `OutboundEmailDelivery` records,
+  delivery modes, and `buildProjectInvitationEmail`.
+- Current owner UI creates/copies invite links, but does not send email.
 
 ## Scope
-- Keep Resend as the outbound email provider because the existing
-  verification/password-reset path already uses `RESEND_API_KEY` and
-  `RESEND_FROM_EMAIL`.
-- Replace the current narrow transactional email helper with an
-  app-owned outbound email service that records each delivery attempt.
-- Track provider, sender, recipient, template key, subject, status, provider
-  response id/status, error code/message, timestamps, and safe metadata in the
-  database.
-- Refactor email verification and password reset sends to use the shared
-  foundation without changing their token security or user-facing flows.
-- Add a future-ready project invitation template contract without enabling
-  owner-triggered invite email delivery yet.
-- Document provider/env behavior and the explicit no-background-retry decision.
-- Run a live email smoke to `dorian.agaesse@gmail.com` if a usable Resend API
-  key is locally available, without committing or logging secrets.
+- Send project invitation emails through the shared outbound email foundation
+  using the `project_invitation` template key.
+- Resolve absolute invite URLs from the trusted request origin in the API route,
+  then keep email composition and delivery inside service-layer code.
+- Keep invitation creation authoritative in the collaboration service:
+  successful, skipped, or failed email delivery must not make the invite link an
+  anonymous bearer token or weaken email-bound acceptance.
+- Preserve copyable invite links as a fallback for every pending invitation.
+- Add owner-visible delivery feedback for newly created invites and pending
+  invite resend attempts, including skipped/failed states in development,
+  preview, disabled, or provider-failure cases.
+- Add a resend path for active pending invitations so owners can trigger email
+  delivery again without creating a replacement invite.
+- Record safe delivery metadata that ties outbound records to invitation,
+  project, role, and actor identifiers without storing secrets or raw provider
+  payloads.
+- Update docs/runbooks only where behavior or env expectations change.
 
 ## Acceptance Criteria
-1. `tasks/current.md` records TASK-125 scope, acceptance criteria, definition
-   of done, and validation evidence.
-2. Outbound email delivery has a single service entry point with typed template
-   keys and provider configuration resolved through `lib/env.server.ts`.
-3. Delivery attempts are durably recorded in Prisma/PostgreSQL with sent,
-   skipped, and failed outcomes.
-4. Email verification and password reset flows continue to create and clean up
-   tokens correctly when delivery succeeds, is skipped, or fails.
-5. The foundation includes a project-invitation template shape for TASK-104 but
-   does not add app-managed invite sending UX/API behavior.
-6. Provider failures return consistent typed errors and structured logs without
-   exposing secrets.
-7. Focused Vitest coverage exercises provider config, skipped delivery,
-   successful Resend delivery, provider rejection, delivery-record updates, and
-   auth email service integration.
-8. Docs/env examples describe the outbound email provider, sender identity, and
-   current retry/preview behavior.
-9. `journal.md` records implementation decisions and validation evidence.
-10. `tasks/backlog.md` marks TASK-125 complete only after implementation,
-    validation, PR checks, and Copilot review are handled.
+1. `tasks/current.md` records TASK-104 scope, acceptance criteria, definition of
+   done, and validation evidence.
+2. Owner-created project invites trigger app-managed invitation email delivery
+   through `sendOutboundEmail` when delivery mode permits, and record sent,
+   skipped, or failed outcomes in `OutboundEmailDelivery`.
+3. Owners can resend email for active pending invitations from the project
+   contributors/sharing surface without replacing the invitation link.
+4. Email delivery failure is visible to the owner, logged safely, and does not
+   silently revoke, accept, replace, or otherwise mutate the underlying invite.
+5. Invite emails use absolute trusted-origin URLs, sanitized project/inviter
+   fields, role-aware copy, and the existing expiration timestamp.
+6. Existing in-app notification behavior for verified invitees remains intact
+   and is not duplicated into a second notification system.
+7. Direct email-only invites and verified-user invites both keep copy-link
+   fallback behavior.
+8. API/service contracts stay thin and layered: Prisma access remains in
+   `lib/services/**`, provider access stays in the outbound email service, and
+   routes only parse request data, resolve request context, call services, and
+   map responses.
+9. Focused Vitest coverage exercises create-send success, skipped delivery,
+   provider failure, resend success/failure, inactive-invite resend rejection,
+   route payload/context forwarding, and relevant owner UI rendering states.
+10. `journal.md` records implementation decisions and validation evidence before
+    handoff.
 
 ## Definition Of Done
-- TASK-125 uses the dedicated branch/worktree required by `agent.md`.
-- The implementation keeps persistence inside `lib/services/**` and avoids
-  leaking secrets into logs, tests, docs, or commits.
+- TASK-104 uses the dedicated branch required by `agent.md`.
+- The implementation preserves TASK-103's verified-email acceptance boundary and
+  TASK-125's outbound email delivery-mode semantics.
 - Local validation passes: `npm run lint`, `npm test`,
   `npm run test:coverage`, and `npm run build`.
-- A live email smoke to `dorian.agaesse@gmail.com` is attempted and the result
-  is recorded without exposing credentials.
+- UI-affecting sharing changes are covered by focused component/API tests; run
+  `npm run test:e2e` if the implemented interaction requires browser-level
+  verification beyond static/component coverage.
+- A live invitation-email smoke is attempted only if a usable Resend API key and
+  safe recipient are locally available; otherwise the skipped/failure path is
+  documented in validation evidence without exposing secrets.
 - The branch is pushed, a PR is opened, required checks are green, and Copilot
   review feedback is addressed or explicitly resolved.
 
 ## Validation Evidence
-- `npx prisma generate` passed on 2026-05-07 after installing worktree
-  dependencies with `npm ci`.
+- `npm ci` passed on 2026-05-07 in the TASK-104 worktree.
+- `npx prisma generate` passed on 2026-05-07.
+- `npm run db:local:up` could not bind worktree Postgres to `5432` because an
+  existing NexusDash local PostgreSQL service already owned the port; the failed
+  task104 Compose container was removed with `docker compose down`.
+- `npm run db:migrate` passed on 2026-05-07 against
+  `postgresql://postgres:postgres@127.0.0.1:5432/nexusdash?schema=public` with
+  no pending migrations.
 - Focused validation passed on 2026-05-07:
-  `npm test -- --run tests/lib/outbound-email-service.test.ts tests/lib/email-verification-service.test.ts tests/lib/password-reset-service.test.ts tests/lib/env.server.test.ts`
-  with 90 tests passing.
+  `npm test -- tests/components/project-dashboard-owner-sharing-panel.test.tsx tests/components/project-dashboard-owner-access-panel.test.tsx tests/lib/project-collaboration-service.test.ts tests/api/project-sharing.route.test.ts tests/api/project-sharing-invitation-email.route.test.ts`
+  with 5 files and 23 tests passing.
 - `npm run lint` passed on 2026-05-07.
-- `npm test` passed on 2026-05-07 with local DB env and `NODE_ENV=test`: 98
-  files passed, 2 skipped; 758 tests passed, 2 skipped.
-- `npm run test:coverage` passed on 2026-05-07 with 91.23% statements, 81.2%
-  branches, 93.42% functions, and 91.75% lines.
-- `npm run build` passed on 2026-05-07 with local PostgreSQL env and
-  production guard variables.
-- Live outbound email smoke passed on 2026-05-07:
-  `RUN_OUTBOUND_EMAIL_SMOKE=1 OUTBOUND_EMAIL_DELIVERY_MODE=live OUTBOUND_EMAIL_SMOKE_TO=dorian.agaesse@gmail.com npm test -- --run tests/lib/outbound-email-service.live.test.ts`.
-- `npm run test:e2e` first failed because production-mode password recovery had
-  no trusted local request origin; rerunning with
-  `TRUSTED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000` passed on
-  2026-05-07 with all 8 Playwright tests passing.
-- Copilot review on PR #243 produced three comments; follow-up commit
-  `925af2a` sanitized project-invitation subject/plain-text fields, made
-  failed-delivery status updates non-throwing, and changed omitted metadata to
-  SQL NULL via `Prisma.DbNull`.
-- Post-Copilot local validation passed on 2026-05-07:
-  `npm test -- --run tests/lib/outbound-email-service.test.ts tests/lib/outbound-email-templates.test.ts`,
-  `npm run lint`, local DB `NODE_ENV=test npm test`, local DB
-  `NODE_ENV=test npm run test:coverage`, and production-guarded
-  `npm run build`.
-- PR #243 checks passed on 2026-05-07 after the Copilot follow-up:
-  `check-name`, `Quality Core (lint, test, coverage, build)`,
-  `E2E Smoke (Playwright)`, and `Container Image (build + metadata artifact)`.
-- All three Copilot review threads were replied to and resolved on PR #243.
-- Local database note: the task worktree's Compose Postgres could not bind
-  port `5432` because `nexus_dash_issue214_codex-postgres-1` was already
-  running there. Validation used that reachable local PostgreSQL service and
-  applied the TASK-125 migration successfully.
+- Full local DB `NODE_ENV=test npm test` passed on 2026-05-07 with 105 files
+  passed, 2 skipped; 778 tests passed, 2 skipped.
+- Full local DB `NODE_ENV=test npm run test:coverage` passed on 2026-05-07
+  with 91.23% statements, 81.2% branches, 93.42% functions, and 91.75% lines.
+- A first `npm run build` attempt failed because non-Vercel production build
+  validation treated outbound email `auto` as live and no local
+  `RESEND_API_KEY` was intentionally exposed to the build command.
+- Production-guarded `OUTBOUND_EMAIL_DELIVERY_MODE=disabled npm run build`
+  passed on 2026-05-07 with local PostgreSQL, trusted localhost origins, and a
+  local agent token signing secret.
+- `npm run test:e2e` passed on 2026-05-07 with local PostgreSQL,
+  `OUTBOUND_EMAIL_DELIVERY_MODE=disabled`, trusted localhost origins, and all 8
+  Playwright tests passing.
+- Manual live invite smoke passed on 2026-05-07 against the local app:
+  created project `cmovu31nw0000swsz9nhd1q80`, invited
+  `galo.guccy@gmail.com` as an email-only recipient and
+  `dorian.agaesse@gmail.com` as a matched verified local account, and recorded
+  two `project_invitation` outbound delivery rows with `sent` status and
+  provider message ids present.
 
 ## Out Of Scope
-- Owner-facing project invite email delivery; this remains TASK-104.
-- Background workers, automatic retry queues, bounce webhooks, suppression
-  lists, and notification-preference UI.
-- Changing auth token TTLs, verification/reset copy beyond shared template
-  plumbing, or widening agent/API scopes.
+- Background retry workers, bounce webhooks, suppression lists, digesting, and
+  notification preference UI.
+- Changing invite token/identity semantics or allowing anonymous link claiming.
+- App-managed outbound email for notification digests or due-date reminders;
+  those remain TASK-225 and TASK-226.
+- Calendar, attachment, and agent API scope changes.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,8 +4,8 @@
 TASK-104
 
 ## Status
-Implemented locally on `feature/task-104-invite-email-delivery`; PR workflow
-pending.
+Complete on `feature/task-104-invite-email-delivery`; PR #245 is open with
+required checks green and Copilot review feedback resolved.
 
 ## Objective
 Add app-managed email delivery for project collaboration invitations so project
@@ -114,6 +114,17 @@ and outbound-email observability foundation.
   `dorian.agaesse@gmail.com` as a matched verified local account, and recorded
   two `project_invitation` outbound delivery rows with `sent` status and
   provider message ids present.
+- PR #245 was opened ready for review on 2026-05-07. Copilot's three
+  actionable review threads were addressed in commit `49ea2e4` by validating
+  invite URL origins, separating original inviter metadata from resend actor
+  metadata, and restoring jsdom globals in roadmap component tests.
+- Post-review focused validation passed on 2026-05-07:
+  `npm test -- tests/lib/project-collaboration-service.test.ts tests/components/project-roadmap-panel.test.tsx`,
+  `npm run lint`, and production-guarded
+  `OUTBOUND_EMAIL_DELIVERY_MODE=disabled npm run build`.
+- PR #245 required checks passed on 2026-05-07: `check-name`,
+  `Quality Core (lint, test, coverage, build)`, `E2E Smoke (Playwright)`, and
+  `Container Image (build + metadata artifact)`.
 
 ## Out Of Scope
 - Background retry workers, bounce webhooks, suppression lists, digesting, and

--- a/tests/api/project-sharing-invitation-email.route.test.ts
+++ b/tests/api/project-sharing-invitation-email.route.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const apiGuardMock = vi.hoisted(() => ({
+  requireAuthenticatedApiUser: vi.fn(),
+}));
+
+const collaborationServiceMock = vi.hoisted(() => ({
+  sendProjectInvitationEmailForOwner: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/api-guard", () => ({
+  requireAuthenticatedApiUser: apiGuardMock.requireAuthenticatedApiUser,
+}));
+
+vi.mock("@/lib/services/project-collaboration-service", () => ({
+  sendProjectInvitationEmailForOwner:
+    collaborationServiceMock.sendProjectInvitationEmailForOwner,
+}));
+
+import { POST } from "@/app/api/projects/[projectId]/sharing/invitations/[invitationId]/email/route";
+
+async function readJson(response: Response): Promise<Record<string, unknown>> {
+  return (await response.json()) as Record<string, unknown>;
+}
+
+describe("project sharing invitation email route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiGuardMock.requireAuthenticatedApiUser.mockResolvedValue({
+      ok: true,
+      userId: "user-1",
+    });
+  });
+
+  test("returns auth failure response when request is unauthenticated", async () => {
+    apiGuardMock.requireAuthenticatedApiUser.mockResolvedValueOnce({
+      ok: false,
+      response: NextResponse.json({ error: "unauthorized" }, { status: 401 }),
+    });
+
+    const response = await POST(
+      new NextRequest(
+        "http://localhost/api/projects/project-1/sharing/invitations/invite-1/email",
+        { method: "POST" }
+      ),
+      { params: { projectId: "project-1", invitationId: "invite-1" } }
+    );
+
+    expect(response.status).toBe(401);
+    await expect(readJson(response)).resolves.toEqual({ error: "unauthorized" });
+    expect(
+      collaborationServiceMock.sendProjectInvitationEmailForOwner
+    ).not.toHaveBeenCalled();
+  });
+
+  test("forwards resend context to the collaboration service", async () => {
+    collaborationServiceMock.sendProjectInvitationEmailForOwner.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: {
+        invitation: {
+          invitationId: "invite-1",
+        },
+        emailDelivery: {
+          status: "sent",
+          deliveryId: "delivery-1",
+          provider: "resend",
+          providerMessageId: "provider-1",
+          providerStatus: null,
+          error: null,
+        },
+      },
+    });
+
+    const response = await POST(
+      new NextRequest(
+        "http://localhost/api/projects/project-1/sharing/invitations/invite-1/email",
+        {
+          method: "POST",
+        }
+      ),
+      { params: { projectId: "project-1", invitationId: "invite-1" } }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(readJson(response)).resolves.toEqual({
+      invitation: {
+        invitationId: "invite-1",
+      },
+      emailDelivery: {
+        status: "sent",
+        deliveryId: "delivery-1",
+        provider: "resend",
+        providerMessageId: "provider-1",
+        providerStatus: null,
+        error: null,
+      },
+    });
+    expect(
+      collaborationServiceMock.sendProjectInvitationEmailForOwner
+    ).toHaveBeenCalledWith({
+      actorUserId: "user-1",
+      projectId: "project-1",
+      invitationId: "invite-1",
+      appOrigin: "http://localhost:3000",
+    });
+  });
+
+  test("maps service errors to JSON errors", async () => {
+    collaborationServiceMock.sendProjectInvitationEmailForOwner.mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      error: "invitation-not-active",
+    });
+
+    const response = await POST(
+      new NextRequest(
+        "http://localhost/api/projects/project-1/sharing/invitations/invite-1/email",
+        {
+          method: "POST",
+        }
+      ),
+      { params: { projectId: "project-1", invitationId: "invite-1" } }
+    );
+
+    expect(response.status).toBe(409);
+    await expect(readJson(response)).resolves.toEqual({
+      error: "invitation-not-active",
+    });
+  });
+});

--- a/tests/api/project-sharing.route.test.ts
+++ b/tests/api/project-sharing.route.test.ts
@@ -133,6 +133,7 @@ describe("project sharing route", () => {
       projectId: "project-1",
       invitedEmail: "user2@example.com",
       role: "viewer",
+      appOrigin: "http://localhost:3000",
     });
   });
 });

--- a/tests/components/project-dashboard-owner-access-panel.test.tsx
+++ b/tests/components/project-dashboard-owner-access-panel.test.tsx
@@ -31,9 +31,12 @@ describe("project-dashboard-owner-access-panel", () => {
         },
         isMutatingMemberId: null,
         isMutatingInvitationId: null,
+        sendingInvitationEmailId: null,
+        invitationEmailDeliveries: {},
         onRoleChange: () => {},
         onRemoveMember: () => {},
         onCopyInvitationLink: () => true,
+        onSendInvitationEmail: () => {},
         onRevokeInvitation: () => {},
       })
     );
@@ -73,9 +76,21 @@ describe("project-dashboard-owner-access-panel", () => {
         },
         isMutatingMemberId: null,
         isMutatingInvitationId: null,
+        sendingInvitationEmailId: null,
+        invitationEmailDeliveries: {
+          "invite-1": {
+            status: "failed",
+            deliveryId: "delivery-1",
+            provider: "resend",
+            providerMessageId: null,
+            providerStatus: null,
+            error: "provider-unavailable",
+          },
+        },
         onRoleChange: () => {},
         onRemoveMember: () => {},
         onCopyInvitationLink: () => true,
+        onSendInvitationEmail: () => {},
         onRevokeInvitation: () => {},
       })
     );
@@ -84,6 +99,8 @@ describe("project-dashboard-owner-access-panel", () => {
     expect(result).toContain("Pending");
     expect(result).toContain('aria-label="Invite link for person@example.com"');
     expect(result).toContain('aria-label="Copy invite link for person@example.com"');
+    expect(result).toContain("Resend email");
+    expect(result).toContain("Email provider unavailable.");
     expect(result).toContain("/invite/project/invite-1");
   });
 });

--- a/tests/components/project-dashboard-owner-access-panel.test.tsx
+++ b/tests/components/project-dashboard-owner-access-panel.test.tsx
@@ -47,7 +47,7 @@ describe("project-dashboard-owner-access-panel", () => {
     expect(result).toContain("data:image/svg+xml");
   });
 
-  test("renders the inline copy control for pending email invitations", () => {
+  test("renders email resend and copy fallback for pending email invitations", () => {
     const result = renderToStaticMarkup(
       React.createElement(ProjectDashboardOwnerAccessPanel, {
         isLoadingSharing: false,
@@ -97,10 +97,10 @@ describe("project-dashboard-owner-access-panel", () => {
 
     expect(result).toContain("Contributors");
     expect(result).toContain("Pending");
-    expect(result).toContain('aria-label="Invite link for person@example.com"');
-    expect(result).toContain('aria-label="Copy invite link for person@example.com"');
+    expect(result).toContain("Copy link");
     expect(result).toContain("Resend email");
     expect(result).toContain("Email provider unavailable.");
-    expect(result).toContain("/invite/project/invite-1");
+    expect(result).not.toContain('aria-label="Invite link for person@example.com"');
+    expect(result).not.toContain("/invite/project/invite-1");
   });
 });

--- a/tests/components/project-dashboard-owner-sharing-panel.test.tsx
+++ b/tests/components/project-dashboard-owner-sharing-panel.test.tsx
@@ -28,11 +28,19 @@ describe("project-dashboard-owner-sharing-panel", () => {
             invitedByEmail: "owner@example.com",
             role: "editor",
             createdAt: "2026-03-25T10:00:00.000Z",
-            expiresAt: "2026-04-08T10:00:00.000Z",
-            inviteLinkPath: "/invite/project/invite-1",
-          },
-          url: "https://nexusdash.test/invite/project/invite-1",
+          expiresAt: "2026-04-08T10:00:00.000Z",
+          inviteLinkPath: "/invite/project/invite-1",
         },
+        url: "https://nexusdash.test/invite/project/invite-1",
+        emailDelivery: {
+          status: "sent",
+          deliveryId: "delivery-1",
+          provider: "resend",
+          providerMessageId: "provider-1",
+          providerStatus: null,
+          error: null,
+        },
+      },
         isSearchingUsers: false,
         isInvitingUserId: null,
         searchMessage: null,
@@ -47,6 +55,7 @@ describe("project-dashboard-owner-sharing-panel", () => {
     expect(result).toContain("Share access");
     expect(result).toContain("Invite link ready");
     expect(result).toContain("Bound to person@example.com.");
+    expect(result).toContain("Invitation email sent.");
     expect(result).toContain("https://nexusdash.test/invite/project/invite-1");
     expect(result).toContain('aria-label="Copy invite link for person@example.com"');
   });

--- a/tests/components/project-dashboard-owner-sharing-panel.test.tsx
+++ b/tests/components/project-dashboard-owner-sharing-panel.test.tsx
@@ -7,7 +7,7 @@ import { ProjectDashboardOwnerSharingPanel } from "@/components/project-dashboar
 (globalThis as { React?: typeof React }).React = React;
 
 describe("project-dashboard-owner-sharing-panel", () => {
-  test("renders an inline generated-link state for direct email invites", () => {
+  test("renders an invitation-sent state for direct email invites", () => {
     const result = renderToStaticMarkup(
       React.createElement(ProjectDashboardOwnerSharingPanel, {
         inviteQuery: "person@example.com",
@@ -28,19 +28,19 @@ describe("project-dashboard-owner-sharing-panel", () => {
             invitedByEmail: "owner@example.com",
             role: "editor",
             createdAt: "2026-03-25T10:00:00.000Z",
-          expiresAt: "2026-04-08T10:00:00.000Z",
-          inviteLinkPath: "/invite/project/invite-1",
+            expiresAt: "2026-04-08T10:00:00.000Z",
+            inviteLinkPath: "/invite/project/invite-1",
+          },
+          url: "https://nexusdash.test/invite/project/invite-1",
+          emailDelivery: {
+            status: "sent",
+            deliveryId: "delivery-1",
+            provider: "resend",
+            providerMessageId: "provider-1",
+            providerStatus: null,
+            error: null,
+          },
         },
-        url: "https://nexusdash.test/invite/project/invite-1",
-        emailDelivery: {
-          status: "sent",
-          deliveryId: "delivery-1",
-          provider: "resend",
-          providerMessageId: "provider-1",
-          providerStatus: null,
-          error: null,
-        },
-      },
         isSearchingUsers: false,
         isInvitingUserId: null,
         searchMessage: null,
@@ -53,11 +53,92 @@ describe("project-dashboard-owner-sharing-panel", () => {
     );
 
     expect(result).toContain("Share access");
-    expect(result).toContain("Invite link ready");
-    expect(result).toContain("Bound to person@example.com.");
+    expect(result).toContain("Invitation sent");
+    expect(result).toContain(
+      "Sent to person@example.com with a link that expires in 24 hours."
+    );
     expect(result).toContain("Invitation email sent.");
+    expect(result).not.toContain("https://nexusdash.test/invite/project/invite-1");
+    expect(result).not.toContain(
+      'aria-label="Copy invite link for person@example.com"'
+    );
+  });
+
+  test("keeps copy-link fallback visible when direct email delivery fails", () => {
+    const result = renderToStaticMarkup(
+      React.createElement(ProjectDashboardOwnerSharingPanel, {
+        inviteQuery: "person@example.com",
+        inviteEmailCandidate: "person@example.com",
+        inviteRole: "editor",
+        inviteResults: [],
+        generatedInvitationLink: {
+          invitation: {
+            invitationId: "invite-1",
+            projectId: "project-1",
+            projectName: "Project One",
+            invitedEmail: "person@example.com",
+            invitedUserId: null,
+            invitedUserDisplayName: null,
+            invitedUserUsernameTag: null,
+            invitedByDisplayName: "Owner",
+            invitedByUsernameTag: "owner#1234",
+            invitedByEmail: "owner@example.com",
+            role: "editor",
+            createdAt: "2026-03-25T10:00:00.000Z",
+            expiresAt: "2026-04-08T10:00:00.000Z",
+            inviteLinkPath: "/invite/project/invite-1",
+          },
+          url: "https://nexusdash.test/invite/project/invite-1",
+          emailDelivery: {
+            status: "failed",
+            deliveryId: "delivery-1",
+            provider: "resend",
+            providerMessageId: null,
+            providerStatus: null,
+            error: "provider-unavailable",
+          },
+        },
+        isSearchingUsers: false,
+        isInvitingUserId: null,
+        searchMessage: null,
+        onInviteQueryChange: () => {},
+        onInviteRoleChange: () => {},
+        onInviteByEmail: () => {},
+        onInvite: () => {},
+        onCopyInvitationLink: () => true,
+      })
+    );
+
+    expect(result).toContain("Invitation ready");
+    expect(result).toContain("Bound to person@example.com.");
+    expect(result).toContain("Email provider unavailable.");
     expect(result).toContain("https://nexusdash.test/invite/project/invite-1");
     expect(result).toContain('aria-label="Copy invite link for person@example.com"');
+  });
+
+  test("renders a send-invitation CTA for email addresses without an account match", () => {
+    const result = renderToStaticMarkup(
+      React.createElement(ProjectDashboardOwnerSharingPanel, {
+        inviteQuery: "newperson@example.com",
+        inviteEmailCandidate: "newperson@example.com",
+        inviteRole: "editor",
+        inviteResults: [],
+        generatedInvitationLink: null,
+        isSearchingUsers: false,
+        isInvitingUserId: null,
+        searchMessage: "No verified account found yet. Send an invitation below.",
+        onInviteQueryChange: () => {},
+        onInviteRoleChange: () => {},
+        onInviteByEmail: () => {},
+        onInvite: () => {},
+        onCopyInvitationLink: () => true,
+      })
+    );
+
+    expect(result).toContain("newperson@example.com");
+    expect(result).toContain("Send an invitation email with a 24-hour link.");
+    expect(result).toContain("Send invitation");
+    expect(result).not.toContain("Create link");
   });
 
   test("hides the raw email create-link row when a verified user matches exactly", () => {
@@ -89,6 +170,7 @@ describe("project-dashboard-owner-sharing-panel", () => {
 
     expect(result).toContain("Person Example");
     expect(result).not.toContain("Create link");
+    expect(result).not.toContain("Send invitation");
     expect(result).not.toContain("Press Enter or click below");
   });
 });

--- a/tests/components/project-roadmap-panel.test.tsx
+++ b/tests/components/project-roadmap-panel.test.tsx
@@ -33,13 +33,10 @@ vi.mock("@/lib/hooks/use-project-section-expanded", () => ({
 import { ProjectRoadmapPanel } from "@/components/project-roadmap-panel";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-vi.stubGlobal("fetch", fetchMock);
-
 function installMatchMediaMock(matches = true) {
-  Object.defineProperty(window, "matchMedia", {
-    configurable: true,
-    writable: true,
-    value: vi.fn().mockImplementation((query: string) => ({
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockImplementation((query: string) => ({
       matches,
       media: query,
       onchange: null,
@@ -48,8 +45,8 @@ function installMatchMediaMock(matches = true) {
       addListener: vi.fn(),
       removeListener: vi.fn(),
       dispatchEvent: vi.fn(),
-    })),
-  });
+    }))
+  );
 }
 
 class ResizeObserverMock {
@@ -78,6 +75,7 @@ async function renderWithRoot(root: Root, ui: React.ReactElement) {
 describe("project-roadmap-panel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal("fetch", fetchMock);
     installMatchMediaMock();
     vi.stubGlobal("ResizeObserver", ResizeObserverMock);
     projectSectionExpandedMock.isExpanded = false;
@@ -86,6 +84,7 @@ describe("project-roadmap-panel", () => {
 
   afterEach(() => {
     document.body.innerHTML = "";
+    vi.unstubAllGlobals();
   });
 
   test("expands the section before opening the create event flow", async () => {

--- a/tests/components/project-roadmap-panel.test.tsx
+++ b/tests/components/project-roadmap-panel.test.tsx
@@ -35,6 +35,29 @@ import { ProjectRoadmapPanel } from "@/components/project-roadmap-panel";
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 vi.stubGlobal("fetch", fetchMock);
 
+function installMatchMediaMock(matches = true) {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+class ResizeObserverMock {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+
 function createTestRenderer() {
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -55,6 +78,8 @@ async function renderWithRoot(root: Root, ui: React.ReactElement) {
 describe("project-roadmap-panel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    installMatchMediaMock();
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
     projectSectionExpandedMock.isExpanded = false;
     fetchMock.mockReset();
   });

--- a/tests/lib/project-collaboration-service.test.ts
+++ b/tests/lib/project-collaboration-service.test.ts
@@ -146,6 +146,7 @@ describe("project-collaboration-service", () => {
           invitationId: "invite-1",
           projectId: "project-1",
           invitedByUserId: "owner-1",
+          triggeredByUserId: "owner-1",
           role: "editor",
         },
       })
@@ -229,6 +230,74 @@ describe("project-collaboration-service", () => {
     expect(prismaMock.projectInvitation.create).toHaveBeenCalledTimes(1);
   });
 
+  test("rejects unsafe invite email origins without calling outbound provider", async () => {
+    prismaMock.project.findFirst.mockResolvedValueOnce({
+      ownerId: "owner-1",
+      memberships: [],
+    });
+    prismaMock.projectInvitation.updateMany.mockResolvedValueOnce({ count: 0 });
+    prismaMock.project.findUnique.mockResolvedValueOnce({
+      id: "project-1",
+      name: "Launch Plan",
+      owner: {
+        email: "owner@example.com",
+      },
+    });
+    prismaMock.user.findUnique
+      .mockResolvedValueOnce({
+        email: "owner@example.com",
+      })
+      .mockResolvedValueOnce(null);
+    prismaMock.projectMembership.findFirst.mockResolvedValueOnce(null);
+    prismaMock.projectInvitation.findMany.mockResolvedValueOnce([]);
+    prismaMock.projectInvitation.create.mockResolvedValueOnce({
+      id: "invite-unsafe-origin",
+      projectId: "project-1",
+      invitedEmail: "invitee@example.com",
+      role: "viewer",
+      createdAt: new Date("2026-05-07T10:00:00.000Z"),
+      expiresAt: new Date("2026-05-21T10:00:00.000Z"),
+      acceptedAt: null,
+      revokedAt: null,
+      replacedAt: null,
+      project: {
+        id: "project-1",
+        name: "Launch Plan",
+      },
+      invitedByUser: {
+        id: "owner-1",
+        email: "owner@example.com",
+        name: "Owner",
+        username: "owner",
+        usernameDiscriminator: "1234",
+      },
+    });
+
+    const result = await inviteUserToProject({
+      actorUserId: "owner-1",
+      projectId: "project-1",
+      invitedEmail: "invitee@example.com",
+      role: "viewer",
+      appOrigin: "javascript:alert(1)",
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: 201,
+      data: {
+        invitation: {
+          invitationId: "invite-unsafe-origin",
+        },
+        emailDelivery: {
+          status: "failed",
+          deliveryId: null,
+          error: "invite-url-unavailable",
+        },
+      },
+    });
+    expect(outboundEmailServiceMock.sendOutboundEmail).not.toHaveBeenCalled();
+  });
+
   test("resends email for an active pending project invitation", async () => {
     prismaMock.project.findFirst.mockResolvedValueOnce({
       ownerId: "owner-1",
@@ -297,6 +366,17 @@ describe("project-collaboration-service", () => {
       },
     });
     expect(outboundEmailServiceMock.sendOutboundEmail).toHaveBeenCalledTimes(1);
+    expect(outboundEmailServiceMock.sendOutboundEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: {
+          invitationId: "invite-3",
+          projectId: "project-1",
+          invitedByUserId: "owner-1",
+          triggeredByUserId: "owner-1",
+          role: "editor",
+        },
+      })
+    );
   });
 
   test("rejects resend for inactive project invitations", async () => {

--- a/tests/lib/project-collaboration-service.test.ts
+++ b/tests/lib/project-collaboration-service.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const prismaMock = vi.hoisted(() => ({
   $queryRaw: vi.fn(),
@@ -63,7 +63,14 @@ describe("project-collaboration-service", () => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   test("sends project invitation email after creating an invite", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-07T10:00:00.000Z"));
+
     prismaMock.project.findFirst.mockResolvedValueOnce({
       ownerId: "owner-1",
       memberships: [],
@@ -89,7 +96,7 @@ describe("project-collaboration-service", () => {
       invitedEmail: "invitee@example.com",
       role: "editor",
       createdAt: new Date("2026-05-07T10:00:00.000Z"),
-      expiresAt: new Date("2026-05-21T10:00:00.000Z"),
+      expiresAt: new Date("2026-05-08T10:00:00.000Z"),
       acceptedAt: null,
       revokedAt: null,
       replacedAt: null,
@@ -154,6 +161,13 @@ describe("project-collaboration-service", () => {
     expect(outboundEmailServiceMock.sendOutboundEmail.mock.calls[0][0].text).toContain(
       "https://nexusdash.test/invite/project/invite-1"
     );
+    expect(prismaMock.projectInvitation.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          expiresAt: new Date("2026-05-08T10:00:00.000Z"),
+        }),
+      })
+    );
   });
 
   test("keeps a created invite when project invitation email delivery fails", async () => {
@@ -182,7 +196,7 @@ describe("project-collaboration-service", () => {
       invitedEmail: "invitee@example.com",
       role: "viewer",
       createdAt: new Date("2026-05-07T10:00:00.000Z"),
-      expiresAt: new Date("2026-05-21T10:00:00.000Z"),
+      expiresAt: new Date("2026-05-08T10:00:00.000Z"),
       acceptedAt: null,
       revokedAt: null,
       replacedAt: null,
@@ -256,7 +270,7 @@ describe("project-collaboration-service", () => {
       invitedEmail: "invitee@example.com",
       role: "viewer",
       createdAt: new Date("2026-05-07T10:00:00.000Z"),
-      expiresAt: new Date("2026-05-21T10:00:00.000Z"),
+      expiresAt: new Date("2026-05-08T10:00:00.000Z"),
       acceptedAt: null,
       revokedAt: null,
       replacedAt: null,

--- a/tests/lib/project-collaboration-service.test.ts
+++ b/tests/lib/project-collaboration-service.test.ts
@@ -7,11 +7,13 @@ const prismaMock = vi.hoisted(() => ({
     findMany: vi.fn(),
   },
   projectInvitation: {
+    create: vi.fn(),
     findMany: vi.fn(),
     findUnique: vi.fn(),
     updateMany: vi.fn(),
   },
   projectMembership: {
+    findFirst: vi.fn(),
     findUnique: vi.fn(),
     create: vi.fn(),
     deleteMany: vi.fn(),
@@ -27,6 +29,10 @@ const notificationServiceMock = vi.hoisted(() => ({
   resolveProjectInvitationNotifications: vi.fn(),
 }));
 
+const outboundEmailServiceMock = vi.hoisted(() => ({
+  sendOutboundEmail: vi.fn(),
+}));
+
 vi.mock("@/lib/prisma", () => ({
   prisma: prismaMock,
 }));
@@ -38,17 +44,302 @@ vi.mock("@/lib/services/notification-service", () => ({
     notificationServiceMock.resolveProjectInvitationNotifications,
 }));
 
+vi.mock("@/lib/services/outbound-email-service", () => ({
+  sendOutboundEmail: outboundEmailServiceMock.sendOutboundEmail,
+}));
+
 import {
   countPendingProjectInvitationsForUser,
   getProjectInvitationRecipientView,
+  inviteUserToProject,
   listPendingProjectInvitationsForUser,
   respondToProjectInvitation,
   searchProjectMembersForMention,
+  sendProjectInvitationEmailForOwner,
 } from "@/lib/services/project-collaboration-service";
 
 describe("project-collaboration-service", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  test("sends project invitation email after creating an invite", async () => {
+    prismaMock.project.findFirst.mockResolvedValueOnce({
+      ownerId: "owner-1",
+      memberships: [],
+    });
+    prismaMock.projectInvitation.updateMany.mockResolvedValueOnce({ count: 0 });
+    prismaMock.project.findUnique.mockResolvedValueOnce({
+      id: "project-1",
+      name: "Launch Plan",
+      owner: {
+        email: "owner@example.com",
+      },
+    });
+    prismaMock.user.findUnique
+      .mockResolvedValueOnce({
+        email: "owner@example.com",
+      })
+      .mockResolvedValueOnce(null);
+    prismaMock.projectMembership.findFirst.mockResolvedValueOnce(null);
+    prismaMock.projectInvitation.findMany.mockResolvedValueOnce([]);
+    prismaMock.projectInvitation.create.mockResolvedValueOnce({
+      id: "invite-1",
+      projectId: "project-1",
+      invitedEmail: "invitee@example.com",
+      role: "editor",
+      createdAt: new Date("2026-05-07T10:00:00.000Z"),
+      expiresAt: new Date("2026-05-21T10:00:00.000Z"),
+      acceptedAt: null,
+      revokedAt: null,
+      replacedAt: null,
+      project: {
+        id: "project-1",
+        name: "Launch Plan",
+      },
+      invitedByUser: {
+        id: "owner-1",
+        email: "owner@example.com",
+        name: "Owner",
+        username: "owner",
+        usernameDiscriminator: "1234",
+      },
+    });
+    outboundEmailServiceMock.sendOutboundEmail.mockResolvedValueOnce({
+      ok: true,
+      delivery: "sent",
+      deliveryId: "delivery-1",
+      provider: "resend",
+      providerMessageId: "provider-1",
+    });
+
+    const result = await inviteUserToProject({
+      actorUserId: "owner-1",
+      projectId: "project-1",
+      invitedEmail: "invitee@example.com",
+      role: "editor",
+      appOrigin: "https://nexusdash.test",
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: 201,
+      data: {
+        invitation: {
+          invitationId: "invite-1",
+          invitedEmail: "invitee@example.com",
+          inviteLinkPath: "/invite/project/invite-1",
+        },
+        emailDelivery: {
+          status: "sent",
+          deliveryId: "delivery-1",
+          providerMessageId: "provider-1",
+          error: null,
+        },
+      },
+    });
+    expect(outboundEmailServiceMock.sendOutboundEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        templateKey: "project_invitation",
+        to: "invitee@example.com",
+        metadata: {
+          invitationId: "invite-1",
+          projectId: "project-1",
+          invitedByUserId: "owner-1",
+          role: "editor",
+        },
+      })
+    );
+    expect(outboundEmailServiceMock.sendOutboundEmail.mock.calls[0][0].text).toContain(
+      "https://nexusdash.test/invite/project/invite-1"
+    );
+  });
+
+  test("keeps a created invite when project invitation email delivery fails", async () => {
+    prismaMock.project.findFirst.mockResolvedValueOnce({
+      ownerId: "owner-1",
+      memberships: [],
+    });
+    prismaMock.projectInvitation.updateMany.mockResolvedValueOnce({ count: 0 });
+    prismaMock.project.findUnique.mockResolvedValueOnce({
+      id: "project-1",
+      name: "Launch Plan",
+      owner: {
+        email: "owner@example.com",
+      },
+    });
+    prismaMock.user.findUnique
+      .mockResolvedValueOnce({
+        email: "owner@example.com",
+      })
+      .mockResolvedValueOnce(null);
+    prismaMock.projectMembership.findFirst.mockResolvedValueOnce(null);
+    prismaMock.projectInvitation.findMany.mockResolvedValueOnce([]);
+    prismaMock.projectInvitation.create.mockResolvedValueOnce({
+      id: "invite-2",
+      projectId: "project-1",
+      invitedEmail: "invitee@example.com",
+      role: "viewer",
+      createdAt: new Date("2026-05-07T10:00:00.000Z"),
+      expiresAt: new Date("2026-05-21T10:00:00.000Z"),
+      acceptedAt: null,
+      revokedAt: null,
+      replacedAt: null,
+      project: {
+        id: "project-1",
+        name: "Launch Plan",
+      },
+      invitedByUser: {
+        id: "owner-1",
+        email: "owner@example.com",
+        name: "Owner",
+        username: "owner",
+        usernameDiscriminator: "1234",
+      },
+    });
+    outboundEmailServiceMock.sendOutboundEmail.mockResolvedValueOnce({
+      ok: false,
+      error: "provider-unavailable",
+      deliveryId: "delivery-2",
+      provider: "resend",
+    });
+
+    const result = await inviteUserToProject({
+      actorUserId: "owner-1",
+      projectId: "project-1",
+      invitedEmail: "invitee@example.com",
+      role: "viewer",
+      appOrigin: "https://nexusdash.test",
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: 201,
+      data: {
+        invitation: {
+          invitationId: "invite-2",
+        },
+        emailDelivery: {
+          status: "failed",
+          deliveryId: "delivery-2",
+          error: "provider-unavailable",
+        },
+      },
+    });
+    expect(prismaMock.projectInvitation.create).toHaveBeenCalledTimes(1);
+  });
+
+  test("resends email for an active pending project invitation", async () => {
+    prismaMock.project.findFirst.mockResolvedValueOnce({
+      ownerId: "owner-1",
+      memberships: [],
+    });
+    prismaMock.projectInvitation.findUnique.mockResolvedValueOnce({
+      id: "invite-3",
+      projectId: "project-1",
+      invitedEmail: "verified@example.com",
+      role: "editor",
+      createdAt: new Date("2026-05-07T10:00:00.000Z"),
+      expiresAt: new Date("2099-05-21T10:00:00.000Z"),
+      acceptedAt: null,
+      revokedAt: null,
+      replacedAt: null,
+      project: {
+        id: "project-1",
+        name: "Launch Plan",
+      },
+      invitedByUser: {
+        id: "owner-1",
+        email: "owner@example.com",
+        name: "Owner",
+        username: "owner",
+        usernameDiscriminator: "1234",
+      },
+    });
+    prismaMock.user.findMany.mockResolvedValueOnce([
+      {
+        id: "invitee-1",
+        email: "verified@example.com",
+        name: "Verified",
+        username: "verified",
+        usernameDiscriminator: "5678",
+        avatarSeed: null,
+      },
+    ]);
+    outboundEmailServiceMock.sendOutboundEmail.mockResolvedValueOnce({
+      ok: true,
+      delivery: "skipped",
+      deliveryId: "delivery-3",
+      provider: "resend",
+      providerMessageId: null,
+    });
+
+    const result = await sendProjectInvitationEmailForOwner({
+      actorUserId: "owner-1",
+      projectId: "project-1",
+      invitationId: "invite-3",
+      appOrigin: "https://nexusdash.test",
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: 200,
+      data: {
+        invitation: {
+          invitedUserId: "invitee-1",
+          invitedUserDisplayName: "verified#5678",
+        },
+        emailDelivery: {
+          status: "skipped",
+          deliveryId: "delivery-3",
+          error: null,
+        },
+      },
+    });
+    expect(outboundEmailServiceMock.sendOutboundEmail).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects resend for inactive project invitations", async () => {
+    prismaMock.project.findFirst.mockResolvedValueOnce({
+      ownerId: "owner-1",
+      memberships: [],
+    });
+    prismaMock.projectInvitation.findUnique.mockResolvedValueOnce({
+      id: "invite-4",
+      projectId: "project-1",
+      invitedEmail: "invitee@example.com",
+      role: "editor",
+      createdAt: new Date("2026-05-07T10:00:00.000Z"),
+      expiresAt: new Date("2099-05-21T10:00:00.000Z"),
+      acceptedAt: new Date("2026-05-08T10:00:00.000Z"),
+      revokedAt: null,
+      replacedAt: null,
+      project: {
+        id: "project-1",
+        name: "Launch Plan",
+      },
+      invitedByUser: {
+        id: "owner-1",
+        email: "owner@example.com",
+        name: "Owner",
+        username: "owner",
+        usernameDiscriminator: "1234",
+      },
+    });
+
+    const result = await sendProjectInvitationEmailForOwner({
+      actorUserId: "owner-1",
+      projectId: "project-1",
+      invitationId: "invite-4",
+      appOrigin: "https://nexusdash.test",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 409,
+      error: "invitation-not-active",
+    });
+    expect(outboundEmailServiceMock.sendOutboundEmail).not.toHaveBeenCalled();
   });
 
   test("includes the actor in member search for agent callers", async () => {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -13,7 +13,7 @@ export default defineConfig({
   },
   test: {
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.{ts,tsx}"],
     coverage: {
       provider: "v8",
       reporter: ["text", "html", "json-summary"],


### PR DESCRIPTION
## Summary
- Sends project invitation emails through the shared outbound email service when owners create invites.
- Adds an owner resend endpoint and UI feedback while preserving copy-link fallback and email-bound acceptance semantics.
- Records TASK-104 validation evidence and updates the outbound email runbook.

## Validation
- `npm run lint`
- `NODE_ENV=test npm test` with local PostgreSQL
- `NODE_ENV=test npm run test:coverage` with local PostgreSQL
- `OUTBOUND_EMAIL_DELIVERY_MODE=disabled npm run build` with local PostgreSQL and trusted localhost origins
- `OUTBOUND_EMAIL_DELIVERY_MODE=disabled npm run test:e2e` with local PostgreSQL and trusted localhost origins
- Manual live invite smoke: created local project `cmovu31nw0000swsz9nhd1q80`, invited `galo.guccy@gmail.com` and `dorian.agaesse@gmail.com`, and verified two sent `project_invitation` delivery rows with provider message ids present.