### PR TITLE
TASK-228 clarify scheduler endpoint method

### DIFF
--- a/journal.md
+++ b/journal.md
@@ -13,6 +13,11 @@ Use it for important implementation milestones, blockers, validation runs, and r
 ## Recent Entries (Most Relevant)
 
 ### 2026-05-14
+- Type: Validation
+- Summary: Production notification email dispatch endpoint smoke passed with the protected Vercel production secret.
+- Evidence: Pulled production Vercel env into ignored `tmp/vercel-production-smoke.env`, confirmed `https://nexus-dash.app/api/health/live` returned 200, and invoked `GET https://nexus-dash.app/api/cron/notification-emails` with `x-notification-email-dispatch-secret`. The endpoint returned 200 with `ok: true`, `groupsClaimed: 0`, `recipientEmailsAttempted: 0`, and `errors: 0`. A first `POST` probe returned 405, confirming QStash must call the documented `GET` method.
+
+### 2026-05-14
 - Type: Planning
 - Summary: Added TASK-228 for QStash production scheduler activation after PR #254 merged.
 - Evidence: PR #254 merged as `e83dfa73b9ede02775bdd3d8a467c4b521fe8f7b`. TASK-227 delivered the durable notification email orchestration and protected endpoint, but QStash itself is not provisioned in code. Because the Vercel plan will not be upgraded and Hobby cron cannot run sub-hour schedules, TASK-228 now tracks activation of an Upstash QStash Schedule or equivalent managed HTTP scheduler, including the 5-minute cadence, protected header, retries/visibility, redaction, and production smoke validation.

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -17,7 +17,7 @@ Use this file to capture tasks discovered during development. Each entry should 
 - ID: TASK-228
   Title: QStash notification email scheduler activation - production cadence and smoke validation
   Status: Pending
-  Rationale: Vercel will remain on the Hobby plan, so Vercel Cron cannot provide the sub-hour cadence required by TASK-227 notification email debounce/max-delay behavior. Provision an Upstash QStash Schedule, or an equivalent managed HTTP scheduler with retries and visibility, to invoke `POST /api/cron/notification-emails` every 5 minutes with the protected dispatch header. Document the scheduler ownership, redaction/retry settings, and run a production smoke for a verified recipient without exposing secrets.
+  Rationale: Vercel will remain on the Hobby plan, so Vercel Cron cannot provide the sub-hour cadence required by TASK-227 notification email debounce/max-delay behavior. Provision an Upstash QStash Schedule, or an equivalent managed HTTP scheduler with retries and visibility, to invoke `GET /api/cron/notification-emails` every 5 minutes with the protected dispatch header. Document the scheduler ownership, redaction/retry settings, and run a production smoke for a verified recipient without exposing secrets.
   Dependencies: TASK-125, TASK-227
 - ID: TASK-226
   Title: Task due-date email reminders - 3-day deadline warning delivery


### PR DESCRIPTION
## Summary
- Correct TASK-228 scheduler method to `GET /api/cron/notification-emails`
- Record production endpoint smoke evidence from `https://nexus-dash.app`

## Validation
- `git diff --check`
- Production smoke: `/api/health/live` returned 200; authenticated `GET /api/cron/notification-emails` returned 200 with `ok: true`, zero claimed groups, and zero errors

## Notes
- No secrets are included. Production env was pulled into ignored `tmp/vercel-production-smoke.env` for the smoke invocation only.