### PR TITLE
Fix Vercel promote target normalization

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -336,8 +336,12 @@ jobs:
           fi
 
           if [[ "$target" == https://*https://* ]]; then
-            normalized_target="https://${target#https://}"
-            normalized_target="${normalized_target%%https://*}"
+            target_tail="${target#https://}"
+            normalized_target="https://${target_tail%%https://*}"
+            if [ "$normalized_target" = "https://" ]; then
+              echo "::error::deployment_id_or_url could not be normalized."
+              exit 1
+            fi
             echo "::warning::deployment_id_or_url contained more than one URL; using the first deployment URL."
             target="$normalized_target"
           fi

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -321,17 +321,34 @@ jobs:
           echo "deployment_url=$deployment_url" >> "$GITHUB_OUTPUT"
           echo "$deployment_url" > staged-production-deployment.txt
 
-      - name: Validate deployment target exists
+      - name: Normalize deployment target
         if: inputs.action == 'promote' || inputs.action == 'rollback'
+        env:
+          DEPLOYMENT_INPUT: ${{ inputs.deployment_id_or_url }}
         run: |
-          if [ -z "${{ inputs.deployment_id_or_url }}" ]; then
+          raw_target="$DEPLOYMENT_INPUT"
+          target=$(printf '%s' "$raw_target" | tr -d '[:space:]')
+
+          if [ -z "$target" ]; then
             echo "::error::deployment_id_or_url is required for promote/rollback."
             echo "::error::Use a deployment URL/ID from workflow artifacts or the Vercel dashboard."
             exit 1
           fi
 
-          if ! npx vercel@${VERCEL_CLI_VERSION} inspect "${{ inputs.deployment_id_or_url }}" --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN" > /tmp/vercel-inspect.txt 2>&1; then
-            echo "::error::Deployment '${{ inputs.deployment_id_or_url }}' could not be validated for this project."
+          if [[ "$target" == https://*https://* ]]; then
+            normalized_target="https://${target#https://}"
+            normalized_target="${normalized_target%%https://*}"
+            echo "::warning::deployment_id_or_url contained more than one URL; using the first deployment URL."
+            target="$normalized_target"
+          fi
+
+          echo "DEPLOYMENT_TARGET=$target" >> "$GITHUB_ENV"
+
+      - name: Validate deployment target exists
+        if: inputs.action == 'promote' || inputs.action == 'rollback'
+        run: |
+          if ! npx vercel@${VERCEL_CLI_VERSION} inspect "$DEPLOYMENT_TARGET" --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN" > /tmp/vercel-inspect.txt 2>&1; then
+            echo "::error::Deployment '$DEPLOYMENT_TARGET' could not be validated for this project."
             echo "::error::Use a valid deployment URL/ID from previous workflow artifacts or from the Vercel dashboard."
             cat /tmp/vercel-inspect.txt
             exit 1
@@ -340,12 +357,12 @@ jobs:
       - name: Promote deployment to production
         if: inputs.action == 'promote'
         run: |
-          npx vercel@${VERCEL_CLI_VERSION} promote "${{ inputs.deployment_id_or_url }}" --yes --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN"
+          npx vercel@${VERCEL_CLI_VERSION} promote "$DEPLOYMENT_TARGET" --yes --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN"
 
       - name: Rollback production deployment
         if: inputs.action == 'rollback'
         run: |
-          npx vercel@${VERCEL_CLI_VERSION} rollback "${{ inputs.deployment_id_or_url }}" --yes --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN"
+          npx vercel@${VERCEL_CLI_VERSION} rollback "$DEPLOYMENT_TARGET" --yes --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN"
 
       - name: Upload preview deployment artifact
         if: inputs.action == 'deploy-preview'
@@ -381,5 +398,6 @@ jobs:
             echo "- Next step: run with \`action=promote\`." >> "$GITHUB_STEP_SUMMARY"
           fi
           if [ "${{ inputs.action }}" = "promote" ] || [ "${{ inputs.action }}" = "rollback" ]; then
-            echo "- Deployment target: \`${{ inputs.deployment_id_or_url }}\`" >> "$GITHUB_STEP_SUMMARY"
+            target="${DEPLOYMENT_TARGET:-<not-normalized>}"
+            echo "- Deployment target: \`${target}\`" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/journal.md
+++ b/journal.md
@@ -13,6 +13,11 @@ Use it for important implementation milestones, blockers, validation runs, and r
 ## Recent Entries (Most Relevant)
 
 ### 2026-05-14
+- Type: Execution
+- Summary: Hardened manual Vercel promote/rollback target handling after a failed promote run.
+- Evidence: Run `25861160816` failed because `deployment_id_or_url` contained the same Vercel deployment URL twice, producing a malformed `.apphttps://...` target. The deploy workflow now normalizes the promote/rollback target once, trims accidental whitespace, warns and uses the first URL if two `https://` deployment URLs are pasted together, and uses the normalized value for inspect, promote/rollback, and the job summary.
+
+### 2026-05-14
 - Type: Planning
 - Summary: Added TASK-228 for QStash production scheduler activation after PR #254 merged.
 - Evidence: PR #254 merged as `e83dfa73b9ede02775bdd3d8a467c4b521fe8f7b`. TASK-227 delivered the durable notification email orchestration and protected endpoint, but QStash itself is not provisioned in code. Because the Vercel plan will not be upgraded and Hobby cron cannot run sub-hour schedules, TASK-228 now tracks activation of an Upstash QStash Schedule or equivalent managed HTTP scheduler, including the 5-minute cadence, protected header, retries/visibility, redaction, and production smoke validation.


### PR DESCRIPTION
## Summary
- Normalize manual promote/rollback deployment targets before Vercel inspect/promote/rollback
- Trim accidental whitespace and recover from the duplicated URL shape that caused run `25861160816` to fail
- Record the failure evidence in the journal

## Validation
- `git diff --check`
- Local normalization simulation using the exact malformed `.apphttps://...` input from failed run `25861160816`

## Notes
- Root cause was the workflow receiving the same deployment URL twice with no separator. This patch makes the manual workflow resilient to that paste shape and ensures the job summary reports the normalized target.