### PR TITLE
TASK-227 production notification email orchestration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,8 +63,10 @@ RESEND_API_KEY=
 RESEND_FROM_EMAIL="NexusDash <noreply@nexus-dash.app>"
 
 # Notification email digest/reminder dispatch.
-# The GitHub Actions scheduler or another trusted scheduler sends
-# Authorization: Bearer $CRON_SECRET to the dispatch endpoint.
-# NOTIFICATION_EMAIL_DISPATCH_SECRET takes precedence when set.
+# Production should use Vercel Cron when the deployment plan supports a
+# sub-hour cadence, otherwise use a managed HTTP scheduler such as QStash.
+# The manual GitHub Actions diagnostic workflow sends
+# x-notification-email-dispatch-secret: $NOTIFICATION_EMAIL_DISPATCH_SECRET.
+# CRON_SECRET remains a legacy bearer-token fallback for other trusted callers.
 CRON_SECRET=
 NOTIFICATION_EMAIL_DISPATCH_SECRET=

--- a/.github/workflows/notification-email-dispatch.yml
+++ b/.github/workflows/notification-email-dispatch.yml
@@ -1,8 +1,6 @@
-name: Notification Email Dispatch
+name: Notification Email Dispatch Diagnostic
 
 on:
-  schedule:
-    - cron: "*/15 * * * *"
   workflow_dispatch:
     inputs:
       target_url:
@@ -19,8 +17,9 @@ concurrency:
 
 jobs:
   dispatch:
-    name: Dispatch notification emails
+    name: Dispatch notification emails manually
     runs-on: ubuntu-latest
+    environment: production
     timeout-minutes: 5
     env:
       DISPATCH_URL: ${{ inputs.target_url || vars.NOTIFICATION_EMAIL_DISPATCH_URL }}
@@ -45,6 +44,6 @@ jobs:
       - name: Call notification email dispatcher
         run: |
           dispatch_origin="${DISPATCH_URL%/}"
-          curl --fail --silent --show-error --max-time 120 \
-            --header "Authorization: Bearer $DISPATCH_SECRET" \
+          curl --fail-with-body --silent --show-error --max-time 120 \
+            --header "x-notification-email-dispatch-secret: $DISPATCH_SECRET" \
             "$dispatch_origin/api/cron/notification-emails"

--- a/README.md
+++ b/README.md
@@ -280,22 +280,42 @@ Digest/reminder dispatch endpoint:
 
 ```bash
 GET /api/cron/notification-emails
+```
+
+Authenticate with the dedicated scheduler header:
+
+```bash
+x-notification-email-dispatch-secret: <CRON_SECRET-or-NOTIFICATION_EMAIL_DISPATCH_SECRET>
+```
+
+or the bearer fallback:
+
+```bash
 Authorization: Bearer <CRON_SECRET-or-NOTIFICATION_EMAIL_DISPATCH_SECRET>
 ```
 
-The dispatcher scans verified users, sends one project digest only after the
-latest eligible mention/assignment notification has been quiet for at least 30
-minutes, and sends one reminder for unresolved/unread project invitations after
-6 hours. Sending email never marks notifications read or resolved.
+Notification creation/refreshed paths enqueue durable recipient/project groups.
+Project activity waits for a 30-minute quiet window, but the first unsent
+activity in a group is capped at a 60-minute max delay. Due groups claimed in
+one dispatcher run are batched by recipient, with project sections in one email
+when several projects are ready together. Project invitation reminders are sent
+once after 6 hours when the verified invited user has not opened, accepted,
+declined, or otherwise resolved the invitation notification. Sending email never
+marks notifications read or resolved.
 
-`.github/workflows/notification-email-dispatch.yml` calls the endpoint every 15
-minutes from GitHub Actions because the current Vercel plan does not support
-sub-daily Vercel Cron schedules. Configure repository variable
-`NOTIFICATION_EMAIL_DISPATCH_URL` with the production app origin, plus
-repository secret `NOTIFICATION_EMAIL_DISPATCH_SECRET` or `CRON_SECRET`.
-Preview deployments should be validated by running the same workflow manually
-with `target_url=<preview-url>` or by calling the endpoint directly with the
-same bearer secret.
+Production scheduler decision:
+
+- Preferred: Vercel Cron invoking this endpoint every 10-15 minutes on a plan
+  that supports sub-hour cron cadence. Vercel Cron invokes production
+  deployments only; preview validation must invoke the endpoint manually.
+- Current Hobby-plan blocker: Vercel Hobby cron is limited to daily schedules,
+  so it cannot satisfy the 60-minute max-delay requirement.
+- Hobby-compatible production alternative: use a managed HTTP scheduler with
+  retries/visibility, such as Upstash QStash Schedule, to call the same endpoint
+  with `x-notification-email-dispatch-secret`.
+
+`.github/workflows/notification-email-dispatch.yml` is manual-only diagnostic
+tooling for operators. It is not the production scheduler.
 
 ## CI/CD
 
@@ -306,7 +326,7 @@ same bearer secret.
 - `Container Image (build + metadata artifact)`
 - `Check Branch Name` (PR branch naming contract)
 - `Dependency Security` (scheduled + manual `npm audit` baseline with artifacts)
-- `Notification Email Dispatch` (scheduled + manual protected dispatch call)
+- `Notification Email Dispatch Diagnostic` (manual protected dispatch call)
 
 Branch-name note:
 - human-authored PR branches must use `feature/*`, `fix/*`, `refactor/*`,

--- a/app/api/cron/notification-emails/route.ts
+++ b/app/api/cron/notification-emails/route.ts
@@ -23,9 +23,29 @@ function timingSafeEquals(left: string, right: string): boolean {
   return crypto.timingSafeEqual(leftBuffer, rightBuffer);
 }
 
+function readBearerToken(request: NextRequest): string {
+  const authorization = request.headers.get("authorization")?.trim() ?? "";
+  if (!authorization) {
+    return "";
+  }
+
+  const [scheme, ...valueParts] = authorization.split(/\s+/);
+  if (scheme.toLowerCase() !== "bearer") {
+    return "";
+  }
+
+  return valueParts.join(" ").trim();
+}
+
 function isAuthorized(request: NextRequest, secret: string): boolean {
-  const authorization = request.headers.get("authorization") ?? "";
-  return timingSafeEquals(authorization, `Bearer ${secret}`);
+  const bearerToken = readBearerToken(request);
+  const dispatchSecret =
+    request.headers.get("x-notification-email-dispatch-secret")?.trim() ?? "";
+
+  return (
+    timingSafeEquals(bearerToken, secret) ||
+    timingSafeEquals(dispatchSecret, secret)
+  );
 }
 
 function resolveDispatchOrigin(request: NextRequest): string {

--- a/docs/runbooks/vercel-env-contract-and-secrets.md
+++ b/docs/runbooks/vercel-env-contract-and-secrets.md
@@ -59,20 +59,33 @@ fails. The current foundation does not run background retry workers, bounce
 webhooks, suppression handling, or notification preferences; failed sends are
 recorded and returned to the caller synchronously.
 
-TASK-225 adds project notification email digests and delayed project invitation
-reminders. The dispatcher is exposed at `/api/cron/notification-emails`, expects
-`Authorization: Bearer <secret>`, and is called every 15 minutes by
-`.github/workflows/notification-email-dispatch.yml`. The repository scheduler is
-used because the current Vercel Hobby plan rejects sub-daily Vercel Cron
-schedules during deployment. Configure repository variable
-`NOTIFICATION_EMAIL_DISPATCH_URL` with the production app origin and repository
-secret `NOTIFICATION_EMAIL_DISPATCH_SECRET` or `CRON_SECRET` with the same value
-configured in the app runtime. It sends project activity digests only after the
-recipient/project group has been quiet for at least 30 minutes, and sends a
-single invitation reminder when an existing in-app invitation notification stays
-unresolved/unread for 6 hours. Preview deployments can be validated by running
-the workflow manually with `target_url=<preview-url>` or by invoking the
-endpoint directly with the same bearer secret.
+TASK-227 owns production-grade project notification email orchestration. The
+dispatcher is exposed at `/api/cron/notification-emails` and accepts either
+`x-notification-email-dispatch-secret: <secret>` or
+`Authorization: Bearer <secret>`. Notification creation/refreshed paths enqueue
+durable recipient/project groups. Project activity waits for a 30-minute quiet
+window, but the first unsent activity in a group is capped at a 60-minute max
+delay. Due groups are claimed safely by the dispatcher and batched by recipient
+with project sections. Invitation reminders send once after 6 hours when a
+verified invited user has not opened, accepted, declined, or otherwise resolved
+the invitation notification.
+
+Scheduler decision:
+
+- Preferred production path: Vercel Cron every 10-15 minutes on a plan that
+  supports sub-hour cron cadence. Vercel Cron invokes production deployments
+  only; it does not run on preview deployments.
+- Current blocker: the present Hobby-plan deployment cannot use the required
+  Vercel Cron cadence because Hobby cron is daily-only.
+- Production alternative while staying on Hobby: configure a managed HTTP
+  scheduler with retries/visibility, such as Upstash QStash Schedule, to call
+  the same endpoint with `x-notification-email-dispatch-secret`.
+- GitHub Actions dispatch is manual diagnostic tooling only; it must not be the
+  primary production scheduler for notification email delivery.
+
+Preview deployments can be validated by invoking the endpoint directly with the
+same dispatch secret. A live email smoke additionally needs
+`OUTBOUND_EMAIL_DELIVERY_MODE=live` and a real `RESEND_API_KEY`.
 
 If Google OAuth is enabled:
 
@@ -135,6 +148,9 @@ Important:
   environments when agent access behavior needs to be validated end to end.
 - Preview email smoke tests need `OUTBOUND_EMAIL_DELIVERY_MODE=live` and a real
   `RESEND_API_KEY`. The default `auto` mode records preview attempts as skipped.
+- Vercel Cron schedule changes are production-deployment behavior. Preview
+  validation should call the protected endpoint manually and should not be used
+  as evidence that Vercel Cron itself ran.
 - Keep `GOOGLE_TOKEN_ENCRYPTION_KEY` stable per environment. Rotating it
   requires token re-authorization because existing encrypted tokens may become
   unreadable.

--- a/journal.md
+++ b/journal.md
@@ -14,6 +14,16 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ### 2026-05-13
 - Type: Execution
+- Summary: TASK-227 addressed Copilot PR #254 review feedback on migration backfills, retryability, reconciliation scale, dispatch-time verification, and env docs.
+- Evidence: Changed the TASK-227 migration to backfill runtime-compatible grouping keys and ISO source fingerprints, merge duplicate pending project digest rows before adding the active grouping-key index, and declare the source fingerprint index in Prisma. Reconciliation now queries uncovered notification candidates directly instead of scanning all verified users or repeatedly consuming the cap on covered notifications. Stale claimed groups are released back to `pending` for retry. Dispatch reloads and rechecks `emailVerified` before sending. `.env.example` now matches the manual diagnostic workflow and preferred dispatch header.
+
+### 2026-05-13
+- Type: Validation
+- Summary: TASK-227 Copilot follow-up passed focused, migration, lint, full test, coverage, and build validation.
+- Evidence: Focused orchestration suite passed after review fixes with 4 files and 83 tests. A fresh temporary local database `nexusdash_task227_migration_check` applied all 35 migrations successfully via `npm run db:migrate`, then was dropped. `npm run lint` passed. Local PostgreSQL `NODE_ENV=test npm test` passed (107 files passed, 2 skipped; 802 tests passed, 2 skipped). Local PostgreSQL `NODE_ENV=test npm run test:coverage` passed (91.23% statements, 81.2% branches, 93.42% functions, 91.75% lines). Production-guarded `npm run build` passed with local PostgreSQL, disabled outbound delivery mode, localhost trusted origins, local agent signing secret, local Google token key, and explicit `NEXTAUTH_URL`/`NEXTAUTH_SECRET`.
+
+### 2026-05-13
+- Type: Execution
 - Summary: TASK-227 started from the required dedicated worktree and audited TASK-225/PR #246 plus PR #252.
 - Evidence: Reused existing worktree `../nexus_dash_task227`, switched it from deleted `docs/task-227-prod-notification-delivery` to `feature/task-227-production-grade-notification-email-orchestration` at `origin/main`, rewrote `tasks/current.md` for TASK-227, inspected PR #246 and PR #252, and checked recent `Notification Email Dispatch` runs. Run `25752062859` failed with empty dispatch URL/secret; run `25826658473` on `fix/task-225-notification-dispatch-workflow` reached Vercel deployment protection and returned 401 HTML; run `25826921991` on `main` still returned 401 through the bearer path.
 

--- a/journal.md
+++ b/journal.md
@@ -13,6 +13,31 @@ Use it for important implementation milestones, blockers, validation runs, and r
 ## Recent Entries (Most Relevant)
 
 ### 2026-05-13
+- Type: Execution
+- Summary: TASK-227 started from the required dedicated worktree and audited TASK-225/PR #246 plus PR #252.
+- Evidence: Reused existing worktree `../nexus_dash_task227`, switched it from deleted `docs/task-227-prod-notification-delivery` to `feature/task-227-production-grade-notification-email-orchestration` at `origin/main`, rewrote `tasks/current.md` for TASK-227, inspected PR #246 and PR #252, and checked recent `Notification Email Dispatch` runs. Run `25752062859` failed with empty dispatch URL/secret; run `25826658473` on `fix/task-225-notification-dispatch-workflow` reached Vercel deployment protection and returned 401 HTML; run `25826921991` on `main` still returned 401 through the bearer path.
+
+### 2026-05-13
+- Type: Execution
+- Summary: TASK-227 replaced scan-time notification email dispatch with durable debounce orchestration.
+- Evidence: Added TASK-227 migration `20260513120000_task227_notification_email_orchestration` for grouping keys, first/latest pending timestamps, send-after/max-send timestamps, claim state, attempt counters, and source fingerprints. Reworked `lib/services/project-notification-email-service.ts` so notification creation/refreshed paths enqueue pending recipient/project groups, dispatcher claims due groups with `FOR UPDATE SKIP LOCKED`, batches due groups by recipient, and records sent/skipped/failed outcomes against outbound delivery attempts. Wired ingestion from `lib/services/notification-service.ts`.
+
+### 2026-05-13
+- Type: Execution
+- Summary: TASK-227 demoted GitHub Actions scheduling and documented the production scheduler decision.
+- Evidence: `.github/workflows/notification-email-dispatch.yml` is now manual-only diagnostic tooling using `x-notification-email-dispatch-secret`. README/runbook guidance now states Vercel Cron is the preferred production path on a plan with sub-hour cadence, the current Hobby plan is blocked by daily-only cron, and a managed HTTP scheduler such as Upstash QStash Schedule is the Hobby-compatible production alternative. Preview validation remains manual endpoint invocation because Vercel Cron runs only on production deployments.
+
+### 2026-05-13
+- Type: Validation
+- Summary: TASK-227 focused orchestration validation passed during implementation.
+- Evidence: `npm ci`; `npx prisma validate`; `npm test -- --run tests/lib/project-notification-email-service.test.ts tests/api/notification-email-dispatch.route.test.ts tests/lib/outbound-email-templates.test.ts tests/lib/env.server.test.ts` passed with 4 files and 81 tests. Focused notification producer regression also passed with `npm test -- --run tests/lib/notification-service.test.ts tests/api/task-comments.route.test.ts tests/api/task-update.route.test.ts` (3 files, 41 tests).
+
+### 2026-05-13
+- Type: Validation
+- Summary: TASK-227 local validation baseline passed.
+- Evidence: `npm run lint`; local PostgreSQL `npm run db:migrate` applied `20260513120000_task227_notification_email_orchestration`; local DB `NODE_ENV=test npm test` passed (107 files passed, 2 skipped; 800 tests passed, 2 skipped); local DB `NODE_ENV=test npm run test:coverage` passed (91.23% statements, 81.2% branches, 93.42% functions, 91.75% lines); production-guarded `npm run build` passed with local PostgreSQL, disabled outbound delivery mode, localhost trusted origins, local agent signing secret, local Google token key, and explicit `NEXTAUTH_URL`/`NEXTAUTH_SECRET`. `npm run db:local:up` was blocked by port 5432 already being allocated, so the existing local PostgreSQL service was used.
+
+### 2026-05-13
 - Type: Planning
 - Summary: Added TASK-227 to clarify the production-grade notification email refactor.
 - Evidence: Added `tasks/task-227-production-grade-notification-email-orchestration.md` and queued TASK-227 in `tasks/backlog.md`. The task captures the product goal as grouped project notification email delivery with debounce and a hard maximum delay, separates TASK-226 due-date reminder business logic, directs the next implementation away from GitHub Actions as the primary production scheduler, and updates TASK-225 tracking to reflect that PR #246 has merged.

--- a/lib/services/notification-service.ts
+++ b/lib/services/notification-service.ts
@@ -1,6 +1,7 @@
 import { Prisma } from "@prisma/client";
 
 import { logServerError } from "@/lib/observability/logger";
+import { enqueueNotificationEmailForNotification } from "@/lib/services/project-notification-email-service";
 import { type DbClient, withActorRlsContext } from "@/lib/services/rls-context";
 
 const NOTIFICATION_TYPE_PROJECT_INVITATION = "project_invitation";
@@ -285,6 +286,43 @@ function mapNotification(
   };
 }
 
+async function enqueueEmailForNotificationWhere(input: {
+  db: DbClient;
+  where: {
+    recipientUserId: string;
+    sourceType: string;
+    sourceId: string;
+  };
+}): Promise<void> {
+  const notification = await input.db.notification.findFirst({
+    where: input.where,
+    select: {
+      id: true,
+      recipientUserId: true,
+      type: true,
+      title: true,
+      body: true,
+      targetPath: true,
+      sourceType: true,
+      sourceId: true,
+      metadata: true,
+      readAt: true,
+      resolvedAt: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+
+  if (!notification) {
+    return;
+  }
+
+  await enqueueNotificationEmailForNotification({
+    db: input.db,
+    notification,
+  });
+}
+
 function mapPendingInvitationRow(
   row: PendingInvitationMetadataRow
 ): ProjectInvitationNotificationInput {
@@ -369,6 +407,10 @@ async function createOrRefreshProjectInvitationNotification(input: {
       ],
       skipDuplicates: true,
     });
+    await enqueueEmailForNotificationWhere({
+      db: input.db,
+      where: notificationWhere,
+    });
     return;
   }
 
@@ -383,6 +425,10 @@ async function createOrRefreshProjectInvitationNotification(input: {
     existingNotification.resolvedAt === null;
 
   if (notificationUnchanged) {
+    await enqueueEmailForNotificationWhere({
+      db: input.db,
+      where: notificationWhere,
+    });
     return;
   }
 
@@ -396,6 +442,10 @@ async function createOrRefreshProjectInvitationNotification(input: {
       metadata,
       resolvedAt: null,
     },
+  });
+  await enqueueEmailForNotificationWhere({
+    db: input.db,
+    where: notificationWhere,
   });
 }
 
@@ -810,6 +860,10 @@ async function createOrRefreshTaskCommentMentionNotification(input: {
       ],
       skipDuplicates: true,
     });
+    await enqueueEmailForNotificationWhere({
+      db: input.db,
+      where: notificationWhere,
+    });
     return;
   }
 
@@ -824,6 +878,10 @@ async function createOrRefreshTaskCommentMentionNotification(input: {
     existingNotification.resolvedAt === null;
 
   if (notificationUnchanged) {
+    await enqueueEmailForNotificationWhere({
+      db: input.db,
+      where: notificationWhere,
+    });
     return;
   }
 
@@ -837,6 +895,10 @@ async function createOrRefreshTaskCommentMentionNotification(input: {
       metadata,
       resolvedAt: null,
     },
+  });
+  await enqueueEmailForNotificationWhere({
+    db: input.db,
+    where: notificationWhere,
   });
 }
 
@@ -1019,6 +1081,10 @@ async function createOrRefreshTaskAssignmentNotification(input: {
       ],
       skipDuplicates: true,
     });
+    await enqueueEmailForNotificationWhere({
+      db: input.db,
+      where: notificationWhere,
+    });
     return;
   }
 
@@ -1033,6 +1099,10 @@ async function createOrRefreshTaskAssignmentNotification(input: {
     existingNotification.resolvedAt === null;
 
   if (notificationUnchanged) {
+    await enqueueEmailForNotificationWhere({
+      db: input.db,
+      where: notificationWhere,
+    });
     return;
   }
 
@@ -1046,6 +1116,10 @@ async function createOrRefreshTaskAssignmentNotification(input: {
       metadata,
       resolvedAt: null,
     },
+  });
+  await enqueueEmailForNotificationWhere({
+    db: input.db,
+    where: notificationWhere,
   });
 }
 

--- a/lib/services/outbound-email-templates.ts
+++ b/lib/services/outbound-email-templates.ts
@@ -139,24 +139,48 @@ export interface ProjectNotificationDigestEmailItem {
   targetUrl: string;
 }
 
-export function buildProjectNotificationDigestEmail(input: {
+export interface ProjectNotificationDigestEmailSection {
   projectName: string;
   notificationCount: number;
   items: ProjectNotificationDigestEmailItem[];
   projectUrl: string;
-  notificationsUrl: string;
   omittedCount?: number;
-}): OutboundEmailMessage {
-  const plainProjectName = sanitizePlainText(input.projectName) || "a project";
-  const safeProjectName = escapeHtmlText(plainProjectName);
-  const safeProjectUrl = escapeHtmlAttribute(input.projectUrl);
-  const safeNotificationsUrl = escapeHtmlAttribute(input.notificationsUrl);
-  const notificationLabel =
-    input.notificationCount === 1 ? "update" : "updates";
-  const subject = truncateSubject(
-    `${input.notificationCount} ${notificationLabel} for ${plainProjectName} on NexusDash`
-  );
-  const digestItems = input.items.map((item) => {
+}
+
+type ProjectNotificationDigestEmailInput =
+  | {
+      sections: ProjectNotificationDigestEmailSection[];
+      notificationsUrl: string;
+    }
+  | {
+      projectName: string;
+      notificationCount: number;
+      items: ProjectNotificationDigestEmailItem[];
+      projectUrl: string;
+      notificationsUrl: string;
+      omittedCount?: number;
+    };
+
+function normalizeDigestSections(
+  input: ProjectNotificationDigestEmailInput
+): ProjectNotificationDigestEmailSection[] {
+  if ("sections" in input) {
+    return input.sections;
+  }
+
+  return [
+    {
+      projectName: input.projectName,
+      notificationCount: input.notificationCount,
+      items: input.items,
+      projectUrl: input.projectUrl,
+      omittedCount: input.omittedCount,
+    },
+  ];
+}
+
+function normalizeDigestItems(items: ProjectNotificationDigestEmailItem[]) {
+  return items.map((item) => {
     const plainLabel = sanitizePlainText(item.label) || "Project update";
     const prefix = item.count > 1 ? `${item.count}x ` : "";
 
@@ -165,39 +189,93 @@ export function buildProjectNotificationDigestEmail(input: {
       targetUrl: item.targetUrl,
     };
   });
-  const omittedCount = Math.max(0, input.omittedCount ?? 0);
+}
+
+export function buildProjectNotificationDigestEmail(
+  input: ProjectNotificationDigestEmailInput
+): OutboundEmailMessage {
+  const sections = normalizeDigestSections(input)
+    .map((section) => ({
+      ...section,
+      projectName: sanitizePlainText(section.projectName) || "a project",
+      notificationCount: Math.max(0, section.notificationCount),
+      omittedCount: Math.max(0, section.omittedCount ?? 0),
+    }))
+    .filter((section) => section.notificationCount > 0);
+  const totalNotifications = sections.reduce(
+    (total, section) => total + section.notificationCount,
+    0
+  );
+  const safeNotificationsUrl = escapeHtmlAttribute(input.notificationsUrl);
+  const notificationLabel =
+    totalNotifications === 1 ? "update" : "updates";
+  const subject =
+    sections.length === 1
+      ? truncateSubject(
+          `${totalNotifications} ${notificationLabel} for ${sections[0].projectName} on NexusDash`
+        )
+      : truncateSubject(
+          `${totalNotifications} ${notificationLabel} across ${sections.length} projects on NexusDash`
+        );
 
   const textLines = [
-    `You have ${input.notificationCount} unread ${notificationLabel} for ${plainProjectName}.`,
+    sections.length === 1
+      ? `You have ${totalNotifications} unread ${notificationLabel} for ${sections[0].projectName}.`
+      : `You have ${totalNotifications} unread ${notificationLabel} across ${sections.length} projects.`,
     "",
-    ...digestItems.map((item) => `- ${item.label}: ${item.targetUrl}`),
-    ...(omittedCount > 0
-      ? [`- ${omittedCount} more ${omittedCount === 1 ? "update" : "updates"} in NexusDash.`]
-      : []),
+    ...sections.flatMap((section) => {
+      const digestItems = normalizeDigestItems(section.items);
+      return [
+        section.projectName,
+        ...digestItems.map((item) => `- ${item.label}: ${item.targetUrl}`),
+        ...(section.omittedCount > 0
+          ? [
+              `- ${section.omittedCount} more ${section.omittedCount === 1 ? "update" : "updates"} in NexusDash.`,
+            ]
+          : []),
+        `Open project: ${section.projectUrl}`,
+        "",
+      ];
+    }),
     "",
-    `Open project: ${input.projectUrl}`,
     `Open notification center: ${input.notificationsUrl}`,
   ];
 
-  const htmlItems = digestItems
-    .map((item) => {
-      const safeLabel = escapeHtmlText(item.label);
-      const safeTargetUrl = escapeHtmlAttribute(item.targetUrl);
-      return `<li><a href="${safeTargetUrl}">${safeLabel}</a></li>`;
+  const htmlSections = sections
+    .map((section) => {
+      const digestItems = normalizeDigestItems(section.items);
+      const htmlItems = digestItems
+        .map((item) => {
+          const safeLabel = escapeHtmlText(item.label);
+          const safeTargetUrl = escapeHtmlAttribute(item.targetUrl);
+          return `<li><a href="${safeTargetUrl}">${safeLabel}</a></li>`;
+        })
+        .join("");
+      const omittedHtml =
+        section.omittedCount > 0
+          ? `<li>${section.omittedCount} more ${section.omittedCount === 1 ? "update" : "updates"} in NexusDash.</li>`
+          : "";
+      const safeProjectName = escapeHtmlText(section.projectName);
+      const safeProjectUrl = escapeHtmlAttribute(section.projectUrl);
+
+      return (
+        `<h2>${safeProjectName}</h2>` +
+        `<ul>${htmlItems}${omittedHtml}</ul>` +
+        `<p><a href="${safeProjectUrl}">Open project</a></p>`
+      );
     })
     .join("");
-  const omittedHtml =
-    omittedCount > 0
-      ? `<li>${omittedCount} more ${omittedCount === 1 ? "update" : "updates"} in NexusDash.</li>`
-      : "";
 
   return {
     subject,
     text: textLines.join("\n"),
     html:
-      `<p>You have <strong>${input.notificationCount}</strong> unread ${notificationLabel} for <strong>${safeProjectName}</strong>.</p>` +
-      `<ul>${htmlItems}${omittedHtml}</ul>` +
-      `<p><a href="${safeProjectUrl}">Open project</a></p>` +
+      `<p>You have <strong>${totalNotifications}</strong> unread ${notificationLabel}${
+        sections.length === 1
+          ? ""
+          : ` across <strong>${sections.length}</strong> projects`
+      }.</p>` +
+      htmlSections +
       `<p><a href="${safeNotificationsUrl}">Open notification center</a></p>`,
   };
 }

--- a/lib/services/project-notification-email-service.ts
+++ b/lib/services/project-notification-email-service.ts
@@ -34,7 +34,8 @@ type NotificationEmailStatus = "sent" | "skipped" | "failed";
 
 interface VerifiedRecipient {
   id: string;
-  email: string;
+  email: string | null;
+  emailVerified: Date | null;
   name: string | null;
 }
 
@@ -544,75 +545,72 @@ export async function enqueueNotificationEmailForNotification(input: {
   });
 }
 
-async function reconcilePendingNotificationEmailGroups(now: Date): Promise<number> {
-  const recipients = await prisma.user.findMany({
-    where: {
-      email: {
-        not: null,
-      },
-      emailVerified: {
-        not: null,
-      },
-    },
-    orderBy: [{ createdAt: "asc" }],
-    select: {
-      id: true,
-    },
-  });
+async function findUncoveredNotificationEmailCandidates(
+  limit: number
+): Promise<NotificationRecord[]> {
+  return prisma.$queryRaw<NotificationRecord[]>(Prisma.sql`
+    SELECT
+      notification."id",
+      notification."recipientUserId",
+      notification."type",
+      notification."title",
+      notification."body",
+      notification."targetPath",
+      notification."sourceType",
+      notification."sourceId",
+      notification."metadata",
+      notification."readAt",
+      notification."resolvedAt",
+      notification."createdAt",
+      notification."updatedAt"
+    FROM "Notification" notification
+    INNER JOIN "User" recipient
+      ON recipient."id" = notification."recipientUserId"
+    WHERE notification."readAt" IS NULL
+      AND notification."resolvedAt" IS NULL
+      AND notification."type" IN (
+        ${NOTIFICATION_TYPE_PROJECT_INVITATION},
+        ${NOTIFICATION_TYPE_TASK_COMMENT_MENTION},
+        ${NOTIFICATION_TYPE_TASK_ASSIGNMENT}
+      )
+      AND recipient."email" IS NOT NULL
+      AND recipient."emailVerified" IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1
+        FROM "ProjectNotificationEmailItem" item
+        INNER JOIN "ProjectNotificationEmail" email
+          ON email."id" = item."emailId"
+        WHERE item."notificationId" = notification."id"
+          AND item."sourceFingerprint" =
+            notification."id" || ':' ||
+            to_char(notification."updatedAt", 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+          AND email."status" IN ('pending', 'dispatching', 'sent', 'skipped')
+      )
+    ORDER BY notification."updatedAt" ASC, notification."id" ASC
+    LIMIT ${limit}
+  `);
+}
 
+async function reconcilePendingNotificationEmailGroups(): Promise<number> {
+  const notifications = await findUncoveredNotificationEmailCandidates(
+    MAX_RECONCILE_NOTIFICATIONS
+  );
   let reconciled = 0;
-  for (const recipient of recipients) {
-    if (reconciled >= MAX_RECONCILE_NOTIFICATIONS) {
-      break;
-    }
 
-    await withActorRlsContext(recipient.id, async (db) => {
-      const notifications = await db.notification.findMany({
-        where: {
-          recipientUserId: recipient.id,
-          readAt: null,
-          resolvedAt: null,
-          type: {
-            in: [
-              NOTIFICATION_TYPE_PROJECT_INVITATION,
-              NOTIFICATION_TYPE_TASK_COMMENT_MENTION,
-              NOTIFICATION_TYPE_TASK_ASSIGNMENT,
-            ],
-          },
-        },
-        orderBy: [{ updatedAt: "asc" }],
-        take: MAX_RECONCILE_NOTIFICATIONS - reconciled,
-        select: {
-          id: true,
-          recipientUserId: true,
-          type: true,
-          title: true,
-          body: true,
-          targetPath: true,
-          sourceType: true,
-          sourceId: true,
-          metadata: true,
-          readAt: true,
-          resolvedAt: true,
-          createdAt: true,
-          updatedAt: true,
-        },
+  for (const notification of notifications) {
+    await withActorRlsContext(notification.recipientUserId, async (db) => {
+      await enqueueNotificationEmailForNotification({
+        db,
+        notification,
       });
-
-      for (const notification of notifications) {
-        await enqueueNotificationEmailForNotification({
-          db,
-          notification,
-        });
-        reconciled += 1;
-      }
     });
+    reconciled += 1;
   }
 
   return reconciled;
 }
 
-async function failStaleDispatchingGroups(now: Date): Promise<void> {
+async function releaseStaleDispatchingGroups(now: Date): Promise<void> {
   const staleBefore = new Date(now.getTime() - STALE_DISPATCHING_MS);
   await prisma.projectNotificationEmail.updateMany({
     where: {
@@ -622,10 +620,12 @@ async function failStaleDispatchingGroups(now: Date): Promise<void> {
       },
     },
     data: {
-      status: "failed",
+      status: "pending",
       errorCode: "dispatch-claim-stale",
       claimToken: null,
-      completedAt: now,
+      claimedAt: null,
+      completedAt: null,
+      sendAfterAt: now,
     },
   });
 }
@@ -692,6 +692,7 @@ async function loadClaimedGroupsForRecipient(input: {
           select: {
             id: true,
             email: true,
+            emailVerified: true,
             name: true,
           },
         },
@@ -730,9 +731,7 @@ async function loadClaimedGroupsForRecipient(input: {
       },
     });
 
-    return groups.filter((group): group is ClaimedEmailGroup =>
-      Boolean(group.recipient.email)
-    );
+    return groups;
   });
 }
 
@@ -997,6 +996,25 @@ async function dispatchRecipientBatch(input: {
   }
 
   const notificationIds = sections.flatMap((section) => section.notificationIds);
+  if (!input.recipient.email || !input.recipient.emailVerified) {
+    await markGroupsComplete({
+      groupIds: sections.map((section) => section.groupId),
+      status: "skipped",
+      now: input.now,
+      errorCode: "recipient-email-not-verified",
+    });
+    return {
+      status: "skipped",
+      attempted: false,
+      sentGroupIds: [],
+      skippedGroupIds: [
+        ...skippedGroupIds,
+        ...sections.map((section) => section.groupId),
+      ],
+      failedGroupIds: [],
+    };
+  }
+
   const message = buildProjectNotificationDigestEmail({
     sections: sections.map((section) => section.section),
     notificationsUrl: buildAbsoluteUrl(input.appOrigin, "/account/notifications"),
@@ -1085,13 +1103,13 @@ export async function dispatchProjectNotificationEmails(input: {
 
   try {
     summary.notificationsReconciled =
-      await reconcilePendingNotificationEmailGroups(now);
+      await reconcilePendingNotificationEmailGroups();
   } catch (error) {
     summary.errors += 1;
     logServerError("dispatchProjectNotificationEmails.reconcile", error);
   }
 
-  await failStaleDispatchingGroups(now);
+  await releaseStaleDispatchingGroups(now);
 
   const claimedGroupIds = await claimDueGroups({
     now,

--- a/lib/services/project-notification-email-service.ts
+++ b/lib/services/project-notification-email-service.ts
@@ -6,9 +6,9 @@ import { logServerError, logServerInfo } from "@/lib/observability/logger";
 import { prisma } from "@/lib/prisma";
 import { sendOutboundEmail } from "@/lib/services/outbound-email-service";
 import {
-  buildProjectInvitationEmail,
   buildProjectNotificationDigestEmail,
   type ProjectNotificationDigestEmailItem,
+  type ProjectNotificationDigestEmailSection,
 } from "@/lib/services/outbound-email-templates";
 import { type DbClient, withActorRlsContext } from "@/lib/services/rls-context";
 
@@ -17,11 +17,20 @@ const NOTIFICATION_TYPE_TASK_COMMENT_MENTION = "task_comment_mention";
 const NOTIFICATION_TYPE_TASK_ASSIGNMENT = "task_assignment";
 const EMAIL_KIND_PROJECT_DIGEST = "project_digest";
 const EMAIL_KIND_PROJECT_INVITATION_REMINDER = "project_invitation_reminder";
+
 const QUIET_WINDOW_MS = 30 * 60 * 1000;
+const MAX_ACTIVITY_DELAY_MS = 60 * 60 * 1000;
 const INVITATION_REMINDER_AFTER_MS = 6 * 60 * 60 * 1000;
-const PENDING_RETRY_GRACE_MS = 30 * 60 * 1000;
+const STALE_DISPATCHING_MS = 30 * 60 * 1000;
 const MAX_GROUPS_PER_DISPATCH = 100;
-const MAX_DIGEST_BODY_ITEMS = 12;
+const MAX_RECONCILE_NOTIFICATIONS = 500;
+const MAX_DIGEST_BODY_ITEMS_PER_PROJECT = 12;
+
+type NotificationEmailKind =
+  | typeof EMAIL_KIND_PROJECT_DIGEST
+  | typeof EMAIL_KIND_PROJECT_INVITATION_REMINDER;
+
+type NotificationEmailStatus = "sent" | "skipped" | "failed";
 
 interface VerifiedRecipient {
   id: string;
@@ -31,6 +40,7 @@ interface VerifiedRecipient {
 
 interface NotificationRecord {
   id: string;
+  recipientUserId: string;
   type: string;
   title: string;
   body: string | null;
@@ -38,55 +48,74 @@ interface NotificationRecord {
   sourceType: string;
   sourceId: string;
   metadata: Prisma.JsonValue | null;
+  readAt: Date | null;
+  resolvedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
 }
 
-interface DigestCandidate {
-  notification: NotificationRecord;
+interface QueueDetails {
+  kind: NotificationEmailKind;
   projectId: string;
   projectName: string;
-  taskId: string;
-  taskTitle: string;
-  actorDisplayName: string;
-  targetPath: string;
-  activityKind: "mention" | "assignment";
-  activityAt: Date;
+  sourceKey: string;
+  groupingKey: string;
+  firstPendingNotificationAt: Date;
+  latestPendingNotificationAt: Date;
+  sendAfterAt: Date;
+  maxSendAt: Date;
+  sourceFingerprint: string;
+  metadata: Prisma.InputJsonObject;
 }
 
-interface DigestGroup {
-  recipient: VerifiedRecipient;
+interface ClaimedNotificationItem {
+  id: string;
+  notificationId: string;
+  notificationUpdatedAt: Date | null;
+  sourceFingerprint: string | null;
+  notification: NotificationRecord;
+}
+
+interface ClaimedEmailGroup {
+  id: string;
+  kind: NotificationEmailKind;
+  recipientUserId: string;
   projectId: string;
-  projectName: string;
-  candidates: DigestCandidate[];
+  sourceKey: string;
+  groupingKey: string;
+  firstPendingNotificationAt: Date;
+  latestPendingNotificationAt: Date;
+  sendAfterAt: Date;
+  maxSendAt: Date;
   windowStartedAt: Date;
   windowEndedAt: Date;
   latestNotificationAt: Date;
+  notificationCount: number;
+  recipient: VerifiedRecipient;
+  project: {
+    id: string;
+    name: string;
+  };
+  items: ClaimedNotificationItem[];
 }
 
-interface InvitationReminderCandidate {
-  recipient: VerifiedRecipient;
-  notification: NotificationRecord;
-  invitationId: string;
+interface PreparedSection {
+  groupId: string;
   projectId: string;
-  projectName: string;
-  invitedByDisplayName: string;
-  role: "editor" | "viewer";
-  expiresAt: Date;
-  targetPath: string;
-  createdAt: Date;
+  section: ProjectNotificationDigestEmailSection;
+  notificationIds: string[];
 }
 
 export interface DispatchProjectNotificationEmailsSummary {
-  usersScanned: number;
-  digestsAttempted: number;
-  digestsSent: number;
-  digestsSkipped: number;
-  digestsFailed: number;
-  invitationRemindersAttempted: number;
-  invitationRemindersSent: number;
-  invitationRemindersSkipped: number;
-  invitationRemindersFailed: number;
+  notificationsReconciled: number;
+  groupsClaimed: number;
+  recipientEmailsAttempted: number;
+  recipientEmailsSent: number;
+  recipientEmailsSkipped: number;
+  recipientEmailsFailed: number;
+  groupsSent: number;
+  groupsSkipped: number;
+  groupsFailed: number;
   errors: number;
 }
 
@@ -144,24 +173,31 @@ function normalizeAppOrigin(appOrigin: string | null | undefined): string {
   return "http://localhost:3000";
 }
 
-function createSourceKey(notificationIds: string[]): string {
-  return crypto
-    .createHash("sha256")
-    .update(notificationIds.slice().sort().join("\n"))
-    .digest("hex");
+function createClaimToken(): string {
+  return crypto.randomBytes(16).toString("hex");
 }
 
-function isUniqueConstraintFailure(error: unknown): boolean {
-  return (
-    error instanceof Prisma.PrismaClientKnownRequestError &&
-    error.code === "P2002"
-  );
+function createSourceFingerprint(notification: {
+  id: string;
+  updatedAt: Date;
+}): string {
+  return `${notification.id}:${notification.updatedAt.toISOString()}`;
 }
 
-function mapDeliveryStatus(result: Awaited<ReturnType<typeof sendOutboundEmail>>) {
+function createSourceKeyFromFingerprint(sourceFingerprint: string): string {
+  return crypto.createHash("sha256").update(sourceFingerprint).digest("hex");
+}
+
+function mapDeliveryStatus(
+  result: Awaited<ReturnType<typeof sendOutboundEmail>>
+): {
+  status: NotificationEmailStatus;
+  deliveryId: string | null;
+  errorCode: string | null;
+} {
   if (!result.ok) {
     return {
-      status: "failed" as const,
+      status: "failed",
       deliveryId: result.deliveryId,
       errorCode: result.error,
     };
@@ -174,180 +210,342 @@ function mapDeliveryStatus(result: Awaited<ReturnType<typeof sendOutboundEmail>>
   };
 }
 
-function getDigestCandidate(notification: NotificationRecord): DigestCandidate | null {
+function calculateActivitySchedule(input: {
+  firstPendingNotificationAt: Date;
+  latestPendingNotificationAt: Date;
+}) {
+  const quietSendAfterAt = new Date(
+    input.latestPendingNotificationAt.getTime() + QUIET_WINDOW_MS
+  );
+  const maxSendAt = new Date(
+    input.firstPendingNotificationAt.getTime() + MAX_ACTIVITY_DELAY_MS
+  );
+
+  return {
+    sendAfterAt: minDate(quietSendAfterAt, maxSendAt),
+    maxSendAt,
+  };
+}
+
+function createActivityGroupingKey(input: {
+  recipientUserId: string;
+  projectId: string;
+}): string {
+  return [
+    EMAIL_KIND_PROJECT_DIGEST,
+    input.recipientUserId,
+    input.projectId,
+  ].join(":");
+}
+
+function createInvitationGroupingKey(input: {
+  recipientUserId: string;
+  projectId: string;
+  invitationId: string;
+}): string {
+  return [
+    EMAIL_KIND_PROJECT_INVITATION_REMINDER,
+    input.recipientUserId,
+    input.projectId,
+    input.invitationId,
+  ].join(":");
+}
+
+function getQueueDetails(notification: NotificationRecord): QueueDetails | null {
   if (!isJsonObject(notification.metadata)) {
     return null;
   }
 
   const projectId = readString(notification.metadata, "projectId");
   const projectName = readString(notification.metadata, "projectName");
-  const taskId = readString(notification.metadata, "taskId");
-  const taskTitle = readString(notification.metadata, "taskTitle");
-  const targetPath = readString(notification.metadata, "targetPath");
-
-  if (!projectId || !projectName || !taskId || !taskTitle || !targetPath) {
+  if (!projectId || !projectName) {
     return null;
   }
 
-  if (notification.type === NOTIFICATION_TYPE_TASK_COMMENT_MENTION) {
-    const actorDisplayName = readString(notification.metadata, "authorDisplayName");
-    if (!actorDisplayName) {
-      return null;
-    }
+  const sourceFingerprint = createSourceFingerprint(notification);
+  const activityAt = maxDate(notification.createdAt, notification.updatedAt);
+
+  if (
+    notification.type === NOTIFICATION_TYPE_TASK_COMMENT_MENTION ||
+    notification.type === NOTIFICATION_TYPE_TASK_ASSIGNMENT
+  ) {
+    const schedule = calculateActivitySchedule({
+      firstPendingNotificationAt: activityAt,
+      latestPendingNotificationAt: activityAt,
+    });
 
     return {
-      notification,
+      kind: EMAIL_KIND_PROJECT_DIGEST,
       projectId,
       projectName,
-      taskId,
-      taskTitle,
-      actorDisplayName,
-      targetPath,
-      activityKind: "mention",
-      activityAt: maxDate(notification.createdAt, notification.updatedAt),
+      sourceKey: createSourceKeyFromFingerprint(sourceFingerprint),
+      groupingKey: createActivityGroupingKey({
+        recipientUserId: notification.recipientUserId,
+        projectId,
+      }),
+      firstPendingNotificationAt: activityAt,
+      latestPendingNotificationAt: activityAt,
+      sendAfterAt: schedule.sendAfterAt,
+      maxSendAt: schedule.maxSendAt,
+      sourceFingerprint,
+      metadata: {
+        projectId,
+        projectName,
+        quietWindowMinutes: QUIET_WINDOW_MS / 60_000,
+        maxDelayMinutes: MAX_ACTIVITY_DELAY_MS / 60_000,
+      },
     };
   }
 
-  if (notification.type === NOTIFICATION_TYPE_TASK_ASSIGNMENT) {
-    const actorDisplayName = readString(notification.metadata, "actorDisplayName");
-    if (!actorDisplayName) {
+  if (notification.type === NOTIFICATION_TYPE_PROJECT_INVITATION) {
+    const invitationId = readString(notification.metadata, "invitationId");
+    if (!invitationId) {
       return null;
     }
 
+    const sendAfterAt = new Date(
+      notification.createdAt.getTime() + INVITATION_REMINDER_AFTER_MS
+    );
+
     return {
-      notification,
+      kind: EMAIL_KIND_PROJECT_INVITATION_REMINDER,
       projectId,
       projectName,
-      taskId,
-      taskTitle,
-      actorDisplayName,
-      targetPath,
-      activityKind: "assignment",
-      activityAt: maxDate(notification.createdAt, notification.updatedAt),
+      sourceKey: invitationId,
+      groupingKey: createInvitationGroupingKey({
+        recipientUserId: notification.recipientUserId,
+        projectId,
+        invitationId,
+      }),
+      firstPendingNotificationAt: notification.createdAt,
+      latestPendingNotificationAt: notification.createdAt,
+      sendAfterAt,
+      maxSendAt: sendAfterAt,
+      sourceFingerprint,
+      metadata: {
+        invitationId,
+        projectId,
+        projectName,
+        reminderAfterHours: INVITATION_REMINDER_AFTER_MS / 3_600_000,
+      },
     };
   }
 
   return null;
 }
 
-function getInvitationReminderCandidate(input: {
-  recipient: VerifiedRecipient;
+async function isRecipientVerified(db: DbClient, recipientUserId: string) {
+  const recipient = await db.user.findUnique({
+    where: { id: recipientUserId },
+    select: {
+      email: true,
+      emailVerified: true,
+    },
+  });
+
+  return Boolean(recipient?.email && recipient.emailVerified);
+}
+
+async function isNotificationFingerprintCovered(input: {
+  db: DbClient;
+  notificationId: string;
+  sourceFingerprint: string;
+  kind: NotificationEmailKind;
+}): Promise<boolean> {
+  const existing = await input.db.projectNotificationEmailItem.findFirst({
+    where: {
+      notificationId: input.notificationId,
+      sourceFingerprint: input.sourceFingerprint,
+      email: {
+        kind: input.kind,
+        status: {
+          in: ["pending", "dispatching", "sent", "skipped"],
+        },
+      },
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  return Boolean(existing);
+}
+
+async function countGroupItems(db: DbClient, emailId: string): Promise<number> {
+  return db.projectNotificationEmailItem.count({
+    where: {
+      emailId,
+    },
+  });
+}
+
+async function attachNotificationToGroup(input: {
+  db: DbClient;
+  emailId: string;
   notification: NotificationRecord;
-  invitation: {
-    id: string;
-    invitedEmail: string;
-    role: "editor" | "viewer";
-    expiresAt: Date;
-    acceptedAt: Date | null;
-    revokedAt: Date | null;
-    replacedAt: Date | null;
-    project: {
-      id: string;
-      name: string;
-    };
-    invitedByUser: {
-      email: string | null;
-      name: string | null;
-      username: string | null;
-      usernameDiscriminator: string | null;
-    };
-  };
-  now: Date;
-}): InvitationReminderCandidate | null {
-  if (
-    input.invitation.acceptedAt ||
-    input.invitation.revokedAt ||
-    input.invitation.replacedAt ||
-    input.invitation.expiresAt <= input.now ||
-    input.invitation.invitedEmail.toLowerCase() !==
-      input.recipient.email.toLowerCase()
-  ) {
-    return null;
-  }
+  sourceFingerprint: string;
+}) {
+  const existingItem = await input.db.projectNotificationEmailItem.findFirst({
+    where: {
+      emailId: input.emailId,
+      notificationId: input.notification.id,
+    },
+    select: {
+      id: true,
+    },
+  });
 
-  const metadata = isJsonObject(input.notification.metadata)
-    ? input.notification.metadata
-    : null;
-  const targetPath =
-    metadata ? readString(metadata, "inviteLinkPath") : null;
-  const displayName =
-    input.invitation.invitedByUser.username &&
-    input.invitation.invitedByUser.usernameDiscriminator
-      ? `${input.invitation.invitedByUser.username}#${input.invitation.invitedByUser.usernameDiscriminator}`
-      : input.invitation.invitedByUser.name ||
-        input.invitation.invitedByUser.email ||
-        "Someone";
-
-  return {
-    recipient: input.recipient,
-    notification: input.notification,
-    invitationId: input.invitation.id,
-    projectId: input.invitation.project.id,
-    projectName: input.invitation.project.name,
-    invitedByDisplayName: displayName,
-    role: input.invitation.role,
-    expiresAt: input.invitation.expiresAt,
-    targetPath:
-      targetPath ?? `/invite/project/${encodeURIComponent(input.invitation.id)}`,
-    createdAt: input.notification.createdAt,
-  };
-}
-
-function summarizeDigestGroup(
-  group: DigestGroup,
-  appOrigin: string
-): {
-  items: ProjectNotificationDigestEmailItem[];
-  omittedCount: number;
-} {
-  const collapsed = new Map<
-    string,
-    {
-      label: string;
-      count: number;
-      targetPath: string;
-    }
-  >();
-
-  for (const candidate of group.candidates) {
-    const key = [
-      candidate.activityKind,
-      candidate.taskId,
-      candidate.actorDisplayName,
-    ].join(":");
-    const existing = collapsed.get(key);
-
-    if (existing) {
-      existing.count += 1;
-      continue;
-    }
-
-    const label =
-      candidate.activityKind === "mention"
-        ? `${candidate.actorDisplayName} mentioned you on ${candidate.taskTitle}`
-        : `${candidate.actorDisplayName} assigned you to ${candidate.taskTitle}`;
-
-    collapsed.set(key, {
-      label,
-      count: 1,
-      targetPath: candidate.targetPath,
+  if (existingItem) {
+    await input.db.projectNotificationEmailItem.update({
+      where: {
+        id: existingItem.id,
+      },
+      data: {
+        notificationUpdatedAt: input.notification.updatedAt,
+        sourceFingerprint: input.sourceFingerprint,
+      },
     });
+    return;
   }
 
-  const allItems = Array.from(collapsed.values()).map((item) => ({
-    label: item.label,
-    count: item.count,
-    targetUrl: buildAbsoluteUrl(appOrigin, item.targetPath),
-  }));
-
-  return {
-    items: allItems.slice(0, MAX_DIGEST_BODY_ITEMS),
-    omittedCount: Math.max(0, allItems.length - MAX_DIGEST_BODY_ITEMS),
-  };
+  await input.db.projectNotificationEmailItem.create({
+    data: {
+      emailId: input.emailId,
+      notificationId: input.notification.id,
+      notificationUpdatedAt: input.notification.updatedAt,
+      sourceFingerprint: input.sourceFingerprint,
+    },
+  });
 }
 
-async function findVerifiedRecipients(): Promise<VerifiedRecipient[]> {
-  const users = await prisma.user.findMany({
+export async function enqueueNotificationEmailForNotification(input: {
+  db: DbClient;
+  notification: NotificationRecord;
+}): Promise<void> {
+  if (input.notification.readAt || input.notification.resolvedAt) {
+    return;
+  }
+
+  const details = getQueueDetails(input.notification);
+  if (!details) {
+    return;
+  }
+
+  if (!(await isRecipientVerified(input.db, input.notification.recipientUserId))) {
+    return;
+  }
+
+  if (
+    await isNotificationFingerprintCovered({
+      db: input.db,
+      notificationId: input.notification.id,
+      sourceFingerprint: details.sourceFingerprint,
+      kind: details.kind,
+    })
+  ) {
+    return;
+  }
+
+  const pendingGroup = await input.db.projectNotificationEmail.findFirst({
+    where: {
+      groupingKey: details.groupingKey,
+      status: "pending",
+    },
+    select: {
+      id: true,
+      firstPendingNotificationAt: true,
+      latestPendingNotificationAt: true,
+    },
+  });
+
+  if (!pendingGroup) {
+    try {
+      await input.db.projectNotificationEmail.create({
+        data: {
+          kind: details.kind,
+          recipientUserId: input.notification.recipientUserId,
+          projectId: details.projectId,
+          sourceKey: details.sourceKey,
+          groupingKey: details.groupingKey,
+          firstPendingNotificationAt: details.firstPendingNotificationAt,
+          latestPendingNotificationAt: details.latestPendingNotificationAt,
+          sendAfterAt: details.sendAfterAt,
+          maxSendAt: details.maxSendAt,
+          windowStartedAt: details.firstPendingNotificationAt,
+          windowEndedAt: details.latestPendingNotificationAt,
+          latestNotificationAt: details.latestPendingNotificationAt,
+          notificationCount: 1,
+          status: "pending",
+          metadata: details.metadata,
+          items: {
+            create: [
+              {
+                notificationId: input.notification.id,
+                notificationUpdatedAt: input.notification.updatedAt,
+                sourceFingerprint: details.sourceFingerprint,
+              },
+            ],
+          },
+        },
+      });
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2002"
+      ) {
+        return;
+      }
+      throw error;
+    }
+    return;
+  }
+
+  await attachNotificationToGroup({
+    db: input.db,
+    emailId: pendingGroup.id,
+    notification: input.notification,
+    sourceFingerprint: details.sourceFingerprint,
+  });
+
+  const firstPendingNotificationAt = minDate(
+    pendingGroup.firstPendingNotificationAt,
+    details.firstPendingNotificationAt
+  );
+  const latestPendingNotificationAt = maxDate(
+    pendingGroup.latestPendingNotificationAt,
+    details.latestPendingNotificationAt
+  );
+  const schedule =
+    details.kind === EMAIL_KIND_PROJECT_DIGEST
+      ? calculateActivitySchedule({
+          firstPendingNotificationAt,
+          latestPendingNotificationAt,
+        })
+      : {
+          sendAfterAt: details.sendAfterAt,
+          maxSendAt: details.maxSendAt,
+        };
+
+  await input.db.projectNotificationEmail.update({
+    where: {
+      id: pendingGroup.id,
+    },
+    data: {
+      firstPendingNotificationAt,
+      latestPendingNotificationAt,
+      sendAfterAt: schedule.sendAfterAt,
+      maxSendAt: schedule.maxSendAt,
+      windowStartedAt: firstPendingNotificationAt,
+      windowEndedAt: latestPendingNotificationAt,
+      latestNotificationAt: latestPendingNotificationAt,
+      notificationCount: await countGroupItems(input.db, pendingGroup.id),
+      metadata: details.metadata,
+    },
+  });
+}
+
+async function reconcilePendingNotificationEmailGroups(now: Date): Promise<number> {
+  const recipients = await prisma.user.findMany({
     where: {
       email: {
         not: null,
@@ -359,555 +557,510 @@ async function findVerifiedRecipients(): Promise<VerifiedRecipient[]> {
     orderBy: [{ createdAt: "asc" }],
     select: {
       id: true,
-      email: true,
-      name: true,
     },
   });
 
-  return users
-    .filter((user): user is VerifiedRecipient => Boolean(user.email))
-    .map((user) => ({
-      id: user.id,
-      email: user.email,
-      name: user.name,
-    }));
-}
+  let reconciled = 0;
+  for (const recipient of recipients) {
+    if (reconciled >= MAX_RECONCILE_NOTIFICATIONS) {
+      break;
+    }
 
-async function getAlreadyCoveredNotificationIds(
-  db: DbClient,
-  notificationIds: string[],
-  kind: typeof EMAIL_KIND_PROJECT_DIGEST | typeof EMAIL_KIND_PROJECT_INVITATION_REMINDER,
-  now: Date
-): Promise<Set<string>> {
-  if (notificationIds.length === 0) {
-    return new Set();
+    await withActorRlsContext(recipient.id, async (db) => {
+      const notifications = await db.notification.findMany({
+        where: {
+          recipientUserId: recipient.id,
+          readAt: null,
+          resolvedAt: null,
+          type: {
+            in: [
+              NOTIFICATION_TYPE_PROJECT_INVITATION,
+              NOTIFICATION_TYPE_TASK_COMMENT_MENTION,
+              NOTIFICATION_TYPE_TASK_ASSIGNMENT,
+            ],
+          },
+        },
+        orderBy: [{ updatedAt: "asc" }],
+        take: MAX_RECONCILE_NOTIFICATIONS - reconciled,
+        select: {
+          id: true,
+          recipientUserId: true,
+          type: true,
+          title: true,
+          body: true,
+          targetPath: true,
+          sourceType: true,
+          sourceId: true,
+          metadata: true,
+          readAt: true,
+          resolvedAt: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      });
+
+      for (const notification of notifications) {
+        await enqueueNotificationEmailForNotification({
+          db,
+          notification,
+        });
+        reconciled += 1;
+      }
+    });
   }
 
-  const pendingRetryThreshold = new Date(now.getTime() - PENDING_RETRY_GRACE_MS);
-  const rows = await db.projectNotificationEmailItem.findMany({
+  return reconciled;
+}
+
+async function failStaleDispatchingGroups(now: Date): Promise<void> {
+  const staleBefore = new Date(now.getTime() - STALE_DISPATCHING_MS);
+  await prisma.projectNotificationEmail.updateMany({
     where: {
-      notificationId: {
-        in: notificationIds,
-      },
-      email: {
-        kind,
-        OR: [
-          {
-            status: {
-              in: ["sent", "skipped"],
-            },
-          },
-          {
-            status: "pending",
-            createdAt: {
-              gte: pendingRetryThreshold,
-            },
-          },
-        ],
+      status: "dispatching",
+      claimedAt: {
+        lt: staleBefore,
       },
     },
-    select: {
-      notificationId: true,
+    data: {
+      status: "failed",
+      errorCode: "dispatch-claim-stale",
+      claimToken: null,
+      completedAt: now,
     },
-  });
-
-  return new Set(rows.map((row) => row.notificationId));
-}
-
-async function collectDigestGroupsForRecipient(input: {
-  recipient: VerifiedRecipient;
-  now: Date;
-}): Promise<DigestGroup[]> {
-  return withActorRlsContext(input.recipient.id, async (db) => {
-    const notifications = await db.notification.findMany({
-      where: {
-        recipientUserId: input.recipient.id,
-        readAt: null,
-        resolvedAt: null,
-        type: {
-          in: [
-            NOTIFICATION_TYPE_TASK_COMMENT_MENTION,
-            NOTIFICATION_TYPE_TASK_ASSIGNMENT,
-          ],
-        },
-      },
-      orderBy: [{ createdAt: "asc" }],
-      select: {
-        id: true,
-        type: true,
-        title: true,
-        body: true,
-        targetPath: true,
-        sourceType: true,
-        sourceId: true,
-        metadata: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    });
-
-    const coveredIds = await getAlreadyCoveredNotificationIds(
-      db,
-      notifications.map((notification) => notification.id),
-      EMAIL_KIND_PROJECT_DIGEST,
-      input.now
-    );
-    const candidates = notifications
-      .filter((notification) => !coveredIds.has(notification.id))
-      .map(getDigestCandidate)
-      .filter((candidate): candidate is DigestCandidate => Boolean(candidate));
-
-    const groupsByProject = new Map<string, DigestGroup>();
-    for (const candidate of candidates) {
-      const existing = groupsByProject.get(candidate.projectId);
-      if (!existing) {
-        groupsByProject.set(candidate.projectId, {
-          recipient: input.recipient,
-          projectId: candidate.projectId,
-          projectName: candidate.projectName,
-          candidates: [candidate],
-          windowStartedAt: candidate.activityAt,
-          windowEndedAt: candidate.activityAt,
-          latestNotificationAt: candidate.activityAt,
-        });
-        continue;
-      }
-
-      existing.candidates.push(candidate);
-      existing.windowStartedAt = minDate(
-        existing.windowStartedAt,
-        candidate.activityAt
-      );
-      existing.windowEndedAt = maxDate(existing.windowEndedAt, candidate.activityAt);
-      existing.latestNotificationAt = maxDate(
-        existing.latestNotificationAt,
-        candidate.activityAt
-      );
-    }
-
-    const quietThreshold = new Date(input.now.getTime() - QUIET_WINDOW_MS);
-    return Array.from(groupsByProject.values()).filter(
-      (group) => group.latestNotificationAt <= quietThreshold
-    );
   });
 }
 
-async function collectInvitationRemindersForRecipient(input: {
-  recipient: VerifiedRecipient;
+async function claimDueGroups(input: {
   now: Date;
-}): Promise<InvitationReminderCandidate[]> {
-  return withActorRlsContext(input.recipient.id, async (db) => {
-    const reminderThreshold = new Date(
-      input.now.getTime() - INVITATION_REMINDER_AFTER_MS
-    );
-    const notifications = await db.notification.findMany({
+  limit: number;
+  claimToken: string;
+}): Promise<string[]> {
+  const rows = await prisma.$queryRaw<{ id: string }[]>(Prisma.sql`
+    WITH due AS (
+      SELECT "id"
+      FROM "ProjectNotificationEmail"
+      WHERE "status" = 'pending'
+        AND "sendAfterAt" <= ${input.now}
+      ORDER BY "sendAfterAt" ASC, "createdAt" ASC
+      LIMIT ${input.limit}
+      FOR UPDATE SKIP LOCKED
+    )
+    UPDATE "ProjectNotificationEmail" AS email
+    SET
+      "status" = 'dispatching',
+      "claimToken" = ${input.claimToken},
+      "claimedAt" = ${input.now},
+      "attemptCount" = "attemptCount" + 1,
+      "lastAttemptAt" = ${input.now},
+      "updatedAt" = ${input.now}
+    FROM due
+    WHERE email."id" = due."id"
+    RETURNING email."id"
+  `);
+
+  return rows.map((row) => row.id);
+}
+
+async function loadClaimedGroupsForRecipient(input: {
+  recipientUserId: string;
+  claimToken: string;
+}): Promise<ClaimedEmailGroup[]> {
+  return withActorRlsContext(input.recipientUserId, async (db) => {
+    const groups = await db.projectNotificationEmail.findMany({
       where: {
-        recipientUserId: input.recipient.id,
-        type: NOTIFICATION_TYPE_PROJECT_INVITATION,
-        readAt: null,
-        resolvedAt: null,
-        createdAt: {
-          lte: reminderThreshold,
-        },
+        recipientUserId: input.recipientUserId,
+        status: "dispatching",
+        claimToken: input.claimToken,
       },
-      orderBy: [{ createdAt: "asc" }],
+      orderBy: [{ sendAfterAt: "asc" }, { createdAt: "asc" }],
       select: {
         id: true,
-        type: true,
-        title: true,
-        body: true,
-        targetPath: true,
-        sourceType: true,
-        sourceId: true,
-        metadata: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    });
-
-    const coveredIds = await getAlreadyCoveredNotificationIds(
-      db,
-      notifications.map((notification) => notification.id),
-      EMAIL_KIND_PROJECT_INVITATION_REMINDER,
-      input.now
-    );
-    const candidates: InvitationReminderCandidate[] = [];
-    const notificationsByInvitationId = new Map(
-      notifications
-        .filter((notification) => !coveredIds.has(notification.id))
-        .map((notification) => [notification.sourceId, notification])
-    );
-
-    if (notificationsByInvitationId.size === 0) {
-      return candidates;
-    }
-
-    const invitations = await db.projectInvitation.findMany({
-      where: {
-        id: {
-          in: Array.from(notificationsByInvitationId.keys()),
+        kind: true,
+        recipientUserId: true,
+        projectId: true,
+        sourceKey: true,
+        groupingKey: true,
+        firstPendingNotificationAt: true,
+        latestPendingNotificationAt: true,
+        sendAfterAt: true,
+        maxSendAt: true,
+        windowStartedAt: true,
+        windowEndedAt: true,
+        latestNotificationAt: true,
+        notificationCount: true,
+        recipient: {
+          select: {
+            id: true,
+            email: true,
+            name: true,
+          },
         },
-      },
-      select: {
-        id: true,
-        invitedEmail: true,
-        role: true,
-        expiresAt: true,
-        acceptedAt: true,
-        revokedAt: true,
-        replacedAt: true,
         project: {
           select: {
             id: true,
             name: true,
           },
         },
-        invitedByUser: {
+        items: {
+          orderBy: [{ createdAt: "asc" }],
           select: {
-            email: true,
-            name: true,
-            username: true,
-            usernameDiscriminator: true,
+            id: true,
+            notificationId: true,
+            notificationUpdatedAt: true,
+            sourceFingerprint: true,
+            notification: {
+              select: {
+                id: true,
+                recipientUserId: true,
+                type: true,
+                title: true,
+                body: true,
+                targetPath: true,
+                sourceType: true,
+                sourceId: true,
+                metadata: true,
+                readAt: true,
+                resolvedAt: true,
+                createdAt: true,
+                updatedAt: true,
+              },
+            },
           },
         },
       },
     });
 
-    for (const invitation of invitations) {
-      const notification = notificationsByInvitationId.get(invitation.id);
-      if (!notification) {
-        continue;
-      }
+    return groups.filter((group): group is ClaimedEmailGroup =>
+      Boolean(group.recipient.email)
+    );
+  });
+}
 
-      const invitationRole = invitation.role;
-      if (invitationRole !== "editor" && invitationRole !== "viewer") {
-        continue;
-      }
+function buildActivityItems(input: {
+  group: ClaimedEmailGroup;
+  appOrigin: string;
+}): PreparedSection | null {
+  const collapsed = new Map<
+    string,
+    {
+      label: string;
+      count: number;
+      targetPath: string;
+    }
+  >();
+  const notificationIds: string[] = [];
 
-      const candidate = getInvitationReminderCandidate({
-        recipient: input.recipient,
-        notification,
-        invitation: {
-          ...invitation,
-          role: invitationRole,
-        },
-        now: input.now,
-      });
-
-      if (candidate) {
-        candidates.push(candidate);
-      }
+  for (const item of input.group.items) {
+    const notification = item.notification;
+    if (
+      notification.readAt ||
+      notification.resolvedAt ||
+      item.sourceFingerprint !== createSourceFingerprint(notification) ||
+      !isJsonObject(notification.metadata)
+    ) {
+      continue;
     }
 
-    return candidates;
-  });
-}
+    const taskId = readString(notification.metadata, "taskId");
+    const taskTitle = readString(notification.metadata, "taskTitle");
+    const targetPath = readString(notification.metadata, "targetPath");
+    if (!taskId || !taskTitle || !targetPath) {
+      continue;
+    }
 
-async function hasRecentProjectEmail(input: {
-  kind: typeof EMAIL_KIND_PROJECT_DIGEST | typeof EMAIL_KIND_PROJECT_INVITATION_REMINDER;
-  recipientUserId: string;
-  projectId: string;
-  since: Date;
-}): Promise<boolean> {
-  const existing = await prisma.projectNotificationEmail.findFirst({
-    where: {
-      kind: input.kind,
-      recipientUserId: input.recipientUserId,
-      projectId: input.projectId,
-      createdAt: {
-        gte: input.since,
-      },
-    },
-    select: {
-      id: true,
-    },
-  });
+    const actorDisplayName =
+      notification.type === NOTIFICATION_TYPE_TASK_COMMENT_MENTION
+        ? readString(notification.metadata, "authorDisplayName")
+        : readString(notification.metadata, "actorDisplayName");
+    if (!actorDisplayName) {
+      continue;
+    }
 
-  return Boolean(existing);
-}
-
-async function findRetryableEmailRecord(input: {
-  kind: typeof EMAIL_KIND_PROJECT_DIGEST | typeof EMAIL_KIND_PROJECT_INVITATION_REMINDER;
-  recipientUserId: string;
-  projectId: string;
-  sourceKey: string;
-  now: Date;
-}): Promise<{ id: string } | null> {
-  const pendingRetryThreshold = new Date(
-    input.now.getTime() - PENDING_RETRY_GRACE_MS
-  );
-
-  return prisma.projectNotificationEmail.findFirst({
-    where: {
-      kind: input.kind,
-      recipientUserId: input.recipientUserId,
-      projectId: input.projectId,
-      sourceKey: input.sourceKey,
-      OR: [
-        {
-          status: "failed",
-        },
-        {
-          status: "pending",
-          createdAt: {
-            lt: pendingRetryThreshold,
-          },
-        },
-      ],
-    },
-    select: {
-      id: true,
-    },
-  });
-}
-
-async function markEmailAttemptStarted(id: string): Promise<void> {
-  await prisma.projectNotificationEmail.update({
-    where: { id },
-    data: {
-      status: "pending",
-      outboundEmailDeliveryId: null,
-      errorCode: null,
-      completedAt: null,
-    },
-  });
-}
-
-async function markEmailComplete(input: {
-  id: string;
-  result: Awaited<ReturnType<typeof sendOutboundEmail>>;
-}): Promise<"sent" | "skipped" | "failed"> {
-  const mapped = mapDeliveryStatus(input.result);
-
-  await prisma.projectNotificationEmail.update({
-    where: { id: input.id },
-    data: {
-      status: mapped.status,
-      outboundEmailDeliveryId: mapped.deliveryId,
-      errorCode: mapped.errorCode,
-      completedAt: new Date(),
-    },
-  });
-
-  return mapped.status;
-}
-
-async function sendDigestGroup(input: {
-  group: DigestGroup;
-  appOrigin: string;
-  now: Date;
-}): Promise<"sent" | "skipped" | "failed" | "duplicate" | "rate-limited"> {
-  const notificationIds = input.group.candidates.map(
-    (candidate) => candidate.notification.id
-  );
-  const sourceKey = createSourceKey(notificationIds);
-  const recentThreshold = new Date(input.now.getTime() - QUIET_WINDOW_MS);
-
-  if (
-    await hasRecentProjectEmail({
-      kind: EMAIL_KIND_PROJECT_DIGEST,
-      recipientUserId: input.group.recipient.id,
-      projectId: input.group.projectId,
-      since: recentThreshold,
-    })
-  ) {
-    return "rate-limited";
+    const activityKind =
+      notification.type === NOTIFICATION_TYPE_TASK_COMMENT_MENTION
+        ? "mention"
+        : "assignment";
+    const key = [activityKind, taskId, actorDisplayName].join(":");
+    const existing = collapsed.get(key);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      collapsed.set(key, {
+        label:
+          activityKind === "mention"
+            ? `${actorDisplayName} mentioned you on ${taskTitle}`
+            : `${actorDisplayName} assigned you to ${taskTitle}`,
+        count: 1,
+        targetPath,
+      });
+    }
+    notificationIds.push(notification.id);
   }
 
-  let emailRecord: { id: string } | null = await findRetryableEmailRecord({
-    kind: EMAIL_KIND_PROJECT_DIGEST,
-    recipientUserId: input.group.recipient.id,
-    projectId: input.group.projectId,
-    sourceKey,
-    now: input.now,
-  });
+  if (notificationIds.length === 0) {
+    return null;
+  }
 
-  try {
-    if (emailRecord) {
-      await markEmailAttemptStarted(emailRecord.id);
-    } else {
-      emailRecord = await prisma.projectNotificationEmail.create({
-        data: {
-          kind: EMAIL_KIND_PROJECT_DIGEST,
-          recipientUserId: input.group.recipient.id,
-          projectId: input.group.projectId,
-          sourceKey,
-          windowStartedAt: input.group.windowStartedAt,
-          windowEndedAt: input.group.windowEndedAt,
-          latestNotificationAt: input.group.latestNotificationAt,
-          notificationCount: input.group.candidates.length,
-          status: "pending",
-          metadata: {
-            notificationIds,
-            quietWindowMinutes: QUIET_WINDOW_MS / 60_000,
-          },
-          items: {
-            create: notificationIds.map((notificationId) => ({
-              notificationId,
-            })),
+  const allItems: ProjectNotificationDigestEmailItem[] = Array.from(
+    collapsed.values()
+  ).map((item) => ({
+    label: item.label,
+    count: item.count,
+    targetUrl: buildAbsoluteUrl(input.appOrigin, item.targetPath),
+  }));
+
+  return {
+    groupId: input.group.id,
+    projectId: input.group.projectId,
+    notificationIds,
+    section: {
+      projectName: input.group.project.name,
+      projectUrl: buildProjectUrl(input.appOrigin, input.group.projectId),
+      notificationCount: notificationIds.length,
+      items: allItems.slice(0, MAX_DIGEST_BODY_ITEMS_PER_PROJECT),
+      omittedCount: Math.max(
+        0,
+        allItems.length - MAX_DIGEST_BODY_ITEMS_PER_PROJECT
+      ),
+    },
+  };
+}
+
+async function buildInvitationReminderItem(input: {
+  group: ClaimedEmailGroup;
+  appOrigin: string;
+  now: Date;
+}): Promise<PreparedSection | null> {
+  const item = input.group.items[0];
+  if (!item) {
+    return null;
+  }
+
+  const notification = item.notification;
+  if (
+    notification.readAt ||
+    notification.resolvedAt ||
+    item.sourceFingerprint !== createSourceFingerprint(notification) ||
+    !isJsonObject(notification.metadata)
+  ) {
+    return null;
+  }
+
+  const invitationId = readString(notification.metadata, "invitationId");
+  const role = readString(notification.metadata, "role");
+  const invitedByDisplayName = readString(
+    notification.metadata,
+    "invitedByDisplayName"
+  );
+  const inviteLinkPath = readString(notification.metadata, "inviteLinkPath");
+  if (
+    !invitationId ||
+    (role !== "editor" && role !== "viewer") ||
+    !invitedByDisplayName ||
+    !inviteLinkPath
+  ) {
+    return null;
+  }
+
+  const invitation = await withActorRlsContext(
+    input.group.recipientUserId,
+    async (db) =>
+      db.projectInvitation.findFirst({
+        where: {
+          id: invitationId,
+          acceptedAt: null,
+          revokedAt: null,
+          replacedAt: null,
+          expiresAt: {
+            gt: input.now,
           },
         },
         select: {
           id: true,
         },
-      });
-    }
-  } catch (error) {
-    if (isUniqueConstraintFailure(error)) {
-      return "duplicate";
-    }
-    throw error;
+      })
+  );
+
+  if (!invitation) {
+    return null;
   }
 
-  const summary = summarizeDigestGroup(input.group, input.appOrigin);
+  return {
+    groupId: input.group.id,
+    projectId: input.group.projectId,
+    notificationIds: [notification.id],
+    section: {
+      projectName: input.group.project.name,
+      projectUrl: buildProjectUrl(input.appOrigin, input.group.projectId),
+      notificationCount: 1,
+      items: [
+        {
+          label: `Reminder: ${invitedByDisplayName} invited you to ${
+            role === "viewer" ? "view" : "collaborate on"
+          } ${input.group.project.name}`,
+          count: 1,
+          targetUrl: buildAbsoluteUrl(input.appOrigin, inviteLinkPath),
+        },
+      ],
+      omittedCount: 0,
+    },
+  };
+}
+
+async function buildPreparedSection(input: {
+  group: ClaimedEmailGroup;
+  appOrigin: string;
+  now: Date;
+}): Promise<PreparedSection | null> {
+  if (input.group.kind === EMAIL_KIND_PROJECT_DIGEST) {
+    return buildActivityItems({
+      group: input.group,
+      appOrigin: input.appOrigin,
+    });
+  }
+
+  return buildInvitationReminderItem(input);
+}
+
+async function markGroupsComplete(input: {
+  groupIds: string[];
+  status: NotificationEmailStatus;
+  now: Date;
+  outboundEmailDeliveryId?: string | null;
+  errorCode?: string | null;
+}) {
+  if (input.groupIds.length === 0) {
+    return;
+  }
+
+  await prisma.projectNotificationEmail.updateMany({
+    where: {
+      id: {
+        in: input.groupIds,
+      },
+    },
+    data: {
+      status: input.status,
+      outboundEmailDeliveryId: input.outboundEmailDeliveryId ?? null,
+      errorCode: input.errorCode ?? null,
+      claimToken: null,
+      completedAt: input.now,
+    },
+  });
+}
+
+async function dispatchRecipientBatch(input: {
+  recipient: VerifiedRecipient;
+  groups: ClaimedEmailGroup[];
+  appOrigin: string;
+  now: Date;
+}): Promise<{
+  status: "sent" | "skipped" | "failed";
+  attempted: boolean;
+  sentGroupIds: string[];
+  skippedGroupIds: string[];
+  failedGroupIds: string[];
+}> {
+  const sections: PreparedSection[] = [];
+  for (const group of input.groups) {
+    const section = await buildPreparedSection({
+      group,
+      appOrigin: input.appOrigin,
+      now: input.now,
+    });
+
+    if (section) {
+      sections.push(section);
+    }
+  }
+
+  const sectionGroupIds = new Set(sections.map((section) => section.groupId));
+  const skippedGroupIds = input.groups
+    .filter((group) => !sectionGroupIds.has(group.id))
+    .map((group) => group.id);
+
+  await markGroupsComplete({
+    groupIds: skippedGroupIds,
+    status: "skipped",
+    now: input.now,
+    errorCode: "no-current-eligible-notifications",
+  });
+
+  if (sections.length === 0) {
+    return {
+      status: "skipped",
+      attempted: false,
+      sentGroupIds: [],
+      skippedGroupIds,
+      failedGroupIds: [],
+    };
+  }
+
+  const notificationIds = sections.flatMap((section) => section.notificationIds);
   const message = buildProjectNotificationDigestEmail({
-    projectName: input.group.projectName,
-    notificationCount: input.group.candidates.length,
-    items: summary.items,
-    omittedCount: summary.omittedCount,
-    projectUrl: buildProjectUrl(input.appOrigin, input.group.projectId),
+    sections: sections.map((section) => section.section),
     notificationsUrl: buildAbsoluteUrl(input.appOrigin, "/account/notifications"),
   });
 
   const result = await sendOutboundEmail({
     templateKey: "project_notification_digest",
-    to: input.group.recipient.email,
+    to: input.recipient.email,
     subject: message.subject,
     text: message.text,
     html: message.html,
     metadata: {
-      projectId: input.group.projectId,
-      recipientUserId: input.group.recipient.id,
+      recipientUserId: input.recipient.id,
+      projectIds: sections.map((section) => section.projectId),
+      groupIds: sections.map((section) => section.groupId),
       notificationIds,
-      notificationCount: input.group.candidates.length,
-      windowStartedAt: input.group.windowStartedAt.toISOString(),
-      windowEndedAt: input.group.windowEndedAt.toISOString(),
+      notificationCount: notificationIds.length,
+      projectSectionCount: sections.length,
     },
   });
+  const mapped = mapDeliveryStatus(result);
+  const deliveredGroupIds = sections.map((section) => section.groupId);
 
-  return markEmailComplete({
-    id: emailRecord.id,
-    result,
-  });
-}
-
-async function sendInvitationReminder(input: {
-  candidate: InvitationReminderCandidate;
-  appOrigin: string;
-  now: Date;
-}): Promise<"sent" | "skipped" | "failed" | "duplicate" | "rate-limited"> {
-  const recentThreshold = new Date(input.now.getTime() - QUIET_WINDOW_MS);
-  if (
-    await hasRecentProjectEmail({
-      kind: EMAIL_KIND_PROJECT_INVITATION_REMINDER,
-      recipientUserId: input.candidate.recipient.id,
-      projectId: input.candidate.projectId,
-      since: recentThreshold,
-    })
-  ) {
-    return "rate-limited";
-  }
-
-  let emailRecord: { id: string } | null = await findRetryableEmailRecord({
-    kind: EMAIL_KIND_PROJECT_INVITATION_REMINDER,
-    recipientUserId: input.candidate.recipient.id,
-    projectId: input.candidate.projectId,
-    sourceKey: input.candidate.invitationId,
+  await markGroupsComplete({
+    groupIds: deliveredGroupIds,
+    status: mapped.status,
     now: input.now,
+    outboundEmailDeliveryId: mapped.deliveryId,
+    errorCode: mapped.errorCode,
   });
 
-  try {
-    if (emailRecord) {
-      await markEmailAttemptStarted(emailRecord.id);
-    } else {
-      emailRecord = await prisma.projectNotificationEmail.create({
-        data: {
-          kind: EMAIL_KIND_PROJECT_INVITATION_REMINDER,
-          recipientUserId: input.candidate.recipient.id,
-          projectId: input.candidate.projectId,
-          sourceKey: input.candidate.invitationId,
-          windowStartedAt: input.candidate.createdAt,
-          windowEndedAt: input.candidate.createdAt,
-          latestNotificationAt: input.candidate.createdAt,
-          notificationCount: 1,
-          status: "pending",
-          metadata: {
-            invitationId: input.candidate.invitationId,
-            reminderAfterHours: INVITATION_REMINDER_AFTER_MS / 3_600_000,
-          },
-          items: {
-            create: [
-              {
-                notificationId: input.candidate.notification.id,
-              },
-            ],
-          },
-        },
-        select: {
-          id: true,
-        },
-      });
-    }
-  } catch (error) {
-    if (isUniqueConstraintFailure(error)) {
-      return "duplicate";
-    }
-    throw error;
+  return {
+    status: mapped.status,
+    attempted: true,
+    sentGroupIds: mapped.status === "sent" ? deliveredGroupIds : [],
+    skippedGroupIds:
+      mapped.status === "skipped"
+        ? [...skippedGroupIds, ...deliveredGroupIds]
+        : skippedGroupIds,
+    failedGroupIds: mapped.status === "failed" ? deliveredGroupIds : [],
+  };
+}
+
+async function loadClaimedRecipientIds(input: {
+  groupIds: string[];
+}): Promise<string[]> {
+  if (input.groupIds.length === 0) {
+    return [];
   }
 
-  const inviteUrl = buildAbsoluteUrl(input.appOrigin, input.candidate.targetPath);
-  const message = buildProjectInvitationEmail({
-    inviteUrl,
-    projectName: input.candidate.projectName,
-    invitedByDisplayName: input.candidate.invitedByDisplayName,
-    role: input.candidate.role,
-    expiresAt: input.candidate.expiresAt,
-    variant: "reminder",
-  });
-
-  const result = await sendOutboundEmail({
-    templateKey: "project_invitation",
-    to: input.candidate.recipient.email,
-    subject: message.subject,
-    text: message.text,
-    html: message.html,
-    metadata: {
-      invitationId: input.candidate.invitationId,
-      projectId: input.candidate.projectId,
-      recipientUserId: input.candidate.recipient.id,
-      deliveryReason: "six_hour_invitation_reminder",
+  const rows = await prisma.projectNotificationEmail.findMany({
+    where: {
+      id: {
+        in: input.groupIds,
+      },
+    },
+    distinct: ["recipientUserId"],
+    orderBy: [{ recipientUserId: "asc" }],
+    select: {
+      recipientUserId: true,
     },
   });
 
-  return markEmailComplete({
-    id: emailRecord.id,
-    result,
-  });
-}
-
-function applyOutcome(
-  summary: DispatchProjectNotificationEmailsSummary,
-  kind: "digest" | "invitation-reminder",
-  outcome: "sent" | "skipped" | "failed" | "duplicate" | "rate-limited"
-) {
-  if (kind === "digest") {
-    if (outcome === "sent") {
-      summary.digestsSent += 1;
-    } else if (outcome === "failed") {
-      summary.digestsFailed += 1;
-    } else {
-      summary.digestsSkipped += 1;
-    }
-    return;
-  }
-
-  if (outcome === "sent") {
-    summary.invitationRemindersSent += 1;
-  } else if (outcome === "failed") {
-    summary.invitationRemindersFailed += 1;
-  } else {
-    summary.invitationRemindersSkipped += 1;
-  }
+  return rows.map((row) => row.recipientUserId);
 }
 
 export async function dispatchProjectNotificationEmails(input: {
@@ -916,69 +1069,78 @@ export async function dispatchProjectNotificationEmails(input: {
 } = {}): Promise<DispatchProjectNotificationEmailsSummary> {
   const appOrigin = normalizeAppOrigin(input.appOrigin);
   const now = input.now ?? new Date();
+  const claimToken = createClaimToken();
   const summary: DispatchProjectNotificationEmailsSummary = {
-    usersScanned: 0,
-    digestsAttempted: 0,
-    digestsSent: 0,
-    digestsSkipped: 0,
-    digestsFailed: 0,
-    invitationRemindersAttempted: 0,
-    invitationRemindersSent: 0,
-    invitationRemindersSkipped: 0,
-    invitationRemindersFailed: 0,
+    notificationsReconciled: 0,
+    groupsClaimed: 0,
+    recipientEmailsAttempted: 0,
+    recipientEmailsSent: 0,
+    recipientEmailsSkipped: 0,
+    recipientEmailsFailed: 0,
+    groupsSent: 0,
+    groupsSkipped: 0,
+    groupsFailed: 0,
     errors: 0,
   };
 
-  const recipients = await findVerifiedRecipients();
-  let groupAttempts = 0;
+  try {
+    summary.notificationsReconciled =
+      await reconcilePendingNotificationEmailGroups(now);
+  } catch (error) {
+    summary.errors += 1;
+    logServerError("dispatchProjectNotificationEmails.reconcile", error);
+  }
 
-  for (const recipient of recipients) {
-    summary.usersScanned += 1;
+  await failStaleDispatchingGroups(now);
 
+  const claimedGroupIds = await claimDueGroups({
+    now,
+    limit: MAX_GROUPS_PER_DISPATCH,
+    claimToken,
+  });
+  summary.groupsClaimed = claimedGroupIds.length;
+
+  const recipientIds = await loadClaimedRecipientIds({
+    groupIds: claimedGroupIds,
+  });
+
+  for (const recipientUserId of recipientIds) {
     try {
-      const digestGroups = await collectDigestGroupsForRecipient({
+      const groups = await loadClaimedGroupsForRecipient({
+        recipientUserId,
+        claimToken,
+      });
+      const recipient = groups[0]?.recipient;
+      if (!recipient || groups.length === 0) {
+        continue;
+      }
+
+      const outcome = await dispatchRecipientBatch({
         recipient,
+        groups,
+        appOrigin,
         now,
       });
 
-      for (const group of digestGroups) {
-        if (groupAttempts >= MAX_GROUPS_PER_DISPATCH) {
-          break;
-        }
-
-        groupAttempts += 1;
-        summary.digestsAttempted += 1;
-        const outcome = await sendDigestGroup({
-          group,
-          appOrigin,
-          now,
-        });
-        applyOutcome(summary, "digest", outcome);
+      if (outcome.attempted) {
+        summary.recipientEmailsAttempted += 1;
       }
 
-      const invitationReminders = await collectInvitationRemindersForRecipient({
-        recipient,
-        now,
-      });
-
-      for (const candidate of invitationReminders) {
-        if (groupAttempts >= MAX_GROUPS_PER_DISPATCH) {
-          break;
-        }
-
-        groupAttempts += 1;
-        summary.invitationRemindersAttempted += 1;
-        const outcome = await sendInvitationReminder({
-          candidate,
-          appOrigin,
-          now,
-        });
-        applyOutcome(summary, "invitation-reminder", outcome);
+      if (outcome.status === "sent") {
+        summary.recipientEmailsSent += 1;
+      } else if (outcome.status === "failed") {
+        summary.recipientEmailsFailed += 1;
+      } else {
+        summary.recipientEmailsSkipped += 1;
       }
+
+      summary.groupsSent += outcome.sentGroupIds.length;
+      summary.groupsSkipped += outcome.skippedGroupIds.length;
+      summary.groupsFailed += outcome.failedGroupIds.length;
     } catch (error) {
       summary.errors += 1;
       logServerError("dispatchProjectNotificationEmails.recipient", error, {
-        recipientUserId: recipient.id,
+        recipientUserId,
       });
     }
   }

--- a/prisma/migrations/20260513120000_task227_notification_email_orchestration/migration.sql
+++ b/prisma/migrations/20260513120000_task227_notification_email_orchestration/migration.sql
@@ -1,0 +1,56 @@
+ALTER TYPE "ProjectNotificationEmailStatus" ADD VALUE IF NOT EXISTS 'dispatching';
+ALTER TYPE "ProjectNotificationEmailStatus" ADD VALUE IF NOT EXISTS 'superseded';
+
+ALTER TABLE "ProjectNotificationEmail"
+ADD COLUMN "groupingKey" VARCHAR(191),
+ADD COLUMN "firstPendingNotificationAt" TIMESTAMP(3),
+ADD COLUMN "latestPendingNotificationAt" TIMESTAMP(3),
+ADD COLUMN "sendAfterAt" TIMESTAMP(3),
+ADD COLUMN "maxSendAt" TIMESTAMP(3),
+ADD COLUMN "claimToken" VARCHAR(64),
+ADD COLUMN "claimedAt" TIMESTAMP(3),
+ADD COLUMN "attemptCount" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN "lastAttemptAt" TIMESTAMP(3);
+
+UPDATE "ProjectNotificationEmail"
+SET
+  "groupingKey" =
+    "kind"::text || ':' || "recipientUserId" || ':' || "projectId" || ':' || "sourceKey",
+  "firstPendingNotificationAt" = "windowStartedAt",
+  "latestPendingNotificationAt" = "latestNotificationAt",
+  "sendAfterAt" = "windowEndedAt",
+  "maxSendAt" = "windowEndedAt"
+WHERE "groupingKey" IS NULL;
+
+ALTER TABLE "ProjectNotificationEmail"
+ALTER COLUMN "groupingKey" SET NOT NULL,
+ALTER COLUMN "firstPendingNotificationAt" SET NOT NULL,
+ALTER COLUMN "latestPendingNotificationAt" SET NOT NULL,
+ALTER COLUMN "sendAfterAt" SET NOT NULL,
+ALTER COLUMN "maxSendAt" SET NOT NULL;
+
+ALTER TABLE "ProjectNotificationEmailItem"
+ADD COLUMN "notificationUpdatedAt" TIMESTAMP(3),
+ADD COLUMN "sourceFingerprint" VARCHAR(160);
+
+UPDATE "ProjectNotificationEmailItem" item
+SET
+  "notificationUpdatedAt" = notification."updatedAt",
+  "sourceFingerprint" = item."notificationId" || ':' || notification."updatedAt"::text
+FROM "Notification" notification
+WHERE notification."id" = item."notificationId";
+
+CREATE INDEX "ProjectNotificationEmail_kind_status_sendAfterAt_idx"
+ON "ProjectNotificationEmail"("kind", "status", "sendAfterAt");
+
+CREATE INDEX "ProjectNotificationEmail_groupingKey_status_idx"
+ON "ProjectNotificationEmail"("groupingKey", "status");
+
+CREATE UNIQUE INDEX "ProjectNotificationEmail_active_groupingKey_key"
+ON "ProjectNotificationEmail"("groupingKey")
+WHERE "status" = 'pending';
+
+CREATE INDEX "ProjectNotificationEmailItem_sourceFingerprint_idx"
+ON "ProjectNotificationEmailItem"("sourceFingerprint");
+
+DROP INDEX IF EXISTS "ProjectNotificationEmail_kind_status_createdAt_idx";

--- a/prisma/migrations/20260513120000_task227_notification_email_orchestration/migration.sql
+++ b/prisma/migrations/20260513120000_task227_notification_email_orchestration/migration.sql
@@ -15,7 +15,13 @@ ADD COLUMN "lastAttemptAt" TIMESTAMP(3);
 UPDATE "ProjectNotificationEmail"
 SET
   "groupingKey" =
-    "kind"::text || ':' || "recipientUserId" || ':' || "projectId" || ':' || "sourceKey",
+    CASE
+      WHEN "kind" = 'project_digest'
+        THEN "kind"::text || ':' || "recipientUserId" || ':' || "projectId"
+      WHEN "kind" = 'project_invitation_reminder'
+        THEN "kind"::text || ':' || "recipientUserId" || ':' || "projectId" || ':' || "sourceKey"
+      ELSE "kind"::text || ':' || "recipientUserId" || ':' || "projectId" || ':' || "sourceKey"
+    END,
   "firstPendingNotificationAt" = "windowStartedAt",
   "latestPendingNotificationAt" = "latestNotificationAt",
   "sendAfterAt" = "windowEndedAt",
@@ -36,9 +42,94 @@ ADD COLUMN "sourceFingerprint" VARCHAR(160);
 UPDATE "ProjectNotificationEmailItem" item
 SET
   "notificationUpdatedAt" = notification."updatedAt",
-  "sourceFingerprint" = item."notificationId" || ':' || notification."updatedAt"::text
+  "sourceFingerprint" =
+    item."notificationId" || ':' ||
+    to_char(notification."updatedAt", 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
 FROM "Notification" notification
 WHERE notification."id" = item."notificationId";
+
+WITH ranked_pending_groups AS (
+  SELECT
+    "id",
+    first_value("id") OVER (
+      PARTITION BY "groupingKey"
+      ORDER BY "createdAt" ASC, "id" ASC
+    ) AS "keeperId",
+    row_number() OVER (
+      PARTITION BY "groupingKey"
+      ORDER BY "createdAt" ASC, "id" ASC
+    ) AS "rank"
+  FROM "ProjectNotificationEmail"
+  WHERE "status" = 'pending'
+)
+DELETE FROM "ProjectNotificationEmailItem" duplicate_item
+USING ranked_pending_groups duplicate_group, "ProjectNotificationEmailItem" keeper_item
+WHERE duplicate_group."rank" > 1
+  AND duplicate_item."emailId" = duplicate_group."id"
+  AND keeper_item."emailId" = duplicate_group."keeperId"
+  AND keeper_item."notificationId" = duplicate_item."notificationId";
+
+WITH ranked_pending_groups AS (
+  SELECT
+    "id",
+    first_value("id") OVER (
+      PARTITION BY "groupingKey"
+      ORDER BY "createdAt" ASC, "id" ASC
+    ) AS "keeperId",
+    row_number() OVER (
+      PARTITION BY "groupingKey"
+      ORDER BY "createdAt" ASC, "id" ASC
+    ) AS "rank"
+  FROM "ProjectNotificationEmail"
+  WHERE "status" = 'pending'
+)
+UPDATE "ProjectNotificationEmailItem" item
+SET "emailId" = duplicate_group."keeperId"
+FROM ranked_pending_groups duplicate_group
+WHERE duplicate_group."rank" > 1
+  AND item."emailId" = duplicate_group."id";
+
+WITH group_rollups AS (
+  SELECT
+    email."id",
+    COUNT(item."id")::integer AS "notificationCount",
+    MIN(COALESCE(notification."updatedAt", email."firstPendingNotificationAt")) AS "firstPendingNotificationAt",
+    MAX(COALESCE(notification."updatedAt", email."latestPendingNotificationAt")) AS "latestPendingNotificationAt"
+  FROM "ProjectNotificationEmail" email
+  LEFT JOIN "ProjectNotificationEmailItem" item ON item."emailId" = email."id"
+  LEFT JOIN "Notification" notification ON notification."id" = item."notificationId"
+  WHERE email."status" = 'pending'
+  GROUP BY email."id"
+)
+UPDATE "ProjectNotificationEmail" email
+SET
+  "notificationCount" = group_rollups."notificationCount",
+  "firstPendingNotificationAt" = group_rollups."firstPendingNotificationAt",
+  "latestPendingNotificationAt" = group_rollups."latestPendingNotificationAt",
+  "windowStartedAt" = group_rollups."firstPendingNotificationAt",
+  "windowEndedAt" = group_rollups."latestPendingNotificationAt",
+  "latestNotificationAt" = group_rollups."latestPendingNotificationAt"
+FROM group_rollups
+WHERE email."id" = group_rollups."id";
+
+WITH ranked_pending_groups AS (
+  SELECT
+    "id",
+    row_number() OVER (
+      PARTITION BY "groupingKey"
+      ORDER BY "createdAt" ASC, "id" ASC
+    ) AS "rank"
+  FROM "ProjectNotificationEmail"
+  WHERE "status" = 'pending'
+)
+UPDATE "ProjectNotificationEmail" email
+SET
+  "status" = 'superseded',
+  "errorCode" = 'superseded-by-grouping-key',
+  "completedAt" = NOW()
+FROM ranked_pending_groups duplicate_group
+WHERE duplicate_group."rank" > 1
+  AND email."id" = duplicate_group."id";
 
 CREATE INDEX "ProjectNotificationEmail_kind_status_sendAfterAt_idx"
 ON "ProjectNotificationEmail"("kind", "status", "sendAfterAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,26 +20,26 @@ model User {
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 
-  accounts                   Account[]
-  sessions                   Session[]
-  ownedProjects              Project[]                 @relation("ProjectOwner")
-  projectMemberships         ProjectMembership[]
-  projectInvitationsSent     ProjectInvitation[]       @relation("ProjectInvitationInviter")
-  taskAttachments            TaskAttachment[]          @relation("TaskAttachmentUploader")
-  taskComments               TaskComment[]             @relation("TaskCommentAuthor")
-  tasksCreated              Task[]                    @relation("TaskCreatedBy")
-  tasksUpdated              Task[]                    @relation("TaskUpdatedBy")
-  tasksAssigned             Task[]                    @relation("TaskAssignee")
-  resourceAttachments        ResourceAttachment[]      @relation("ResourceAttachmentUploader")
-  googleCalendarCredential   GoogleCalendarCredential?
-  emailVerificationTokens    EmailVerificationToken[]
-  passwordResetTokens        PasswordResetToken[]
-  createdApiCredentials      ApiCredential[]           @relation("ApiCredentialCreatedBy")
-  revokedApiCredentials      ApiCredential[]           @relation("ApiCredentialRevokedBy")
-  authAuditEvents            AuthAuditEvent[]          @relation("AuthAuditEventActorUser")
-  notifications              Notification[]            @relation("NotificationRecipient")
-  projectNotificationEmails  ProjectNotificationEmail[] @relation("ProjectNotificationEmailRecipient")
-  taskCommentReactions       TaskCommentReaction[]
+  accounts                  Account[]
+  sessions                  Session[]
+  ownedProjects             Project[]                  @relation("ProjectOwner")
+  projectMemberships        ProjectMembership[]
+  projectInvitationsSent    ProjectInvitation[]        @relation("ProjectInvitationInviter")
+  taskAttachments           TaskAttachment[]           @relation("TaskAttachmentUploader")
+  taskComments              TaskComment[]              @relation("TaskCommentAuthor")
+  tasksCreated              Task[]                     @relation("TaskCreatedBy")
+  tasksUpdated              Task[]                     @relation("TaskUpdatedBy")
+  tasksAssigned             Task[]                     @relation("TaskAssignee")
+  resourceAttachments       ResourceAttachment[]       @relation("ResourceAttachmentUploader")
+  googleCalendarCredential  GoogleCalendarCredential?
+  emailVerificationTokens   EmailVerificationToken[]
+  passwordResetTokens       PasswordResetToken[]
+  createdApiCredentials     ApiCredential[]            @relation("ApiCredentialCreatedBy")
+  revokedApiCredentials     ApiCredential[]            @relation("ApiCredentialRevokedBy")
+  authAuditEvents           AuthAuditEvent[]           @relation("AuthAuditEventActorUser")
+  notifications             Notification[]             @relation("NotificationRecipient")
+  projectNotificationEmails ProjectNotificationEmail[] @relation("ProjectNotificationEmailRecipient")
+  taskCommentReactions      TaskCommentReaction[]
 
   @@unique([username, usernameDiscriminator])
   @@index([username])
@@ -180,17 +180,17 @@ model Project {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
-  owner          User                 @relation("ProjectOwner", fields: [ownerId], references: [id], onDelete: Cascade)
-  tasks          Task[]
-  epics          Epic[]
-  roadmapPhases  RoadmapPhase[]
-  roadmapEvents  RoadmapEvent[]
-  resources      Resource[]
-  memberships    ProjectMembership[]
-  invitations    ProjectInvitation[]
-  taskRelations  TaskRelation[]
-  apiCredentials ApiCredential[]
-  authAuditEvents AuthAuditEvent[]
+  owner              User                       @relation("ProjectOwner", fields: [ownerId], references: [id], onDelete: Cascade)
+  tasks              Task[]
+  epics              Epic[]
+  roadmapPhases      RoadmapPhase[]
+  roadmapEvents      RoadmapEvent[]
+  resources          Resource[]
+  memberships        ProjectMembership[]
+  invitations        ProjectInvitation[]
+  taskRelations      TaskRelation[]
+  apiCredentials     ApiCredential[]
+  authAuditEvents    AuthAuditEvent[]
   notificationEmails ProjectNotificationEmail[]
 
   @@index([ownerId])
@@ -247,7 +247,7 @@ model Notification {
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @updatedAt
 
-  recipient User @relation("NotificationRecipient", fields: [recipientUserId], references: [id], onDelete: Cascade)
+  recipient  User                           @relation("NotificationRecipient", fields: [recipientUserId], references: [id], onDelete: Cascade)
   emailItems ProjectNotificationEmailItem[]
 
   @@unique([recipientUserId, sourceType, sourceId])
@@ -264,45 +264,59 @@ enum ProjectNotificationEmailKind {
 
 enum ProjectNotificationEmailStatus {
   pending
+  dispatching
   sent
   skipped
   failed
+  superseded
 }
 
 model ProjectNotificationEmail {
-  id                      String                         @id @default(cuid())
-  kind                    ProjectNotificationEmailKind
-  recipientUserId         String
-  projectId               String
-  sourceKey               String                         @db.VarChar(128)
-  windowStartedAt         DateTime
-  windowEndedAt           DateTime
-  latestNotificationAt    DateTime
-  notificationCount       Int
-  status                  ProjectNotificationEmailStatus @default(pending)
-  outboundEmailDeliveryId String?
-  errorCode               String?                        @db.VarChar(80)
-  metadata                Json?
-  completedAt             DateTime?
-  createdAt               DateTime                       @default(now())
-  updatedAt               DateTime                       @updatedAt
+  id                          String                         @id @default(cuid())
+  kind                        ProjectNotificationEmailKind
+  recipientUserId             String
+  projectId                   String
+  sourceKey                   String                         @db.VarChar(128)
+  groupingKey                 String                         @db.VarChar(191)
+  firstPendingNotificationAt  DateTime
+  latestPendingNotificationAt DateTime
+  sendAfterAt                 DateTime
+  maxSendAt                   DateTime
+  windowStartedAt             DateTime
+  windowEndedAt               DateTime
+  latestNotificationAt        DateTime
+  notificationCount           Int
+  status                      ProjectNotificationEmailStatus @default(pending)
+  claimToken                  String?                        @db.VarChar(64)
+  claimedAt                   DateTime?
+  attemptCount                Int                            @default(0)
+  lastAttemptAt               DateTime?
+  outboundEmailDeliveryId     String?
+  errorCode                   String?                        @db.VarChar(80)
+  metadata                    Json?
+  completedAt                 DateTime?
+  createdAt                   DateTime                       @default(now())
+  updatedAt                   DateTime                       @updatedAt
 
-  recipient             User                   @relation("ProjectNotificationEmailRecipient", fields: [recipientUserId], references: [id], onDelete: Cascade)
-  project               Project                @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  outboundEmailDelivery OutboundEmailDelivery? @relation(fields: [outboundEmailDeliveryId], references: [id], onDelete: SetNull)
+  recipient             User                           @relation("ProjectNotificationEmailRecipient", fields: [recipientUserId], references: [id], onDelete: Cascade)
+  project               Project                        @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  outboundEmailDelivery OutboundEmailDelivery?         @relation(fields: [outboundEmailDeliveryId], references: [id], onDelete: SetNull)
   items                 ProjectNotificationEmailItem[]
 
   @@unique([kind, recipientUserId, projectId, sourceKey])
   @@index([recipientUserId, projectId, createdAt])
-  @@index([kind, status, createdAt])
+  @@index([kind, status, sendAfterAt])
+  @@index([groupingKey, status])
   @@index([outboundEmailDeliveryId])
 }
 
 model ProjectNotificationEmailItem {
-  id             String   @id @default(cuid())
-  emailId        String
-  notificationId String
-  createdAt      DateTime @default(now())
+  id                    String    @id @default(cuid())
+  emailId               String
+  notificationId        String
+  notificationUpdatedAt DateTime?
+  sourceFingerprint     String?   @db.VarChar(160)
+  createdAt             DateTime  @default(now())
 
   email        ProjectNotificationEmail @relation(fields: [emailId], references: [id], onDelete: Cascade)
   notification Notification             @relation(fields: [notificationId], references: [id], onDelete: Cascade)
@@ -336,7 +350,7 @@ model RoadmapPhase {
   createdAt   DateTime               @default(now())
   updatedAt   DateTime               @updatedAt
 
-  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  project Project        @relation(fields: [projectId], references: [id], onDelete: Cascade)
   events  RoadmapEvent[]
 
   @@unique([id, projectId])
@@ -415,21 +429,21 @@ model TaskComment {
   content      String
   createdAt    DateTime @default(now())
 
-  reactions    TaskCommentReaction[]
+  reactions TaskCommentReaction[]
 
   @@index([taskId, createdAt])
   @@index([authorUserId])
 }
 
 model TaskCommentReaction {
-  id        String      @id @default(cuid())
+  id        String   @id @default(cuid())
   commentId String
   userId    String
   emoji     String
-  createdAt DateTime    @default(now())
+  createdAt DateTime @default(now())
 
-  comment   TaskComment @relation(fields: [commentId], references: [id], onDelete: Cascade)
-  user      User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  comment TaskComment @relation(fields: [commentId], references: [id], onDelete: Cascade)
+  user    User        @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([commentId, userId, emoji])
   @@index([commentId])
@@ -563,20 +577,20 @@ enum AuthRateLimitScope {
 }
 
 model ApiCredential {
-  id              String   @id @default(cuid())
+  id              String    @id @default(cuid())
   projectId       String
   createdByUserId String
   revokedByUserId String?
-  label           String   @db.VarChar(80)
-  publicId        String   @unique @db.VarChar(64)
+  label           String    @db.VarChar(80)
+  publicId        String    @unique @db.VarChar(64)
   secretHash      String
   expiresAt       DateTime?
   lastUsedAt      DateTime?
   lastExchangedAt DateTime?
   lastRotatedAt   DateTime?
   revokedAt       DateTime?
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
 
   project       Project                   @relation(fields: [projectId], references: [id], onDelete: Cascade)
   createdByUser User                      @relation("ApiCredentialCreatedBy", fields: [createdByUserId], references: [id], onDelete: Cascade)
@@ -601,21 +615,21 @@ model ApiCredentialScopeGrant {
 }
 
 model AuthAuditEvent {
-  id           String            @id @default(cuid())
+  id           String             @id @default(cuid())
   projectId    String
   credentialId String?
   actorUserId  String?
   actorKind    AuthAuditActorKind
   action       AuthAuditAction
-  requestId    String?           @db.VarChar(128)
-  ipAddress    String?           @db.VarChar(64)
-  userAgent    String?           @db.VarChar(512)
+  requestId    String?            @db.VarChar(128)
+  ipAddress    String?            @db.VarChar(64)
+  userAgent    String?            @db.VarChar(512)
   metadata     Json?
-  createdAt    DateTime          @default(now())
+  createdAt    DateTime           @default(now())
 
-  project    Project       @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  project    Project        @relation(fields: [projectId], references: [id], onDelete: Cascade)
   credential ApiCredential? @relation(fields: [credentialId], references: [id], onDelete: SetNull)
-  actorUser  User?         @relation("AuthAuditEventActorUser", fields: [actorUserId], references: [id], onDelete: SetNull)
+  actorUser  User?          @relation("AuthAuditEventActorUser", fields: [actorUserId], references: [id], onDelete: SetNull)
 
   @@index([projectId, createdAt])
   @@index([credentialId, createdAt])
@@ -624,12 +638,12 @@ model AuthAuditEvent {
 
 model AuthRateLimitBucket {
   scope        AuthRateLimitScope
-  key          String    @db.VarChar(191)
-  windowStart  DateTime  @db.Timestamptz(6)
-  attemptCount Int       @default(0)
-  blockedUntil DateTime? @db.Timestamptz(6)
-  createdAt    DateTime  @default(now()) @db.Timestamptz(6)
-  updatedAt    DateTime  @updatedAt @db.Timestamptz(6)
+  key          String             @db.VarChar(191)
+  windowStart  DateTime           @db.Timestamptz(6)
+  attemptCount Int                @default(0)
+  blockedUntil DateTime?          @db.Timestamptz(6)
+  createdAt    DateTime           @default(now()) @db.Timestamptz(6)
+  updatedAt    DateTime           @updatedAt @db.Timestamptz(6)
 
   @@id([scope, key, windowStart])
   @@index([scope, key, blockedUntil])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -323,6 +323,7 @@ model ProjectNotificationEmailItem {
 
   @@unique([emailId, notificationId])
   @@index([notificationId])
+  @@index([sourceFingerprint])
 }
 
 model Epic {

--- a/project.md
+++ b/project.md
@@ -24,6 +24,9 @@ NexusDash is a personal/team execution workspace that keeps project planning, de
   - unread/read state and resolved lifecycle
   - project invitation delivery, accept/decline actions, and notification-aware account menu counts
   - foundation for future mention and activity producers
+  - DB-backed notification email orchestration for project activity digests and
+    invitation reminders, with recipient/project grouping, debounce timing, and
+    outbound delivery records
 - Task comments:
   - project-scoped, append-only task discussion threads
   - chronological author-attributed comment history in the task detail modal
@@ -56,6 +59,9 @@ NexusDash is a personal/team execution workspace that keeps project planning, de
 - Storage: `StorageProvider` abstraction (`local` or `r2`)
 - Testing: Vitest + Playwright
 - Runtime/deploy: Docker, GitHub Actions, Vercel CLI staged production deploy/promotion/rollback
+- Notification email scheduling: Vercel Cron when the Vercel plan supports
+  sub-hour cadence; otherwise a managed HTTP scheduler calls the same protected
+  endpoint. GitHub Actions dispatch is manual diagnostic tooling only.
 
 ## 4. Data Model Snapshot
 
@@ -68,6 +74,8 @@ Current schema includes:
 - Collaboration on tasks: `TaskComment`
 - Attachments: `TaskAttachment`, `ResourceAttachment` with `uploadedByUserId`
 - Calendar: `GoogleCalendarCredential` (one row per user)
+- Notification email orchestration: `ProjectNotificationEmail` and
+  `ProjectNotificationEmailItem`
 
 Source of truth: [`prisma/schema.prisma`](./prisma/schema.prisma)
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -6,12 +6,12 @@ Use this file to capture tasks discovered during development. Each entry should 
 ### Execution Queue (Now / Next)
 - ID: TASK-225
   Title: Project notification email digests - grouped, rate-limited outbound summaries
-  Status: Merged via PR #246; production scheduler remediation/refactor tracked by TASK-227
+  Status: Done via PR #246; production scheduler/orchestration remediation owned by TASK-227
   Rationale: Extend the notification center with project-grouped outbound email digests so important in-app activity can reach users by email without sending one message per notification, especially when agents generate frequent task/comment activity. The first design should batch by recipient and project, collapse repetitive agent events, apply a controlled cadence, and preserve the in-app notification inbox as the source of truth.
   Dependencies: TASK-123, TASK-125
 - ID: TASK-227
   Title: Production-grade notification email orchestration - debounce, grouping, and scheduler refactor
-  Status: Pending
+  Status: In progress on `feature/task-227-production-grade-notification-email-orchestration`
   Rationale: Refactor the TASK-225 email notification dispatch into a production-grade app-owned delivery architecture that notifies users about important project activity without email spam. The design should group notifications by recipient and project, debounce clustered activity with a hard maximum notification delay, avoid relying on GitHub Actions as the primary production scheduler, and leave task due-date reminder production to TASK-226 while providing a clean extension point for it.
   Dependencies: TASK-123, TASK-125, TASK-225
 - ID: TASK-226

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,226 +1,166 @@
-# Current Task: TASK-225 Project Notification Email Digests
+# Current Task: TASK-227 Production-Grade Notification Email Orchestration
 
 ## Task ID
-TASK-225
+TASK-227
 
 ## Status
-Implemented on `feature/task-225-project-notification-email-digests` and merged
-via PR #246. Follow-up production scheduler remediation/refactor is tracked by
-TASK-227.
+In progress on dedicated worktree `../nexus_dash_task227` and branch
+`feature/task-227-production-grade-notification-email-orchestration`.
 
 ## Objective
-Extend the notification center with project-grouped outbound email digests so
-important unread in-app activity can reach users by email without sending one
-email per notification. The implementation should keep the in-app notification
-inbox as the source of truth, batch eligible notifications by recipient and
-project, collapse repetitive agent-heavy activity, and enforce a predictable
-quiet-window/rate-limit policy before sending through the TASK-125 outbound
-email foundation.
+Own the project notification email dispatch feature end to end and turn the
+TASK-225 digest/reminder work into production-grade notification email
+orchestration. Users should receive useful email about project activity without
+being spammed, especially when they belong to many projects or agent activity
+creates bursts of mentions and assignments.
 
-## Background
-- TASK-123 shipped the durable in-app notification center.
-- TASK-124 and later work added task comment mention notifications.
-- TASK-125 shipped the reusable outbound email service and delivery records.
-- TASK-104 shipped app-managed initial project invitation email delivery and
-  owner-triggered resend for active invitations.
-- Current notification types include project invitations, task comment
-  mentions, and task assignments.
-- The intended product behavior is debounce-style: avoid sending while a user
-  is still receiving clustered notifications, then send one grouped email after
-  the user's eligible notification activity has been quiet long enough.
-- There is no general background job runner in the app yet, so this task must
-  introduce a narrow, documented scheduled dispatch path instead of hiding
-  digest sends inside ordinary page loads.
+## Context And Audit Notes
+- TASK-123 shipped the in-app notification center, which remains the source of
+  truth. Email delivery must not mark notifications read or resolved.
+- TASK-125 shipped the reusable outbound email foundation and
+  `OutboundEmailDelivery` records.
+- TASK-225/PR #246 added useful digest/reminder service code, templates, tests,
+  and a protected endpoint, but its dispatcher scanned notifications at send
+  time, had no durable pending debounce queue, sent per project rather than
+  recipient-level project sections, and made GitHub Actions the primary
+  scheduler after Vercel Hobby rejected `*/15` cron.
+- PR #252 usefully identified production failure evidence and hardened endpoint
+  auth, but it still preserved GitHub Actions as the primary scheduler. Keep the
+  header-parsing lesson; do not keep the scheduler as the production design.
+- Recent run evidence:
+  - run `25752062859` failed before reaching the app because dispatch URL and
+    secret were empty in the workflow context.
+  - run `25826658473` on `fix/task-225-notification-dispatch-workflow` reached
+    Vercel deployment protection and returned 401 HTML.
+  - run `25826921991` on `main` still returned 401 through the bearer path.
+- Current Vercel docs confirm Hobby cron is daily only; a sub-hour scheduler
+  needs Vercel Pro Cron or an external managed scheduler. TASK-227 documents
+  this blocker and removes GitHub Actions as the production scheduler.
 
-## Scope
-- Add a project notification digest/reminder data model for per-recipient,
-  per-project delivery windows, idempotency, and rate limiting.
-- Add a digest selection service that reads unresolved, unread notification
-  records, groups them by recipient and project, and excludes notifications
-  that are already resolved, already read, or already covered by a sent/skipped
-  digest.
-- Add a digest template key and builder to
-  `lib/services/outbound-email-templates.ts` with plain text and HTML summaries
-  that link back to the relevant project or notification targets.
-- Send digests through `sendOutboundEmail`, recording safe metadata that
-  identifies digest window, recipient user id, project id, notification count,
-  and source notification ids without exposing secrets.
-- Collapse repetitive activity from the same project/task/source type so several
-  tags, comments, or assignments within a few minutes produce one grouped digest
-  section instead of one email or one noisy line per raw notification.
-- Enforce a quiet-window cadence: a project digest becomes eligible only when
-  the latest eligible notification for that recipient/project is at least 30
-  minutes old.
-- Keep an additional rate limit so repeated scheduled dispatches cannot send
-  more than one project digest per recipient/project inside the configured
-  cadence window.
-- Include a project-invitation reminder path for existing in-app invitation
-  notifications: if the invited verified user has not opened/accepted/declined
-  the invitation after 6 hours, send a reminder email. This reminder must reuse
-  the existing invitation email template/delivery foundation and add separate
-  reminder idempotency.
-- Add a protected dispatch endpoint for scheduled execution. Protect it with a
-  dedicated server-side secret and document the required runtime env contract.
-- Document the production dispatch path. The current Vercel plan rejects
-  sub-daily Vercel Cron schedules, so the repo uses a scheduled GitHub Actions
-  workflow to call the protected endpoint every 15 minutes.
-- Keep notification reads/resolution user-driven; sending a digest or reminder
-  must not mark notifications as read or resolved.
+## Product Behavior
+- Email-eligible project activity is grouped by recipient, project, and delivery
+  kind.
+- New eligible activity creates or refreshes a pending group instead of sending
+  immediately.
+- Project activity groups use debounce timing:
+  - quiet window: 30 minutes by default
+  - max delay: 60 minutes from the first unsent activity in the group
+  - `sendAfterAt = min(latestPendingNotificationAt + quietWindow,
+    firstPendingNotificationAt + maxDelay)`
+- If several project groups are due for a recipient in one dispatcher run, send
+  one recipient-level email with project sections.
+- Invitation reminders are due once an invited verified user has not opened,
+  accepted, declined, or otherwise resolved the invitation notification for 6
+  hours. Reminder idempotency is once per invitation/recipient reminder window.
+- TASK-226 owns task due-date reminder business logic. This task leaves a clean
+  extension point but does not implement due-date reminders.
 
-## Assumptions
-- First release uses a 30-minute quiet window after the latest eligible
-  recipient/project notification, plus a conservative scheduled dispatcher. This
-  is not a literal per-user timer; the scheduler periodically selects groups
-  whose latest activity is old enough.
-- Regular activity digests include active project-scoped notification types with
-  reliable `projectId` metadata: task comment mentions and task assignments.
-- Project invitations are included only as delayed reminders for verified users
-  who already have an in-app invitation notification and have not acted within 6
-  hours. Initial invite email delivery and owner manual resend remain TASK-104
-  behavior.
-- Users do not get notification preference UI in this task. The first release
-  uses verified account email addresses and global delivery-mode behavior from
-  TASK-125.
-- Digest dispatch failures should be recorded on outbound email delivery rows
-  and in digest/reminder state without retrying in a tight loop. Automatic
-  retry/backoff workers remain out of scope unless introduced by a later
-  background-jobs task.
+## Scheduler Decision
+- Preferred production scheduler: Vercel Cron on a plan that supports sub-hour
+  cadence, configured to invoke the protected endpoint on production only.
+- Current blocker: Vercel Hobby cron rejects sub-daily schedules, so the current
+  account cannot deploy the required cadence through Vercel Cron.
+- Production alternative when the account stays on Hobby: use a managed HTTP
+  scheduler with retries/visibility, such as Upstash QStash Schedule, to invoke
+  the same protected endpoint. GitHub Actions remains only as manual diagnostic
+  tooling, not the primary production scheduler.
+- Preview validation manually invokes the protected endpoint/service because
+  Vercel Cron runs only on production deployments.
 
 ## Acceptance Criteria
-1. `tasks/current.md` records TASK-225 scope, acceptance criteria, definition of
-   done, assumptions, and validation evidence.
-2. Prisma/PostgreSQL includes durable tracking that supports per-recipient,
-   per-project windowing, idempotency, status, notification membership, and
-   links to outbound email delivery attempts where available.
-3. A service-layer digest collector selects only eligible unresolved/unread
-   notifications for verified users, groups by recipient and project, and
-   preserves project access boundaries.
-4. A digest composer collapses repetitive notification activity and produces
-   deterministic plain text and HTML content with safe escaping/sanitization.
-5. The outbound email template contract includes a typed
-   `project_notification_digest` template key and tests for the generated email
-   shape.
-6. Digest dispatch uses the TASK-125 outbound email service and records sent,
-   skipped, and failed outcomes without logging secrets or raw provider
-   credentials.
-7. Quiet-window logic prevents sending a digest until the latest eligible
-   notification in that recipient/project group is at least 30 minutes old.
-8. Rate limiting prevents more than one digest or invitation reminder for the
-   same recipient/project/source window when dispatch is called repeatedly.
-9. Project invitation reminders are sent only for unresolved/unread existing
-   invitation notifications that are at least 6 hours old and have not already
-   produced a reminder for that invitation/recipient.
-10. Sending a digest or reminder does not mutate notification `readAt` or
-    `resolvedAt`; the notification center remains the source of truth.
-11. A protected operational endpoint exists for running digest dispatch, with
-    documented environment variables and safe local/preview invocation steps.
-12. Focused tests cover eligibility filtering, grouping, collapse semantics,
-    idempotency/rate limiting, successful sends, skipped delivery, provider
-    failure handling, delayed invitation reminders, and endpoint authorization.
-13. `README.md`, `docs/runbooks/vercel-env-contract-and-secrets.md`, and
-    `journal.md` are updated with digest behavior, env/cron assumptions,
-    validation outcomes, and any operational caveats.
+1. Durable DB-backed notification email state tracks grouping key, first pending
+   notification time, latest pending notification time, send-after time,
+   max-send time, status, source notification membership/idempotency, claim
+   state, and outbound delivery correlation.
+2. Email-eligible notification creation/refresh paths update the correct pending
+   group in the service layer.
+3. Normal project activity is delayed until quiet, but no later than about one
+   hour from the first unsent activity.
+4. Dispatcher safely claims due groups and is idempotent under repeated or
+   concurrent invocations.
+5. Due groups are batched into recipient-level emails with concise project
+   sections when multiple projects are ready together.
+6. Email content is deterministic, safely escaped, and concise for bursty
+   agent-generated activity.
+7. Provider sent/skipped/failed outcomes are recorded through TASK-125 outbound
+   delivery records and linked back to orchestration groups without logging
+   secrets.
+8. Invitation reminders are sent only after 6 hours of no user action and only
+   once per invitation/recipient reminder window.
+9. Sending email does not mutate notification `readAt` or `resolvedAt`.
+10. Runtime secrets flow through `lib/env.server.ts`; routes/cron endpoints stay
+    thin and persistence access stays in `lib/services/**`.
+11. GitHub Actions scheduled dispatch is demoted to manual diagnostics, and docs
+    explain the production scheduler decision.
+12. Focused tests cover debounce timing, max delay, grouping by project,
+    multi-project recipient batching, idempotency, concurrent claim behavior,
+    invitation reminders, provider failure, and endpoint authorization.
+13. README, env runbook, journal, backlog, and current task docs are updated
+    with behavior, ops, validation, and caveats.
 
 ## Definition Of Done
-- Work runs on the dedicated TASK-225 branch/worktree and follows
-  `1 task = 1 branch = 1 PR`.
-- Persistence access remains inside `lib/services/**`; routes stay thin
-  transport adapters.
-- Runtime secrets flow through `lib/env.server.ts` and are documented without
-  committing secret values.
-- Local validation passes: `npm run lint`, `npm test`, `npm run test:coverage`,
-  and `npm run build`.
-- Focused digest tests pass and are named in validation evidence.
-- The dispatch endpoint has an authorization-negative test and a safe manual
-  dispatch smoke recorded.
-- If UI-visible notification behavior changes, run the relevant Playwright smoke
-  flow. If preview validation is required, use `PLAYWRIGHT_BASE_URL=<preview-url>`
-  as documented in `agent.md` and `README.md`.
-- Branch is pushed, PR is opened ready for review, required checks are green,
-  Copilot review feedback is addressed or resolved, and the final handoff
-  includes the delivered commit SHA or SHAs.
-- A preview deploy is triggered from this branch via `deploy-vercel.yml` with an
-  explicit `git_ref`, and preview validation sends real test email to
-  `dorian.agaesse@gmail.com` without exposing credentials.
+- Work remains on
+  `feature/task-227-production-grade-notification-email-orchestration`.
+- Local validation passes: `npm run lint`, `npm test`,
+  `npm run test:coverage`, and `npm run build`.
+- Focused notification email orchestration tests pass and are named in
+  validation evidence.
+- Playwright is run only if UI-visible behavior changes.
+- A safe real-smoke plan for `dorian.agaesse@gmail.com` is documented without
+  exposing secrets.
+- Branch is pushed, a ready-for-review PR is opened, CI is monitored, Copilot
+  review feedback is inspected and addressed/resolved, and final handoff
+  includes PR URL, commit SHA(s), validation results, scheduler decision, and
+  operational caveats.
+
+## Validation Plan
+- Focused:
+  - `npm test -- --run tests/lib/project-notification-email-service.test.ts tests/api/notification-email-dispatch.route.test.ts tests/lib/outbound-email-templates.test.ts tests/lib/env.server.test.ts`
+- Baseline:
+  - `npm run lint`
+  - `npm test`
+  - `npm run test:coverage`
+  - `npm run build`
+- Preview/manual smoke:
+  - deploy preview with explicit `git_ref=<branch>` if live endpoint validation
+    is needed
+  - confirm workflow logs checked out the branch ref
+  - create mention/assignment activity for `dorian.agaesse@gmail.com`
+  - invoke the protected dispatch endpoint after the debounce window using a
+    secret supplied outside the repo
 
 ## Validation Evidence
-- `npm ci` passed on 2026-05-08 in the TASK-225 worktree.
-- `npx prisma generate` passed on 2026-05-08 after adding the TASK-225 digest
-  tracking models.
-- `npm run db:local:up` started a fresh local PostgreSQL container for the
-  TASK-225 worktree.
-- `npm run db:migrate` passed on 2026-05-08 against
+- `npm ci` passed and generated Prisma Client.
+- `npx prisma validate` passed.
+- Focused orchestration validation passed:
+  `npm test -- --run tests/lib/project-notification-email-service.test.ts tests/api/notification-email-dispatch.route.test.ts tests/lib/outbound-email-templates.test.ts tests/lib/env.server.test.ts`
+  with 4 files and 81 tests.
+- Focused notification producer regression passed:
+  `npm test -- --run tests/lib/notification-service.test.ts tests/api/task-comments.route.test.ts tests/api/task-update.route.test.ts`
+  with 3 files and 41 tests.
+- `npm run lint` passed.
+- First plain `npm test` failed because this shell lacked `DATABASE_URL`; reran
+  with documented local PostgreSQL env.
+- `npm run db:local:up` could not bind port `5432` because an existing local
+  PostgreSQL container was already using it; used the existing
+  `127.0.0.1:5432` service instead.
+- `npm run db:migrate` passed against
   `postgresql://postgres:postgres@127.0.0.1:5432/nexusdash?schema=public`,
-  applying all 34 migrations including
-  `20260508110000_task225_project_notification_email_digests`.
-- Focused validation passed on 2026-05-08:
-  `npm test -- --run tests/lib/project-notification-email-service.test.ts tests/api/notification-email-dispatch.route.test.ts tests/lib/outbound-email-templates.test.ts tests/lib/env.server.test.ts`
-  with 4 files and 76 tests passing.
-- `npm run lint` passed on 2026-05-08.
-- Full local DB `NODE_ENV=test npm test` passed on 2026-05-08 with 107 files
-  passed, 2 skipped; 795 tests passed, 2 skipped.
-- Full local DB `NODE_ENV=test npm run test:coverage` passed on 2026-05-08
-  with 91.23% statements, 81.2% branches, 93.42% functions, and 91.75% lines.
-- A first `npm run build` attempt passed TypeScript after two TASK-225 type
-  fixes, then failed during page data collection because `NEXTAUTH_URL` was set
-  without `NEXTAUTH_SECRET` in the local build shell.
-- Production-guarded `npm run build` passed on 2026-05-08 with local
-  PostgreSQL, `OUTBOUND_EMAIL_DELIVERY_MODE=disabled`, localhost trusted
-  origins, local `AGENT_TOKEN_SIGNING_SECRET`, and local `NEXTAUTH_SECRET`.
-- PR #246 opened on 2026-05-08 from
-  `feature/task-225-project-notification-email-digests`; initial GitHub checks
-  passed: Quality Core, E2E Smoke, Container Image, and branch-name check.
-- Copilot review feedback on PR #246 was addressed by making failed/stale
-  pending dispatch records retryable, limiting notification coverage to
-  sent/skipped/fresh pending email attempts, removing the fixed first-250-user
-  scan cap, and batching invitation lookups.
-- Post-Copilot focused validation passed on 2026-05-08:
-  `npm test -- --run tests/lib/project-notification-email-service.test.ts tests/api/notification-email-dispatch.route.test.ts tests/lib/outbound-email-templates.test.ts tests/lib/env.server.test.ts`
-  with 4 files and 77 tests passing.
-- Post-Copilot `npm run lint` passed on 2026-05-08.
-- Post-Copilot full local DB `NODE_ENV=test npm test` passed on 2026-05-08
-  with 107 files passed, 2 skipped; 796 tests passed, 2 skipped.
-- Post-Copilot full local DB `NODE_ENV=test npm run test:coverage` passed on
-  2026-05-08 with 91.23% statements, 81.2% branches, 93.42% functions, and
-  91.75% lines.
-- Post-Copilot production-guarded `npm run build` passed on 2026-05-08 with
-  local PostgreSQL, disabled outbound delivery mode, localhost trusted origins,
-  local agent signing secret, and local NextAuth secret.
-- The first explicit-ref preview deployment workflow run (`25583050495`) checked
-  out `feature/task-225-project-notification-email-digests`, generated Prisma,
-  applied migrations, and built the app, then failed at Vercel deploy because
-  Vercel Hobby rejects the `*/15` cron expression in `vercel.json`. Scheduler
-  wiring was moved to GitHub Actions so branch previews can deploy on this
-  account while preserving the 15-minute dispatch cadence.
-- Added a `postinstall` Prisma generation hook after live-email preview smoke
-  exposed that plain Vercel remote builds do not run the workflow's explicit
-  `npx prisma generate` step. The workflow still runs the explicit step before
-  prebuilt deploys; `postinstall` makes direct Vercel preview deploys
-  self-sufficient.
-- Updated `Dockerfile` to copy `prisma/` and `prisma.config.ts` before
-  `npm ci`, so the `postinstall` hook can find the schema during container
-  builds.
-- Final PR checks passed on 2026-05-08 after the Dockerfile follow-up:
-  Quality Core, E2E Smoke, Container Image, and branch-name check.
-- Explicit-ref preview deployment via workflow run `25583379928` passed after
-  moving the scheduler off Vercel Cron. Artifact URL:
-  `https://nexus-dash-55krfi0nt-dorian-agaesses-projects.vercel.app`.
-- Live-email smoke preview deployment with real Resend delivery mode passed at
-  `https://nexus-dash-lpkmzden2-dorian-agaesses-projects.vercel.app`.
-  The agent API smoke passed through Vercel protection with `vercel curl`,
-  creating assignment and mention activity for the configured Dorian user.
-- Real dispatch smoke passed on 2026-05-08 after the 30-minute quiet window:
-  `GET /api/cron/notification-emails` returned `ok: true` with
-  `digestsAttempted: 1`, `digestsSent: 1`, `digestsFailed: 0`, and
-  `errors: 0`. This sent the project notification digest to
-  `dorian.agaesse@gmail.com`.
-- Invitation reminder behavior is covered by local service and endpoint tests;
-  no live 6-hour preview reminder was forced during this smoke.
+  applying `20260513120000_task227_notification_email_orchestration`.
+- Local DB `NODE_ENV=test npm test` passed with 107 files passed, 2 skipped;
+  800 tests passed, 2 skipped.
+- Local DB `NODE_ENV=test npm run test:coverage` passed with 91.23% statements,
+  81.2% branches, 93.42% functions, and 91.75% lines.
+- First `npm run build` attempt failed because the inherited shell had
+  `NEXTAUTH_URL` without an effective matching `NEXTAUTH_SECRET`; reran with
+  both explicitly set.
+- Production-guarded `npm run build` passed with local PostgreSQL, disabled
+  outbound delivery mode, localhost trusted origins, local agent signing secret,
+  local Google token key, and explicit `NEXTAUTH_URL`/`NEXTAUTH_SECRET`.
 
 ## Out Of Scope
-- TASK-226 task due-date reminder emails.
-- Per-user notification preference UI, unsubscribe management, bounce webhooks,
-  suppression lists, or provider webhook processing.
-- A general-purpose background job framework beyond the narrow digest dispatch
-  path needed for this task.
-- Marking notifications read/resolved as a side effect of email delivery.
+- TASK-226 task due-date reminder business rules.
+- User notification preference UI, unsubscribe management, bounce webhooks, and
+  suppression-list UX.
+- A broad background job framework unrelated to notification email dispatch.
+- Marking in-app notifications read/resolved as a side effect of email sending.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -134,7 +134,8 @@ creates bursts of mentions and assignments.
 - `npx prisma validate` passed.
 - Focused orchestration validation passed:
   `npm test -- --run tests/lib/project-notification-email-service.test.ts tests/api/notification-email-dispatch.route.test.ts tests/lib/outbound-email-templates.test.ts tests/lib/env.server.test.ts`
-  with 4 files and 81 tests.
+  with 4 files and 81 tests initially, then 83 tests after Copilot review
+  fixes.
 - Focused notification producer regression passed:
   `npm test -- --run tests/lib/notification-service.test.ts tests/api/task-comments.route.test.ts tests/api/task-update.route.test.ts`
   with 3 files and 41 tests.
@@ -148,7 +149,8 @@ creates bursts of mentions and assignments.
   `postgresql://postgres:postgres@127.0.0.1:5432/nexusdash?schema=public`,
   applying `20260513120000_task227_notification_email_orchestration`.
 - Local DB `NODE_ENV=test npm test` passed with 107 files passed, 2 skipped;
-  800 tests passed, 2 skipped.
+  800 tests passed, 2 skipped initially, then 802 tests passed, 2 skipped after
+  Copilot review fixes.
 - Local DB `NODE_ENV=test npm run test:coverage` passed with 91.23% statements,
   81.2% branches, 93.42% functions, and 91.75% lines.
 - First `npm run build` attempt failed because the inherited shell had
@@ -157,6 +159,9 @@ creates bursts of mentions and assignments.
 - Production-guarded `npm run build` passed with local PostgreSQL, disabled
   outbound delivery mode, localhost trusted origins, local agent signing secret,
   local Google token key, and explicit `NEXTAUTH_URL`/`NEXTAUTH_SECRET`.
+- Copilot review fixes replayed all migrations against a fresh temporary local
+  database `nexusdash_task227_migration_check`; `npm run db:migrate` applied
+  all 35 migrations successfully, then the temporary database was dropped.
 
 ## Out Of Scope
 - TASK-226 task due-date reminder business rules.

--- a/tests/api/notification-email-dispatch.route.test.ts
+++ b/tests/api/notification-email-dispatch.route.test.ts
@@ -91,6 +91,53 @@ describe("notification email dispatch route", () => {
     expect(dispatchMock.dispatchProjectNotificationEmails).not.toHaveBeenCalled();
   });
 
+  test("rejects requests with the wrong dispatch secret header", async () => {
+    const response = await GET(
+      new NextRequest("https://nexus-dash.app/api/cron/notification-emails", {
+        headers: {
+          "x-notification-email-dispatch-secret": "wrong-secret",
+        },
+      })
+    );
+
+    expect(response.status).toBe(401);
+    await expect(readJson(response)).resolves.toEqual({ error: "unauthorized" });
+    expect(dispatchMock.dispatchProjectNotificationEmails).not.toHaveBeenCalled();
+  });
+
+  test("accepts bearer token auth with case-insensitive scheme and extra spaces", async () => {
+    const response = await GET(
+      new NextRequest("https://nexus-dash.app/api/cron/notification-emails", {
+        headers: {
+          authorization: "  bearer   dispatch-secret-0123456789abcdef  ",
+        },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(readJson(response)).resolves.toMatchObject({ ok: true });
+    expect(dispatchMock.dispatchProjectNotificationEmails).toHaveBeenCalledWith({
+      appOrigin: "https://nexus-dash.app",
+    });
+  });
+
+  test("dispatches notification emails with the dedicated dispatch secret header", async () => {
+    const response = await GET(
+      new NextRequest("https://nexus-dash.app/api/cron/notification-emails", {
+        headers: {
+          "x-notification-email-dispatch-secret":
+            " dispatch-secret-0123456789abcdef ",
+        },
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(readJson(response)).resolves.toMatchObject({ ok: true });
+    expect(dispatchMock.dispatchProjectNotificationEmails).toHaveBeenCalledWith({
+      appOrigin: "https://nexus-dash.app",
+    });
+  });
+
   test("dispatches notification emails with the trusted app origin", async () => {
     const response = await GET(
       new NextRequest("https://nexus-dash.app/api/cron/notification-emails", {

--- a/tests/lib/project-notification-email-service.test.ts
+++ b/tests/lib/project-notification-email-service.test.ts
@@ -1,23 +1,29 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const prismaMock = vi.hoisted(() => ({
+  $queryRaw: vi.fn(),
   user: {
     findMany: vi.fn(),
+    findUnique: vi.fn(),
   },
   notification: {
     findMany: vi.fn(),
   },
   projectInvitation: {
-    findMany: vi.fn(),
-    findUnique: vi.fn(),
+    findFirst: vi.fn(),
   },
   projectNotificationEmail: {
     create: vi.fn(),
     findFirst: vi.fn(),
+    findMany: vi.fn(),
     update: vi.fn(),
+    updateMany: vi.fn(),
   },
   projectNotificationEmailItem: {
-    findMany: vi.fn(),
+    count: vi.fn(),
+    create: vi.fn(),
+    findFirst: vi.fn(),
+    update: vi.fn(),
   },
 }));
 
@@ -40,17 +46,20 @@ vi.mock("@/lib/services/outbound-email-service", () => ({
 
 vi.mock("@/lib/observability/logger", () => loggerMock);
 
-import { dispatchProjectNotificationEmails } from "@/lib/services/project-notification-email-service";
+import {
+  dispatchProjectNotificationEmails,
+  enqueueNotificationEmailForNotification,
+} from "@/lib/services/project-notification-email-service";
 
-const now = new Date("2026-05-08T12:00:00.000Z");
-const oldDate = new Date("2026-05-08T11:00:00.000Z");
-const recentDate = new Date("2026-05-08T11:45:00.000Z");
+const now = new Date("2026-05-13T12:00:00.000Z");
+const oldDate = new Date("2026-05-13T11:00:00.000Z");
 
 function mentionNotification(overrides: Record<string, unknown> = {}) {
   return {
     id: "notification-mention-1",
+    recipientUserId: "user-1",
     type: "task_comment_mention",
-    title: "Mentioned in: Ship digest",
+    title: "Mentioned in: Ship orchestration",
     body: "Agent mentioned you.",
     targetPath: "/projects/project-1?taskId=task-1&commentId=comment-1",
     sourceType: "task_comment_mention",
@@ -58,9 +67,9 @@ function mentionNotification(overrides: Record<string, unknown> = {}) {
     metadata: {
       commentId: "comment-1",
       taskId: "task-1",
-      taskTitle: "Ship digest",
+      taskTitle: "Ship orchestration",
       projectId: "project-1",
-      projectName: "Email Project",
+      projectName: "Alpha",
       mentionedUsername: "dorian",
       mentionedUserId: "user-1",
       mentionedUserDisplayName: "Dorian",
@@ -79,22 +88,23 @@ function mentionNotification(overrides: Record<string, unknown> = {}) {
 function assignmentNotification(overrides: Record<string, unknown> = {}) {
   return {
     id: "notification-assignment-1",
+    recipientUserId: "user-1",
     type: "task_assignment",
-    title: "Assigned: Review digest",
+    title: "Assigned: Review queue",
     body: "Owner assigned you.",
-    targetPath: "/projects/project-1?taskId=task-2",
+    targetPath: "/projects/project-2?taskId=task-2",
     sourceType: "task_assignment",
     sourceId: "task-2",
     metadata: {
       taskId: "task-2",
-      taskTitle: "Review digest",
-      projectId: "project-1",
-      projectName: "Email Project",
+      taskTitle: "Review queue",
+      projectId: "project-2",
+      projectName: "Beta",
       assignedUserId: "user-1",
       assignedUserDisplayName: "Dorian",
       actorUserId: "owner-1",
       actorDisplayName: "Owner",
-      targetPath: "/projects/project-1?taskId=task-2",
+      targetPath: "/projects/project-2?taskId=task-2",
     },
     readAt: null,
     resolvedAt: null,
@@ -107,8 +117,9 @@ function assignmentNotification(overrides: Record<string, unknown> = {}) {
 function invitationNotification(overrides: Record<string, unknown> = {}) {
   return {
     id: "notification-invite-1",
+    recipientUserId: "user-1",
     type: "project_invitation",
-    title: "Project invitation: Email Project",
+    title: "Project invitation: Alpha",
     body: "Owner invited you.",
     targetPath: "/invite/project/invite-1",
     sourceType: "project_invitation",
@@ -116,43 +127,89 @@ function invitationNotification(overrides: Record<string, unknown> = {}) {
     metadata: {
       invitationId: "invite-1",
       projectId: "project-1",
-      projectName: "Email Project",
+      projectName: "Alpha",
       invitedEmail: "dorian.agaesse@gmail.com",
       invitedByDisplayName: "Owner",
       invitedByEmail: "owner@example.com",
       role: "editor",
-      expiresAt: "2026-05-09T11:00:00.000Z",
+      expiresAt: "2026-05-14T11:00:00.000Z",
       inviteLinkPath: "/invite/project/invite-1",
     },
     readAt: null,
     resolvedAt: null,
-    createdAt: new Date("2026-05-08T05:00:00.000Z"),
-    updatedAt: new Date("2026-05-08T05:00:00.000Z"),
+    createdAt: new Date("2026-05-13T05:00:00.000Z"),
+    updatedAt: new Date("2026-05-13T05:00:00.000Z"),
     ...overrides,
+  };
+}
+
+function claimedGroup(input: {
+  id: string;
+  kind?: "project_digest" | "project_invitation_reminder";
+  projectId: string;
+  projectName: string;
+  notification: ReturnType<typeof mentionNotification>;
+}) {
+  return {
+    id: input.id,
+    kind: input.kind ?? "project_digest",
+    recipientUserId: "user-1",
+    projectId: input.projectId,
+    sourceKey: input.notification.id,
+    groupingKey: `${input.kind ?? "project_digest"}:user-1:${input.projectId}`,
+    firstPendingNotificationAt: input.notification.createdAt,
+    latestPendingNotificationAt: input.notification.updatedAt,
+    sendAfterAt: new Date("2026-05-13T11:30:00.000Z"),
+    maxSendAt: new Date("2026-05-13T12:00:00.000Z"),
+    windowStartedAt: input.notification.createdAt,
+    windowEndedAt: input.notification.updatedAt,
+    latestNotificationAt: input.notification.updatedAt,
+    notificationCount: 1,
+    recipient: {
+      id: "user-1",
+      email: "dorian.agaesse@gmail.com",
+      name: "Dorian",
+    },
+    project: {
+      id: input.projectId,
+      name: input.projectName,
+    },
+    items: [
+      {
+        id: `${input.id}-item`,
+        notificationId: input.notification.id,
+        notificationUpdatedAt: input.notification.updatedAt,
+        sourceFingerprint: `${input.notification.id}:${input.notification.updatedAt.toISOString()}`,
+        notification: input.notification,
+      },
+    ],
   };
 }
 
 describe("project-notification-email-service", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    prismaMock.user.findMany.mockResolvedValue([
-      {
-        id: "user-1",
-        email: "dorian.agaesse@gmail.com",
-        name: "Dorian",
-      },
-    ]);
+    prismaMock.user.findMany.mockResolvedValue([]);
+    prismaMock.user.findUnique.mockResolvedValue({
+      email: "dorian.agaesse@gmail.com",
+      emailVerified: new Date("2026-05-01T00:00:00.000Z"),
+    });
     prismaMock.notification.findMany.mockResolvedValue([]);
-    prismaMock.projectNotificationEmailItem.findMany.mockResolvedValue([]);
-    prismaMock.projectNotificationEmail.findFirst.mockResolvedValue(null);
+    prismaMock.projectInvitation.findFirst.mockResolvedValue({ id: "invite-1" });
     prismaMock.projectNotificationEmail.create.mockResolvedValue({
       id: "email-1",
     });
+    prismaMock.projectNotificationEmail.findFirst.mockResolvedValue(null);
+    prismaMock.projectNotificationEmail.findMany.mockResolvedValue([]);
     prismaMock.projectNotificationEmail.update.mockResolvedValue({
       id: "email-1",
     });
-    prismaMock.projectInvitation.findMany.mockResolvedValue([]);
-    prismaMock.projectInvitation.findUnique.mockResolvedValue(null);
+    prismaMock.projectNotificationEmail.updateMany.mockResolvedValue({
+      count: 0,
+    });
+    prismaMock.projectNotificationEmailItem.count.mockResolvedValue(1);
+    prismaMock.projectNotificationEmailItem.findFirst.mockResolvedValue(null);
+    prismaMock.$queryRaw.mockResolvedValue([]);
     outboundEmailMock.sendOutboundEmail.mockResolvedValue({
       ok: true,
       delivery: "sent",
@@ -162,21 +219,118 @@ describe("project-notification-email-service", () => {
     });
   });
 
-  test("sends a quiet-window digest for grouped project notifications", async () => {
-    prismaMock.notification.findMany
-      .mockResolvedValueOnce([
-        mentionNotification(),
-        mentionNotification({
-          id: "notification-mention-2",
-          sourceId: "comment-2",
-          metadata: {
-            ...mentionNotification().metadata,
-            commentId: "comment-2",
-          },
+  test("ingests a project activity notification into a debounced pending group", async () => {
+    await enqueueNotificationEmailForNotification({
+      db: prismaMock as never,
+      notification: mentionNotification(),
+    });
+
+    expect(prismaMock.projectNotificationEmail.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          kind: "project_digest",
+          recipientUserId: "user-1",
+          projectId: "project-1",
+          groupingKey: "project_digest:user-1:project-1",
+          firstPendingNotificationAt: oldDate,
+          latestPendingNotificationAt: oldDate,
+          sendAfterAt: new Date("2026-05-13T11:30:00.000Z"),
+          maxSendAt: new Date("2026-05-13T12:00:00.000Z"),
         }),
-        assignmentNotification(),
-      ])
-      .mockResolvedValueOnce([]);
+      })
+    );
+  });
+
+  test("extends the quiet window but caps send-after at the maximum delay", async () => {
+    prismaMock.projectNotificationEmail.findFirst.mockResolvedValueOnce({
+      id: "email-1",
+      firstPendingNotificationAt: new Date("2026-05-13T10:50:00.000Z"),
+      latestPendingNotificationAt: new Date("2026-05-13T10:50:00.000Z"),
+    });
+    prismaMock.projectNotificationEmailItem.count.mockResolvedValueOnce(2);
+
+    await enqueueNotificationEmailForNotification({
+      db: prismaMock as never,
+      notification: mentionNotification({
+        id: "notification-mention-2",
+        sourceId: "comment-2",
+        createdAt: new Date("2026-05-13T11:40:00.000Z"),
+        updatedAt: new Date("2026-05-13T11:40:00.000Z"),
+        metadata: {
+          ...mentionNotification().metadata,
+          commentId: "comment-2",
+        },
+      }),
+    });
+
+    expect(prismaMock.projectNotificationEmail.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "email-1" },
+        data: expect.objectContaining({
+          latestPendingNotificationAt: new Date("2026-05-13T11:40:00.000Z"),
+          sendAfterAt: new Date("2026-05-13T11:50:00.000Z"),
+          maxSendAt: new Date("2026-05-13T11:50:00.000Z"),
+          notificationCount: 2,
+        }),
+      })
+    );
+  });
+
+  test("does not enqueue a notification fingerprint already sent or skipped", async () => {
+    prismaMock.projectNotificationEmailItem.findFirst.mockResolvedValueOnce({
+      id: "item-1",
+    });
+
+    await enqueueNotificationEmailForNotification({
+      db: prismaMock as never,
+      notification: mentionNotification(),
+    });
+
+    expect(prismaMock.projectNotificationEmail.create).not.toHaveBeenCalled();
+  });
+
+  test("creates invitation reminder groups for the six-hour reminder window", async () => {
+    await enqueueNotificationEmailForNotification({
+      db: prismaMock as never,
+      notification: invitationNotification(),
+    });
+
+    expect(prismaMock.projectNotificationEmail.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          kind: "project_invitation_reminder",
+          sourceKey: "invite-1",
+          groupingKey: "project_invitation_reminder:user-1:project-1:invite-1",
+          sendAfterAt: new Date("2026-05-13T11:00:00.000Z"),
+          maxSendAt: new Date("2026-05-13T11:00:00.000Z"),
+        }),
+      })
+    );
+  });
+
+  test("batches multiple due project groups into one recipient email", async () => {
+    const mention = mentionNotification();
+    const assignment = assignmentNotification();
+    prismaMock.$queryRaw.mockResolvedValueOnce([
+      { id: "email-1" },
+      { id: "email-2" },
+    ]);
+    prismaMock.projectNotificationEmail.findMany
+      .mockResolvedValueOnce([{ recipientUserId: "user-1" }])
+      .mockResolvedValueOnce([
+        claimedGroup({
+          id: "email-1",
+          projectId: "project-1",
+          projectName: "Alpha",
+          notification: mention,
+        }),
+        claimedGroup({
+          id: "email-2",
+          projectId: "project-2",
+          projectName: "Beta",
+          notification: assignment,
+        }),
+      ]);
 
     const summary = await dispatchProjectNotificationEmails({
       appOrigin: "https://preview.nexusdash.test",
@@ -184,132 +338,37 @@ describe("project-notification-email-service", () => {
     });
 
     expect(summary).toMatchObject({
-      digestsAttempted: 1,
-      digestsSent: 1,
-      digestsFailed: 0,
+      groupsClaimed: 2,
+      recipientEmailsAttempted: 1,
+      recipientEmailsSent: 1,
+      groupsSent: 2,
     });
-    expect(prismaMock.projectNotificationEmail.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          kind: "project_digest",
-          recipientUserId: "user-1",
-          projectId: "project-1",
-          notificationCount: 3,
-        }),
-      })
-    );
     expect(outboundEmailMock.sendOutboundEmail).toHaveBeenCalledWith(
       expect.objectContaining({
         templateKey: "project_notification_digest",
         to: "dorian.agaesse@gmail.com",
-        subject: "3 updates for Email Project on NexusDash",
-        text: expect.stringContaining("2x Agent mentioned you on Ship digest"),
+        subject: "2 updates across 2 projects on NexusDash",
+        text: expect.stringContaining("Alpha"),
         metadata: expect.objectContaining({
-          projectId: "project-1",
-          notificationCount: 3,
+          projectIds: ["project-1", "project-2"],
+          groupIds: ["email-1", "email-2"],
         }),
       })
     );
   });
 
-  test("does not send while the latest notification is still inside the quiet window", async () => {
-    prismaMock.notification.findMany
+  test("marks provider failures on all groups in the recipient batch", async () => {
+    prismaMock.$queryRaw.mockResolvedValueOnce([{ id: "email-1" }]);
+    prismaMock.projectNotificationEmail.findMany
+      .mockResolvedValueOnce([{ recipientUserId: "user-1" }])
       .mockResolvedValueOnce([
-        mentionNotification({
-          updatedAt: recentDate,
+        claimedGroup({
+          id: "email-1",
+          projectId: "project-1",
+          projectName: "Alpha",
+          notification: mentionNotification(),
         }),
-      ])
-      .mockResolvedValueOnce([]);
-
-    const summary = await dispatchProjectNotificationEmails({
-      appOrigin: "https://preview.nexusdash.test",
-      now,
-    });
-
-    expect(summary.digestsAttempted).toBe(0);
-    expect(prismaMock.projectNotificationEmail.create).not.toHaveBeenCalled();
-    expect(outboundEmailMock.sendOutboundEmail).not.toHaveBeenCalled();
-  });
-
-  test("does not resend notifications already covered by a digest", async () => {
-    prismaMock.notification.findMany
-      .mockResolvedValueOnce([mentionNotification()])
-      .mockResolvedValueOnce([]);
-    prismaMock.projectNotificationEmailItem.findMany.mockResolvedValueOnce([
-      {
-        notificationId: "notification-mention-1",
-      },
-    ]);
-
-    const summary = await dispatchProjectNotificationEmails({
-      appOrigin: "https://preview.nexusdash.test",
-      now,
-    });
-
-    expect(summary.digestsAttempted).toBe(0);
-    expect(prismaMock.projectNotificationEmailItem.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          email: expect.objectContaining({
-            kind: "project_digest",
-            OR: expect.arrayContaining([
-              expect.objectContaining({
-                status: {
-                  in: ["sent", "skipped"],
-                },
-              }),
-              expect.objectContaining({
-                status: "pending",
-              }),
-            ]),
-          }),
-        }),
-      })
-    );
-    expect(outboundEmailMock.sendOutboundEmail).not.toHaveBeenCalled();
-  });
-
-  test("retries a failed digest tracking row instead of permanently covering notifications", async () => {
-    prismaMock.notification.findMany
-      .mockResolvedValueOnce([mentionNotification()])
-      .mockResolvedValueOnce([]);
-    prismaMock.projectNotificationEmail.findFirst
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce({
-        id: "email-failed",
-      });
-
-    const summary = await dispatchProjectNotificationEmails({
-      appOrigin: "https://preview.nexusdash.test",
-      now,
-    });
-
-    expect(summary.digestsSent).toBe(1);
-    expect(prismaMock.projectNotificationEmail.create).not.toHaveBeenCalled();
-    expect(prismaMock.projectNotificationEmail.update).toHaveBeenNthCalledWith(1, {
-      where: { id: "email-failed" },
-      data: {
-        status: "pending",
-        outboundEmailDeliveryId: null,
-        errorCode: null,
-        completedAt: null,
-      },
-    });
-    expect(prismaMock.projectNotificationEmail.update).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        where: { id: "email-failed" },
-        data: expect.objectContaining({
-          status: "sent",
-        }),
-      })
-    );
-  });
-
-  test("records provider failure on the digest tracking row", async () => {
-    prismaMock.notification.findMany
-      .mockResolvedValueOnce([mentionNotification()])
-      .mockResolvedValueOnce([]);
+      ]);
     outboundEmailMock.sendOutboundEmail.mockResolvedValueOnce({
       ok: false,
       error: "provider-rejected",
@@ -323,90 +382,40 @@ describe("project-notification-email-service", () => {
       now,
     });
 
-    expect(summary.digestsFailed).toBe(1);
-    expect(prismaMock.projectNotificationEmail.update).toHaveBeenCalledWith({
-      where: { id: "email-1" },
-      data: expect.objectContaining({
-        status: "failed",
-        outboundEmailDeliveryId: "delivery-1",
-        errorCode: "provider-rejected",
-      }),
-    });
-  });
-
-  test("sends a six-hour invitation reminder once", async () => {
-    prismaMock.notification.findMany
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([invitationNotification()]);
-    prismaMock.projectInvitation.findMany.mockResolvedValueOnce([{
-      id: "invite-1",
-      invitedEmail: "dorian.agaesse@gmail.com",
-      role: "editor",
-      expiresAt: new Date("2026-05-09T11:00:00.000Z"),
-      acceptedAt: null,
-      revokedAt: null,
-      replacedAt: null,
-      project: {
-        id: "project-1",
-        name: "Email Project",
-      },
-      invitedByUser: {
-        email: "owner@example.com",
-        name: "Owner",
-        username: null,
-        usernameDiscriminator: null,
-      },
-    }]);
-
-    const summary = await dispatchProjectNotificationEmails({
-      appOrigin: "https://preview.nexusdash.test",
-      now,
-    });
-
-    expect(summary).toMatchObject({
-      invitationRemindersAttempted: 1,
-      invitationRemindersSent: 1,
-    });
-    expect(prismaMock.projectNotificationEmail.create).toHaveBeenCalledWith(
+    expect(summary.recipientEmailsFailed).toBe(1);
+    expect(summary.groupsFailed).toBe(1);
+    expect(prismaMock.projectNotificationEmail.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
+        where: { id: { in: ["email-1"] } },
         data: expect.objectContaining({
-          kind: "project_invitation_reminder",
-          sourceKey: "invite-1",
-          notificationCount: 1,
+          status: "failed",
+          outboundEmailDeliveryId: "delivery-1",
+          errorCode: "provider-rejected",
         }),
       })
     );
-    expect(outboundEmailMock.sendOutboundEmail).toHaveBeenCalledWith(
-      expect.objectContaining({
-        templateKey: "project_invitation",
-        to: "dorian.agaesse@gmail.com",
-        subject: "Reminder: invitation to Email Project on NexusDash",
-        metadata: expect.objectContaining({
-          deliveryReason: "six_hour_invitation_reminder",
-        }),
-      })
-    );
-    expect(prismaMock.projectInvitation.findMany).toHaveBeenCalledTimes(1);
   });
 
-  test("skips invitation reminders that already have tracking items", async () => {
-    prismaMock.notification.findMany
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([invitationNotification()]);
-    prismaMock.projectNotificationEmailItem.findMany
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([
-        {
-          notificationId: "notification-invite-1",
-        },
-      ]);
-
+  test("does not send when no groups are claimed, preserving repeated-call idempotency", async () => {
     const summary = await dispatchProjectNotificationEmails({
       appOrigin: "https://preview.nexusdash.test",
       now,
     });
 
-    expect(summary.invitationRemindersAttempted).toBe(0);
+    expect(summary.groupsClaimed).toBe(0);
     expect(outboundEmailMock.sendOutboundEmail).not.toHaveBeenCalled();
+  });
+
+  test("claims due groups with the database query used for concurrent dispatch safety", async () => {
+    await dispatchProjectNotificationEmails({
+      appOrigin: "https://preview.nexusdash.test",
+      now,
+    });
+
+    expect(
+      (prismaMock.$queryRaw.mock.calls[0][0] as { strings: string[] }).strings.join(
+        " "
+      )
+    ).toContain("FOR UPDATE SKIP LOCKED");
   });
 });

--- a/tests/lib/project-notification-email-service.test.ts
+++ b/tests/lib/project-notification-email-service.test.ts
@@ -168,6 +168,7 @@ function claimedGroup(input: {
     recipient: {
       id: "user-1",
       email: "dorian.agaesse@gmail.com",
+      emailVerified: new Date("2026-05-01T00:00:00.000Z"),
       name: "Dorian",
     },
     project: {
@@ -311,10 +312,12 @@ describe("project-notification-email-service", () => {
   test("batches multiple due project groups into one recipient email", async () => {
     const mention = mentionNotification();
     const assignment = assignmentNotification();
-    prismaMock.$queryRaw.mockResolvedValueOnce([
-      { id: "email-1" },
-      { id: "email-2" },
-    ]);
+    prismaMock.$queryRaw
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { id: "email-1" },
+        { id: "email-2" },
+      ]);
     prismaMock.projectNotificationEmail.findMany
       .mockResolvedValueOnce([{ recipientUserId: "user-1" }])
       .mockResolvedValueOnce([
@@ -358,7 +361,9 @@ describe("project-notification-email-service", () => {
   });
 
   test("marks provider failures on all groups in the recipient batch", async () => {
-    prismaMock.$queryRaw.mockResolvedValueOnce([{ id: "email-1" }]);
+    prismaMock.$queryRaw
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: "email-1" }]);
     prismaMock.projectNotificationEmail.findMany
       .mockResolvedValueOnce([{ recipientUserId: "user-1" }])
       .mockResolvedValueOnce([
@@ -406,6 +411,64 @@ describe("project-notification-email-service", () => {
     expect(outboundEmailMock.sendOutboundEmail).not.toHaveBeenCalled();
   });
 
+  test("releases stale dispatching groups back to pending for retry", async () => {
+    await dispatchProjectNotificationEmails({
+      appOrigin: "https://preview.nexusdash.test",
+      now,
+    });
+
+    expect(prismaMock.projectNotificationEmail.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: "dispatching",
+          claimedAt: {
+            lt: new Date("2026-05-13T11:30:00.000Z"),
+          },
+        }),
+        data: expect.objectContaining({
+          status: "pending",
+          errorCode: "dispatch-claim-stale",
+          claimToken: null,
+          claimedAt: null,
+          completedAt: null,
+          sendAfterAt: now,
+        }),
+      })
+    );
+  });
+
+  test("skips dispatch if the recipient email is no longer verified", async () => {
+    const group = claimedGroup({
+      id: "email-1",
+      projectId: "project-1",
+      projectName: "Alpha",
+      notification: mentionNotification(),
+    });
+    prismaMock.$queryRaw
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: "email-1" }]);
+    prismaMock.projectNotificationEmail.findMany
+      .mockResolvedValueOnce([{ recipientUserId: "user-1" }])
+      .mockResolvedValueOnce([
+        {
+          ...group,
+          recipient: {
+            ...group.recipient,
+            emailVerified: null,
+          },
+        },
+      ]);
+
+    const summary = await dispatchProjectNotificationEmails({
+      appOrigin: "https://preview.nexusdash.test",
+      now,
+    });
+
+    expect(summary.groupsClaimed).toBe(1);
+    expect(summary.recipientEmailsAttempted).toBe(0);
+    expect(outboundEmailMock.sendOutboundEmail).not.toHaveBeenCalled();
+  });
+
   test("claims due groups with the database query used for concurrent dispatch safety", async () => {
     await dispatchProjectNotificationEmails({
       appOrigin: "https://preview.nexusdash.test",
@@ -413,9 +476,11 @@ describe("project-notification-email-service", () => {
     });
 
     expect(
-      (prismaMock.$queryRaw.mock.calls[0][0] as { strings: string[] }).strings.join(
-        " "
+      prismaMock.$queryRaw.mock.calls.some((call) =>
+        (call[0] as { strings: string[] }).strings
+          .join(" ")
+          .includes("FOR UPDATE SKIP LOCKED")
       )
-    ).toContain("FOR UPDATE SKIP LOCKED");
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Refactor TASK-225 notification email dispatch into durable DB-backed orchestration with recipient/project grouping, debounce timing, max-delay tracking, source fingerprints, claim state, and outbound delivery correlation.
- Wire email-eligible notification create/refresh paths to enqueue pending groups, and dispatch due groups with `FOR UPDATE SKIP LOCKED` claiming plus recipient-level emails containing project sections.
- Demote the GitHub Actions scheduler to manual diagnostics, keep the protected endpoint with dedicated-header auth, and document the Vercel Cron/Hobby-plan scheduler decision plus managed HTTP scheduler fallback.

## Validation
- `npm ci`
- `npx prisma validate`
- `npm test -- --run tests/lib/project-notification-email-service.test.ts tests/api/notification-email-dispatch.route.test.ts tests/lib/outbound-email-templates.test.ts tests/lib/env.server.test.ts`
- `npm test -- --run tests/lib/notification-service.test.ts tests/api/task-comments.route.test.ts tests/api/task-update.route.test.ts`
- `npm run lint`
- local PostgreSQL `npm run db:migrate`
- local DB `NODE_ENV=test npm test`
- local DB `NODE_ENV=test npm run test:coverage`
- production-guarded `npm run build`

## Scheduler decision
Vercel Cron is the preferred production scheduler when the deployment plan supports sub-hour cadence. The current Hobby-plan evidence blocks that because Hobby cron is daily-only, so production on Hobby should use a managed HTTP scheduler with retries/visibility, such as Upstash QStash Schedule, to call the same protected endpoint. GitHub Actions dispatch is manual diagnostic tooling only.

## Smoke plan
For `dorian.agaesse@gmail.com`, deploy a preview from this branch with explicit `git_ref`, configure live outbound email mode and the dispatch secret outside the repo, create mention/assignment activity through the app or agent API, wait until the debounce window is due, and invoke `/api/cron/notification-emails` with `x-notification-email-dispatch-secret`. Do not print or commit the secret.