### PR TITLE
fix: enforce serverless-safe Supabase pooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,11 +45,12 @@ R2_SIGNED_URL_TTL_SECONDS=300
 # DIRECT_URL=postgresql://postgres:postgres@127.0.0.1:5432/nexusdash?schema=public
 #
 # Remote/Supabase-style deployment values:
-DATABASE_URL=postgresql://<user>:<password>@<pooler-host>:5432/postgres?sslmode=require
+# Vercel/serverless runtime must use Supabase transaction pooling on port 6543.
+DATABASE_URL=postgresql://<user>:<password>@<pooler-host>:6543/postgres?sslmode=require
 # Required in production. Must target the direct DB host (not pooler).
 # For Supabase production/preview:
-# - DATABASE_URL => transaction/session pooler host (*.pooler.supabase.com)
-# - DIRECT_URL   => direct host (db.<project-ref>.supabase.co)
+# - DATABASE_URL => transaction pooler host (*.pooler.supabase.com:6543)
+# - DIRECT_URL   => direct host (db.<project-ref>.supabase.co:5432)
 # In local/dev, DIRECT_URL may match DATABASE_URL if a direct host is unavailable.
 DIRECT_URL=postgresql://<user>:<password>@<direct-host>:5432/postgres?sslmode=require
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,19 @@ Notes:
   - different runtime/direct endpoints
   - TLS
   - Supabase pooler/direct host sanity rules (when Supabase hosts are used)
+  - Supabase runtime traffic on the transaction pooler port `6543`; the
+    session pooler port `5432` is rejected for `DATABASE_URL` because it can
+    exhaust session clients under Vercel/serverless request bursts
+
+For Supabase production/preview:
+
+- `DATABASE_URL`: transaction pooler URL, `*.pooler.supabase.com:6543`, with
+  TLS enabled.
+- `DIRECT_URL`: direct database URL, `db.<project-ref>.supabase.co:5432`, with
+  TLS enabled.
+- Prisma runtime automatically adds the compatibility flags needed for the
+  Supabase transaction pooler when constructing the `@prisma/adapter-pg`
+  connection string.
 
 ## Environment Contract (Server)
 
@@ -351,6 +364,8 @@ Required GitHub secrets:
 - `VERCEL_TOKEN`
 - `VERCEL_ORG_ID`
 - `VERCEL_PROJECT_ID`
+- `DATABASE_URL` (runtime connection; Supabase transaction pooler on port `6543`)
+- `DIRECT_URL` (direct database connection; Supabase direct host on port `5432`)
 - `MIGRATION_DATABASE_URL` (admin-capable migration connection; must not be the runtime `DATABASE_URL`)
 - `AGENT_TOKEN_SIGNING_SECRET` (required for production deploys; preview workflow falls back to a placeholder when intentionally unset)
 - Preview deployments still need `AGENT_TOKEN_SIGNING_SECRET` at runtime. GitHub Actions fallback values do not automatically populate Vercel's shared preview runtime unless the deployment explicitly passes them through.

--- a/docs/runbooks/database-connection-hardening.md
+++ b/docs/runbooks/database-connection-hardening.md
@@ -14,8 +14,16 @@ In production with remote hosts, these URLs must:
 - use TLS (for example `?sslmode=require`)
 
 For Supabase production:
-- `DATABASE_URL` should use `*.pooler.supabase.com`
-- `DIRECT_URL` should use `db.<project-ref>.supabase.co`
+- `DATABASE_URL` must use the Supabase transaction pooler:
+  `*.pooler.supabase.com:6543`
+- `DIRECT_URL` must use the direct database endpoint:
+  `db.<project-ref>.supabase.co:5432`
+
+Do not use the Supabase session pooler (`*.pooler.supabase.com:5432`) for
+`DATABASE_URL` in Vercel/serverless runtime. Session mode is capped by the
+pooler session `pool_size` and can return `EMAXCONNSESSION` during normal
+serverless bursts. Transaction mode on port `6543` is the intended path for
+short-lived/serverless application connections.
 
 ## Environment Baseline
 - Local development:
@@ -25,7 +33,7 @@ For Supabase production:
   - keep ephemeral/local endpoints where possible.
   - avoid production credentials in CI.
 - Production:
-  - pooled runtime URL in `DATABASE_URL`
+  - transaction-pooled runtime URL in `DATABASE_URL`
   - direct migration/admin URL in `DIRECT_URL`
   - TLS enabled on both URLs
 
@@ -47,5 +55,8 @@ For Supabase production:
 - `validateServerRuntimeConfig()` passes in the target environment.
 - `/api/health/ready` returns healthy status after deploy.
 - Prisma migrations run using `DIRECT_URL`.
-- Runtime traffic uses pooled connection path (`DATABASE_URL`).
+- Runtime traffic uses Supabase transaction pooling (`DATABASE_URL` on port
+  `6543`) when the database is Supabase.
+- Vercel logs do not show `EMAXCONNSESSION` during representative authenticated
+  request bursts.
 - No credentials appear in logs, errors, or build artifacts.

--- a/docs/runbooks/vercel-env-contract-and-secrets.md
+++ b/docs/runbooks/vercel-env-contract-and-secrets.md
@@ -24,6 +24,25 @@ Optional but bounded:
 
 - `AGENT_ACCESS_TOKEN_TTL_SECONDS` (`300-900`, default `600`)
 
+## Database Runtime
+
+Required for Vercel runtime/deployments:
+
+- `DATABASE_URL`
+- `DIRECT_URL`
+
+For Supabase-backed Vercel deployments:
+
+- `DATABASE_URL` must be the Supabase transaction pooler URL:
+  `*.pooler.supabase.com:6543`.
+- `DIRECT_URL` must be the Supabase direct database URL:
+  `db.<project-ref>.supabase.co:5432`.
+- Both values must enforce TLS, for example `?sslmode=require`.
+
+Do not configure `DATABASE_URL` with the Supabase session pooler on port `5432`.
+That shape can exhaust the session pool under normal Vercel/serverless request
+bursts and is rejected by runtime validation.
+
 ## Outbound Email
 
 Provider:

--- a/journal.md
+++ b/journal.md
@@ -12,6 +12,16 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ## Recent Entries (Most Relevant)
 
+### 2026-05-15
+- Type: Execution
+- Summary: TASK-258 hardened production database pooling after `EMAXCONNSESSION` incident.
+- Evidence: Opened issue #258 after production logs showed `DriverAdapterError: (EMAXCONNSESSION) max clients reached in session mode` on `/account/notifications` and `/`. Masked env inspection found the ignored production runtime `DATABASE_URL` shape used the Supabase pooler on port `5432` (session mode). Runtime validation now rejects Supabase session-pooler `DATABASE_URL` in production, accepts transaction-pooler port `6543`, and normalizes Prisma runtime URLs with Supabase transaction-pooler compatibility flags. GitHub production `DATABASE_URL` and Vercel Production `DATABASE_URL` were updated to the derived transaction-pooler shape without printing secret values.
+
+### 2026-05-15
+- Type: Validation
+- Summary: TASK-258 local validation passed.
+- Evidence: `npm ci`; `npm test -- --run tests/lib/env.server.test.ts` passed with 68 tests; `npm run lint` passed; `npm run db:local:up` could not bind port `5432` because another local PostgreSQL service was already using it; `npm run db:migrate` passed against the existing local `127.0.0.1:5432` database with no pending migrations; local DB `NODE_ENV=test npm test` passed (107 files passed, 2 skipped; 807 tests passed, 2 skipped); local DB `NODE_ENV=test npm run test:coverage` passed (91.23% statements, 81.2% branches, 93.42% functions, 91.75% lines); production-guarded `npm run build` passed with local PostgreSQL and safe local runtime secrets.
+
 ### 2026-05-14
 - Type: Execution
 - Summary: Hardened manual Vercel promote/rollback target handling after a failed promote run.

--- a/lib/env.server.ts
+++ b/lib/env.server.ts
@@ -114,17 +114,31 @@ export function getPrismaPgRuntimeConnectionString(): string {
     return databaseUrl;
   }
 
+  const host = parsedUrl.hostname.toLowerCase();
+  const port = parsedUrl.port || DEFAULT_POSTGRES_PORT;
+  const isSupabaseTransactionPooler =
+    host.endsWith(".pooler.supabase.com") &&
+    port === SUPABASE_TRANSACTION_POOLER_PORT;
+  let changed = false;
+
+  if (
+    isSupabaseTransactionPooler &&
+    !parsedUrl.searchParams.has("pgbouncer")
+  ) {
+    parsedUrl.searchParams.set("pgbouncer", "true");
+    changed = true;
+  }
+
   const sslMode = (parsedUrl.searchParams.get("sslmode") ?? "").toLowerCase();
-  if (sslMode !== "require") {
-    return databaseUrl;
+  if (
+    sslMode === "require" &&
+    (parsedUrl.searchParams.get("uselibpqcompat") ?? "").length === 0
+  ) {
+    parsedUrl.searchParams.set("uselibpqcompat", "true");
+    changed = true;
   }
 
-  if ((parsedUrl.searchParams.get("uselibpqcompat") ?? "").length > 0) {
-    return parsedUrl.toString();
-  }
-
-  parsedUrl.searchParams.set("uselibpqcompat", "true");
-  return parsedUrl.toString();
+  return changed ? parsedUrl.toString() : databaseUrl;
 }
 
 export interface SupabaseClientRuntimeConfig {
@@ -369,6 +383,8 @@ function assertPostgresConnectionString(name: string, value: string): void {
 const LOCAL_DATABASE_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
 const SECURE_SSL_MODES = new Set(["require", "verify-ca", "verify-full"]);
 const DEFAULT_POSTGRES_PORT = "5432";
+const SUPABASE_SESSION_POOLER_PORT = "5432";
+const SUPABASE_TRANSACTION_POOLER_PORT = "6543";
 
 interface ParsedDatabaseConnectionString {
   rawValue: string;
@@ -465,6 +481,25 @@ function assertProductionDatabaseConnectionHardening(
   if (directUrl.isPoolerHost) {
     throw new Error(
       "DIRECT_URL must target a direct database endpoint, not a pooler host."
+    );
+  }
+
+  if (
+    databaseUrl.isSupabasePoolerHost &&
+    databaseUrl.port !== SUPABASE_TRANSACTION_POOLER_PORT
+  ) {
+    throw new Error(
+      `DATABASE_URL must use the Supabase transaction pooler port ${SUPABASE_TRANSACTION_POOLER_PORT} in production; port ${SUPABASE_SESSION_POOLER_PORT} is session mode and can exhaust serverless clients.`
+    );
+  }
+
+  if (
+    directUrl.isSupabaseHost &&
+    !directUrl.isSupabasePoolerHost &&
+    directUrl.port !== DEFAULT_POSTGRES_PORT
+  ) {
+    throw new Error(
+      `DIRECT_URL must use the Supabase direct database port ${DEFAULT_POSTGRES_PORT} in production.`
     );
   }
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -4,6 +4,11 @@ Use this file to capture tasks discovered during development. Each entry should 
 
 ## Pending
 ### Execution Queue (Now / Next)
+- ID: TASK-258
+  Title: Production DB session pool exhaustion - serverless-safe Supabase runtime pooling
+  Status: In progress (issue #258)
+  Rationale: Production authenticated navigation after notification email smoke hit `EMAXCONNSESSION` because runtime traffic was using the Supabase session pooler shape. Harden the runtime env contract and validation so Vercel/serverless runtime traffic uses the transaction pooler while direct migration/admin traffic stays on the direct endpoint.
+  Dependencies: TASK-022, TASK-125, TASK-227
 - ID: TASK-225
   Title: Project notification email digests - grouped, rate-limited outbound summaries
   Status: Done via PR #246; production scheduler/orchestration remediation owned by TASK-227

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,171 +1,113 @@
-# Current Task: TASK-227 Production-Grade Notification Email Orchestration
+# Current Task: TASK-258 Production DB Session Pool Exhaustion
 
 ## Task ID
-TASK-227
+TASK-258
 
 ## Status
-Done via PR #254. Production scheduler activation for the non-upgraded Vercel
-Hobby plan is tracked separately as TASK-228.
+In progress on dedicated worktree `../nexus_dash_task258` and branch
+`fix/task-258-db-session-pool-exhaustion`.
+
+## Source
+- GitHub issue: #258
+- Incident: production notification email smoke succeeded, then authenticated
+  navigation around account/notification/project pages intermittently returned
+  server error pages.
 
 ## Objective
-Own the project notification email dispatch feature end to end and turn the
-TASK-225 digest/reminder work into production-grade notification email
-orchestration. Users should receive useful email about project activity without
-being spammed, especially when they belong to many projects or agent activity
-creates bursts of mentions and assignments.
+Prevent production authenticated request bursts from exhausting the
+Supabase/Postgres session pool. Runtime traffic must use the serverless-safe
+Supabase transaction pooler, while direct/admin migration traffic continues to
+use the direct database endpoint.
 
-## Context And Audit Notes
-- TASK-123 shipped the in-app notification center, which remains the source of
-  truth. Email delivery must not mark notifications read or resolved.
-- TASK-125 shipped the reusable outbound email foundation and
-  `OutboundEmailDelivery` records.
-- TASK-225/PR #246 added useful digest/reminder service code, templates, tests,
-  and a protected endpoint, but its dispatcher scanned notifications at send
-  time, had no durable pending debounce queue, sent per project rather than
-  recipient-level project sections, and made GitHub Actions the primary
-  scheduler after Vercel Hobby rejected `*/15` cron.
-- PR #252 usefully identified production failure evidence and hardened endpoint
-  auth, but it still preserved GitHub Actions as the primary scheduler. Keep the
-  header-parsing lesson; do not keep the scheduler as the production design.
-- Recent run evidence:
-  - run `25752062859` failed before reaching the app because dispatch URL and
-    secret were empty in the workflow context.
-  - run `25826658473` on `fix/task-225-notification-dispatch-workflow` reached
-    Vercel deployment protection and returned 401 HTML.
-  - run `25826921991` on `main` still returned 401 through the bearer path.
-- Current Vercel docs confirm Hobby cron is daily only; a sub-hour scheduler
-  needs Vercel Pro Cron or an external managed scheduler. TASK-227 documents
-  this blocker and removes GitHub Actions as the production scheduler.
+## Evidence
+- Vercel logs around the incident showed:
+  `DriverAdapterError: (EMAXCONNSESSION) max clients reached in session mode -
+  max clients are limited to pool_size: 15`.
+- The local ignored production env snapshot showed `DATABASE_URL` pointed at a
+  Supabase pooler host on port `5432`, which is session mode.
+- Supabase documentation describes transaction pooling on port `6543` as the
+  serverless/short-lived connection path; session pooling remains on port
+  `5432`.
 
-## Product Behavior
-- Email-eligible project activity is grouped by recipient, project, and delivery
-  kind.
-- New eligible activity creates or refreshes a pending group instead of sending
-  immediately.
-- Project activity groups use debounce timing:
-  - quiet window: 30 minutes by default
-  - max delay: 60 minutes from the first unsent activity in the group
-  - `sendAfterAt = min(latestPendingNotificationAt + quietWindow,
-    firstPendingNotificationAt + maxDelay)`
-- If several project groups are due for a recipient in one dispatcher run, send
-  one recipient-level email with project sections.
-- Invitation reminders are due once an invited verified user has not opened,
-  accepted, declined, or otherwise resolved the invitation notification for 6
-  hours. Reminder idempotency is once per invitation/recipient reminder window.
-- TASK-226 owns task due-date reminder business logic. This task leaves a clean
-  extension point but does not implement due-date reminders.
-
-## Scheduler Decision
-- Preferred production scheduler: Vercel Cron on a plan that supports sub-hour
-  cadence, configured to invoke the protected endpoint on production only.
-- Current blocker: Vercel Hobby cron rejects sub-daily schedules, so the current
-  account cannot deploy the required cadence through Vercel Cron.
-- Production alternative when the account stays on Hobby: use a managed HTTP
-  scheduler with retries/visibility, such as Upstash QStash Schedule, to invoke
-  the same protected endpoint. GitHub Actions remains only as manual diagnostic
-  tooling, not the primary production scheduler.
-- Preview validation manually invokes the protected endpoint/service because
-  Vercel Cron runs only on production deployments.
+## Assumptions
+- Vercel and GitHub production secret values must not be printed or committed.
+- `DIRECT_URL` remains direct/non-pooler for migrations and admin workflows.
+- RLS must remain enforced through `withActorRlsContext`.
+- A production env change may be required in addition to code/docs, but the
+  repository should fail fast on the known unsafe Supabase session-pooler shape.
 
 ## Acceptance Criteria
-1. Durable DB-backed notification email state tracks grouping key, first pending
-   notification time, latest pending notification time, send-after time,
-   max-send time, status, source notification membership/idempotency, claim
-   state, and outbound delivery correlation.
-2. Email-eligible notification creation/refresh paths update the correct pending
-   group in the service layer.
-3. Normal project activity is delayed until quiet, but no later than about one
-   hour from the first unsent activity.
-4. Dispatcher safely claims due groups and is idempotent under repeated or
-   concurrent invocations.
-5. Due groups are batched into recipient-level emails with concise project
-   sections when multiple projects are ready together.
-6. Email content is deterministic, safely escaped, and concise for bursty
-   agent-generated activity.
-7. Provider sent/skipped/failed outcomes are recorded through TASK-125 outbound
-   delivery records and linked back to orchestration groups without logging
-   secrets.
-8. Invitation reminders are sent only after 6 hours of no user action and only
-   once per invitation/recipient reminder window.
-9. Sending email does not mutate notification `readAt` or `resolvedAt`.
-10. Runtime secrets flow through `lib/env.server.ts`; routes/cron endpoints stay
-    thin and persistence access stays in `lib/services/**`.
-11. GitHub Actions scheduled dispatch is demoted to manual diagnostics, and docs
-    explain the production scheduler decision.
-12. Focused tests cover debounce timing, max delay, grouping by project,
-    multi-project recipient batching, idempotency, concurrent claim behavior,
-    invitation reminders, provider failure, and endpoint authorization.
-13. README, env runbook, journal, backlog, and current task docs are updated
-    with behavior, ops, validation, and caveats.
+1. Production runtime validation rejects Supabase pooler `DATABASE_URL` values
+   that point at session mode (`5432`) instead of transaction mode (`6543`).
+2. Validation continues to allow local development database URLs and non-Supabase
+   remote providers that satisfy the existing hardening rules.
+3. Runtime Prisma connection-string normalization preserves existing behavior
+   and remains compatible with Supabase transaction-pooler URLs.
+4. Tests cover the rejected session-pooler case and the accepted
+   transaction-pooler case.
+5. README and runbooks clearly document the Supabase/Vercel contract:
+   `DATABASE_URL` is transaction pooler on port `6543`; `DIRECT_URL` is direct
+   database endpoint on port `5432`; secrets are never logged.
+6. Production env validation/smoke evidence is recorded without exposing secret
+   values.
+7. GitHub issue #258 is referenced in the PR.
 
 ## Definition Of Done
-- Work remains on
-  `feature/task-227-production-grade-notification-email-orchestration`.
-- Local validation passes: `npm run lint`, `npm test`,
-  `npm run test:coverage`, and `npm run build`.
-- Focused notification email orchestration tests pass and are named in
-  validation evidence.
-- Playwright is run only if UI-visible behavior changes.
-- A safe real-smoke plan for `dorian.agaesse@gmail.com` is documented without
-  exposing secrets.
-- Branch is pushed, a ready-for-review PR is opened, CI is monitored, Copilot
-  review feedback is inspected and addressed/resolved, and final handoff
-  includes PR URL, commit SHA(s), validation results, scheduler decision, and
-  operational caveats.
+- Work remains on `fix/task-258-db-session-pool-exhaustion`.
+- `tasks/current.md`, `tasks/backlog.md`, `journal.md`, README, and the DB/env
+  runbooks are updated where behavior/operations changed.
+- Required validation passes:
+  - `npm run lint`
+  - `npm test`
+  - `npm run test:coverage`
+  - `npm run build`
+- A ready-for-review PR is opened and linked to issue #258.
+- CI and Copilot review are monitored; actionable review feedback is addressed.
+- Final handoff includes PR URL, commit SHA(s), validation results, deployment
+  status, and remaining operational caveats.
 
 ## Validation Plan
 - Focused:
-  - `npm test -- --run tests/lib/project-notification-email-service.test.ts tests/api/notification-email-dispatch.route.test.ts tests/lib/outbound-email-templates.test.ts tests/lib/env.server.test.ts`
+  - `npm test -- --run tests/lib/env.server.test.ts`
 - Baseline:
   - `npm run lint`
   - `npm test`
   - `npm run test:coverage`
   - `npm run build`
-- Preview/manual smoke:
-  - deploy preview with explicit `git_ref=<branch>` if live endpoint validation
-    is needed
-  - confirm workflow logs checked out the branch ref
-  - create mention/assignment activity for `dorian.agaesse@gmail.com`
-  - invoke the protected dispatch endpoint after the debounce window using a
-    secret supplied outside the repo
+- Production after merge/deploy:
+  - Verify `/api/health/live`.
+  - Verify no new `EMAXCONNSESSION` logs during a representative authenticated
+    navigation/notification smoke burst.
 
 ## Validation Evidence
+- Masked production env inspection confirmed the pre-fix local ignored
+  production `DATABASE_URL` shape was Supabase pooler host on port `5432`
+  with TLS, while `DIRECT_URL` was Supabase direct host on port `5432`.
+- Updated GitHub production environment secret `DATABASE_URL` to the derived
+  Supabase transaction-pooler shape on port `6543` without printing the value.
+- Updated Vercel Production `DATABASE_URL` to the derived Supabase
+  transaction-pooler shape on port `6543` without printing the value.
 - `npm ci` passed and generated Prisma Client.
-- `npx prisma validate` passed.
-- Focused orchestration validation passed:
-  `npm test -- --run tests/lib/project-notification-email-service.test.ts tests/api/notification-email-dispatch.route.test.ts tests/lib/outbound-email-templates.test.ts tests/lib/env.server.test.ts`
-  with 4 files and 81 tests initially, then 83 tests after Copilot review
-  fixes.
-- Focused notification producer regression passed:
-  `npm test -- --run tests/lib/notification-service.test.ts tests/api/task-comments.route.test.ts tests/api/task-update.route.test.ts`
-  with 3 files and 41 tests.
+- Focused env validation passed:
+  `npm test -- --run tests/lib/env.server.test.ts` with 68 tests.
 - `npm run lint` passed.
-- First plain `npm test` failed because this shell lacked `DATABASE_URL`; reran
-  with documented local PostgreSQL env.
-- `npm run db:local:up` could not bind port `5432` because an existing local
-  PostgreSQL container was already using it; used the existing
-  `127.0.0.1:5432` service instead.
+- `npm run db:local:up` could not bind port `5432` because another local
+  PostgreSQL service was already using it; validation used that existing
+  `127.0.0.1:5432` service.
 - `npm run db:migrate` passed against
-  `postgresql://postgres:postgres@127.0.0.1:5432/nexusdash?schema=public`,
-  applying `20260513120000_task227_notification_email_orchestration`.
+  `postgresql://postgres:postgres@127.0.0.1:5432/nexusdash?schema=public`;
+  no pending migrations.
 - Local DB `NODE_ENV=test npm test` passed with 107 files passed, 2 skipped;
-  800 tests passed, 2 skipped initially, then 802 tests passed, 2 skipped after
-  Copilot review fixes.
-- Local DB `NODE_ENV=test npm run test:coverage` passed with 91.23% statements,
-  81.2% branches, 93.42% functions, and 91.75% lines.
-- First `npm run build` attempt failed because the inherited shell had
-  `NEXTAUTH_URL` without an effective matching `NEXTAUTH_SECRET`; reran with
-  both explicitly set.
+  807 tests passed, 2 skipped.
+- Local DB `NODE_ENV=test npm run test:coverage` passed with 91.23%
+  statements, 81.2% branches, 93.42% functions, and 91.75% lines.
 - Production-guarded `npm run build` passed with local PostgreSQL, disabled
-  outbound delivery mode, localhost trusted origins, local agent signing secret,
-  local Google token key, and explicit `NEXTAUTH_URL`/`NEXTAUTH_SECRET`.
-- Copilot review fixes replayed all migrations against a fresh temporary local
-  database `nexusdash_task227_migration_check`; `npm run db:migrate` applied
-  all 35 migrations successfully, then the temporary database was dropped.
+  outbound delivery mode, localhost trusted origins, local agent signing
+  secret, local Google token key, and explicit `NEXTAUTH_URL`/`NEXTAUTH_SECRET`.
 
 ## Out Of Scope
-- TASK-226 task due-date reminder business rules.
-- User notification preference UI, unsubscribe management, bounce webhooks, and
-  suppression-list UX.
-- A broad background job framework unrelated to notification email dispatch.
-- Marking in-app notifications read/resolved as a side effect of email sending.
+- Changing notification email business logic beyond any validation evidence
+  needed for the incident.
+- Removing RLS or weakening project/user authorization boundaries.
+- Broad dashboard performance rewrites.
+- Paid infrastructure upgrades as the only fix.

--- a/tests/lib/env.server.test.ts
+++ b/tests/lib/env.server.test.ts
@@ -198,6 +198,28 @@ describe("env.server", () => {
     );
   });
 
+  test("adds prisma pg compatibility flags for supabase transaction pooler runtime", () => {
+    vi.stubEnv(
+      "DATABASE_URL",
+      "postgresql://runtime-user:pwd@project.pooler.supabase.com:6543/postgres?sslmode=require"
+    );
+
+    expect(getPrismaPgRuntimeConnectionString()).toBe(
+      "postgresql://runtime-user:pwd@project.pooler.supabase.com:6543/postgres?sslmode=require&pgbouncer=true&uselibpqcompat=true"
+    );
+  });
+
+  test("preserves existing prisma pg pgbouncer flag for supabase transaction pooler runtime", () => {
+    vi.stubEnv(
+      "DATABASE_URL",
+      "postgresql://runtime-user:pwd@project.pooler.supabase.com:6543/postgres?sslmode=require&pgbouncer=true"
+    );
+
+    expect(getPrismaPgRuntimeConnectionString()).toBe(
+      "postgresql://runtime-user:pwd@project.pooler.supabase.com:6543/postgres?sslmode=require&pgbouncer=true&uselibpqcompat=true"
+    );
+  });
+
   test("returns null when supabase pair is fully empty/unset", () => {
     vi.stubEnv("SUPABASE_URL", "");
     vi.stubEnv("SUPABASE_PUBLISHABLE_KEY", "");
@@ -770,11 +792,57 @@ describe("env.server", () => {
     );
   });
 
-  test("allows mixed provider endpoints when database is Supabase and direct is non-Supabase", () => {
+  test("fails runtime validation when supabase database url uses session pooler port in production", () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv(
       "DATABASE_URL",
       "postgresql://runtime-user:pwd@project.pooler.supabase.com:5432/postgres?sslmode=require"
+    );
+    vi.stubEnv(
+      "DIRECT_URL",
+      "postgresql://admin-user:pwd@db.project-ref.supabase.co:5432/postgres?sslmode=require"
+    );
+
+    expect(() => validateServerRuntimeConfig()).toThrow(
+      "DATABASE_URL must use the Supabase transaction pooler port 6543 in production; port 5432 is session mode and can exhaust serverless clients."
+    );
+  });
+
+  test("passes runtime validation when supabase database url uses transaction pooler port in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv(
+      "DATABASE_URL",
+      "postgresql://runtime-user:pwd@project.pooler.supabase.com:6543/postgres?sslmode=require"
+    );
+    vi.stubEnv(
+      "DIRECT_URL",
+      "postgresql://admin-user:pwd@db.project-ref.supabase.co:5432/postgres?sslmode=require"
+    );
+
+    expect(() => validateServerRuntimeConfig()).not.toThrow();
+  });
+
+  test("fails runtime validation when supabase direct url uses a non-direct port in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv(
+      "DATABASE_URL",
+      "postgresql://runtime-user:pwd@project.pooler.supabase.com:6543/postgres?sslmode=require"
+    );
+    vi.stubEnv(
+      "DIRECT_URL",
+      "postgresql://admin-user:pwd@db.project-ref.supabase.co:6543/postgres?sslmode=require"
+    );
+
+    expect(() => validateServerRuntimeConfig()).toThrow(
+      "DIRECT_URL must use the Supabase direct database port 5432 in production."
+    );
+  });
+
+  test("allows mixed provider endpoints when database is Supabase and direct is non-Supabase", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv(
+      "DATABASE_URL",
+      "postgresql://runtime-user:pwd@project.pooler.supabase.com:6543/postgres?sslmode=require"
     );
     vi.stubEnv(
       "DIRECT_URL",


### PR DESCRIPTION
## Summary
- Reject Supabase session-pooler `DATABASE_URL` values in production and require transaction pooler port `6543` for runtime traffic.
- Normalize Prisma `@prisma/adapter-pg` runtime URLs with Supabase transaction-pooler compatibility flags.
- Update env examples, README, runbooks, task docs, and journal with the production DB pooling contract.
- Updated GitHub production and Vercel Production `DATABASE_URL` secrets to the derived transaction-pooler shape without printing values.

Closes #258.

## Validation
- `npm ci`
- `npm test -- --run tests/lib/env.server.test.ts`
- `npm run lint`
- `npm run db:migrate` with local PostgreSQL `127.0.0.1:5432`
- `NODE_ENV=test npm test` with local PostgreSQL
- `NODE_ENV=test npm run test:coverage` with local PostgreSQL
- `npm run build` with local-safe production runtime env

## Operational notes
- `npm run db:local:up` could not bind port `5432` because an existing local PostgreSQL service was already using it; validation used that existing service.
- The production env update must be included in rollout evidence: `DATABASE_URL` is now Supabase pooler port `6543`, `DIRECT_URL` remains direct port `5432`.
- After deployment, verify `/api/health/live` and check Vercel logs for absence of new `EMAXCONNSESSION` during authenticated navigation/notification smoke.