### PR TITLE
TASK-267 Add notification task handoff briefs

### DIFF
--- a/journal.md
+++ b/journal.md
@@ -14,6 +14,11 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ### 2026-05-16
 - Type: Planning
+- Summary: TASK-267 drafted dedicated handoff briefs for the next notification/email tasks.
+- Evidence: Added `tasks/task-228-qstash-notification-email-scheduler-activation.md`, `tasks/task-265-notification-actor-attribution-and-self-notification-rules.md`, and `tasks/task-226-task-due-date-email-reminders.md`; linked them from `tasks/backlog.md`; kept the change documentation-only so scheduler activation, actor attribution, and due-date reminder implementation remain separate PRs.
+
+### 2026-05-16
+- Type: Planning
 - Summary: TASK-264 cleaned the notification backlog path after production digest smoke.
 - Evidence: Production multi-notification smoke succeeded: two atomic assignment notifications produced one grouped digest email after manual dispatch, and repeat dispatch sent nothing. The same smoke showed QStash/managed scheduling is not live yet, so TASK-228 was promoted as the next scheduler task. Added TASK-265 for agent/human notification attribution and self-notification rules, and TASK-266 for the recurring production `pg@9` client query deprecation warning observed in Vercel logs.
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -9,16 +9,19 @@ Use this file to capture tasks discovered during development. Each entry should 
   Status: Next
   Rationale: Production smoke proved notification email grouping works only when the protected dispatcher is invoked manually. Vercel will remain on the Hobby plan, so Vercel Cron cannot provide the sub-hour cadence required by TASK-227 notification email debounce/max-delay behavior. Provision an Upstash QStash Schedule, or an equivalent managed HTTP scheduler with retries and visibility, to invoke `GET /api/cron/notification-emails` every 5 minutes with the protected dispatch header. Document scheduler ownership, redaction/retry settings, and run a production smoke proving due groups are sent automatically without exposing secrets.
   Dependencies: TASK-125, TASK-227
+  Brief: `tasks/task-228-qstash-notification-email-scheduler-activation.md`
 - ID: TASK-265
   Title: Notification actor attribution and self-notification rules
   Status: Next
   Rationale: Production email smoke confirmed the digest shape, but agent-authored assignment/mention copy can read as if the human account performed the action (for example `dorian1 assigned you...`) because agent API actions currently reuse the credential owner's actor identity. Tighten notification metadata and email/in-app copy so agent activity is attributed to the agent/system, human activity is attributed to the human actor, and self-notifications are consistently suppressed for human self-assignment/self-mention while remaining allowed for genuine agent-to-user activity.
   Dependencies: TASK-123, TASK-124, TASK-127, TASK-227, TASK-260
+  Brief: `tasks/task-265-notification-actor-attribution-and-self-notification-rules.md`
 - ID: TASK-226
   Title: Task due-date email reminders - 3-day deadline warning delivery
   Status: Pending (after TASK-228 scheduler activation)
   Rationale: Send task reminder emails when assigned or owned work is three days from its due date, with idempotent delivery tracking and anti-spam semantics so each reminder fires predictably once per task/user deadline window rather than repeating on every app visit.
   Dependencies: TASK-101, TASK-125, TASK-063, TASK-228
+  Brief: `tasks/task-226-task-due-date-email-reminders.md`
 - ID: TASK-266
   Title: Production pg query deprecation warning cleanup
   Status: Pending

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,45 +1,49 @@
-# Current Task: TASK-264 Notification Backlog Cleanup
+# Current Task: TASK-267 Notification Task Briefs
 
 ## Task ID
-TASK-264
+TASK-267
 
 ## Status
-In progress on dedicated worktree `../nexus_dash_task264` and branch
-`feature/task-264-notification-backlog-cleanup`.
+In progress on dedicated worktree `../nexus_dash_task267` and branch
+`docs/task-267-notification-task-briefs`.
 
 ## Source
-- Post-smoke planning after PR #262 and PR #263 merged.
-- User feedback: `TASK-228` was hard to see from the active checkout, and the
-  backlog should make the next notification path explicit.
-- Production smoke result: grouped notification email delivery works when the
-  dispatcher runs, but QStash/managed scheduler activation is not live.
+- User request to draft dedicated task `.md` briefs for TASK-228, TASK-265, and
+  TASK-226 so a future agent session can take over cleanly.
+- Existing backlog sequence after PR #264: scheduler activation first, actor
+  attribution/self-notification next, then due-date reminders after scheduler
+  activation.
 
 ## Objective
-Clean the backlog so `main` clearly shows the next notification/email work:
-QStash scheduler activation, notification actor attribution/self-notification
-rules, due-date reminder sequencing, and the production `pg@9` deprecation
-warning follow-up.
+Create dedicated task handoff documents for the next notification/email work:
+QStash scheduler activation, notification actor attribution and
+self-notification rules, and task due-date email reminders.
 
 ## Acceptance Criteria
-1. Completed notification/deployment tasks are moved out of the active
-   execution queue.
-2. `TASK-228` is visible as the next scheduler activation task.
-3. A new task captures notification actor attribution and self-notification
-   rules.
-4. The due-date reminder task is sequenced after scheduler activation.
-5. The production `pg@9` warning observed during smoke validation is tracked.
+1. `tasks/task-228-qstash-notification-email-scheduler-activation.md` captures
+   scheduler intent, endpoint contract, acceptance criteria, and smoke plan.
+2. `tasks/task-265-notification-actor-attribution-and-self-notification-rules.md`
+   captures actor attribution and self-notification behavior in enough detail
+   for implementation.
+3. `tasks/task-226-task-due-date-email-reminders.md` captures due-date reminder
+   product rules, sequencing after scheduler activation, and validation plan.
+4. `tasks/backlog.md` links each backlog item to its dedicated task brief.
+5. `journal.md` records the documentation handoff.
 
 ## Definition Of Done
-- `tasks/backlog.md`, `tasks/current.md`, and `journal.md` are updated.
-- Validation is limited to Markdown/task consistency because this is a
-  docs-only cleanup.
-- A ready-for-review PR is opened and checks/Copilot review are monitored.
+- Work remains documentation-only.
+- The branch is pushed and a PR is opened for review.
+- Validation confirms Markdown/task consistency.
+- Copilot review and checks are monitored.
 
 ## Validation Plan
 - `git diff --check`
-- Review changed Markdown for duplicate task IDs and execution queue order.
+- Review the three task files for actionable startup context, acceptance
+  criteria, validation plans, and explicit out-of-scope boundaries.
+- Review `tasks/backlog.md` links to the new briefs.
 
 ## Out Of Scope
 - Implementing QStash.
 - Changing notification/email runtime behavior.
-- Fixing `pg@9` deprecation warnings.
+- Implementing actor attribution behavior.
+- Implementing due-date reminders.

--- a/tasks/task-226-task-due-date-email-reminders.md
+++ b/tasks/task-226-task-due-date-email-reminders.md
@@ -1,0 +1,184 @@
+# TASK-226 Task Due-Date Email Reminders
+
+Date: 2026-05-16
+Branch: `feature/task-226-task-due-date-email-reminders`
+
+## Summary
+
+Implement task due-date reminder business logic so users receive a predictable
+email reminder when assigned or owned work is three days from its due date.
+
+This task should start only after TASK-228 has activated a production scheduler.
+The reminder logic should reuse the production-grade outbound email and
+notification email orchestration foundations instead of inventing a separate
+cron-only path.
+
+## Product Intent
+
+Users should be nudged before work becomes urgent, without repeated reminder
+spam.
+
+Default product rule:
+
+- Send one reminder per task, recipient, and due-date window when the task is
+  three calendar days from its deadline.
+- If a due date changes, treat the new deadline as a new reminder window only
+  when it becomes eligible again.
+- Do not send reminders for completed work.
+- Do not send reminders to users who no longer have access to the project.
+- Do not send reminders on every app visit or every scheduler invocation.
+
+## Current Context
+
+- Tasks currently store `deadlineAt` as a date-only value.
+- Existing task APIs expose `deadlineDate`.
+- TASK-227 added notification email orchestration with durable grouping,
+  debounce, idempotent delivery recording, and a protected dispatcher.
+- TASK-228 owns the production scheduler needed to call the dispatcher
+  automatically.
+- The in-app notification center should remain the durable source of truth for
+  notification email delivery unless this task deliberately documents and
+  justifies an email-only exception.
+
+## Design Recommendation
+
+Prefer creating a durable in-app notification for each eligible task reminder,
+then queueing that notification into the existing notification email
+orchestration.
+
+Suggested source identity:
+
+```text
+sourceType: task_due_date_reminder
+sourceId: <taskId>:<recipientUserId>:<deadlineDate>
+```
+
+Suggested notification type:
+
+```text
+task_due_date_reminder
+```
+
+Suggested metadata:
+
+- `taskId`
+- `taskTitle`
+- `projectId`
+- `projectName`
+- `recipientUserId`
+- `deadlineDate`
+- `daysUntilDue`
+- `targetPath`
+
+If the final implementation uses a separate reminder table instead, it must
+still provide durable idempotency and clear observability equivalent to the
+notification/email state used by TASK-227.
+
+## Eligibility Questions To Resolve In Code
+
+Before implementation, inspect the data model and decide:
+
+- Who receives reminders?
+  - assigned user if the task has an assignee
+  - owner/creator when there is no assignee
+  - both owner and assignee only if that matches existing product language
+- Which statuses count as completed?
+  - likely exclude `Done`
+  - confirm current task status enum/constants
+- How date-only deadlines are interpreted across time zones.
+  - Prefer calendar-day comparison through existing `lib/task-deadline` helpers
+    if they fit.
+- How reminder idempotency behaves if the deadline changes away and then back.
+
+Record the decisions in `tasks/current.md` and `journal.md` before coding.
+
+## Files To Inspect First
+
+- `agent.md`
+- `tasks/current.md`
+- `tasks/backlog.md`
+- `project.md`
+- `README.md`
+- `lib/task-deadline.ts`
+- `lib/services/project-task-service.ts`
+- `lib/services/notification-service.ts`
+- `lib/services/project-notification-email-service.ts`
+- `lib/services/outbound-email-templates.ts`
+- `app/api/cron/notification-emails/route.ts`
+- `prisma/schema.prisma`
+- tests for task deadlines, task service, notification service, email
+  orchestration, and dispatch endpoint
+
+## Implementation Guidance
+
+1. Start from TASK-228's scheduler reality. Do not build a second unrelated
+   scheduler.
+2. Add task reminder notification type and metadata mapping in the service
+   layer.
+3. Add a reminder discovery/reconciliation function that finds reminders due in
+   the three-day window.
+4. Make reminder discovery idempotent under repeated scheduler calls and safe
+   under concurrent invocations.
+5. Queue reminder notifications into the existing email orchestration.
+6. Extend email templates with concise due-date reminder copy.
+7. Ensure reminders do not mark existing notifications read/resolved.
+8. Keep API routes and cron handlers thin.
+9. Keep persistence access inside `lib/services/**`.
+10. Add a production smoke plan that does not expose secrets.
+
+## Acceptance Criteria
+
+1. A task due in three days creates exactly one reminder per eligible recipient
+   for that task/deadline window.
+2. Repeated scheduler/dispatcher calls do not create duplicate reminders or
+   duplicate emails.
+3. Completed tasks do not generate due-date reminders.
+4. Tasks without due dates do not generate due-date reminders.
+5. Users without project access do not receive reminders.
+6. Changing a task deadline is handled deterministically and is covered by
+   tests.
+7. Reminder emails use the shared outbound email foundation and existing email
+   delivery observability.
+8. Reminder notifications, if created in-app, remain unread/read independent of
+   email delivery.
+9. Tests cover eligibility, idempotency, date-window boundaries, completed task
+   exclusion, provider failure, and scheduler integration.
+10. README, runbook, `journal.md`, `tasks/backlog.md`, and `tasks/current.md`
+    are updated with the final behavior.
+
+## Validation Plan
+
+Local and CI:
+
+- `npm run lint`
+- `npm test`
+- `npm run test:coverage`
+- `npm run build`
+
+Focused tests to add or update:
+
+- `tests/lib/task-deadline.test.ts`
+- `tests/lib/notification-service.test.ts`
+- `tests/lib/project-notification-email-service.test.ts`
+- `tests/lib/outbound-email-templates.test.ts`
+- route or service tests for scheduler/dispatcher integration
+
+Production smoke after merge/deploy:
+
+1. Create or identify a production test project and task visible to
+   `dorian.agaesse@gmail.com`.
+2. Set the task due date to exactly three calendar days from the smoke date.
+3. Let the scheduler run.
+4. Confirm one reminder notification/email is created.
+5. Re-run or wait for another scheduler cycle.
+6. Confirm no duplicate reminder is sent.
+7. Mark the in-app notification read and confirm email delivery did not depend
+   on read state.
+
+## Out Of Scope
+
+- Scheduler provisioning; that is TASK-228.
+- Actor attribution/self-notification cleanup; that is TASK-265.
+- Instant in-app push delivery; that is TASK-263.
+- Reminder preference UI or unsubscribe/suppression preferences unless required
+  by a legal/compliance decision.

--- a/tasks/task-228-qstash-notification-email-scheduler-activation.md
+++ b/tasks/task-228-qstash-notification-email-scheduler-activation.md
@@ -1,0 +1,158 @@
+# TASK-228 QStash Notification Email Scheduler Activation
+
+Date: 2026-05-16
+Branch: `feature/task-228-qstash-notification-email-scheduler-activation`
+
+## Summary
+
+Activate a real production scheduler for notification email dispatch. TASK-227
+implemented durable DB-backed notification email orchestration and the protected
+HTTP dispatcher, and production smoke proved that grouped digest delivery works
+when the dispatcher is invoked manually. What is still missing is an external
+managed scheduler that invokes the dispatcher often enough to honor the
+notification email debounce and one-hour max-delay contract.
+
+Vercel will remain on the current plan, so do not rely on Vercel Cron for this
+feature unless the plan/frequency constraint has changed. Prefer Upstash QStash
+Schedules, or an equivalent managed HTTP scheduler with retries, auditability,
+and operational visibility.
+
+## Current Evidence
+
+- Production digest smoke succeeded after manual invocation of
+  `GET /api/cron/notification-emails`.
+- Immediate dispatch after creating notifications correctly returned no sends
+  because the debounce window was not due.
+- A later manual dispatch sent one grouped recipient email containing multiple
+  notification items.
+- A repeat manual dispatch sent nothing, proving idempotency for the tested
+  batch.
+- QStash is not currently live: no configured scheduler was observed, and due
+  email groups did not send automatically during smoke.
+
+## Product Intent
+
+Users should receive useful email notifications without email spam:
+
+- The in-app notification center remains the source of truth.
+- Email dispatch groups due project notification groups by recipient.
+- Normal project activity uses debounce semantics:
+  - wait for the group to become quiet
+  - do not delay the first unsent activity by more than about one hour
+- Project invitation reminders fire once when a verified invitee has not
+  opened, accepted, or declined within the reminder window.
+- Scheduler cadence should be frequent enough that the email service, not the
+  scheduler, owns the user-facing quiet-window timing.
+
+## Existing Endpoint Contract
+
+The app already exposes:
+
+```text
+GET /api/cron/notification-emails
+```
+
+Production URL:
+
+```text
+https://nexus-dash.app/api/cron/notification-emails
+```
+
+Accepted auth headers:
+
+```text
+x-notification-email-dispatch-secret: <NOTIFICATION_EMAIL_DISPATCH_SECRET>
+```
+
+or:
+
+```text
+Authorization: Bearer <NOTIFICATION_EMAIL_DISPATCH_SECRET>
+```
+
+The secret is resolved through `lib/env.server.ts`. Do not print, log, commit,
+or paste the secret.
+
+## Implementation Guidance
+
+1. Confirm the endpoint still passes authorization tests and local smoke.
+2. Provision an Upstash QStash Schedule, or document why an equivalent managed
+   scheduler is being used instead.
+3. Configure it to invoke the production endpoint every 5 minutes.
+4. Send the configured dispatch secret through an HTTP header, preferably
+   `x-notification-email-dispatch-secret`.
+5. Enable provider retry/visibility features, but make app idempotency the
+   primary duplicate-send defense.
+6. Update docs with:
+   - scheduler provider
+   - cadence
+   - target URL
+   - auth header name, not value
+   - ownership and rotation notes
+   - how to pause/disable the schedule
+   - how to inspect scheduler deliveries
+7. Keep GitHub Actions dispatch as manual diagnostic tooling only, or remove it
+   if it is misleading and no longer useful.
+
+## Files To Inspect First
+
+- `agent.md`
+- `tasks/current.md`
+- `tasks/backlog.md`
+- `tasks/task-227-production-grade-notification-email-orchestration.md`
+- `README.md`
+- `docs/runbooks/vercel-env-contract-and-secrets.md`
+- `app/api/cron/notification-emails/route.ts`
+- `lib/env.server.ts`
+- `lib/services/project-notification-email-service.ts`
+- `.github/workflows/notification-email-dispatch.yml`
+- `journal.md` entries for TASK-125, TASK-225, TASK-227, PR #254, PR #262,
+  PR #263, and the production smoke
+
+## Acceptance Criteria
+
+1. Production has a managed scheduler invoking
+   `GET https://nexus-dash.app/api/cron/notification-emails` every 5 minutes.
+2. The scheduler uses the protected dispatch secret without exposing the value
+   in code, logs, docs, GitHub comments, or screenshots.
+3. Manual endpoint invocation remains possible for preview/diagnostic smoke.
+4. GitHub Actions is not the primary production scheduler.
+5. A due notification email group sends automatically without manual endpoint
+   invocation.
+6. Repeated scheduler calls do not produce duplicate emails.
+7. Scheduler delivery failures are observable through the chosen provider.
+8. README, runbook, `journal.md`, `tasks/backlog.md`, and `tasks/current.md`
+   reflect the final operational contract.
+
+## Validation Plan
+
+Local and CI:
+
+- `npm run lint`
+- `npm test`
+- `npm run test:coverage`
+- `npm run build`
+
+Focused:
+
+- `npm test -- --run tests/api/notification-email-dispatch.route.test.ts`
+- `npm test -- --run tests/lib/project-notification-email-service.test.ts`
+
+Production smoke:
+
+1. Create one or more email-eligible notifications for
+   `dorian.agaesse@gmail.com`.
+2. Confirm the notification appears in-app.
+3. Do not manually invoke the dispatcher after the initial setup check.
+4. Wait beyond the debounce window plus one scheduler cadence.
+5. Confirm one grouped email arrives.
+6. Confirm the email links work.
+7. Confirm a later scheduler invocation does not duplicate the email.
+8. Confirm scheduler logs show successful invocations without secret exposure.
+
+## Out Of Scope
+
+- Changing notification grouping semantics.
+- Implementing due-date reminder business logic; that is TASK-226.
+- Changing actor attribution or self-notification rules; that is TASK-265.
+- Adding instant in-app push behavior; that is TASK-263.

--- a/tasks/task-265-notification-actor-attribution-and-self-notification-rules.md
+++ b/tasks/task-265-notification-actor-attribution-and-self-notification-rules.md
@@ -1,0 +1,166 @@
+# TASK-265 Notification Actor Attribution And Self-Notification Rules
+
+Date: 2026-05-16
+Branch: `feature/task-265-notification-actor-attribution-self-notification`
+
+## Summary
+
+Make notification copy and notification creation rules correctly distinguish
+human-authored activity from agent-authored activity, and suppress human
+self-notifications where they do not make product sense.
+
+Production notification email smoke confirmed that digest grouping works, but
+agent-authored assignment or mention copy can currently read as if the human
+credential owner performed the action, for example `dorian1 assigned you...`.
+That is confusing when the action came from an agent API credential owned by
+that user.
+
+## Product Intent
+
+Notifications should answer two questions clearly:
+
+- what happened?
+- who or what caused it?
+
+Expected behavior:
+
+- If a human user mentions another user, copy names the human actor.
+- If an agent acts through an agent credential, copy names the agent or clearly
+  says the action came from an agent/system context.
+- If a human user assigns a task to themselves, no assignment notification is
+  created for that human.
+- If a human user mentions themselves, no mention notification is created for
+  that human.
+- If an agent owned by a user assigns or mentions that same user, notification
+  is allowed because the actor is the agent, not a human self-action.
+- In-app notifications stay atomic: one notification per artifact/action.
+- Email digests group those atomic notifications; do not reintroduce in-app
+  grouping in this task.
+
+## Current Likely Root Cause
+
+Agent API requests currently execute with the credential owner's user id as the
+effective actor for authorization/RLS. Notification builders receive fields like
+`actorUserId`, `actorDisplayName`, `authorUsername`, and `authorDisplayName`,
+which can make an agent action look like a direct human action.
+
+The fix should preserve the authorization actor used for RLS while adding or
+passing a separate notification actor identity for display and self-notification
+decisions.
+
+## Recommended Model
+
+Keep two concepts separate:
+
+- authorization actor: the user id used to enforce project access and RLS
+- notification actor: the product actor displayed to recipients and used for
+  self-notification suppression
+
+Suggested notification actor shape:
+
+```ts
+type NotificationActorKind = "user" | "agent" | "system";
+
+interface NotificationActorSummary {
+  kind: NotificationActorKind;
+  userId?: string;
+  displayName: string;
+  credentialId?: string;
+  credentialName?: string;
+}
+```
+
+Implementation does not have to use this exact type, but metadata should remain
+durable and explicit enough that email templates and in-app notification views
+do not infer actor kind from display text.
+
+## Files To Inspect First
+
+- `agent.md`
+- `tasks/current.md`
+- `tasks/backlog.md`
+- `project.md`
+- `README.md`
+- `lib/services/notification-service.ts`
+- `lib/services/project-notification-email-service.ts`
+- `lib/services/outbound-email-templates.ts`
+- `lib/services/project-task-service.ts`
+- `lib/services/project-agent-access-service.ts`
+- `app/api/projects/[projectId]/tasks/route.ts`
+- `app/api/projects/[projectId]/tasks/[taskId]/comments/route.ts`
+- agent API task/comment routes under `app/api/agent/**`, if present
+- tests covering task assignment, task comments, notification service, and email
+  templates
+
+## Implementation Guidance
+
+1. Trace all notification producers for:
+   - task assignments
+   - task comment mentions
+   - project invitations, if actor copy is touched
+2. Identify how agent-authenticated task/comment writes pass actor identity.
+3. Add an explicit actor summary at the service boundary instead of only passing
+   display strings.
+4. Store actor kind and stable actor fields in notification metadata.
+5. Update in-app notification body generation to use the actor summary.
+6. Update email digest rendering to use the same durable metadata.
+7. Suppress notifications only when the actor is a human user and
+   `actor.userId === recipientUserId`.
+8. Do not suppress agent-to-owner notifications solely because the agent
+   credential belongs to that user.
+9. Keep routes thin; service-layer notification logic should own the rules.
+10. Avoid broad notification schema rewrites unless they are required for
+    durable metadata.
+
+## Acceptance Criteria
+
+1. Human self-assignment does not create an in-app notification or queued email.
+2. Human self-mention does not create an in-app notification or queued email.
+3. Human-to-other-user assignment and mention still create one atomic in-app
+   notification per action.
+4. Agent-to-user assignment and mention create notifications even when the
+   credential owner is the recipient.
+5. Agent-authored notification copy clearly attributes the action to an agent,
+   not to the credential owner's human display name.
+6. Email digest copy uses the same actor attribution as the in-app
+   notification.
+7. Existing TASK-260 behavior remains intact: in-app notifications are atomic,
+   email digest grouping happens only in the email orchestration layer.
+8. Tests cover human self suppression, human-to-human delivery, agent-to-owner
+   delivery, and email template copy.
+
+## Validation Plan
+
+Local and CI:
+
+- `npm run lint`
+- `npm test`
+- `npm run test:coverage`
+- `npm run build`
+
+Focused tests to add or update:
+
+- `tests/lib/notification-service.test.ts`
+- `tests/lib/project-notification-email-service.test.ts`
+- `tests/lib/outbound-email-templates.test.ts`
+- task/comment route or service tests for human self-assignment/self-mention
+- agent API tests that prove agent-authored activity is attributed as agent
+
+Manual smoke after production deploy:
+
+1. As a human user, assign a task to yourself.
+2. Confirm no in-app notification is created for that self-assignment.
+3. As a human user, mention yourself in a comment.
+4. Confirm no in-app notification is created for that self-mention.
+5. Through an agent credential, assign or mention the credential owner.
+6. Confirm an in-app notification appears and names the agent/system actor.
+7. Let the email digest send.
+8. Confirm the digest also names the agent/system actor and does not say the
+   human user assigned themselves.
+
+## Out Of Scope
+
+- Adding instant push/SSE/WebSocket updates; that is TASK-263.
+- Changing scheduler activation; that is TASK-228.
+- Implementing due-date reminder business logic; that is TASK-226.
+- Redesigning the notification center UI beyond copy required for attribution.


### PR DESCRIPTION
## Summary
- Add dedicated handoff briefs for TASK-228 QStash scheduler activation, TASK-265 actor attribution/self-notification rules, and TASK-226 due-date email reminders.
- Link the three backlog entries to their new task brief files.
- Update `tasks/current.md` and `journal.md` for the docs-only handoff task.

## Validation
- `git diff --check HEAD~1 HEAD`
- Reviewed task IDs, backlog links, acceptance criteria, validation plans, and out-of-scope boundaries

## Notes
- Documentation-only change. No runtime behavior changes.
- TASK-228, TASK-265, and TASK-226 remain separate implementation tasks.