### PR TITLE
TASK-132 align app version metadata

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,12 @@
 NODE_ENV=development
 APP_PORT=3000
-# Optional app metadata overrides (used in UI chips/footers).
+# Optional app metadata overrides. Local development normally falls back to
+# package.json version and the default repository URL. GitHub/Vercel deploy
+# workflows inject APP_VERSION, APP_ENV, COMMIT_SHA, and APP_REPOSITORY_URL from
+# the checked-out release ref.
 APP_VERSION=
+APP_ENV=
+COMMIT_SHA=
 APP_REPOSITORY_URL=
 
 # Google OAuth / Calendar

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -121,6 +121,17 @@ jobs:
           node-version: 20
           cache: npm
 
+      - name: Resolve app metadata
+        run: |
+          app_version="$(node -p "require('./package.json').version")"
+          commit_sha="$(git rev-parse HEAD)"
+          repository_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+
+          echo "APP_VERSION=$app_version" >> "$GITHUB_ENV"
+          echo "APP_ENV=production" >> "$GITHUB_ENV"
+          echo "COMMIT_SHA=$commit_sha" >> "$GITHUB_ENV"
+          echo "APP_REPOSITORY_URL=$repository_url" >> "$GITHUB_ENV"
+
       - name: Install dependencies
         run: npm ci
 
@@ -149,12 +160,28 @@ jobs:
         run: npx vercel@${VERCEL_CLI_VERSION} pull --yes --environment=production --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN"
 
       - name: Build prebuilt artifact (production)
-        run: npx vercel@${VERCEL_CLI_VERSION} build --prod --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN"
+        run: |
+          APP_VERSION="$APP_VERSION" \
+          APP_ENV="$APP_ENV" \
+          COMMIT_SHA="$COMMIT_SHA" \
+          APP_REPOSITORY_URL="$APP_REPOSITORY_URL" \
+            npx vercel@${VERCEL_CLI_VERSION} build --prod --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN"
 
       - name: Deploy staged production build
         id: deploy_staged
         run: |
-          deployment_url=$(npx vercel@${VERCEL_CLI_VERSION} deploy --prebuilt --prod --skip-domain --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN")
+          deployment_url=$(
+            npx vercel@${VERCEL_CLI_VERSION} deploy \
+              --prebuilt \
+              --prod \
+              --skip-domain \
+              --scope="$VERCEL_SCOPE" \
+              --token="$VERCEL_TOKEN" \
+              -e "APP_VERSION=$APP_VERSION" \
+              -e "APP_ENV=$APP_ENV" \
+              -e "COMMIT_SHA=$COMMIT_SHA" \
+              -e "APP_REPOSITORY_URL=$APP_REPOSITORY_URL"
+          )
           echo "deployment_url=$deployment_url" >> "$GITHUB_OUTPUT"
           echo "$deployment_url" > staged-production-deployment.txt
 
@@ -169,6 +196,8 @@ jobs:
         run: |
           echo "## Staged production deployment created" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- App version: \`$APP_VERSION\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- App revision: \`${COMMIT_SHA:0:7}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- URL: \`${{ steps.deploy_staged.outputs.deployment_url }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Next step: run workflow dispatch with \`action=promote\` to promote this deployment." >> "$GITHUB_STEP_SUMMARY"
 
@@ -259,6 +288,22 @@ jobs:
           node-version: 20
           cache: npm
 
+      - name: Resolve app metadata
+        if: ${{ inputs.action == 'deploy-preview' || inputs.action == 'deploy-production-staged' }}
+        run: |
+          app_version="$(node -p "require('./package.json').version")"
+          commit_sha="$(git rev-parse HEAD)"
+          repository_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+          app_env="production"
+          if [ "${{ inputs.action }}" = "deploy-preview" ]; then
+            app_env="preview"
+          fi
+
+          echo "APP_VERSION=$app_version" >> "$GITHUB_ENV"
+          echo "APP_ENV=$app_env" >> "$GITHUB_ENV"
+          echo "COMMIT_SHA=$commit_sha" >> "$GITHUB_ENV"
+          echo "APP_REPOSITORY_URL=$repository_url" >> "$GITHUB_ENV"
+
       - name: Install dependencies
         if: ${{ inputs.action == 'deploy-preview' || inputs.action == 'deploy-production-staged' }}
         run: npm ci
@@ -306,8 +351,23 @@ jobs:
         id: deploy_preview
         run: |
           npx vercel@${VERCEL_CLI_VERSION} pull --yes --environment=preview --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN"
-          npx vercel@${VERCEL_CLI_VERSION} build --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN"
-          deployment_url=$(npx vercel@${VERCEL_CLI_VERSION} deploy --prebuilt --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN" -e "RESEND_API_KEY=$RESEND_API_KEY" -e "AGENT_TOKEN_SIGNING_SECRET=$AGENT_TOKEN_SIGNING_SECRET")
+          APP_VERSION="$APP_VERSION" \
+          APP_ENV="$APP_ENV" \
+          COMMIT_SHA="$COMMIT_SHA" \
+          APP_REPOSITORY_URL="$APP_REPOSITORY_URL" \
+            npx vercel@${VERCEL_CLI_VERSION} build --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN"
+          deployment_url=$(
+            npx vercel@${VERCEL_CLI_VERSION} deploy \
+              --prebuilt \
+              --scope="$VERCEL_SCOPE" \
+              --token="$VERCEL_TOKEN" \
+              -e "RESEND_API_KEY=$RESEND_API_KEY" \
+              -e "AGENT_TOKEN_SIGNING_SECRET=$AGENT_TOKEN_SIGNING_SECRET" \
+              -e "APP_VERSION=$APP_VERSION" \
+              -e "APP_ENV=$APP_ENV" \
+              -e "COMMIT_SHA=$COMMIT_SHA" \
+              -e "APP_REPOSITORY_URL=$APP_REPOSITORY_URL"
+          )
           echo "deployment_url=$deployment_url" >> "$GITHUB_OUTPUT"
           echo "$deployment_url" > preview-deployment.txt
 
@@ -316,8 +376,23 @@ jobs:
         id: deploy_prod_staged
         run: |
           npx vercel@${VERCEL_CLI_VERSION} pull --yes --environment=production --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN"
-          npx vercel@${VERCEL_CLI_VERSION} build --prod --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN"
-          deployment_url=$(npx vercel@${VERCEL_CLI_VERSION} deploy --prebuilt --prod --skip-domain --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN")
+          APP_VERSION="$APP_VERSION" \
+          APP_ENV="$APP_ENV" \
+          COMMIT_SHA="$COMMIT_SHA" \
+          APP_REPOSITORY_URL="$APP_REPOSITORY_URL" \
+            npx vercel@${VERCEL_CLI_VERSION} build --prod --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN"
+          deployment_url=$(
+            npx vercel@${VERCEL_CLI_VERSION} deploy \
+              --prebuilt \
+              --prod \
+              --skip-domain \
+              --scope="$VERCEL_SCOPE" \
+              --token="$VERCEL_TOKEN" \
+              -e "APP_VERSION=$APP_VERSION" \
+              -e "APP_ENV=$APP_ENV" \
+              -e "COMMIT_SHA=$COMMIT_SHA" \
+              -e "APP_REPOSITORY_URL=$APP_REPOSITORY_URL"
+          )
           echo "deployment_url=$deployment_url" >> "$GITHUB_OUTPUT"
           echo "$deployment_url" > staged-production-deployment.txt
 
@@ -390,6 +465,12 @@ jobs:
           echo "## Manual Vercel operation" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- Action: \`${{ inputs.action }}\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "${APP_VERSION:-}" ]; then
+            echo "- App version: \`$APP_VERSION\`" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ -n "${COMMIT_SHA:-}" ]; then
+            echo "- App revision: \`${COMMIT_SHA:0:7}\`" >> "$GITHUB_STEP_SUMMARY"
+          fi
           if [ "${{ inputs.action }}" = "deploy-preview" ]; then
             if [ -n "${{ steps.deploy_preview.outputs.deployment_url }}" ]; then
               echo "- Preview URL: \`${{ steps.deploy_preview.outputs.deployment_url }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -168,6 +168,15 @@ Environment access/validation is centralized in `lib/env.server.ts` and executed
 
 ### Additional rules
 
+- `APP_VERSION` is optional locally and should normally be omitted. When unset,
+  the app reads the product version from `package.json`.
+- `APP_ENV` is optional locally and may be `development`, `preview`,
+  `production`, or `test`. Vercel deploy workflows inject it for preview and
+  production deploys.
+- `COMMIT_SHA` is optional locally and is used only as diagnostic build
+  metadata. The user-facing app version does not include the commit SHA.
+- `APP_REPOSITORY_URL` is optional and defaults to the NexusDash GitHub
+  repository.
 - In production, when Google OAuth is enabled, `GOOGLE_TOKEN_ENCRYPTION_KEY` is required.
 - `AGENT_ACCESS_TOKEN_TTL_SECONDS` is optional, defaults to `600`, and must stay between `300` and `900`.
 - `GOOGLE_CALENDAR_ID` must be unset or `primary`.
@@ -351,6 +360,30 @@ Branch-name note:
 - human-authored PR branches must use `feature/*`, `fix/*`, `refactor/*`,
   `docs/*`, or `chore/*`
 - Dependabot PR branches may use `dependabot/*`
+
+### Release version metadata
+
+`package.json` is the canonical product-version source. Release PRs that
+intentionally change the product version must update both `package.json` and
+`package-lock.json`; Dependabot maintenance PRs must not bump the product
+version by themselves.
+
+The running app displays only the clean product version, for example `v0.2.0`.
+Build revision and runtime environment are kept as diagnostic metadata so
+operators can identify the deployed commit without turning the user-facing
+version into `v0.2.0+<sha>`.
+
+The Vercel deploy workflow resolves metadata from the checked-out ref and
+injects:
+
+- `APP_VERSION`: product version from `package.json`
+- `APP_ENV`: `preview` for preview deploys, `production` for staged production
+- `COMMIT_SHA`: full git commit SHA for diagnostics
+- `APP_REPOSITORY_URL`: GitHub repository URL
+
+After a preview or staged-production deployment, check the workflow summary for
+the resolved app version and short revision. Promoted production keeps the same
+metadata as the staged deployment target.
 
 ### CD workflow
 

--- a/components/app-metadata-pill.tsx
+++ b/components/app-metadata-pill.tsx
@@ -36,7 +36,12 @@ export function AppMetadataPill() {
         <ArrowUpRight className="h-3 w-3" aria-hidden />
       </Link>
       <span className="rounded-full border border-border/70 bg-muted/70 px-2 py-0.5 font-mono text-[11px] text-muted-foreground">
-        {metadata.versionLabel}
+        <span
+          title={metadata.diagnosticLabel}
+          aria-label={metadata.diagnosticLabel}
+        >
+          {metadata.versionLabel}
+        </span>
       </span>
     </div>
   );

--- a/docs/runbooks/vercel-env-contract-and-secrets.md
+++ b/docs/runbooks/vercel-env-contract-and-secrets.md
@@ -24,6 +24,29 @@ Optional but bounded:
 
 - `AGENT_ACCESS_TOKEN_TTL_SECONDS` (`300-900`, default `600`)
 
+## App Metadata
+
+The app displays a clean product version such as `v0.2.0`. The commit SHA is
+not appended to that visible version; it is kept as diagnostic metadata for
+operators.
+
+Source of truth:
+
+- `package.json` is the canonical product-version source.
+- `APP_VERSION` is an environment override. GitHub/Vercel deploy workflows set
+  it from the checked-out `package.json` before deploy.
+- `COMMIT_SHA` identifies the deployed revision. GitHub/Vercel deploy workflows
+  set it from `git rev-parse HEAD`.
+- `APP_ENV` identifies the deployed app environment (`preview` or
+  `production` in the deploy workflow).
+- `APP_REPOSITORY_URL` points metadata links at the repository and is injected
+  by the deploy workflow.
+
+Operators normally do not need to configure these metadata variables manually
+in Vercel. If `APP_VERSION` is set by hand, it must match the intended release
+version from source control rather than a dependency-update or deployment
+attempt number.
+
 ## Database Runtime
 
 Required for Vercel runtime/deployments:

--- a/journal.md
+++ b/journal.md
@@ -30,7 +30,8 @@ Use it for important implementation milestones, blockers, validation runs, and r
   but was blocked by preview database env configuration.
 - Evidence: Workflow run `26104594474` used workflow ref
   `feature/task-132-version-update-system`, checked out
-  `origin/feature/task-132-version-update-system`, and resolved
+  `origin/feature/task-132-version-update-system` at commit `f197129`
+  before later documentation-only tracking updates, and resolved
   `APP_VERSION=0.2.0`, `APP_ENV=preview`, `COMMIT_SHA=f1971290c4909284e2a9f00fccb4dc52b816b892`,
   and `APP_REPOSITORY_URL=https://github.com/dorianagaesse/nexus_dash`. The
   deploy failed during Vercel preview build because the pulled preview

--- a/journal.md
+++ b/journal.md
@@ -12,6 +12,18 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ## Recent Entries (Most Relevant)
 
+### 2026-05-19
+- Type: Execution
+- Summary: TASK-132 implemented production-grade app version metadata.
+- Evidence: Bumped `package.json`/`package-lock.json` to `0.2.0`; changed
+  `lib/app-metadata.ts` so the visible app label is the clean product version
+  while revision/environment remain diagnostic metadata; updated
+  `components/app-metadata-pill.tsx`, Vercel deploy metadata injection,
+  `.env.example`, README, and the Vercel env runbook. Validation passed with
+  focused metadata tests, lint, full Vitest, coverage, production build, and
+  `git diff --check`; DB-backed tests used a temporary PostgreSQL 16 instance
+  on port `55432` because Docker was not running.
+
 ### 2026-05-16
 - Type: Planning
 - Summary: TASK-267 drafted dedicated handoff briefs for the next notification/email tasks.

--- a/journal.md
+++ b/journal.md
@@ -24,6 +24,19 @@ Use it for important implementation milestones, blockers, validation runs, and r
   `git diff --check`; DB-backed tests used a temporary PostgreSQL 16 instance
   on port `55432` because Docker was not running.
 
+### 2026-05-19
+- Type: Validation
+- Summary: TASK-132 branch-scoped preview workflow reached metadata resolution
+  but was blocked by preview database env configuration.
+- Evidence: Workflow run `26104298738` used workflow ref
+  `feature/task-132-version-update-system`, checked out
+  `origin/feature/task-132-version-update-system`, and resolved
+  `APP_VERSION=0.2.0`, `APP_ENV=preview`, `COMMIT_SHA=282a133b0ee986f1012ea4d7e66cbbe9fccf5e93`,
+  and `APP_REPOSITORY_URL=https://github.com/dorianagaesse/nexus_dash`. The
+  deploy failed during Vercel preview build because the pulled preview
+  `DATABASE_URL` still uses the Supabase session-pooler port `5432`; the
+  existing runtime guard requires transaction-pooler port `6543`.
+
 ### 2026-05-16
 - Type: Planning
 - Summary: TASK-267 drafted dedicated handoff briefs for the next notification/email tasks.

--- a/journal.md
+++ b/journal.md
@@ -28,10 +28,10 @@ Use it for important implementation milestones, blockers, validation runs, and r
 - Type: Validation
 - Summary: TASK-132 branch-scoped preview workflow reached metadata resolution
   but was blocked by preview database env configuration.
-- Evidence: Workflow run `26104298738` used workflow ref
+- Evidence: Workflow run `26104594474` used workflow ref
   `feature/task-132-version-update-system`, checked out
   `origin/feature/task-132-version-update-system`, and resolved
-  `APP_VERSION=0.2.0`, `APP_ENV=preview`, `COMMIT_SHA=282a133b0ee986f1012ea4d7e66cbbe9fccf5e93`,
+  `APP_VERSION=0.2.0`, `APP_ENV=preview`, `COMMIT_SHA=f1971290c4909284e2a9f00fccb4dc52b816b892`,
   and `APP_REPOSITORY_URL=https://github.com/dorianagaesse/nexus_dash`. The
   deploy failed during Vercel preview build because the pulled preview
   `DATABASE_URL` still uses the Supabase session-pooler port `5432`; the

--- a/lib/app-metadata.ts
+++ b/lib/app-metadata.ts
@@ -1,6 +1,14 @@
 import packageJson from "@/package.json";
 
 const DEFAULT_REPOSITORY_URL = "https://github.com/dorianagaesse/nexus_dash";
+const SEMVER_WITH_OPTIONAL_PRERELEASE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+
+export type AppRuntimeEnvironment =
+  | "production"
+  | "preview"
+  | "development"
+  | "test"
+  | "unknown";
 
 function readOptionalEnv(name: string): string | null {
   const value = process.env[name];
@@ -12,23 +20,34 @@ function readOptionalEnv(name: string): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
-function normalizeVersion(rawVersion: string): string {
+function normalizeVersion(rawVersion: string, fallbackVersion = "0.0.0"): string {
   const trimmed = rawVersion.trim();
   if (!trimmed) {
+    return normalizeVersion(fallbackVersion, "0.0.0");
+  }
+
+  const withoutPrefix = trimmed.startsWith("v") ? trimmed.slice(1) : trimmed;
+  const visibleVersion = withoutPrefix.split("+")[0] ?? "";
+  if (!SEMVER_WITH_OPTIONAL_PRERELEASE.test(visibleVersion)) {
+    if (fallbackVersion !== rawVersion) {
+      return normalizeVersion(fallbackVersion, "0.0.0");
+    }
+
     return "v0.0.0";
   }
 
-  return trimmed.startsWith("v") ? trimmed : `v${trimmed}`;
+  return `v${visibleVersion}`;
 }
 
 function readVersion(): string {
+  const packageVersion = packageJson.version ?? "0.0.0";
   const configuredVersion =
     readOptionalEnv("APP_VERSION") ?? readOptionalEnv("NEXT_PUBLIC_APP_VERSION");
   if (configuredVersion) {
-    return normalizeVersion(configuredVersion);
+    return normalizeVersion(configuredVersion, packageVersion);
   }
 
-  return normalizeVersion(packageJson.version ?? "0.0.0");
+  return normalizeVersion(packageVersion);
 }
 
 function readRevision(): string | null {
@@ -41,6 +60,31 @@ function readRevision(): string | null {
   }
 
   return revision.slice(0, 7);
+}
+
+function normalizeRuntimeEnvironment(rawEnvironment: string | null): AppRuntimeEnvironment {
+  switch (rawEnvironment?.toLowerCase()) {
+    case "production":
+      return "production";
+    case "preview":
+      return "preview";
+    case "development":
+    case "dev":
+      return "development";
+    case "test":
+      return "test";
+    default:
+      return "unknown";
+  }
+}
+
+function readRuntimeEnvironment(): AppRuntimeEnvironment {
+  return normalizeRuntimeEnvironment(
+    readOptionalEnv("APP_ENV") ??
+      readOptionalEnv("NEXT_PUBLIC_APP_ENV") ??
+      readOptionalEnv("VERCEL_ENV") ??
+      readOptionalEnv("NODE_ENV")
+  );
 }
 
 function normalizeRepositoryUrl(rawUrl: string | null): string {
@@ -77,16 +121,28 @@ export interface AppMetadataSummary {
   versionTag: string;
   versionLabel: string;
   revision: string | null;
+  revisionLabel: string | null;
+  environment: AppRuntimeEnvironment;
+  diagnosticLabel: string;
 }
 
 export function getAppMetadataSummary(): AppMetadataSummary {
   const versionTag = readVersion();
   const revision = readRevision();
+  const revisionLabel = revision ? `build ${revision}` : null;
+  const environment = readRuntimeEnvironment();
+  const diagnosticParts = [versionTag, environment];
+  if (revisionLabel) {
+    diagnosticParts.push(revisionLabel);
+  }
 
   return {
     repositoryUrl: readRepositoryUrl(),
     versionTag,
-    versionLabel: revision ? `${versionTag}+${revision}` : versionTag,
+    versionLabel: versionTag,
     revision,
+    revisionLabel,
+    environment,
+    diagnosticLabel: diagnosticParts.join(" | "),
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexusdash",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexusdash",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1041.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexusdash",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0",

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -40,7 +40,7 @@ Use this file to capture tasks discovered during development. Each entry should 
   Dependencies: TASK-127, TASK-130, TASK-059
 - ID: TASK-132
   Title: Version update system adjustments - align version metadata, automation, and release communication
-  Status: In progress
+  Status: In review via PR #270
   Rationale: Review and adjust the app's version update system so version metadata, dependency-update cadence, release notes, deployment visibility, and any user-facing update indicators stay consistent across automated maintenance, manual releases, and future API or agent-facing surfaces.
   Dependencies: TASK-041, TASK-042, TASK-116
 - ID: TASK-129

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -40,7 +40,7 @@ Use this file to capture tasks discovered during development. Each entry should 
   Dependencies: TASK-127, TASK-130, TASK-059
 - ID: TASK-132
   Title: Version update system adjustments - align version metadata, automation, and release communication
-  Status: Pending
+  Status: In progress
   Rationale: Review and adjust the app's version update system so version metadata, dependency-update cadence, release notes, deployment visibility, and any user-facing update indicators stay consistent across automated maintenance, manual releases, and future API or agent-facing surfaces.
   Dependencies: TASK-041, TASK-042, TASK-116
 - ID: TASK-129

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -5,7 +5,7 @@ TASK-132
 
 ## Status
 Implemented locally on branch `feature/task-132-version-update-system`;
-preview/PR handoff pending.
+PR #270 opened; preview deploy blocked by existing preview database env shape.
 
 ## Source
 - `tasks/backlog.md` pending entry:
@@ -119,10 +119,16 @@ of truth for build and release metadata.
 - `npm run build` - passed after `npx prisma generate` refreshed the local
   Prisma client
 - `git diff --check` - passed
-- If deploy workflow behavior changes:
-  `gh workflow run deploy-vercel.yml -f action=deploy-preview -f git_ref=feature/task-132-version-update-system`,
-  then verify the workflow logs and preview metadata label match the active
-  branch/revision.
+- Preview workflow run `26104298738` used the branch workflow ref
+  `feature/task-132-version-update-system` and checked out
+  `origin/feature/task-132-version-update-system` at commit `282a133`.
+- Run `26104298738` proved the new metadata resolution step produced
+  `APP_VERSION=0.2.0`, `APP_ENV=preview`, `COMMIT_SHA=282a133b0ee986f1012ea4d7e66cbbe9fccf5e93`,
+  and `APP_REPOSITORY_URL=https://github.com/dorianagaesse/nexus_dash`.
+- Preview deployment did not complete because the pulled Vercel preview
+  `DATABASE_URL` still uses the Supabase session-pooler port `5432`; the
+  existing production runtime guard correctly rejects that shape and requires
+  the transaction pooler port `6543`.
 
 ## Out Of Scope
 - Building a public changelog or release-notes product surface unless required

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -119,11 +119,11 @@ of truth for build and release metadata.
 - `npm run build` - passed after `npx prisma generate` refreshed the local
   Prisma client
 - `git diff --check` - passed
-- Preview workflow run `26104298738` used the branch workflow ref
+- Preview workflow run `26104594474` used the branch workflow ref
   `feature/task-132-version-update-system` and checked out
-  `origin/feature/task-132-version-update-system` at commit `282a133`.
-- Run `26104298738` proved the new metadata resolution step produced
-  `APP_VERSION=0.2.0`, `APP_ENV=preview`, `COMMIT_SHA=282a133b0ee986f1012ea4d7e66cbbe9fccf5e93`,
+  `origin/feature/task-132-version-update-system` at commit `f197129`.
+- Run `26104594474` proved the new metadata resolution step produced
+  `APP_VERSION=0.2.0`, `APP_ENV=preview`, `COMMIT_SHA=f1971290c4909284e2a9f00fccb4dc52b816b892`,
   and `APP_REPOSITORY_URL=https://github.com/dorianagaesse/nexus_dash`.
 - Preview deployment did not complete because the pulled Vercel preview
   `DATABASE_URL` still uses the Supabase session-pooler port `5432`; the

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -122,6 +122,7 @@ of truth for build and release metadata.
 - Preview workflow run `26104594474` used the branch workflow ref
   `feature/task-132-version-update-system` and checked out
   `origin/feature/task-132-version-update-system` at commit `f197129`.
+  Later commits only refresh validation/tracking documentation.
 - Run `26104594474` proved the new metadata resolution step produced
   `APP_VERSION=0.2.0`, `APP_ENV=preview`, `COMMIT_SHA=f1971290c4909284e2a9f00fccb4dc52b816b892`,
   and `APP_REPOSITORY_URL=https://github.com/dorianagaesse/nexus_dash`.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,49 +1,146 @@
-# Current Task: TASK-267 Notification Task Briefs
+# Current Task: TASK-132 Version Update System Adjustments
 
 ## Task ID
-TASK-267
+TASK-132
 
 ## Status
-In progress on dedicated worktree `../nexus_dash_task267` and branch
-`docs/task-267-notification-task-briefs`.
+Implemented locally on branch `feature/task-132-version-update-system`;
+preview/PR handoff pending.
 
 ## Source
-- User request to draft dedicated task `.md` briefs for TASK-228, TASK-265, and
-  TASK-226 so a future agent session can take over cleanly.
-- Existing backlog sequence after PR #264: scheduler activation first, actor
-  attribution/self-notification next, then due-date reminders after scheduler
-  activation.
+- `tasks/backlog.md` pending entry:
+  "Version update system adjustments - align version metadata, automation, and
+  release communication."
+- Existing product metadata surface from TASK-087:
+  `lib/app-metadata.ts`, `components/app-metadata-pill.tsx`, and
+  `tests/lib/app-metadata.test.ts`.
+- Existing maintenance/release automation:
+  `.github/dependabot.yml`, `.github/workflows/dependabot-auto-triage.yml`,
+  `.github/workflows/dependabot-repair-agent.yml`, and
+  `.github/workflows/deploy-vercel.yml`.
+- Existing operating context:
+  `agent.md`, `project.md`, `README.md`, `tasks/task-116-*.md`, and
+  `adr/decisions.md`.
 
 ## Objective
-Create dedicated task handoff documents for the next notification/email work:
-QStash scheduler activation, notification actor attribution and
-self-notification rules, and task due-date email reminders.
+Make the app's version/update story coherent across runtime metadata,
+dependency maintenance, release/deploy operations, and user-facing visibility.
+The running app should expose a predictable version and revision label, release
+operators should know how that label is set during preview and production
+deploys, and future API/agent-facing surfaces should have a documented source
+of truth for build and release metadata.
+
+## Current Baseline
+- `package.json` is fixed at `0.1.0`; `lib/app-metadata.ts` falls back to that
+  value when `APP_VERSION` or `NEXT_PUBLIC_APP_VERSION` is absent.
+- Runtime revision labels come from `VERCEL_GIT_COMMIT_SHA`, `GITHUB_SHA`, or
+  `COMMIT_SHA`, shortened to seven characters.
+- The metadata pill always renders in top-right controls and links to the
+  repository, but README only documents `APP_VERSION` and `APP_REPOSITORY_URL`
+  in `.env.example`, not the release/version operating model.
+- Vercel deploy workflows do not explicitly inject `APP_VERSION` or
+  `COMMIT_SHA`; production and preview version labels therefore depend on
+  ambient Vercel/GitHub variables and the unchanged package version.
+- Dependabot maintenance has a separate operating model, but dependency-update
+  cadence and release/version communication are not tied together in docs.
+
+## Scope
+- Audit the current metadata implementation and decide the source of truth for:
+  app version, build revision, repository URL, deployment environment, and any
+  release label shown to users or exposed to API/agent consumers.
+- Adjust metadata helpers so labels are deterministic and defensible for local,
+  CI, preview, and production contexts.
+- Update deploy automation if needed so preview/staged-production deployments
+  pass explicit version/revision inputs instead of relying on ambiguous ambient
+  state.
+- Update documentation so operators understand when to bump `package.json`
+  version, when `APP_VERSION` should be set, how Dependabot updates relate to
+  product releases, and how to validate the running version after deploy.
+- Add or update tests around metadata normalization, fallback order, and any
+  newly exposed metadata contract.
+
+## Likely Touchpoints
+- `lib/app-metadata.ts`
+- `components/app-metadata-pill.tsx`
+- `tests/lib/app-metadata.test.ts`
+- `.github/workflows/deploy-vercel.yml`
+- `.env.example`
+- `README.md`
+- `docs/runbooks/vercel-env-contract-and-secrets.md`
+- `tasks/backlog.md`
+- `journal.md`
 
 ## Acceptance Criteria
-1. `tasks/task-228-qstash-notification-email-scheduler-activation.md` captures
-   scheduler intent, endpoint contract, acceptance criteria, and smoke plan.
-2. `tasks/task-265-notification-actor-attribution-and-self-notification-rules.md`
-   captures actor attribution and self-notification behavior in enough detail
-   for implementation.
-3. `tasks/task-226-task-due-date-email-reminders.md` captures due-date reminder
-   product rules, sequencing after scheduler activation, and validation plan.
-4. `tasks/backlog.md` links each backlog item to its dedicated task brief.
-5. `journal.md` records the documentation handoff.
+1. Runtime metadata has an explicit source-of-truth order for version,
+   revision, repository URL, and environment/release context.
+2. Local, CI, Vercel preview, staged production, and promoted production labels
+   are deterministic and covered by focused tests where practical.
+3. The in-app metadata pill remains useful without exposing secrets or noisy
+   internal implementation details.
+4. Deploy workflow summaries or environment injection make it clear which
+   version/revision was built and deployed.
+5. Documentation explains the release/version operating model, including how
+   dependency-update PRs differ from intentional product version bumps.
+6. Any API/agent-facing metadata decision is either implemented consistently or
+   recorded as explicitly out of scope/follow-up.
+7. `tasks/current.md`, `tasks/backlog.md`, and `journal.md` are updated to
+   reflect the implementation and validation outcome.
 
 ## Definition Of Done
-- Work remains documentation-only.
-- The branch is pushed and a PR is opened for review.
-- Validation confirms Markdown/task consistency.
-- Copilot review and checks are monitored.
+- TASK-132 changes are implemented on the dedicated branch.
+- Focused metadata/workflow tests pass.
+- Repository validation baseline passes unless a blocker is documented:
+  `npm run lint`, `npm test`, `npm run test:coverage`, and `npm run build`.
+- Preview validation is run if deploy workflow behavior or visible app metadata
+  changes require branch-scoped runtime evidence.
+- Documentation reflects the final contract and does not leave versioning
+  behavior implicit.
+- The branch is pushed, a PR is opened, Copilot/check feedback is monitored,
+  and the handoff includes the delivered commit SHA.
+
+## Implementation Summary
+- Bumped the product version from `0.1.0` to `0.2.0` in `package.json` and
+  `package-lock.json`.
+- Changed app metadata so the visible version label is a clean product version
+  (`v0.2.0`) while revision, environment, and build details remain structured
+  diagnostic metadata.
+- Updated the Vercel deploy workflow to resolve `APP_VERSION`, `APP_ENV`,
+  `COMMIT_SHA`, and `APP_REPOSITORY_URL` from the checked-out ref and pass them
+  through build/deploy operations.
+- Documented the release/version operating model in README and the Vercel env
+  runbook.
 
 ## Validation Plan
-- `git diff --check`
-- Review the three task files for actionable startup context, acceptance
-  criteria, validation plans, and explicit out-of-scope boundaries.
-- Review `tasks/backlog.md` links to the new briefs.
+- `npm test -- --run tests/lib/app-metadata.test.ts` - passed
+- `npm run lint` - passed
+- `npm test` - passed with local temporary PostgreSQL on port `55432`
+- `npm run test:coverage` - passed with local temporary PostgreSQL on port
+  `55432`
+- `npm run build` - passed after `npx prisma generate` refreshed the local
+  Prisma client
+- `git diff --check` - passed
+- If deploy workflow behavior changes:
+  `gh workflow run deploy-vercel.yml -f action=deploy-preview -f git_ref=feature/task-132-version-update-system`,
+  then verify the workflow logs and preview metadata label match the active
+  branch/revision.
 
 ## Out Of Scope
-- Implementing QStash.
-- Changing notification/email runtime behavior.
-- Implementing actor attribution behavior.
-- Implementing due-date reminders.
+- Building a public changelog or release-notes product surface unless required
+  to make the metadata contract coherent.
+- Changing Dependabot's safe-lane or Copilot repair policy beyond documenting
+  how dependency updates relate to release communication.
+- Introducing public API version negotiation beyond documenting how future
+  API/agent surfaces should consume app/release metadata.
+- Changing the staged production promote/rollback strategy from TASK-042.
+
+## Decisions
+- `package.json` is the canonical product-version source in git.
+- `APP_VERSION` remains an override/injected deploy value, not the primary
+  release authority.
+- The visible app metadata pill shows only the clean product version
+  (`vX.Y.Z`). Commit SHA/revision stays available as diagnostic metadata, not
+  appended to the visible version.
+- TASK-132 will not add a user-facing release notes path.
+- TASK-132 will not expose build/revision metadata through agent/OpenAPI
+  surfaces. Future API/agent metadata should reuse `lib/app-metadata.ts` and
+  expose structured fields rather than parsing the UI label.

--- a/tests/lib/app-metadata.test.ts
+++ b/tests/lib/app-metadata.test.ts
@@ -68,6 +68,8 @@ describe("app-metadata", () => {
 
   test("strips build metadata from the visible version", () => {
     process.env.APP_VERSION = "v2.4.1+preview.5";
+    delete process.env.VERCEL_GIT_COMMIT_SHA;
+    delete process.env.GITHUB_SHA;
     process.env.COMMIT_SHA = "1234567890";
 
     const summary = getAppMetadataSummary();

--- a/tests/lib/app-metadata.test.ts
+++ b/tests/lib/app-metadata.test.ts
@@ -9,6 +9,10 @@ describe("app-metadata", () => {
   const originalGithubSha = process.env.GITHUB_SHA;
   const originalCommitSha = process.env.COMMIT_SHA;
   const originalRepositoryUrl = process.env.APP_REPOSITORY_URL;
+  const originalAppEnv = process.env.APP_ENV;
+  const originalPublicAppEnv = process.env.NEXT_PUBLIC_APP_ENV;
+  const originalVercelEnv = process.env.VERCEL_ENV;
+  const originalNodeEnv = process.env.NODE_ENV;
 
   function restoreEnv(name: string, value: string | undefined): void {
     if (value === undefined) {
@@ -26,17 +30,25 @@ describe("app-metadata", () => {
     restoreEnv("GITHUB_SHA", originalGithubSha);
     restoreEnv("COMMIT_SHA", originalCommitSha);
     restoreEnv("APP_REPOSITORY_URL", originalRepositoryUrl);
+    restoreEnv("APP_ENV", originalAppEnv);
+    restoreEnv("NEXT_PUBLIC_APP_ENV", originalPublicAppEnv);
+    restoreEnv("VERCEL_ENV", originalVercelEnv);
+    restoreEnv("NODE_ENV", originalNodeEnv);
   });
 
-  test("uses configured version and commit sha when provided", () => {
+  test("uses configured version and keeps revision out of the visible label", () => {
     process.env.APP_VERSION = "2.4.1";
     process.env.VERCEL_GIT_COMMIT_SHA = "abcd1234efgh5678";
+    process.env.VERCEL_ENV = "preview";
 
     const summary = getAppMetadataSummary();
 
     expect(summary.versionTag).toBe("v2.4.1");
     expect(summary.revision).toBe("abcd123");
-    expect(summary.versionLabel).toBe("v2.4.1+abcd123");
+    expect(summary.revisionLabel).toBe("build abcd123");
+    expect(summary.environment).toBe("preview");
+    expect(summary.versionLabel).toBe("v2.4.1");
+    expect(summary.diagnosticLabel).toBe("v2.4.1 | preview | build abcd123");
   });
 
   test("falls back to package.json version when no override exists", () => {
@@ -48,9 +60,30 @@ describe("app-metadata", () => {
 
     const summary = getAppMetadataSummary();
 
-    expect(summary.versionTag).toBe("v0.1.0");
+    expect(summary.versionTag).toBe("v0.2.0");
     expect(summary.revision).toBeNull();
-    expect(summary.versionLabel).toBe("v0.1.0");
+    expect(summary.revisionLabel).toBeNull();
+    expect(summary.versionLabel).toBe("v0.2.0");
+  });
+
+  test("strips build metadata from the visible version", () => {
+    process.env.APP_VERSION = "v2.4.1+preview.5";
+    process.env.COMMIT_SHA = "1234567890";
+
+    const summary = getAppMetadataSummary();
+
+    expect(summary.versionTag).toBe("v2.4.1");
+    expect(summary.versionLabel).toBe("v2.4.1");
+    expect(summary.revision).toBe("1234567");
+  });
+
+  test("falls back to package version when configured version is invalid", () => {
+    process.env.APP_VERSION = "release-candidate";
+
+    const summary = getAppMetadataSummary();
+
+    expect(summary.versionTag).toBe("v0.2.0");
+    expect(summary.versionLabel).toBe("v0.2.0");
   });
 
   test("uses optional repository override when present", () => {
@@ -75,5 +108,14 @@ describe("app-metadata", () => {
     const summary = getAppMetadataSummary();
 
     expect(summary.repositoryUrl).toBe("https://github.com/dorianagaesse/nexus_dash");
+  });
+
+  test("normalizes runtime environment from explicit app env first", () => {
+    process.env.APP_ENV = "production";
+    process.env.VERCEL_ENV = "preview";
+
+    const summary = getAppMetadataSummary();
+
+    expect(summary.environment).toBe("production");
   });
 });


### PR DESCRIPTION
## Summary
- Bump the product version to `0.2.0` and make `package.json` / `package-lock.json` the canonical product-version source.
- Show only the clean product version in the app metadata pill while keeping revision/environment as diagnostic metadata.
- Inject `APP_VERSION`, `APP_ENV`, `COMMIT_SHA`, and `APP_REPOSITORY_URL` from the checked-out ref during Vercel preview/staged production deploys.
- Document the release/version operating model and the Dependabot boundary.
- Refreshed the branch against current `main` after PR #271 merged; conflicts were limited to task/journal docs.

## Local validation
- `npm test -- --run tests/lib/app-metadata.test.ts` passed: 8 tests.
- `npm run lint` passed.
- `NODE_ENV=test DATABASE_URL=... DIRECT_URL=... npm test` passed: 108 files passed, 2 skipped; 815 tests passed, 2 skipped.
- `NODE_ENV=test DATABASE_URL=... DIRECT_URL=... npm run test:coverage` passed: 91.23% statements, 81.2% branches, 93.42% functions, 91.75% lines.
- `DATABASE_URL=... DIRECT_URL=... OUTBOUND_EMAIL_DELIVERY_MODE=disabled AGENT_TOKEN_SIGNING_SECRET=... GOOGLE_TOKEN_ENCRYPTION_KEY=... NEXTAUTH_URL=http://localhost:3000 NEXTAUTH_SECRET=... TRUSTED_ORIGINS=http://localhost:3000 COMMIT_SHA=1234567890abcdef APP_ENV=production npm run build` passed.
- `git diff --check` passed.

## CI
- `check-name` passed on run `26127082945`.
- `Quality Core (lint, test, coverage, build)` passed on run `26127082944`.
- `E2E Smoke (Playwright)` passed on run `26127082944`.
- `Container Image (build + metadata artifact)` passed on run `26127082944`.
- Copilot completed review and generated no comments; there are no review threads.

## Preview evidence
- Branch-scoped workflow run: `26104594474`, launched with `--ref feature/task-132-version-update-system` and `git_ref=feature/task-132-version-update-system`.
- Checkout log shows `git checkout ... -B feature/task-132-version-update-system refs/remotes/origin/feature/task-132-version-update-system` at commit `f197129` before later tracking updates.
- Metadata resolution log shows `APP_VERSION=0.2.0`, `APP_ENV=preview`, `COMMIT_SHA=f1971290c4909284e2a9f00fccb4dc52b816b892`, and `APP_REPOSITORY_URL=https://github.com/dorianagaesse/nexus_dash`.
- Preview deploy is blocked by Vercel Preview environment configuration: the pulled `DATABASE_URL` uses the Supabase session-pooler port `5432`, while the existing runtime guard correctly requires transaction-pooler port `6543`. This is not a TASK-132 code regression and should be fixed in Vercel Preview secrets, not by weakening the guard.
