### PR TITLE
fix: guard production Supabase project refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,19 @@ Notes:
   - Supabase runtime traffic on the transaction pooler port `6543`; the
     session pooler port `5432` is rejected for `DATABASE_URL` because it can
     exhaust session clients under Vercel/serverless request bursts
+  - Supabase project-ref alignment between `DATABASE_URL`, `DIRECT_URL`, and
+    `SUPABASE_URL` so production cannot silently boot against a preview or
+    staging database
 
 For Supabase production/preview:
 
 - `DATABASE_URL`: transaction pooler URL, `*.pooler.supabase.com:6543`, with
-  TLS enabled.
+  TLS enabled. For the shared Supabase pooler, the username must include the
+  project ref, for example `postgres.<project-ref>`.
 - `DIRECT_URL`: direct database URL, `db.<project-ref>.supabase.co:5432`, with
   TLS enabled.
+- `SUPABASE_URL`: the matching client API URL,
+  `https://<project-ref>.supabase.co`.
 - Prisma runtime automatically adds the compatibility flags needed for the
   Supabase transaction pooler when constructing the `@prisma/adapter-pg`
   connection string.

--- a/docs/runbooks/database-connection-hardening.md
+++ b/docs/runbooks/database-connection-hardening.md
@@ -18,6 +18,11 @@ For Supabase production:
   `*.pooler.supabase.com:6543`
 - `DIRECT_URL` must use the direct database endpoint:
   `db.<project-ref>.supabase.co:5432`
+- `DATABASE_URL`, `DIRECT_URL`, and `SUPABASE_URL` must all target the same
+  Supabase project ref. On the shared pooler, the project ref is encoded in the
+  username (`postgres.<project-ref>`). On direct/client URLs, it is encoded in
+  the host (`db.<project-ref>.supabase.co` and
+  `https://<project-ref>.supabase.co`).
 
 Do not use the Supabase session pooler (`*.pooler.supabase.com:5432`) for
 `DATABASE_URL` in Vercel/serverless runtime. Session mode is capped by the
@@ -51,12 +56,38 @@ short-lived/serverless application connections.
 5. Validate readiness endpoint and critical app workflows.
 6. Revoke old credentials after verification succeeds.
 
+## Production Secret Recovery
+
+Restore production database secrets only from the intended Supabase Production
+project dashboard. Do not derive production runtime values from local `.env`
+snapshots, preview files, staging files, or old pulled Vercel env caches.
+
+Use this checklist when production DB routing is suspect:
+
+1. Open the Supabase Production project.
+2. Copy the Production transaction-pooler connection string for `DATABASE_URL`.
+3. Copy the matching Production direct connection string for `DIRECT_URL` and
+   `MIGRATION_DATABASE_URL`.
+4. Confirm the same project ref appears in:
+   - pooler username: `postgres.<project-ref>`
+   - direct host: `db.<project-ref>.supabase.co`
+   - client URL: `https://<project-ref>.supabase.co`
+5. Update Vercel Production runtime secrets and GitHub production environment
+   secrets through their secret managers.
+6. Deploy a staged production build, promote it, then verify `/api/health/live`
+   and an authenticated project list.
+
+Agents must not read, print, or rewrite production secret values during this
+recovery unless the operator explicitly authorizes a specific secret operation.
+
 ## Verification Checklist
 - `validateServerRuntimeConfig()` passes in the target environment.
 - `/api/health/ready` returns healthy status after deploy.
 - Prisma migrations run using `DIRECT_URL`.
 - Runtime traffic uses Supabase transaction pooling (`DATABASE_URL` on port
   `6543`) when the database is Supabase.
+- Supabase project refs match across `DATABASE_URL`, `DIRECT_URL`, and
+  `SUPABASE_URL`.
 - Vercel logs do not show `EMAXCONNSESSION` during representative authenticated
   request bursts.
 - No credentials appear in logs, errors, or build artifacts.

--- a/docs/runbooks/vercel-env-contract-and-secrets.md
+++ b/docs/runbooks/vercel-env-contract-and-secrets.md
@@ -151,6 +151,10 @@ Important:
 
 - Preview builds run with production-like checks (`NODE_ENV=production` during
   build), so missing production-only guards can break preview deploys.
+- Production database secrets must come from the intended Supabase Production
+  project, not local `.env` snapshots or preview/staging files. The app rejects
+  production startup when Supabase project refs differ across `DATABASE_URL`,
+  `DIRECT_URL`, and `SUPABASE_URL`.
 - GitHub-managed preview deploys and Vercel-managed preview deployments do not
   get runtime secrets from the same place:
   - `deploy-vercel.yml` can inject preview fallback values into the specific
@@ -244,6 +248,10 @@ npx vercel env pull .env.production.local --environment=production --yes
 ```
 
 After diagnostics, delete pulled files if not needed.
+
+Do not use pulled production env files as an input source for secret rewrites.
+For production recovery, use the provider dashboards directly and compare only
+non-secret fingerprints such as the Supabase project ref and endpoint mode.
 
 ## PR Readiness Gate (Env-Aware)
 

--- a/journal.md
+++ b/journal.md
@@ -14,6 +14,16 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ### 2026-05-15
 - Type: Execution
+- Summary: TASK-259 added production Supabase project-ref guardrails after runtime DB drift incident.
+- Evidence: Opened issue #260 after production authenticated successfully but showed no projects, indicating `DATABASE_URL` had been overwritten to a valid but wrong Supabase database while `DIRECT_URL`/`MIGRATION_DATABASE_URL` were unchanged. Added validation to compare Supabase project refs extracted from shared pooler usernames, direct DB hosts, and `SUPABASE_URL`; updated README and DB/env runbooks with recovery guidance that agents must not rewrite production secrets without explicit operator authorization.
+
+### 2026-05-15
+- Type: Validation
+- Summary: TASK-259 local validation passed.
+- Evidence: `npm ci`; `npm test -- --run tests/lib/env.server.test.ts` passed with 70 tests; `npm run lint` passed; local PostgreSQL `npm run db:migrate` passed with no pending migrations; local DB `NODE_ENV=test npm test` passed (107 files passed, 2 skipped; 809 tests passed, 2 skipped); local DB `NODE_ENV=test npm run test:coverage` passed with 91.23% statements, 81.2% branches, 93.42% functions, and 91.75% lines; production build passed with local PostgreSQL and safe local runtime secrets.
+
+### 2026-05-15
+- Type: Execution
 - Summary: TASK-258 hardened production database pooling after `EMAXCONNSESSION` incident.
 - Evidence: Opened issue #258 after production logs showed `DriverAdapterError: (EMAXCONNSESSION) max clients reached in session mode` on `/account/notifications` and `/`. Masked env inspection found the ignored production runtime `DATABASE_URL` shape used the Supabase pooler on port `5432` (session mode). Runtime validation now rejects Supabase session-pooler `DATABASE_URL` in production, accepts transaction-pooler port `6543`, and normalizes Prisma runtime URLs with Supabase transaction-pooler compatibility flags. GitHub production `DATABASE_URL` and Vercel Production `DATABASE_URL` were updated to the derived transaction-pooler shape without printing secret values.
 

--- a/lib/env.server.ts
+++ b/lib/env.server.ts
@@ -390,6 +390,7 @@ interface ParsedDatabaseConnectionString {
   rawValue: string;
   host: string;
   port: string;
+  supabaseProjectRef: string | null;
   isLocalHost: boolean;
   isPoolerHost: boolean;
   isSupabaseHost: boolean;
@@ -399,6 +400,41 @@ interface ParsedDatabaseConnectionString {
 
 function isLocalDatabaseHost(host: string): boolean {
   return LOCAL_DATABASE_HOSTS.has(host) || host.endsWith(".local");
+}
+
+function extractSupabaseDirectProjectRef(host: string): string | null {
+  const match = /^db\.([a-z0-9-]+)\.supabase\.co$/i.exec(host);
+  return match?.[1]?.toLowerCase() ?? null;
+}
+
+function extractSupabasePoolerProjectRef(username: string): string | null {
+  const separatorIndex = username.lastIndexOf(".");
+  if (separatorIndex <= 0 || separatorIndex === username.length - 1) {
+    return null;
+  }
+
+  return username.slice(separatorIndex + 1).toLowerCase();
+}
+
+function extractSupabaseClientProjectRef(value: string): string | null {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(value);
+  } catch {
+    throw new Error("SUPABASE_URL must be a valid absolute URL.");
+  }
+
+  const host = parsedUrl.hostname.toLowerCase();
+  if (!host.endsWith(".supabase.co")) {
+    return null;
+  }
+
+  const [projectRef] = host.split(".");
+  if (!projectRef || projectRef === "db") {
+    return null;
+  }
+
+  return projectRef;
 }
 
 function parseDatabaseConnectionString(
@@ -424,11 +460,16 @@ function parseDatabaseConnectionString(
     host.endsWith(".supabase.co") || host.endsWith(".supabase.com");
   const isSupabasePoolerHost = host.endsWith(".pooler.supabase.com");
   const isPoolerHost = /(^|[.-])pooler([.-]|$)/.test(host);
+  const username = decodeURIComponent(parsedUrl.username);
+  const supabaseProjectRef = isSupabasePoolerHost
+    ? extractSupabasePoolerProjectRef(username)
+    : extractSupabaseDirectProjectRef(host);
 
   return {
     rawValue: value,
     host,
     port,
+    supabaseProjectRef,
     isLocalHost: isLocalDatabaseHost(host),
     isPoolerHost,
     isSupabaseHost,
@@ -437,10 +478,39 @@ function parseDatabaseConnectionString(
   };
 }
 
+function assertMatchingSupabaseProjectRefs(
+  databaseUrl: ParsedDatabaseConnectionString,
+  directUrl: ParsedDatabaseConnectionString,
+  supabaseClientProjectRef: string | null
+): void {
+  if (
+    databaseUrl.supabaseProjectRef &&
+    directUrl.supabaseProjectRef &&
+    databaseUrl.supabaseProjectRef !== directUrl.supabaseProjectRef
+  ) {
+    throw new Error(
+      "DATABASE_URL and DIRECT_URL must target the same Supabase project in production."
+    );
+  }
+
+  const databaseProjectRef =
+    databaseUrl.supabaseProjectRef ?? directUrl.supabaseProjectRef;
+  if (
+    databaseProjectRef &&
+    supabaseClientProjectRef &&
+    databaseProjectRef !== supabaseClientProjectRef
+  ) {
+    throw new Error(
+      "SUPABASE_URL must target the same Supabase project as DATABASE_URL and DIRECT_URL in production."
+    );
+  }
+}
+
 function assertProductionDatabaseConnectionHardening(
   databaseUrl: ParsedDatabaseConnectionString,
   directUrl: ParsedDatabaseConnectionString,
-  runtimeEnvironment: RuntimeEnvironment
+  runtimeEnvironment: RuntimeEnvironment,
+  supabaseClientProjectRef: string | null
 ): void {
   if (runtimeEnvironment !== "production") {
     return;
@@ -520,6 +590,12 @@ function assertProductionDatabaseConnectionHardening(
       "DIRECT_URL must use the Supabase direct host in production (for example db.<project-ref>.supabase.co), not the pooler host."
     );
   }
+
+  assertMatchingSupabaseProjectRefs(
+    databaseUrl,
+    directUrl,
+    supabaseClientProjectRef
+  );
 }
 
 export interface ServerRuntimeValidationOptions {
@@ -543,16 +619,21 @@ export function validateServerRuntimeConfig(
     "DIRECT_URL",
     database.directUrl
   );
+  const supabaseConfig = getSupabaseClientRuntimeConfig();
+  let supabaseClientProjectRef: string | null = null;
+  if (supabaseConfig) {
+    assertValidUrl("SUPABASE_URL", supabaseConfig.url);
+    supabaseClientProjectRef = extractSupabaseClientProjectRef(
+      supabaseConfig.url
+    );
+  }
+
   assertProductionDatabaseConnectionHardening(
     parsedDatabaseUrl,
     parsedDirectUrl,
-    runtimeEnvironment
+    runtimeEnvironment,
+    supabaseClientProjectRef
   );
-
-  const supabaseConfig = getSupabaseClientRuntimeConfig();
-  if (supabaseConfig) {
-    assertValidUrl("SUPABASE_URL", supabaseConfig.url);
-  }
 
   assertOptionalEnvironmentGroup(
     ["NEXTAUTH_URL", "NEXTAUTH_SECRET"],

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -4,9 +4,14 @@ Use this file to capture tasks discovered during development. Each entry should 
 
 ## Pending
 ### Execution Queue (Now / Next)
+- ID: TASK-259
+  Title: Production DB project-ref guardrails - prevent runtime/database environment drift
+  Status: In progress (issue #260)
+  Rationale: Production was accidentally pointed at a valid but wrong Supabase database after a runtime `DATABASE_URL` secret rewrite. Add fail-fast validation and runbook guidance so `DATABASE_URL`, `DIRECT_URL`, and `SUPABASE_URL` cannot drift across Supabase project refs in production.
+  Dependencies: TASK-258
 - ID: TASK-258
   Title: Production DB session pool exhaustion - serverless-safe Supabase runtime pooling
-  Status: In progress (issue #258)
+  Status: Done via PR #259
   Rationale: Production authenticated navigation after notification email smoke hit `EMAXCONNSESSION` because runtime traffic was using the Supabase session pooler shape. Harden the runtime env contract and validation so Vercel/serverless runtime traffic uses the transaction pooler while direct migration/admin traffic stays on the direct endpoint.
   Dependencies: TASK-022, TASK-125, TASK-227
 - ID: TASK-225

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,70 +1,60 @@
-# Current Task: TASK-258 Production DB Session Pool Exhaustion
+# Current Task: TASK-259 Production DB Project-Ref Guardrails
 
 ## Task ID
-TASK-258
+TASK-259
 
 ## Status
-In progress on dedicated worktree `../nexus_dash_task258` and branch
-`fix/task-258-db-session-pool-exhaustion`.
+In progress on dedicated worktree `../nexus_dash_task259` and branch
+`fix/task-259-production-db-project-ref-guardrails`.
 
 ## Source
-- GitHub issue: #258
-- Incident: production notification email smoke succeeded, then authenticated
-  navigation around account/notification/project pages intermittently returned
-  server error pages.
+- GitHub issue: #260
+- Incident: after the TASK-258 pooler repair, production could authenticate but
+  the signed-in user saw no projects, indicating runtime `DATABASE_URL` pointed
+  at a valid but wrong Supabase database/environment.
 
 ## Objective
-Prevent production authenticated request bursts from exhausting the
-Supabase/Postgres session pool. Runtime traffic must use the serverless-safe
-Supabase transaction pooler, while direct/admin migration traffic continues to
-use the direct database endpoint.
-
-## Evidence
-- Vercel logs around the incident showed:
-  `DriverAdapterError: (EMAXCONNSESSION) max clients reached in session mode -
-  max clients are limited to pool_size: 15`.
-- The local ignored production env snapshot showed `DATABASE_URL` pointed at a
-  Supabase pooler host on port `5432`, which is session mode.
-- Supabase documentation describes transaction pooling on port `6543` as the
-  serverless/short-lived connection path; session pooling remains on port
-  `5432`.
+Prevent production from silently booting or deploying with database and
+Supabase client environment variables that target different Supabase project
+refs.
 
 ## Assumptions
-- Vercel and GitHub production secret values must not be printed or committed.
-- `DIRECT_URL` remains direct/non-pooler for migrations and admin workflows.
-- RLS must remain enforced through `withActorRlsContext`.
-- A production env change may be required in addition to code/docs, but the
-  repository should fail fast on the known unsafe Supabase session-pooler shape.
+- Agents must not read, print, or rewrite production secret values unless the
+  operator explicitly authorizes a specific secret operation.
+- Production DB restoration must use the intended Supabase Production project
+  dashboard values, not local `.env` snapshots, preview files, staging files, or
+  cached pulled Vercel env files.
+- `DATABASE_URL` remains the runtime pooled URL; `DIRECT_URL` and
+  `MIGRATION_DATABASE_URL` remain direct/admin migration URLs.
 
 ## Acceptance Criteria
-1. Production runtime validation rejects Supabase pooler `DATABASE_URL` values
-   that point at session mode (`5432`) instead of transaction mode (`6543`).
-2. Validation continues to allow local development database URLs and non-Supabase
-   remote providers that satisfy the existing hardening rules.
-3. Runtime Prisma connection-string normalization preserves existing behavior
-   and remains compatible with Supabase transaction-pooler URLs.
-4. Tests cover the rejected session-pooler case and the accepted
-   transaction-pooler case.
-5. README and runbooks clearly document the Supabase/Vercel contract:
-   `DATABASE_URL` is transaction pooler on port `6543`; `DIRECT_URL` is direct
-   database endpoint on port `5432`; secrets are never logged.
-6. Production env validation/smoke evidence is recorded without exposing secret
-   values.
-7. GitHub issue #258 is referenced in the PR.
+1. Production runtime validation extracts Supabase project refs from:
+   - shared pooler username (`postgres.<project-ref>`)
+   - direct DB host (`db.<project-ref>.supabase.co`)
+   - client URL (`https://<project-ref>.supabase.co`)
+2. Production validation rejects mismatches between `DATABASE_URL` and
+   `DIRECT_URL`.
+3. Production validation rejects mismatches between DB URLs and `SUPABASE_URL`
+   when `SUPABASE_URL` is configured.
+4. Existing pooler/direct/TLS hardening from TASK-258 remains intact.
+5. Focused tests cover matching refs and both mismatch cases.
+6. README and runbooks document the recovery process and the no-agent-secret-
+   rewrite policy.
+7. GitHub issue #260 is referenced in the PR.
 
 ## Definition Of Done
-- Work remains on `fix/task-258-db-session-pool-exhaustion`.
-- `tasks/current.md`, `tasks/backlog.md`, `journal.md`, README, and the DB/env
-  runbooks are updated where behavior/operations changed.
-- Required validation passes:
+- Work remains on `fix/task-259-production-db-project-ref-guardrails`.
+- `tasks/current.md`, `tasks/backlog.md`, `journal.md`, README, and env/DB
+  runbooks are updated.
+- Required validation passes or any environment blocker is documented:
   - `npm run lint`
   - `npm test`
   - `npm run test:coverage`
   - `npm run build`
-- A ready-for-review PR is opened and linked to issue #258.
-- CI and Copilot review are monitored; actionable review feedback is addressed.
-- Final handoff includes PR URL, commit SHA(s), validation results, deployment
-  status, and remaining operational caveats.
+- A ready-for-review PR is opened and linked to issue #260.
+- CI/Copilot feedback is monitored and addressed.
+- Final handoff includes PR URL, commit SHA(s), validation results, and the
+  exact operator action needed to restore production secrets.
 
 ## Validation Plan
 - Focused:
@@ -74,40 +64,8 @@ use the direct database endpoint.
   - `npm test`
   - `npm run test:coverage`
   - `npm run build`
-- Production after merge/deploy:
-  - Verify `/api/health/live`.
-  - Verify no new `EMAXCONNSESSION` logs during a representative authenticated
-    navigation/notification smoke burst.
-
-## Validation Evidence
-- Masked production env inspection confirmed the pre-fix local ignored
-  production `DATABASE_URL` shape was Supabase pooler host on port `5432`
-  with TLS, while `DIRECT_URL` was Supabase direct host on port `5432`.
-- Updated GitHub production environment secret `DATABASE_URL` to the derived
-  Supabase transaction-pooler shape on port `6543` without printing the value.
-- Updated Vercel Production `DATABASE_URL` to the derived Supabase
-  transaction-pooler shape on port `6543` without printing the value.
-- `npm ci` passed and generated Prisma Client.
-- Focused env validation passed:
-  `npm test -- --run tests/lib/env.server.test.ts` with 68 tests.
-- `npm run lint` passed.
-- `npm run db:local:up` could not bind port `5432` because another local
-  PostgreSQL service was already using it; validation used that existing
-  `127.0.0.1:5432` service.
-- `npm run db:migrate` passed against
-  `postgresql://postgres:postgres@127.0.0.1:5432/nexusdash?schema=public`;
-  no pending migrations.
-- Local DB `NODE_ENV=test npm test` passed with 107 files passed, 2 skipped;
-  807 tests passed, 2 skipped.
-- Local DB `NODE_ENV=test npm run test:coverage` passed with 91.23%
-  statements, 81.2% branches, 93.42% functions, and 91.75% lines.
-- Production-guarded `npm run build` passed with local PostgreSQL, disabled
-  outbound delivery mode, localhost trusted origins, local agent signing
-  secret, local Google token key, and explicit `NEXTAUTH_URL`/`NEXTAUTH_SECRET`.
 
 ## Out Of Scope
-- Changing notification email business logic beyond any validation evidence
-  needed for the incident.
-- Removing RLS or weakening project/user authorization boundaries.
-- Broad dashboard performance rewrites.
-- Paid infrastructure upgrades as the only fix.
+- Changing or rotating production secrets without explicit operator approval.
+- Migrating data between Supabase projects.
+- Notification email business logic.

--- a/tests/lib/env.server.test.ts
+++ b/tests/lib/env.server.test.ts
@@ -812,14 +812,50 @@ describe("env.server", () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv(
       "DATABASE_URL",
-      "postgresql://runtime-user:pwd@project.pooler.supabase.com:6543/postgres?sslmode=require"
+      "postgresql://postgres.project-ref:pwd@aws-1-eu-west-1.pooler.supabase.com:6543/postgres?sslmode=require"
     );
     vi.stubEnv(
       "DIRECT_URL",
-      "postgresql://admin-user:pwd@db.project-ref.supabase.co:5432/postgres?sslmode=require"
+      "postgresql://postgres:pwd@db.project-ref.supabase.co:5432/postgres?sslmode=require"
     );
+    vi.stubEnv("SUPABASE_URL", "https://project-ref.supabase.co");
+    vi.stubEnv("SUPABASE_PUBLISHABLE_KEY", "pk_test_123");
 
     expect(() => validateServerRuntimeConfig()).not.toThrow();
+  });
+
+  test("fails runtime validation when supabase database and direct urls target different projects in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv(
+      "DATABASE_URL",
+      "postgresql://postgres.preview-ref:pwd@aws-1-eu-west-1.pooler.supabase.com:6543/postgres?sslmode=require"
+    );
+    vi.stubEnv(
+      "DIRECT_URL",
+      "postgresql://postgres:pwd@db.production-ref.supabase.co:5432/postgres?sslmode=require"
+    );
+
+    expect(() => validateServerRuntimeConfig()).toThrow(
+      "DATABASE_URL and DIRECT_URL must target the same Supabase project in production."
+    );
+  });
+
+  test("fails runtime validation when supabase client url targets a different project in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv(
+      "DATABASE_URL",
+      "postgresql://postgres.production-ref:pwd@aws-1-eu-west-1.pooler.supabase.com:6543/postgres?sslmode=require"
+    );
+    vi.stubEnv(
+      "DIRECT_URL",
+      "postgresql://postgres:pwd@db.production-ref.supabase.co:5432/postgres?sslmode=require"
+    );
+    vi.stubEnv("SUPABASE_URL", "https://preview-ref.supabase.co");
+    vi.stubEnv("SUPABASE_PUBLISHABLE_KEY", "pk_test_123");
+
+    expect(() => validateServerRuntimeConfig()).toThrow(
+      "SUPABASE_URL must target the same Supabase project as DATABASE_URL and DIRECT_URL in production."
+    );
   });
 
   test("fails runtime validation when supabase direct url uses a non-direct port in production", () => {


### PR DESCRIPTION
## Summary
- Add production runtime validation that compares Supabase project refs across `DATABASE_URL`, `DIRECT_URL`, and `SUPABASE_URL`.
- Cover the production drift case with focused env tests for matching refs, DB/direct mismatch, and client URL mismatch.
- Update README/runbooks/task docs with production DB recovery guidance and a no-agent-secret-rewrite policy.

Closes #260.

## Validation
- `npm ci`
- `npm test -- --run tests/lib/env.server.test.ts`
- `npm run lint`
- `npm run db:migrate` with local PostgreSQL `127.0.0.1:5432`
- `NODE_ENV=test npm test` with local PostgreSQL
- `NODE_ENV=test npm run test:coverage` with local PostgreSQL
- `npm run build` with local PostgreSQL and safe local runtime secrets

## Production note
This PR does not change production secrets. Production restoration requires an operator to set the intended Supabase Production `DATABASE_URL`, `DIRECT_URL`, and `MIGRATION_DATABASE_URL` values from the Supabase Production dashboard, then redeploy/promote.