### PR TITLE
TASK-225 fix notification dispatch scheduler auth

### DIFF
--- a/.github/workflows/notification-email-dispatch.yml
+++ b/.github/workflows/notification-email-dispatch.yml
@@ -21,6 +21,7 @@ jobs:
   dispatch:
     name: Dispatch notification emails
     runs-on: ubuntu-latest
+    environment: production
     timeout-minutes: 5
     env:
       DISPATCH_URL: ${{ inputs.target_url || vars.NOTIFICATION_EMAIL_DISPATCH_URL }}
@@ -45,6 +46,6 @@ jobs:
       - name: Call notification email dispatcher
         run: |
           dispatch_origin="${DISPATCH_URL%/}"
-          curl --fail --silent --show-error --max-time 120 \
-            --header "Authorization: Bearer $DISPATCH_SECRET" \
+          curl --fail-with-body --silent --show-error --max-time 120 \
+            --header "x-notification-email-dispatch-secret: $DISPATCH_SECRET" \
             "$dispatch_origin/api/cron/notification-emails"

--- a/README.md
+++ b/README.md
@@ -280,8 +280,18 @@ Digest/reminder dispatch endpoint:
 
 ```bash
 GET /api/cron/notification-emails
-Authorization: Bearer <CRON_SECRET-or-NOTIFICATION_EMAIL_DISPATCH_SECRET>
+```
+
+Authenticate with either the dedicated scheduler header:
+
+```bash
 x-notification-email-dispatch-secret: <CRON_SECRET-or-NOTIFICATION_EMAIL_DISPATCH_SECRET>
+```
+
+or the bearer fallback:
+
+```bash
+Authorization: Bearer <CRON_SECRET-or-NOTIFICATION_EMAIL_DISPATCH_SECRET>
 ```
 
 The dispatcher scans verified users, sends one project digest only after the

--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Digest/reminder dispatch endpoint:
 ```bash
 GET /api/cron/notification-emails
 Authorization: Bearer <CRON_SECRET-or-NOTIFICATION_EMAIL_DISPATCH_SECRET>
+x-notification-email-dispatch-secret: <CRON_SECRET-or-NOTIFICATION_EMAIL_DISPATCH_SECRET>
 ```
 
 The dispatcher scans verified users, sends one project digest only after the
@@ -292,10 +293,16 @@ minutes, and sends one reminder for unresolved/unread project invitations after
 minutes from GitHub Actions because the current Vercel plan does not support
 sub-daily Vercel Cron schedules. Configure repository variable
 `NOTIFICATION_EMAIL_DISPATCH_URL` with the production app origin, plus
-repository secret `NOTIFICATION_EMAIL_DISPATCH_SECRET` or `CRON_SECRET`.
+repository or `production` environment secret
+`NOTIFICATION_EMAIL_DISPATCH_SECRET` or `CRON_SECRET`. Configure the same
+secret value in Vercel Production as `NOTIFICATION_EMAIL_DISPATCH_SECRET` or
+`CRON_SECRET`, then redeploy production so the runtime can read it. The workflow
+runs in the GitHub `production` environment and uses the dedicated
+`x-notification-email-dispatch-secret` header to avoid platform auth-header
+handling conflicts.
 Preview deployments should be validated by running the same workflow manually
 with `target_url=<preview-url>` or by calling the endpoint directly with the
-same bearer secret.
+same dispatch secret.
 
 ## CI/CD
 

--- a/app/api/cron/notification-emails/route.ts
+++ b/app/api/cron/notification-emails/route.ts
@@ -23,13 +23,27 @@ function timingSafeEquals(left: string, right: string): boolean {
   return crypto.timingSafeEqual(leftBuffer, rightBuffer);
 }
 
+function readBearerToken(request: NextRequest): string {
+  const authorization = request.headers.get("authorization")?.trim() ?? "";
+  if (!authorization) {
+    return "";
+  }
+
+  const [scheme, ...valueParts] = authorization.split(/\s+/);
+  if (scheme.toLowerCase() !== "bearer") {
+    return "";
+  }
+
+  return valueParts.join(" ").trim();
+}
+
 function isAuthorized(request: NextRequest, secret: string): boolean {
-  const authorization = request.headers.get("authorization") ?? "";
+  const bearerToken = readBearerToken(request);
   const dispatchSecret =
-    request.headers.get("x-notification-email-dispatch-secret") ?? "";
+    request.headers.get("x-notification-email-dispatch-secret")?.trim() ?? "";
 
   return (
-    timingSafeEquals(authorization, `Bearer ${secret}`) ||
+    timingSafeEquals(bearerToken, secret) ||
     timingSafeEquals(dispatchSecret, secret)
   );
 }

--- a/app/api/cron/notification-emails/route.ts
+++ b/app/api/cron/notification-emails/route.ts
@@ -25,7 +25,13 @@ function timingSafeEquals(left: string, right: string): boolean {
 
 function isAuthorized(request: NextRequest, secret: string): boolean {
   const authorization = request.headers.get("authorization") ?? "";
-  return timingSafeEquals(authorization, `Bearer ${secret}`);
+  const dispatchSecret =
+    request.headers.get("x-notification-email-dispatch-secret") ?? "";
+
+  return (
+    timingSafeEquals(authorization, `Bearer ${secret}`) ||
+    timingSafeEquals(dispatchSecret, secret)
+  );
 }
 
 function resolveDispatchOrigin(request: NextRequest): string {

--- a/docs/runbooks/vercel-env-contract-and-secrets.md
+++ b/docs/runbooks/vercel-env-contract-and-secrets.md
@@ -78,7 +78,8 @@ recipient/project group has been quiet for at least 30 minutes, and sends a
 single invitation reminder when an existing in-app invitation notification stays
 unresolved/unread for 6 hours. Preview deployments can be validated by running
 the workflow manually with `target_url=<preview-url>` or by invoking the
-endpoint directly with the same bearer secret.
+endpoint directly with the same dispatch secret; either the dedicated
+`x-notification-email-dispatch-secret` header or the bearer header is accepted.
 
 If Google OAuth is enabled:
 

--- a/docs/runbooks/vercel-env-contract-and-secrets.md
+++ b/docs/runbooks/vercel-env-contract-and-secrets.md
@@ -61,13 +61,19 @@ recorded and returned to the caller synchronously.
 
 TASK-225 adds project notification email digests and delayed project invitation
 reminders. The dispatcher is exposed at `/api/cron/notification-emails`, expects
+`x-notification-email-dispatch-secret: <secret>` or
 `Authorization: Bearer <secret>`, and is called every 15 minutes by
 `.github/workflows/notification-email-dispatch.yml`. The repository scheduler is
 used because the current Vercel Hobby plan rejects sub-daily Vercel Cron
-schedules during deployment. Configure repository variable
-`NOTIFICATION_EMAIL_DISPATCH_URL` with the production app origin and repository
-secret `NOTIFICATION_EMAIL_DISPATCH_SECRET` or `CRON_SECRET` with the same value
-configured in the app runtime. It sends project activity digests only after the
+schedules during deployment. Configure GitHub repository or `production`
+environment variable `NOTIFICATION_EMAIL_DISPATCH_URL` with the production app
+origin, and configure GitHub repository or `production` environment secret
+`NOTIFICATION_EMAIL_DISPATCH_SECRET` or `CRON_SECRET` with the same value
+configured in the app runtime. The workflow runs in the GitHub `production`
+environment so environment-scoped secrets can be used. After adding or rotating
+the app runtime secret in Vercel Production, redeploy production before testing
+the scheduled workflow; existing deployments keep the env snapshot they were
+created with. It sends project activity digests only after the
 recipient/project group has been quiet for at least 30 minutes, and sends a
 single invitation reminder when an existing in-app invitation notification stays
 unresolved/unread for 6 hours. Preview deployments can be validated by running
@@ -135,6 +141,12 @@ Important:
   environments when agent access behavior needs to be validated end to end.
 - Preview email smoke tests need `OUTBOUND_EMAIL_DELIVERY_MODE=live` and a real
   `RESEND_API_KEY`. The default `auto` mode records preview attempts as skipped.
+- GitHub Actions is an acceptable temporary scheduler for this Hobby-plan
+  deployment, but it is not a durable job system. It is tied to the default
+  branch, GitHub scheduling latency, repository Actions health, and GitHub
+  environment configuration. Prefer Vercel Cron on a plan that supports the
+  cadence, or a managed queue/workflow runner, before treating notification
+  dispatch as high-SLA infrastructure.
 - Keep `GOOGLE_TOKEN_ENCRYPTION_KEY` stable per environment. Rotating it
   requires token re-authorization because existing encrypted tokens may become
   unreadable.

--- a/journal.md
+++ b/journal.md
@@ -12,6 +12,16 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ## Recent Entries (Most Relevant)
 
+### 2026-05-12
+- Type: Blocker
+- Summary: Investigated TASK-225 production notification dispatch failures after PR #246 merged.
+- Evidence: GitHub Actions runs for `Notification Email Dispatch` failed repeatedly on `main` before reaching the app. Run `25752062859` failed in `Validate dispatch configuration` with empty `DISPATCH_URL` and `DISPATCH_SECRET`, reporting missing `NOTIFICATION_EMAIL_DISPATCH_URL` and missing `NOTIFICATION_EMAIL_DISPATCH_SECRET`/`CRON_SECRET`. GitHub repo variables were empty, repo secrets lacked the notification secret, and the workflow did not bind the `production` environment, while existing deploy secrets live under that environment. Vercel Production also lacked `NOTIFICATION_EMAIL_DISPATCH_SECRET`/`CRON_SECRET`.
+
+### 2026-05-12
+- Type: Execution
+- Summary: Configured production notification dispatch secrets and hardened scheduler auth.
+- Evidence: Configured GitHub `NOTIFICATION_EMAIL_DISPATCH_URL`, configured shared GitHub/Vercel `NOTIFICATION_EMAIL_DISPATCH_SECRET`, and redeployed/promoted production via workflow runs `25753601331` and `25753746565` so Vercel could receive the new env snapshot. Added support for `x-notification-email-dispatch-secret` alongside bearer auth, updated the scheduler to run in the GitHub `production` environment and call the endpoint with the dedicated header plus `--fail-with-body`, and documented the production env/redeploy requirement and scheduler reliability caveat.
+
 ### 2026-05-08
 - Type: Execution
 - Summary: TASK-104 follow-up made email-only project invites email-first in the owner UI.

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -6,7 +6,7 @@ Use this file to capture tasks discovered during development. Each entry should 
 ### Execution Queue (Now / Next)
 - ID: TASK-225
   Title: Project notification email digests - grouped, rate-limited outbound summaries
-  Status: PR open / preview validated (`feature/task-225-project-notification-email-digests`, PR #246)
+  Status: PR #246 merged; production dispatch workflow remediation in progress on `fix/task-225-notification-dispatch-workflow`
   Rationale: Extend the notification center with project-grouped outbound email digests so important in-app activity can reach users by email without sending one message per notification, especially when agents generate frequent task/comment activity. The first design should batch by recipient and project, collapse repetitive agent events, apply a controlled cadence, and preserve the in-app notification inbox as the source of truth.
   Dependencies: TASK-123, TASK-125
 - ID: TASK-226

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,8 +4,9 @@
 TASK-225
 
 ## Status
-Implemented on `feature/task-225-project-notification-email-digests`; PR #246 is
-open with GitHub checks green and preview email smoke validated.
+Follow-up remediation in progress on
+`fix/task-225-notification-dispatch-workflow` after PR #246 merged and the
+new scheduled notification dispatch workflow failed on `main`.
 
 ## Objective
 Extend the notification center with project-grouped outbound email digests so
@@ -141,6 +142,27 @@ email foundation.
 - A preview deploy is triggered from this branch via `deploy-vercel.yml` with an
   explicit `git_ref`, and preview validation sends real test email to
   `dorian.agaesse@gmail.com` without exposing credentials.
+
+## Follow-Up: Production Dispatch Workflow Remediation
+- Root cause: every scheduled run failed in `Validate dispatch configuration`
+  because `NOTIFICATION_EMAIL_DISPATCH_URL` and
+  `NOTIFICATION_EMAIL_DISPATCH_SECRET`/`CRON_SECRET` were not configured for the
+  workflow context. The workflow also did not attach the GitHub `production`
+  environment, so environment-scoped secrets would not have been visible.
+- Production config action taken on 2026-05-12: configured
+  `NOTIFICATION_EMAIL_DISPATCH_URL` in GitHub, configured a shared
+  `NOTIFICATION_EMAIL_DISPATCH_SECRET` in GitHub and Vercel Production, and
+  redeployed/promoted production so the runtime could receive the Vercel env
+  snapshot.
+- Additional hardening: the dispatch endpoint now accepts a dedicated
+  `x-notification-email-dispatch-secret` header in addition to the original
+  bearer token, and the GitHub scheduler uses that header with
+  `--fail-with-body` so endpoint failures produce useful diagnostics.
+- Operational assessment: GitHub Actions is acceptable as a temporary
+  Hobby-plan scheduler, but it is not the long-term prod-grade choice for
+  notification dispatch. The durable target should be Vercel Cron on a plan that
+  supports the cadence, or a managed queue/workflow runner with retries,
+  visibility, and dead-letter handling.
 
 ## Validation Evidence
 - `npm ci` passed on 2026-05-08 in the TASK-225 worktree.

--- a/tests/api/notification-email-dispatch.route.test.ts
+++ b/tests/api/notification-email-dispatch.route.test.ts
@@ -135,12 +135,30 @@ describe("notification email dispatch route", () => {
     });
   });
 
+  test("accepts bearer token auth with case-insensitive scheme and extra spaces", async () => {
+    const response = await GET(
+      new NextRequest("https://nexus-dash.app/api/cron/notification-emails", {
+        headers: {
+          authorization: "  bearer   dispatch-secret-0123456789abcdef  ",
+        },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(readJson(response)).resolves.toMatchObject({
+      ok: true,
+    });
+    expect(dispatchMock.dispatchProjectNotificationEmails).toHaveBeenCalledWith({
+      appOrigin: "https://nexus-dash.app",
+    });
+  });
+
   test("dispatches notification emails with the dedicated dispatch secret header", async () => {
     const response = await GET(
       new NextRequest("https://nexus-dash.app/api/cron/notification-emails", {
         headers: {
           "x-notification-email-dispatch-secret":
-            "dispatch-secret-0123456789abcdef",
+            " dispatch-secret-0123456789abcdef ",
         },
       })
     );

--- a/tests/api/notification-email-dispatch.route.test.ts
+++ b/tests/api/notification-email-dispatch.route.test.ts
@@ -91,6 +91,20 @@ describe("notification email dispatch route", () => {
     expect(dispatchMock.dispatchProjectNotificationEmails).not.toHaveBeenCalled();
   });
 
+  test("rejects requests with the wrong dispatch secret header", async () => {
+    const response = await GET(
+      new NextRequest("https://nexus-dash.app/api/cron/notification-emails", {
+        headers: {
+          "x-notification-email-dispatch-secret": "wrong-secret",
+        },
+      })
+    );
+
+    expect(response.status).toBe(401);
+    await expect(readJson(response)).resolves.toEqual({ error: "unauthorized" });
+    expect(dispatchMock.dispatchProjectNotificationEmails).not.toHaveBeenCalled();
+  });
+
   test("dispatches notification emails with the trusted app origin", async () => {
     const response = await GET(
       new NextRequest("https://nexus-dash.app/api/cron/notification-emails", {
@@ -115,6 +129,25 @@ describe("notification email dispatch route", () => {
         invitationRemindersFailed: 0,
         errors: 0,
       },
+    });
+    expect(dispatchMock.dispatchProjectNotificationEmails).toHaveBeenCalledWith({
+      appOrigin: "https://nexus-dash.app",
+    });
+  });
+
+  test("dispatches notification emails with the dedicated dispatch secret header", async () => {
+    const response = await GET(
+      new NextRequest("https://nexus-dash.app/api/cron/notification-emails", {
+        headers: {
+          "x-notification-email-dispatch-secret":
+            "dispatch-secret-0123456789abcdef",
+        },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(readJson(response)).resolves.toMatchObject({
+      ok: true,
     });
     expect(dispatchMock.dispatchProjectNotificationEmails).toHaveBeenCalledWith({
       appOrigin: "https://nexus-dash.app",


### PR DESCRIPTION
﻿## Summary
- bind the notification dispatch workflow to the GitHub `production` environment and use a dedicated dispatch-secret header
- keep bearer auth compatibility while accepting `x-notification-email-dispatch-secret` in the cron route
- document the production scheduler config, redeploy requirement, and GitHub Actions reliability caveat

## Root Cause
Scheduled `Notification Email Dispatch` runs failed before calling the app because `NOTIFICATION_EMAIL_DISPATCH_URL` and `NOTIFICATION_EMAIL_DISPATCH_SECRET`/`CRON_SECRET` were not configured in the workflow context. The workflow also did not attach the GitHub `production` environment, so environment-scoped values would not have been visible. After config was added, production still returned `401` through the generic `Authorization` path, so this PR moves the scheduler to a dedicated secret header while preserving bearer compatibility.

## Validation
- `node node_modules/vitest/vitest.mjs run tests/api/notification-email-dispatch.route.test.ts tests/lib/env.server.test.ts` passed: 2 files, 69 tests
- `npm run lint` passed

Note: `npm ci` in the fresh worktree was blocked by very slow registry revalidation and was stopped after dependencies needed for validation were available; validation used the root checkout's complete `node_modules` via a local junction.
