### PR TITLE
fix: keep in-app notifications atomic

### DIFF
--- a/components/notification-awareness-banner.tsx
+++ b/components/notification-awareness-banner.tsx
@@ -3,7 +3,7 @@ import { unstable_noStore as noStore } from "next/cache";
 
 import { AutoDismissingAlert } from "@/components/auto-dismissing-alert";
 import { logServerError } from "@/lib/observability/logger";
-import { listNotificationsForUser } from "@/lib/services/notification-service";
+import { getLatestUnreadNotificationForUser } from "@/lib/services/notification-service";
 
 interface NotificationAwarenessBannerProps {
   actorUserId: string;
@@ -15,9 +15,12 @@ export async function NotificationAwarenessBanner({
   noStore();
   const result = await (async () => {
     try {
-      return await listNotificationsForUser(actorUserId);
+      return await getLatestUnreadNotificationForUser(actorUserId);
     } catch (error) {
-      logServerError("NotificationAwarenessBanner.listNotificationsForUser", error);
+      logServerError(
+        "NotificationAwarenessBanner.getLatestUnreadNotificationForUser",
+        error
+      );
       return null;
     }
   })();
@@ -26,14 +29,11 @@ export async function NotificationAwarenessBanner({
     return null;
   }
 
-  const unreadNotifications = result.data.notifications.filter(
-    (notification) => !notification.readAt
-  );
-  if (unreadNotifications.length === 0) {
+  if (!result.data.notification) {
     return null;
   }
 
-  const latestNotification = unreadNotifications[0];
+  const latestNotification = result.data.notification;
 
   return (
     <AutoDismissingAlert

--- a/components/notification-awareness-banner.tsx
+++ b/components/notification-awareness-banner.tsx
@@ -33,18 +33,13 @@ export async function NotificationAwarenessBanner({
     return null;
   }
 
-  const firstNotification = unreadNotifications[0];
-  const extraCount = unreadNotifications.length - 1;
-  const message =
-    extraCount > 0
-      ? `${firstNotification.title} +${extraCount} more unread notification${extraCount === 1 ? "" : "s"}.`
-      : firstNotification.title;
+  const latestNotification = unreadNotifications[0];
 
   return (
     <AutoDismissingAlert
       message={
         <>
-          {message}{" "}
+          {latestNotification.title}{" "}
           <Link
             href="/account/notifications"
             className="font-medium underline underline-offset-4"

--- a/journal.md
+++ b/journal.md
@@ -12,6 +12,11 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ## Recent Entries (Most Relevant)
 
+### 2026-05-16
+- Type: Execution
+- Summary: TASK-260 kept in-app notification awareness atomic while preserving email digests.
+- Evidence: Production grouped-notification smoke showed the email digest layer works, but in-app awareness copy could read as a grouped notification (`+N more unread notifications`). Updated the notification awareness banner to show only the latest unread atomic notification and link to the notification center for the full list. Added component coverage proving the banner does not render grouped unread text while existing email-service coverage continues to prove recipient/project email batching.
+
 ### 2026-05-15
 - Type: Execution
 - Summary: TASK-259 added production Supabase project-ref guardrails after runtime DB drift incident.

--- a/lib/services/notification-service.ts
+++ b/lib/services/notification-service.ts
@@ -647,6 +647,54 @@ export async function listNotificationsForUser(
   });
 }
 
+export async function getLatestUnreadNotificationForUser(
+  actorUserId: string
+): Promise<ServiceResult<{ notification: NotificationSummary | null }>> {
+  const normalizedActorUserId = normalizeActorUserId(actorUserId);
+  if (!normalizedActorUserId) {
+    return createError(401, "unauthorized");
+  }
+
+  return withActorRlsContext(normalizedActorUserId, async (db) => {
+    try {
+      await syncProjectInvitationNotificationsForUser(
+        db,
+        normalizedActorUserId
+      );
+
+      const notification = await db.notification.findFirst({
+        where: {
+          recipientUserId: normalizedActorUserId,
+          resolvedAt: null,
+          readAt: null,
+        },
+        orderBy: [{ createdAt: "desc" }],
+        select: {
+          id: true,
+          type: true,
+          title: true,
+          body: true,
+          targetPath: true,
+          sourceType: true,
+          sourceId: true,
+          metadata: true,
+          readAt: true,
+          resolvedAt: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      });
+
+      return createSuccess(200, {
+        notification: notification ? mapNotification(notification) : null,
+      });
+    } catch (error) {
+      logServerError("getLatestUnreadNotificationForUser", error);
+      return createError(500, "notification-latest-unread-failed");
+    }
+  });
+}
+
 export async function countUnreadNotificationsForUser(
   actorUserId: string
 ): Promise<number> {

--- a/lib/services/notification-service.ts
+++ b/lib/services/notification-service.ts
@@ -30,7 +30,6 @@ interface PendingInvitationMetadataRow {
   projectId: string;
   projectName: string;
   invitedEmail: string;
-  invitedByUserId: string;
   invitedByEmail: string | null;
   invitedByName: string | null;
   invitedByUsername: string | null;
@@ -125,6 +124,10 @@ export interface NotificationSummary {
   resolvedAt: string | null;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface LatestUnreadNotificationSummary {
+  title: string;
 }
 
 function createError(status: number, error: string): ServiceErrorResult {
@@ -350,7 +353,6 @@ async function listPendingInvitationRowsForCurrentUser(
       project_id AS "projectId",
       project_name AS "projectName",
       invited_email AS "invitedEmail",
-      invited_by_user_id AS "invitedByUserId",
       invited_by_email AS "invitedByEmail",
       invited_by_name AS "invitedByName",
       invited_by_username AS "invitedByUsername",
@@ -649,7 +651,9 @@ export async function listNotificationsForUser(
 
 export async function getLatestUnreadNotificationForUser(
   actorUserId: string
-): Promise<ServiceResult<{ notification: NotificationSummary | null }>> {
+): Promise<
+  ServiceResult<{ notification: LatestUnreadNotificationSummary | null }>
+> {
   const normalizedActorUserId = normalizeActorUserId(actorUserId);
   if (!normalizedActorUserId) {
     return createError(401, "unauthorized");
@@ -670,23 +674,12 @@ export async function getLatestUnreadNotificationForUser(
         },
         orderBy: [{ createdAt: "desc" }],
         select: {
-          id: true,
-          type: true,
           title: true,
-          body: true,
-          targetPath: true,
-          sourceType: true,
-          sourceId: true,
-          metadata: true,
-          readAt: true,
-          resolvedAt: true,
-          createdAt: true,
-          updatedAt: true,
         },
       });
 
       return createSuccess(200, {
-        notification: notification ? mapNotification(notification) : null,
+        notification: notification ? { title: notification.title } : null,
       });
     } catch (error) {
       logServerError("getLatestUnreadNotificationForUser", error);

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -4,9 +4,14 @@ Use this file to capture tasks discovered during development. Each entry should 
 
 ## Pending
 ### Execution Queue (Now / Next)
+- ID: TASK-260
+  Title: Email-only notification digests - keep in-app notifications atomic
+  Status: In progress
+  Rationale: Production smoke confirmed email grouping works, but in-app notification awareness must not present several unread items as one grouped notification. Keep one in-app notification per action/artifact while leaving recipient/project email digest grouping, debounce, and max-delay behavior in the email orchestration layer.
+  Dependencies: TASK-123, TASK-125, TASK-227
 - ID: TASK-259
   Title: Production DB project-ref guardrails - prevent runtime/database environment drift
-  Status: In progress (issue #260)
+  Status: Done via PR #261
   Rationale: Production was accidentally pointed at a valid but wrong Supabase database after a runtime `DATABASE_URL` secret rewrite. Add fail-fast validation and runbook guidance so `DATABASE_URL`, `DIRECT_URL`, and `SUPABASE_URL` cannot drift across Supabase project refs in production.
   Dependencies: TASK-258
 - ID: TASK-258

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,64 +1,66 @@
-# Current Task: TASK-259 Production DB Project-Ref Guardrails
+# Current Task: TASK-260 Email-Only Notification Digests
 
 ## Task ID
-TASK-259
+TASK-260
 
 ## Status
-In progress on dedicated worktree `../nexus_dash_task259` and branch
-`fix/task-259-production-db-project-ref-guardrails`.
+In progress on dedicated worktree `../nexus_dash_task260` and branch
+`fix/task-260-email-only-notification-digests`.
 
 ## Source
-- GitHub issue: #260
-- Incident: after the TASK-258 pooler repair, production could authenticate but
-  the signed-in user saw no projects, indicating runtime `DATABASE_URL` pointed
-  at a valid but wrong Supabase database/environment.
+- Production multi-notification smoke follow-up after TASK-227/TASK-258/TASK-259.
+- User feedback: grouped notifications are desirable for email, but in-app
+  notifications must remain atomic and about one action/artifact.
 
 ## Objective
-Prevent production from silently booting or deploying with database and
-Supabase client environment variables that target different Supabase project
-refs.
+Keep the notification center and in-app notification awareness surfaces focused
+on individual notification artifacts, while preserving recipient/project email
+digest grouping and debounce behavior for outbound email only.
+
+## Product Decision
+The durable `Notification` row remains the source-of-truth unit for in-app
+notification UX. Email orchestration may group those atomic rows through
+`ProjectNotificationEmail` and `ProjectNotificationEmailItem`, but in-app
+surfaces must not describe several notifications as one grouped notification.
+
+This follows the common product pattern used by activity systems: real-time or
+near-real-time in-app notifications are event/activity items, while email is a
+digest channel with debounce, batching, and maximum-delay controls.
 
 ## Assumptions
-- Agents must not read, print, or rewrite production secret values unless the
-  operator explicitly authorizes a specific secret operation.
-- Production DB restoration must use the intended Supabase Production project
-  dashboard values, not local `.env` snapshots, preview files, staging files, or
-  cached pulled Vercel env files.
-- `DATABASE_URL` remains the runtime pooled URL; `DIRECT_URL` and
-  `MIGRATION_DATABASE_URL` remain direct/admin migration URLs.
+- No production secrets are needed for this task.
+- The existing email digest service should keep recipient/project grouping,
+  quiet-window debounce, and max-delay behavior.
+- No websocket/realtime transport is being added here; "real time" in this task
+  means in-app notifications are not email-style digests and each notification
+  row remains independently actionable.
 
 ## Acceptance Criteria
-1. Production runtime validation extracts Supabase project refs from:
-   - shared pooler username (`postgres.<project-ref>`)
-   - direct DB host (`db.<project-ref>.supabase.co`)
-   - client URL (`https://<project-ref>.supabase.co`)
-2. Production validation rejects mismatches between `DATABASE_URL` and
-   `DIRECT_URL`.
-3. Production validation rejects mismatches between DB URLs and `SUPABASE_URL`
-   when `SUPABASE_URL` is configured.
-4. Existing pooler/direct/TLS hardening from TASK-258 remains intact.
-5. Focused tests cover matching refs and both mismatch cases.
-6. README and runbooks document the recovery process and the no-agent-secret-
-   rewrite policy.
-7. GitHub issue #260 is referenced in the PR.
+1. The notification center continues to render one row per `Notification`.
+2. The in-app notification awareness banner does not render digest-style text
+   such as `+N more unread notifications`.
+3. Email digest tests continue to prove multiple project groups can be batched
+   into one recipient email.
+4. Tests cover the in-app/email boundary: in-app surface stays atomic while
+   email remains grouped.
+5. Documentation/task tracking records the product decision.
 
 ## Definition Of Done
-- Work remains on `fix/task-259-production-db-project-ref-guardrails`.
-- `tasks/current.md`, `tasks/backlog.md`, `journal.md`, README, and env/DB
-  runbooks are updated.
+- Work remains on `fix/task-260-email-only-notification-digests`.
+- `tasks/current.md`, `tasks/backlog.md`, and `journal.md` are updated.
 - Required validation passes or any environment blocker is documented:
   - `npm run lint`
   - `npm test`
   - `npm run test:coverage`
   - `npm run build`
-- A ready-for-review PR is opened and linked to issue #260.
+- A ready-for-review PR is opened.
 - CI/Copilot feedback is monitored and addressed.
-- Final handoff includes PR URL, commit SHA(s), validation results, and the
-  exact operator action needed to restore production secrets.
+- Final handoff includes PR URL, commit SHA(s), validation results, and any
+  remaining caveats for production smoke.
 
 ## Validation Plan
 - Focused:
-  - `npm test -- --run tests/lib/env.server.test.ts`
+  - `npm test -- --run tests/components/notification-awareness-banner.test.tsx tests/lib/project-notification-email-service.test.ts`
 - Baseline:
   - `npm run lint`
   - `npm test`
@@ -66,6 +68,6 @@ refs.
   - `npm run build`
 
 ## Out Of Scope
-- Changing or rotating production secrets without explicit operator approval.
-- Migrating data between Supabase projects.
-- Notification email business logic.
+- Adding websocket/SSE realtime transport.
+- Changing outbound email debounce/window timing.
+- Changing production scheduler provisioning.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -60,7 +60,7 @@ digest channel with debounce, batching, and maximum-delay controls.
 
 ## Validation Plan
 - Focused:
-  - `npm test -- --run tests/components/notification-awareness-banner.test.tsx tests/lib/project-notification-email-service.test.ts`
+  - `npm test -- --run tests/components/notification-awareness-banner.test.tsx tests/lib/notification-service.test.ts tests/lib/project-notification-email-service.test.ts`
 - Baseline:
   - `npm run lint`
   - `npm test`

--- a/tests/components/notification-awareness-banner.test.tsx
+++ b/tests/components/notification-awareness-banner.test.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const notificationServiceMock = vi.hoisted(() => ({
+  listNotificationsForUser: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  unstable_noStore: vi.fn(),
+}));
+
+vi.mock("@/lib/observability/logger", () => ({
+  logServerError: vi.fn(),
+}));
+
+vi.mock("@/lib/services/notification-service", () => ({
+  listNotificationsForUser: notificationServiceMock.listNotificationsForUser,
+}));
+
+import { NotificationAwarenessBanner } from "@/components/notification-awareness-banner";
+
+(globalThis as { React?: typeof React }).React = React;
+
+describe("notification-awareness-banner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("renders only the latest atomic notification instead of grouped unread text", async () => {
+    notificationServiceMock.listNotificationsForUser.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: {
+        notifications: [
+          {
+            id: "notification-latest",
+            type: "task_comment_mention",
+            title: "Mentioned in: Task C",
+            body: "Agent mentioned you in a comment on Task C.",
+            targetPath: "/projects/project-1?taskId=task-c",
+            sourceType: "task_comment_mention",
+            sourceId: "comment-c",
+            metadata: null,
+            readAt: null,
+            resolvedAt: null,
+            createdAt: "2026-05-16T00:20:00.000Z",
+            updatedAt: "2026-05-16T00:20:00.000Z",
+          },
+          {
+            id: "notification-older",
+            type: "task_comment_mention",
+            title: "Mentioned in: Task B",
+            body: "Agent mentioned you in a comment on Task B.",
+            targetPath: "/projects/project-1?taskId=task-b",
+            sourceType: "task_comment_mention",
+            sourceId: "comment-b",
+            metadata: null,
+            readAt: null,
+            resolvedAt: null,
+            createdAt: "2026-05-16T00:05:00.000Z",
+            updatedAt: "2026-05-16T00:05:00.000Z",
+          },
+        ],
+      },
+    });
+
+    const result = renderToStaticMarkup(
+      await NotificationAwarenessBanner({ actorUserId: "user-1" })
+    );
+
+    expect(result).toContain("Mentioned in: Task C");
+    expect(result).not.toContain("Mentioned in: Task B");
+    expect(result).not.toContain("more unread notification");
+    expect(result).toContain("Review notifications");
+  });
+
+  test("renders nothing when all notifications are already read", async () => {
+    notificationServiceMock.listNotificationsForUser.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: {
+        notifications: [
+          {
+            id: "notification-read",
+            type: "task_assignment",
+            title: "Assigned: Task A",
+            body: "Owner assigned you to Task A.",
+            targetPath: "/projects/project-1?taskId=task-a",
+            sourceType: "task_assignment",
+            sourceId: "task-a",
+            metadata: null,
+            readAt: "2026-05-16T00:30:00.000Z",
+            resolvedAt: null,
+            createdAt: "2026-05-16T00:00:00.000Z",
+            updatedAt: "2026-05-16T00:00:00.000Z",
+          },
+        ],
+      },
+    });
+
+    const result = await NotificationAwarenessBanner({ actorUserId: "user-1" });
+
+    expect(result).toBeNull();
+  });
+});

--- a/tests/components/notification-awareness-banner.test.tsx
+++ b/tests/components/notification-awareness-banner.test.tsx
@@ -3,7 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const notificationServiceMock = vi.hoisted(() => ({
-  listNotificationsForUser: vi.fn(),
+  getLatestUnreadNotificationForUser: vi.fn(),
 }));
 
 vi.mock("next/cache", () => ({
@@ -15,7 +15,8 @@ vi.mock("@/lib/observability/logger", () => ({
 }));
 
 vi.mock("@/lib/services/notification-service", () => ({
-  listNotificationsForUser: notificationServiceMock.listNotificationsForUser,
+  getLatestUnreadNotificationForUser:
+    notificationServiceMock.getLatestUnreadNotificationForUser,
 }));
 
 import { NotificationAwarenessBanner } from "@/components/notification-awareness-banner";
@@ -28,12 +29,12 @@ describe("notification-awareness-banner", () => {
   });
 
   test("renders only the latest atomic notification instead of grouped unread text", async () => {
-    notificationServiceMock.listNotificationsForUser.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      data: {
-        notifications: [
-          {
+    notificationServiceMock.getLatestUnreadNotificationForUser.mockResolvedValueOnce(
+      {
+        ok: true,
+        status: 200,
+        data: {
+          notification: {
             id: "notification-latest",
             type: "task_comment_mention",
             title: "Mentioned in: Task C",
@@ -47,23 +48,9 @@ describe("notification-awareness-banner", () => {
             createdAt: "2026-05-16T00:20:00.000Z",
             updatedAt: "2026-05-16T00:20:00.000Z",
           },
-          {
-            id: "notification-older",
-            type: "task_comment_mention",
-            title: "Mentioned in: Task B",
-            body: "Agent mentioned you in a comment on Task B.",
-            targetPath: "/projects/project-1?taskId=task-b",
-            sourceType: "task_comment_mention",
-            sourceId: "comment-b",
-            metadata: null,
-            readAt: null,
-            resolvedAt: null,
-            createdAt: "2026-05-16T00:05:00.000Z",
-            updatedAt: "2026-05-16T00:05:00.000Z",
-          },
-        ],
-      },
-    });
+        },
+      }
+    );
 
     const result = renderToStaticMarkup(
       await NotificationAwarenessBanner({ actorUserId: "user-1" })
@@ -73,31 +60,21 @@ describe("notification-awareness-banner", () => {
     expect(result).not.toContain("Mentioned in: Task B");
     expect(result).not.toContain("more unread notification");
     expect(result).toContain("Review notifications");
+    expect(
+      notificationServiceMock.getLatestUnreadNotificationForUser
+    ).toHaveBeenCalledWith("user-1");
   });
 
   test("renders nothing when all notifications are already read", async () => {
-    notificationServiceMock.listNotificationsForUser.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      data: {
-        notifications: [
-          {
-            id: "notification-read",
-            type: "task_assignment",
-            title: "Assigned: Task A",
-            body: "Owner assigned you to Task A.",
-            targetPath: "/projects/project-1?taskId=task-a",
-            sourceType: "task_assignment",
-            sourceId: "task-a",
-            metadata: null,
-            readAt: "2026-05-16T00:30:00.000Z",
-            resolvedAt: null,
-            createdAt: "2026-05-16T00:00:00.000Z",
-            updatedAt: "2026-05-16T00:00:00.000Z",
-          },
-        ],
-      },
-    });
+    notificationServiceMock.getLatestUnreadNotificationForUser.mockResolvedValueOnce(
+      {
+        ok: true,
+        status: 200,
+        data: {
+          notification: null,
+        },
+      }
+    );
 
     const result = await NotificationAwarenessBanner({ actorUserId: "user-1" });
 

--- a/tests/components/notification-awareness-banner.test.tsx
+++ b/tests/components/notification-awareness-banner.test.tsx
@@ -35,18 +35,7 @@ describe("notification-awareness-banner", () => {
         status: 200,
         data: {
           notification: {
-            id: "notification-latest",
-            type: "task_comment_mention",
             title: "Mentioned in: Task C",
-            body: "Agent mentioned you in a comment on Task C.",
-            targetPath: "/projects/project-1?taskId=task-c",
-            sourceType: "task_comment_mention",
-            sourceId: "comment-c",
-            metadata: null,
-            readAt: null,
-            resolvedAt: null,
-            createdAt: "2026-05-16T00:20:00.000Z",
-            updatedAt: "2026-05-16T00:20:00.000Z",
           },
         },
       }

--- a/tests/lib/notification-service.test.ts
+++ b/tests/lib/notification-service.test.ts
@@ -5,6 +5,7 @@ const prismaMock = vi.hoisted(() => ({
   notification: {
     count: vi.fn(),
     createMany: vi.fn(),
+    findFirst: vi.fn(),
     findMany: vi.fn(),
     updateMany: vi.fn(),
   },
@@ -22,6 +23,7 @@ vi.mock("@/lib/observability/logger", () => ({
 
 import {
   countUnreadNotificationsForUser,
+  getLatestUnreadNotificationForUser,
   listNotificationsForUser,
   markAllNotificationsReadForUser,
   resolveProjectInvitationNotifications,
@@ -33,6 +35,7 @@ describe("notification-service", () => {
     vi.clearAllMocks();
     prismaMock.notification.updateMany.mockResolvedValue({ count: 1 });
     prismaMock.notification.createMany.mockResolvedValue({ count: 1 });
+    prismaMock.notification.findFirst.mockResolvedValue(null);
     prismaMock.notification.findMany.mockResolvedValue([]);
     prismaMock.notification.count.mockResolvedValue(0);
     prismaMock.$queryRaw.mockResolvedValue([]);
@@ -146,6 +149,59 @@ describe("notification-service", () => {
         resolvedAt: null,
         readAt: null,
       },
+    });
+  });
+
+  test("fetches only the latest unread unresolved notification for awareness", async () => {
+    prismaMock.notification.findFirst.mockResolvedValueOnce({
+      id: "notification-latest",
+      type: "task_comment_mention",
+      title: "Mentioned in: Task C",
+      body: "Agent mentioned you in a comment on Task C.",
+      targetPath: "/projects/project-1?taskId=task-c",
+      sourceType: "task_comment_mention",
+      sourceId: "comment-c",
+      metadata: null,
+      readAt: null,
+      resolvedAt: null,
+      createdAt: new Date("2026-05-16T00:20:00.000Z"),
+      updatedAt: new Date("2026-05-16T00:20:00.000Z"),
+    });
+
+    const result = await getLatestUnreadNotificationForUser("user-1");
+
+    expect(result).toEqual({
+      ok: true,
+      status: 200,
+      data: {
+        notification: {
+          id: "notification-latest",
+          type: "task_comment_mention",
+          title: "Mentioned in: Task C",
+          body: "Agent mentioned you in a comment on Task C.",
+          targetPath: "/projects/project-1?taskId=task-c",
+          sourceType: "task_comment_mention",
+          sourceId: "comment-c",
+          metadata: null,
+          readAt: null,
+          resolvedAt: null,
+          createdAt: "2026-05-16T00:20:00.000Z",
+          updatedAt: "2026-05-16T00:20:00.000Z",
+        },
+      },
+    });
+    expect(prismaMock.notification.findFirst).toHaveBeenCalledWith({
+      where: {
+        recipientUserId: "user-1",
+        resolvedAt: null,
+        readAt: null,
+      },
+      orderBy: [{ createdAt: "desc" }],
+      select: expect.objectContaining({
+        id: true,
+        title: true,
+        readAt: true,
+      }),
     });
   });
 

--- a/tests/lib/notification-service.test.ts
+++ b/tests/lib/notification-service.test.ts
@@ -48,7 +48,6 @@ describe("notification-service", () => {
         projectId: "project-1",
         projectName: "Shared Project",
         invitedEmail: "invitee@example.com",
-        invitedByUserId: "owner-1",
         invitedByEmail: "owner@example.com",
         invitedByName: "Owner",
         invitedByUsername: "owner",
@@ -154,18 +153,7 @@ describe("notification-service", () => {
 
   test("fetches only the latest unread unresolved notification for awareness", async () => {
     prismaMock.notification.findFirst.mockResolvedValueOnce({
-      id: "notification-latest",
-      type: "task_comment_mention",
       title: "Mentioned in: Task C",
-      body: "Agent mentioned you in a comment on Task C.",
-      targetPath: "/projects/project-1?taskId=task-c",
-      sourceType: "task_comment_mention",
-      sourceId: "comment-c",
-      metadata: null,
-      readAt: null,
-      resolvedAt: null,
-      createdAt: new Date("2026-05-16T00:20:00.000Z"),
-      updatedAt: new Date("2026-05-16T00:20:00.000Z"),
     });
 
     const result = await getLatestUnreadNotificationForUser("user-1");
@@ -175,18 +163,7 @@ describe("notification-service", () => {
       status: 200,
       data: {
         notification: {
-          id: "notification-latest",
-          type: "task_comment_mention",
           title: "Mentioned in: Task C",
-          body: "Agent mentioned you in a comment on Task C.",
-          targetPath: "/projects/project-1?taskId=task-c",
-          sourceType: "task_comment_mention",
-          sourceId: "comment-c",
-          metadata: null,
-          readAt: null,
-          resolvedAt: null,
-          createdAt: "2026-05-16T00:20:00.000Z",
-          updatedAt: "2026-05-16T00:20:00.000Z",
         },
       },
     });
@@ -197,11 +174,9 @@ describe("notification-service", () => {
         readAt: null,
       },
       orderBy: [{ createdAt: "desc" }],
-      select: expect.objectContaining({
-        id: true,
+      select: {
         title: true,
-        readAt: true,
-      }),
+      },
     });
   });
 
@@ -212,7 +187,6 @@ describe("notification-service", () => {
         projectId: "project-1",
         projectName: "Shared Project",
         invitedEmail: "invitee@example.com",
-        invitedByUserId: "owner-1",
         invitedByEmail: "owner@example.com",
         invitedByName: "Owner",
         invitedByUsername: "owner",


### PR DESCRIPTION
## Summary
- Keep the in-app notification awareness banner atomic by showing only the latest unread notification instead of digest-style `+N more unread notifications` copy.
- Add a focused latest-unread notification service query so the banner does not load/filter the full notification list.
- Slim that latest-unread service contract to the one field the banner actually renders, and remove an unused invitation column from the notification sync query.
- Preserve email-only digest behavior through the existing notification email orchestration layer and regression coverage.
- Record TASK-260 product decision in task tracking and journal notes.

## Product decision
In-app notification UX should represent one notification artifact per action. Email remains the digest channel with recipient/project grouping, debounce, and max-delay behavior.

## Validation
- `npm test -- --run tests/components/notification-awareness-banner.test.tsx tests/lib/notification-service.test.ts tests/lib/project-notification-email-service.test.ts`
- `npm run lint`
- `npm test`
- `npm run test:coverage`
- `npm run build`

## Notes
- No production secrets were read or changed.
- No scheduler, email debounce timing, or realtime transport changes are included in this patch.