### PR TITLE
TASK-228 track QStash scheduler activation

### DIFF
--- a/journal.md
+++ b/journal.md
@@ -12,6 +12,11 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ## Recent Entries (Most Relevant)
 
+### 2026-05-14
+- Type: Planning
+- Summary: Added TASK-228 for QStash production scheduler activation after PR #254 merged.
+- Evidence: PR #254 merged as `e83dfa73b9ede02775bdd3d8a467c4b521fe8f7b`. TASK-227 delivered the durable notification email orchestration and protected endpoint, but QStash itself is not provisioned in code. Because the Vercel plan will not be upgraded and Hobby cron cannot run sub-hour schedules, TASK-228 now tracks activation of an Upstash QStash Schedule or equivalent managed HTTP scheduler, including the 5-minute cadence, protected header, retries/visibility, redaction, and production smoke validation.
+
 ### 2026-05-13
 - Type: Execution
 - Summary: TASK-227 addressed Copilot PR #254 review feedback on migration backfills, retryability, reconciliation scale, dispatch-time verification, and env docs.

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -11,9 +11,14 @@ Use this file to capture tasks discovered during development. Each entry should 
   Dependencies: TASK-123, TASK-125
 - ID: TASK-227
   Title: Production-grade notification email orchestration - debounce, grouping, and scheduler refactor
-  Status: In progress on `feature/task-227-production-grade-notification-email-orchestration`
+  Status: Done via PR #254; production scheduler activation tracked by TASK-228
   Rationale: Refactor the TASK-225 email notification dispatch into a production-grade app-owned delivery architecture that notifies users about important project activity without email spam. The design should group notifications by recipient and project, debounce clustered activity with a hard maximum notification delay, avoid relying on GitHub Actions as the primary production scheduler, and leave task due-date reminder production to TASK-226 while providing a clean extension point for it.
   Dependencies: TASK-123, TASK-125, TASK-225
+- ID: TASK-228
+  Title: QStash notification email scheduler activation - production cadence and smoke validation
+  Status: Pending
+  Rationale: Vercel will remain on the Hobby plan, so Vercel Cron cannot provide the sub-hour cadence required by TASK-227 notification email debounce/max-delay behavior. Provision an Upstash QStash Schedule, or an equivalent managed HTTP scheduler with retries and visibility, to invoke `POST /api/cron/notification-emails` every 5 minutes with the protected dispatch header. Document the scheduler ownership, redaction/retry settings, and run a production smoke for a verified recipient without exposing secrets.
+  Dependencies: TASK-125, TASK-227
 - ID: TASK-226
   Title: Task due-date email reminders - 3-day deadline warning delivery
   Status: Pending (promoted after TASK-125 merged via PR #243)

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,8 +4,8 @@
 TASK-227
 
 ## Status
-In progress on dedicated worktree `../nexus_dash_task227` and branch
-`feature/task-227-production-grade-notification-email-orchestration`.
+Done via PR #254. Production scheduler activation for the non-upgraded Vercel
+Hobby plan is tracked separately as TASK-228.
 
 ## Objective
 Own the project notification email dispatch feature end to end and turn the


### PR DESCRIPTION
## Summary
- Mark TASK-227 as done after PR #254 merged
- Add TASK-228 to track QStash or equivalent managed HTTP scheduler activation for notification emails on Vercel Hobby
- Record the post-merge scheduler decision in the journal

## Validation
- `git diff --check`

## Notes
- This is documentation/task tracking only. No runtime code changes.