### PR TITLE
TASK-263 Add realtime notification updates task

### DIFF
--- a/journal.md
+++ b/journal.md
@@ -13,6 +13,11 @@ Use it for important implementation milestones, blockers, validation runs, and r
 ## Recent Entries (Most Relevant)
 
 ### 2026-05-16
+- Type: Planning
+- Summary: TASK-263 captured realtime in-app notification updates as a dedicated follow-up related to TASK-118.
+- Evidence: PR #262 merged the email-only digest boundary and kept in-app notification surfaces atomic. Added a pending notification-specific realtime task for live notification-center rows, unread counts, and awareness banner updates without navigation/manual refresh, while requiring alignment with the broader TASK-118 realtime collaboration transport decision.
+
+### 2026-05-16
 - Type: Execution
 - Summary: TASK-260 kept in-app notification awareness atomic while preserving email digests.
 - Evidence: Production grouped-notification smoke showed the email digest layer works, but in-app awareness copy could read as a grouped notification (`+N more unread notifications`). Updated the notification awareness banner to show only the latest unread atomic notification and link to the notification center for the full list. Added component coverage proving the banner does not render grouped unread text while existing email-service coverage continues to prove recipient/project email batching.

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -6,7 +6,7 @@ Use this file to capture tasks discovered during development. Each entry should 
 ### Execution Queue (Now / Next)
 - ID: TASK-260
   Title: Email-only notification digests - keep in-app notifications atomic
-  Status: In progress
+  Status: Done via PR #262
   Rationale: Production smoke confirmed email grouping works, but in-app notification awareness must not present several unread items as one grouped notification. Keep one in-app notification per action/artifact while leaving recipient/project email digest grouping, debounce, and max-delay behavior in the email orchestration layer.
   Dependencies: TASK-123, TASK-125, TASK-227
 - ID: TASK-259
@@ -78,8 +78,13 @@ Use this file to capture tasks discovered during development. Each entry should 
 - ID: TASK-118
   Title: Real-time collaboration updates - live project refresh for multi-user work
   Status: Pending
-  Rationale: Reduce stale state and manual-refresh friction during shared project work by propagating task, context-card, and related project mutations live across active collaborators, with explicit decisions around subscriptions, optimistic UI, and conflict handling.
+  Rationale: Reduce stale state and manual-refresh friction during shared project work by propagating task, context-card, and related project mutations live across active collaborators, with explicit decisions around subscriptions, optimistic UI, and conflict handling. This should choose the app-wide realtime transport/pattern that notification-specific live updates can reuse.
   Dependencies: TASK-058, TASK-076, TASK-103
+- ID: TASK-263
+  Title: Real-time notification updates - live in-app inbox, counts, and awareness
+  Status: Pending
+  Rationale: Make notification-center rows, unread counts, and the in-app awareness banner update without requiring navigation or manual refresh when assignments, mentions, invitations, or future notification producers create new atomic `Notification` rows. Keep email digest batching fully separate: in-app remains one notification per action/artifact, while email remains the grouped/debounced channel. This task should reuse or align with the broader TASK-118 realtime transport decision rather than introduce a parallel realtime stack.
+  Dependencies: TASK-118, TASK-123, TASK-260
 - ID: TASK-119
   Title: Project collaboration presence UX - member avatars on project pages
   Status: Pending

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,73 +1,52 @@
-# Current Task: TASK-260 Email-Only Notification Digests
+# Current Task: TASK-263 Real-Time Notification Updates
 
 ## Task ID
-TASK-260
+TASK-263
 
 ## Status
-In progress on dedicated worktree `../nexus_dash_task260` and branch
-`fix/task-260-email-only-notification-digests`.
+Backlog captured on dedicated worktree `../nexus_dash_task263` and branch
+`feature/task-263-realtime-notification-updates`.
 
 ## Source
-- Production multi-notification smoke follow-up after TASK-227/TASK-258/TASK-259.
-- User feedback: grouped notifications are desirable for email, but in-app
-  notifications must remain atomic and about one action/artifact.
+- Follow-up after PR #262 made in-app notifications atomic and kept grouped
+  digest behavior email-only.
+- User confirmed that instant push-style updates are a separate architecture
+  concern from the email digest feature.
+- Existing related task: TASK-118 covers broader realtime project refresh.
 
 ## Objective
-Keep the notification center and in-app notification awareness surfaces focused
-on individual notification artifacts, while preserving recipient/project email
-digest grouping and debounce behavior for outbound email only.
+Capture a dedicated notification realtime task that can update the notification
+center, unread counts, and in-app awareness banner without navigation/manual
+refresh, while reusing or aligning with the broader TASK-118 realtime
+transport decision.
 
 ## Product Decision
-The durable `Notification` row remains the source-of-truth unit for in-app
-notification UX. Email orchestration may group those atomic rows through
-`ProjectNotificationEmail` and `ProjectNotificationEmailItem`, but in-app
-surfaces must not describe several notifications as one grouped notification.
+In-app notifications should remain atomic rows: one notification per
+assignment, mention, invitation, or future notification-producing action.
+Realtime delivery, if implemented, changes how quickly those rows appear in
+the UI; it must not turn the in-app notification center into an email-style
+digest.
 
-This follows the common product pattern used by activity systems: real-time or
-near-real-time in-app notifications are event/activity items, while email is a
-digest channel with debounce, batching, and maximum-delay controls.
-
-## Assumptions
-- No production secrets are needed for this task.
-- The existing email digest service should keep recipient/project grouping,
-  quiet-window debounce, and max-delay behavior.
-- No websocket/realtime transport is being added here; "real time" in this task
-  means in-app notifications are not email-style digests and each notification
-  row remains independently actionable.
+Email remains the grouped/debounced channel.
 
 ## Acceptance Criteria
-1. The notification center continues to render one row per `Notification`.
-2. The in-app notification awareness banner does not render digest-style text
-   such as `+N more unread notifications`.
-3. Email digest tests continue to prove multiple project groups can be batched
-   into one recipient email.
-4. Tests cover the in-app/email boundary: in-app surface stays atomic while
-   email remains grouped.
-5. Documentation/task tracking records the product decision.
+1. `tasks/backlog.md` contains a notification-specific realtime task.
+2. The new task is explicitly related to TASK-118 so the app does not grow two
+   independent realtime architectures.
+3. TASK-260 is marked complete now that PR #262 has merged.
+4. The task scope distinguishes live in-app updates from email digest grouping.
 
 ## Definition Of Done
-- Work remains on `fix/task-260-email-only-notification-digests`.
-- `tasks/current.md`, `tasks/backlog.md`, and `journal.md` are updated.
-- Required validation passes or any environment blocker is documented:
-  - `npm run lint`
-  - `npm test`
-  - `npm run test:coverage`
-  - `npm run build`
-- A ready-for-review PR is opened.
-- CI/Copilot feedback is monitored and addressed.
-- Final handoff includes PR URL, commit SHA(s), validation results, and any
-  remaining caveats for production smoke.
+- `tasks/backlog.md`, `tasks/current.md`, and `journal.md` are updated.
+- Validation is limited to docs/task tracking inspection because no app code is
+  changed.
+- A ready-for-review PR is opened for the tracking update.
 
 ## Validation Plan
-- Focused:
-  - `npm test -- --run tests/components/notification-awareness-banner.test.tsx tests/lib/notification-service.test.ts tests/lib/project-notification-email-service.test.ts`
-- Baseline:
-  - `npm run lint`
-  - `npm test`
-  - `npm run test:coverage`
-  - `npm run build`
+- `git diff --check`
+- Review the changed Markdown for task consistency.
 
 ## Out Of Scope
-- Adding websocket/SSE realtime transport.
-- Changing outbound email debounce/window timing.
-- Changing production scheduler provisioning.
+- Implementing SSE/WebSocket/polling.
+- Changing notification or email digest runtime behavior.
+- Changing scheduler provisioning or smoke-test procedure.


### PR DESCRIPTION
## Summary
- Add TASK-263 for live in-app notification updates across notification center rows, unread counts, and the awareness banner.
- Relate TASK-263 to TASK-118 so notification realtime work reuses the broader app realtime transport decision instead of creating a parallel stack.
- Mark TASK-260 complete now that PR #262 has merged.

## Validation
- `git diff --check`
- Reviewed changed Markdown for task consistency

## Notes
- Docs/task tracking only. No runtime behavior changes.
- TASK-263 explicitly keeps in-app notifications atomic and email as the grouped/debounced channel.