### PR TITLE
TASK-268 Schedule notification email dispatch

### DIFF
--- a/.github/workflows/notification-email-dispatch.yml
+++ b/.github/workflows/notification-email-dispatch.yml
@@ -1,10 +1,14 @@
-name: Notification Email Dispatch Diagnostic
+name: Notification Email Dispatch Scheduler
 
 on:
+  schedule:
+    # Temporary production bridge while Vercel remains on Hobby and QStash is not
+    # in use. Run away from the top of the hour to reduce GitHub schedule delay.
+    - cron: "17 */3 * * *"
   workflow_dispatch:
     inputs:
       target_url:
-        description: "Optional app origin override, for example a preview URL"
+        description: "Optional app origin override, for example a preview URL. Scheduled runs default to production."
         required: false
         type: string
 
@@ -17,12 +21,12 @@ concurrency:
 
 jobs:
   dispatch:
-    name: Dispatch notification emails manually
+    name: Dispatch notification emails
     runs-on: ubuntu-latest
     environment: production
     timeout-minutes: 5
     env:
-      DISPATCH_URL: ${{ inputs.target_url || vars.NOTIFICATION_EMAIL_DISPATCH_URL }}
+      DISPATCH_URL: ${{ github.event.inputs.target_url || vars.NOTIFICATION_EMAIL_DISPATCH_URL || 'https://nexus-dash.app' }}
       DISPATCH_SECRET: ${{ secrets.NOTIFICATION_EMAIL_DISPATCH_SECRET || secrets.CRON_SECRET }}
 
     steps:
@@ -30,7 +34,7 @@ jobs:
         run: |
           missing=0
           if [ -z "$DISPATCH_URL" ]; then
-            echo "::error::Missing repository variable NOTIFICATION_EMAIL_DISPATCH_URL."
+            echo "::error::Missing notification email dispatch target URL."
             missing=1
           fi
           if [ -z "$DISPATCH_SECRET" ]; then
@@ -44,6 +48,18 @@ jobs:
       - name: Call notification email dispatcher
         run: |
           dispatch_origin="${DISPATCH_URL%/}"
-          curl --fail-with-body --silent --show-error --max-time 120 \
+          response="$(curl --fail-with-body --silent --show-error --max-time 120 \
             --header "x-notification-email-dispatch-secret: $DISPATCH_SECRET" \
-            "$dispatch_origin/api/cron/notification-emails"
+            "$dispatch_origin/api/cron/notification-emails")"
+          echo "$response"
+          {
+            echo "## Notification Email Dispatch"
+            echo
+            echo "- Trigger: \`${{ github.event_name }}\`"
+            echo "- Target origin: \`$dispatch_origin\`"
+            echo "- Response:"
+            echo
+            echo '```json'
+            echo "$response"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/notification-email-dispatch.yml
+++ b/.github/workflows/notification-email-dispatch.yml
@@ -38,7 +38,7 @@ jobs:
             missing=1
           fi
           if [ -z "$DISPATCH_SECRET" ]; then
-            echo "::error::Missing repository secret NOTIFICATION_EMAIL_DISPATCH_SECRET or CRON_SECRET."
+            echo "::error::Missing GitHub secret NOTIFICATION_EMAIL_DISPATCH_SECRET or CRON_SECRET."
             missing=1
           fi
           if [ "$missing" -eq 1 ]; then
@@ -48,18 +48,28 @@ jobs:
       - name: Call notification email dispatcher
         run: |
           dispatch_origin="${DISPATCH_URL%/}"
+          set +e
           response="$(curl --fail-with-body --silent --show-error --max-time 120 \
             --header "x-notification-email-dispatch-secret: $DISPATCH_SECRET" \
-            "$dispatch_origin/api/cron/notification-emails")"
+            "$dispatch_origin/api/cron/notification-emails" 2>&1)"
+          curl_status=$?
+          set -e
+
           echo "$response"
           {
             echo "## Notification Email Dispatch"
             echo
             echo "- Trigger: \`${{ github.event_name }}\`"
             echo "- Target origin: \`$dispatch_origin\`"
-            echo "- Response:"
+            echo "- Curl exit code: \`$curl_status\`"
+            echo "- Response/output:"
             echo
-            echo '```json'
+            echo '```text'
             echo "$response"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$curl_status" -ne 0 ]; then
+            echo "::error::Notification email dispatch failed with curl exit code $curl_status."
+            exit "$curl_status"
+          fi

--- a/README.md
+++ b/README.md
@@ -324,17 +324,16 @@ marks notifications read or resolved.
 
 Production scheduler decision:
 
-- Preferred: Vercel Cron invoking this endpoint every 10-15 minutes on a plan
-  that supports sub-hour cron cadence. Vercel Cron invokes production
-  deployments only; preview validation must invoke the endpoint manually.
-- Current Hobby-plan blocker: Vercel Hobby cron is limited to daily schedules,
-  so it cannot satisfy the 60-minute max-delay requirement.
-- Hobby-compatible production alternative: use a managed HTTP scheduler with
-  retries/visibility, such as Upstash QStash Schedule, to call the same endpoint
-  with `x-notification-email-dispatch-secret`.
-
-`.github/workflows/notification-email-dispatch.yml` is manual-only diagnostic
-tooling for operators. It is not the production scheduler.
+- Current production bridge: GitHub Actions invokes this endpoint every 3 hours
+  through `.github/workflows/notification-email-dispatch.yml`.
+- This is an accepted early-production tradeoff while Vercel remains on Hobby
+  and no managed scheduler is in use. It preserves durable app-owned queueing
+  and idempotent dispatch, but it does not satisfy the original one-hour
+  max-delay delivery target.
+- Manual workflow dispatch remains available for preview validation and
+  diagnostics by overriding the target URL.
+- Future preferred path: Vercel Cron or a managed HTTP scheduler with
+  retries/visibility on a cadence that satisfies the product delivery target.
 
 ## CI/CD
 
@@ -345,7 +344,8 @@ tooling for operators. It is not the production scheduler.
 - `Container Image (build + metadata artifact)`
 - `Check Branch Name` (PR branch naming contract)
 - `Dependency Security` (scheduled + manual `npm audit` baseline with artifacts)
-- `Notification Email Dispatch Diagnostic` (manual protected dispatch call)
+- `Notification Email Dispatch Scheduler` (scheduled + manual protected
+  dispatch call)
 
 Branch-name note:
 - human-authored PR branches must use `feature/*`, `fix/*`, `refactor/*`,
@@ -370,6 +370,8 @@ Required GitHub secrets:
 - `VERCEL_TOKEN`
 - `VERCEL_ORG_ID`
 - `VERCEL_PROJECT_ID`
+- `NOTIFICATION_EMAIL_DISPATCH_SECRET` or `CRON_SECRET` for scheduled/manual
+  notification email dispatch
 - `DATABASE_URL` (runtime connection; Supabase transaction pooler on port `6543`)
 - `DIRECT_URL` (direct database connection; Supabase direct host on port `5432`)
 - `MIGRATION_DATABASE_URL` (admin-capable migration connection; must not be the runtime `DATABASE_URL`)

--- a/docs/runbooks/vercel-env-contract-and-secrets.md
+++ b/docs/runbooks/vercel-env-contract-and-secrets.md
@@ -91,16 +91,25 @@ the invitation notification.
 
 Scheduler decision:
 
-- Preferred production path: Vercel Cron every 10-15 minutes on a plan that
-  supports sub-hour cron cadence. Vercel Cron invokes production deployments
-  only; it does not run on preview deployments.
-- Current blocker: the present Hobby-plan deployment cannot use the required
-  Vercel Cron cadence because Hobby cron is daily-only.
-- Production alternative while staying on Hobby: configure a managed HTTP
-  scheduler with retries/visibility, such as Upstash QStash Schedule, to call
-  the same endpoint with `x-notification-email-dispatch-secret`.
-- GitHub Actions dispatch is manual diagnostic tooling only; it must not be the
-  primary production scheduler for notification email delivery.
+- Current production bridge: GitHub Actions invokes this endpoint every 3 hours
+  through `.github/workflows/notification-email-dispatch.yml`.
+- This bridge uses the existing durable app queue, protected endpoint, and
+  idempotent dispatcher. It intentionally does not satisfy the original
+  one-hour max-delay delivery target; expected delivery is periodic, usually
+  within one scheduler cadence plus GitHub Actions scheduling delay.
+- Manual GitHub Actions dispatch remains available for preview validation and
+  diagnostics by overriding the target URL.
+- Future preferred path: Vercel Cron or a managed HTTP scheduler with
+  retries/visibility on a cadence that satisfies the product delivery target.
+
+GitHub Actions dispatch requirements:
+
+- The workflow needs `NOTIFICATION_EMAIL_DISPATCH_SECRET` or legacy
+  `CRON_SECRET` as a GitHub secret.
+- `NOTIFICATION_EMAIL_DISPATCH_URL` is optional; when unset, scheduled runs
+  default to `https://nexus-dash.app`.
+- If the workflow uses the GitHub `production` environment for secrets, that
+  environment must allow scheduled jobs to run without manual approval.
 
 Preview deployments can be validated by invoking the endpoint directly with the
 same dispatch secret. A live email smoke additionally needs

--- a/journal.md
+++ b/journal.md
@@ -12,6 +12,11 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ## Recent Entries (Most Relevant)
 
+### 2026-05-19
+- Type: Planning
+- Summary: TASK-268 replaced the QStash scheduler path with a GitHub Actions production bridge.
+- Evidence: User validated moving on without QStash because Upstash account/token setup was too fragile for the current stage. Added TASK-268, superseded active TASK-228, scheduled `.github/workflows/notification-email-dispatch.yml` every 3 hours, and documented that this bridge preserves durable/idempotent dispatch but no longer promises one-hour notification email delivery.
+
 ### 2026-05-16
 - Type: Planning
 - Summary: TASK-267 drafted dedicated handoff briefs for the next notification/email tasks.

--- a/project.md
+++ b/project.md
@@ -59,9 +59,10 @@ NexusDash is a personal/team execution workspace that keeps project planning, de
 - Storage: `StorageProvider` abstraction (`local` or `r2`)
 - Testing: Vitest + Playwright
 - Runtime/deploy: Docker, GitHub Actions, Vercel CLI staged production deploy/promotion/rollback
-- Notification email scheduling: Vercel Cron when the Vercel plan supports
-  sub-hour cadence; otherwise a managed HTTP scheduler calls the same protected
-  endpoint. GitHub Actions dispatch is manual diagnostic tooling only.
+- Notification email scheduling: GitHub Actions currently invokes the protected
+  dispatcher every 3 hours as an early-production bridge while Vercel remains
+  on Hobby and no managed scheduler is in use. This keeps grouped email
+  delivery active but does not provide the original sub-hour delivery target.
 
 ## 4. Data Model Snapshot
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -4,12 +4,12 @@ Use this file to capture tasks discovered during development. Each entry should 
 
 ## Pending
 ### Execution Queue (Now / Next)
-- ID: TASK-228
-  Title: QStash notification email scheduler activation - production cadence and smoke validation
+- ID: TASK-268
+  Title: GitHub Actions notification email scheduler - 3-hour production bridge
   Status: Next
-  Rationale: Production smoke proved notification email grouping works only when the protected dispatcher is invoked manually. Vercel will remain on the Hobby plan, so Vercel Cron cannot provide the sub-hour cadence required by TASK-227 notification email debounce/max-delay behavior. Provision an Upstash QStash Schedule, or an equivalent managed HTTP scheduler with retries and visibility, to invoke `GET /api/cron/notification-emails` every 5 minutes with the protected dispatch header. Document scheduler ownership, redaction/retry settings, and run a production smoke proving due groups are sent automatically without exposing secrets.
+  Rationale: QStash activation created too much operational friction for the current stage, and Vercel remains on Hobby where Vercel Cron is daily-only. Use the existing protected GitHub Actions dispatcher as a temporary production scheduler bridge every 3 hours, keeping the app-owned durable queue/idempotency guarantees while explicitly downgrading the email delivery promise from sub-hour to periodic digest delivery.
   Dependencies: TASK-125, TASK-227
-  Brief: `tasks/task-228-qstash-notification-email-scheduler-activation.md`
+  Brief: `tasks/task-268-github-actions-notification-email-scheduler.md`
 - ID: TASK-265
   Title: Notification actor attribution and self-notification rules
   Status: Next
@@ -18,9 +18,9 @@ Use this file to capture tasks discovered during development. Each entry should 
   Brief: `tasks/task-265-notification-actor-attribution-and-self-notification-rules.md`
 - ID: TASK-226
   Title: Task due-date email reminders - 3-day deadline warning delivery
-  Status: Pending (after TASK-228 scheduler activation)
+  Status: Pending (after TASK-268 scheduler activation)
   Rationale: Send task reminder emails when assigned or owned work is three days from its due date, with idempotent delivery tracking and anti-spam semantics so each reminder fires predictably once per task/user deadline window rather than repeating on every app visit.
-  Dependencies: TASK-101, TASK-125, TASK-063, TASK-228
+  Dependencies: TASK-101, TASK-125, TASK-063, TASK-268
   Brief: `tasks/task-226-task-due-date-email-reminders.md`
 - ID: TASK-266
   Title: Production pg query deprecation warning cleanup
@@ -142,6 +142,16 @@ Use this file to capture tasks discovered during development. Each entry should 
   Dependencies: TASK-051
 
 ## Completed
+- ID: TASK-228
+  Title: QStash notification email scheduler activation - production cadence and smoke validation
+  Status: Superseded (2026-05-19, replaced by TASK-268)
+  Rationale: QStash stayed a valid managed-scheduler option, but the account/token setup created too much operational friction for the current stage. The active production scheduler path moved to the GitHub Actions 3-hour bridge in TASK-268.
+  Dependencies: TASK-125, TASK-227
+- ID: TASK-267
+  Title: Notification task handoff briefs
+  Status: Done (2026-05-17, merged via PR #265)
+  Rationale: Added dedicated handoff briefs for TASK-228, TASK-265, and TASK-226 so future sessions can start from explicit product intent, architecture boundaries, acceptance criteria, and validation plans.
+  Dependencies: TASK-228, TASK-265, TASK-226
 - ID: TASK-260
   Title: Email-only notification digests - keep in-app notifications atomic
   Status: Done (2026-05-16, merged via PR #262)
@@ -160,7 +170,7 @@ Use this file to capture tasks discovered during development. Each entry should 
 - ID: TASK-227
   Title: Production-grade notification email orchestration - debounce, grouping, and scheduler refactor
   Status: Done (2026-05-14, merged via PR #254)
-  Rationale: Refactored project notification email dispatch into durable recipient/project grouped orchestration with debounce, max-delay, concurrency-safe claims, idempotent delivery recording, protected dispatch endpoint, and invitation reminder support. Production scheduler activation remains tracked by TASK-228.
+  Rationale: Refactored project notification email dispatch into durable recipient/project grouped orchestration with debounce, max-delay, concurrency-safe claims, idempotent delivery recording, protected dispatch endpoint, and invitation reminder support. Production scheduler activation is currently tracked by TASK-268 after TASK-228 was superseded.
   Dependencies: TASK-123, TASK-125, TASK-225
 - ID: TASK-225
   Title: Project notification email digests - grouped, rate-limited outbound summaries

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,49 +1,53 @@
-# Current Task: TASK-267 Notification Task Briefs
+# Current Task: TASK-268 GitHub Actions Notification Email Scheduler
 
 ## Task ID
-TASK-267
+TASK-268
 
 ## Status
-In progress on dedicated worktree `../nexus_dash_task267` and branch
-`docs/task-267-notification-task-briefs`.
+In progress on dedicated worktree `../nexus_dash_task268` and branch
+`feature/task-268-github-actions-notification-email-scheduler`.
 
 ## Source
-- User request to draft dedicated task `.md` briefs for TASK-228, TASK-265, and
-  TASK-226 so a future agent session can take over cleanly.
-- Existing backlog sequence after PR #264: scheduler activation first, actor
-  attribution/self-notification next, then due-date reminders after scheduler
-  activation.
+- User decision on 2026-05-19 to abandon QStash for now because the account and
+  token setup created too much operational friction.
+- Vercel remains on Hobby, so Vercel Cron cannot provide sub-day cadence.
+- Existing notification email dispatcher is durable, protected, idempotent, and
+  already production-smoked through manual invocation.
 
 ## Objective
-Create dedicated task handoff documents for the next notification/email work:
-QStash scheduler activation, notification actor attribution and
-self-notification rules, and task due-date email reminders.
+Replace the pending QStash scheduler path with a clean GitHub Actions scheduled
+dispatch bridge that invokes the production notification email dispatcher every
+3 hours and documents the delivery caveat honestly.
 
 ## Acceptance Criteria
-1. `tasks/task-228-qstash-notification-email-scheduler-activation.md` captures
-   scheduler intent, endpoint contract, acceptance criteria, and smoke plan.
-2. `tasks/task-265-notification-actor-attribution-and-self-notification-rules.md`
-   captures actor attribution and self-notification behavior in enough detail
-   for implementation.
-3. `tasks/task-226-task-due-date-email-reminders.md` captures due-date reminder
-   product rules, sequencing after scheduler activation, and validation plan.
-4. `tasks/backlog.md` links each backlog item to its dedicated task brief.
-5. `journal.md` records the documentation handoff.
+1. `.github/workflows/notification-email-dispatch.yml` has a scheduled trigger
+   running every 3 hours and retains manual dispatch.
+2. Scheduled runs default to `https://nexus-dash.app`; manual runs can override
+   the target URL.
+3. The workflow uses the existing protected header and does not log secret
+   values.
+4. `tasks/backlog.md` replaces active TASK-228 QStash work with TASK-268 and
+   keeps TASK-226 sequenced after scheduler activation.
+5. README, project docs, runbook, task briefs, and journal reflect GitHub
+   Actions as the accepted temporary production scheduler bridge.
+6. The documentation clearly states that the 3-hour cadence does not satisfy the
+   original one-hour maximum-delay goal.
 
 ## Definition Of Done
-- Work remains documentation-only.
+- Work remains focused on scheduler workflow and documentation cleanup.
 - The branch is pushed and a PR is opened for review.
-- Validation confirms Markdown/task consistency.
+- Validation confirms workflow/docs consistency.
 - Copilot review and checks are monitored.
 
 ## Validation Plan
 - `git diff --check`
-- Review the three task files for actionable startup context, acceptance
-  criteria, validation plans, and explicit out-of-scope boundaries.
-- Review `tasks/backlog.md` links to the new briefs.
+- Review `.github/workflows/notification-email-dispatch.yml` trigger, default
+  target, secret handling, and manual override behavior.
+- Review changed Markdown for stale active QStash instructions.
+- Let GitHub PR checks run.
 
 ## Out Of Scope
 - Implementing QStash.
-- Changing notification/email runtime behavior.
+- Changing notification grouping/debounce runtime behavior.
 - Implementing actor attribution behavior.
 - Implementing due-date reminders.

--- a/tasks/task-226-task-due-date-email-reminders.md
+++ b/tasks/task-226-task-due-date-email-reminders.md
@@ -8,7 +8,7 @@ Branch: `feature/task-226-task-due-date-email-reminders`
 Implement task due-date reminder business logic so users receive a predictable
 email reminder when assigned or owned work is three days from its due date.
 
-This task should start only after TASK-228 has activated a production scheduler.
+This task should start only after TASK-268 has activated a production scheduler.
 The reminder logic should reuse the production-grade outbound email and
 notification email orchestration foundations instead of inventing a separate
 cron-only path.
@@ -34,7 +34,7 @@ Default product rule:
 - Existing task APIs expose `deadlineDate`.
 - TASK-227 added notification email orchestration with durable grouping,
   debounce, idempotent delivery recording, and a protected dispatcher.
-- TASK-228 owns the production scheduler needed to call the dispatcher
+- TASK-268 owns the production scheduler needed to call the dispatcher
   automatically.
 - The in-app notification center should remain the durable source of truth for
   notification email delivery unless this task deliberately documents and
@@ -111,7 +111,7 @@ Record the decisions in `tasks/current.md` and `journal.md` before coding.
 
 ## Implementation Guidance
 
-1. Start from TASK-228's scheduler reality. Do not build a second unrelated
+1. Start from TASK-268's scheduler reality. Do not build a second unrelated
    scheduler.
 2. Add task reminder notification type and metadata mapping in the service
    layer.
@@ -177,7 +177,7 @@ Production smoke after merge/deploy:
 
 ## Out Of Scope
 
-- Scheduler provisioning; that is TASK-228.
+- Scheduler provisioning; that is TASK-268.
 - Actor attribution/self-notification cleanup; that is TASK-265.
 - Instant in-app push delivery; that is TASK-263.
 - Reminder preference UI or unsubscribe/suppression preferences unless required

--- a/tasks/task-228-qstash-notification-email-scheduler-activation.md
+++ b/tasks/task-228-qstash-notification-email-scheduler-activation.md
@@ -1,158 +1,32 @@
 # TASK-228 QStash Notification Email Scheduler Activation
 
 Date: 2026-05-16
-Branch: `feature/task-228-qstash-notification-email-scheduler-activation`
+Status: Superseded by TASK-268 on 2026-05-19
 
 ## Summary
 
-Activate a real production scheduler for notification email dispatch. TASK-227
-implemented durable DB-backed notification email orchestration and the protected
-HTTP dispatcher, and production smoke proved that grouped digest delivery works
-when the dispatcher is invoked manually. What is still missing is an external
-managed scheduler that invokes the dispatcher often enough to honor the
-notification email debounce and one-hour max-delay contract.
+TASK-228 originally tracked activating Upstash QStash, or an equivalent managed
+HTTP scheduler, for production notification email dispatch. That direction is no
+longer active.
 
-Vercel will remain on the current plan, so do not rely on Vercel Cron for this
-feature unless the plan/frequency constraint has changed. Prefer Upstash QStash
-Schedules, or an equivalent managed HTTP scheduler with retries, auditability,
-and operational visibility.
+The project is moving forward with TASK-268 instead: GitHub Actions invokes the
+protected notification email dispatcher every 3 hours as an early-production
+bridge while Vercel remains on Hobby and no managed scheduler is in use.
 
-## Current Evidence
+## Reason
 
-- Production digest smoke succeeded after manual invocation of
-  `GET /api/cron/notification-emails`.
-- Immediate dispatch after creating notifications correctly returned no sends
-  because the debounce window was not due.
-- A later manual dispatch sent one grouped recipient email containing multiple
-  notification items.
-- A repeat manual dispatch sent nothing, proving idempotency for the tested
-  batch.
-- QStash is not currently live: no configured scheduler was observed, and due
-  email groups did not send automatically during smoke.
+QStash remains a valid future scheduler option, but it created too much
+operational friction for the current stage of the project. The active goal is to
+ship a simpler production scheduler bridge and document the delivery caveat
+honestly rather than block notification email dispatch on another provider setup.
 
-## Product Intent
+## Replacement
 
-Users should receive useful email notifications without email spam:
-
-- The in-app notification center remains the source of truth.
-- Email dispatch groups due project notification groups by recipient.
-- Normal project activity uses debounce semantics:
-  - wait for the group to become quiet
-  - do not delay the first unsent activity by more than about one hour
-- Project invitation reminders fire once when a verified invitee has not
-  opened, accepted, or declined within the reminder window.
-- Scheduler cadence should be frequent enough that the email service, not the
-  scheduler, owns the user-facing quiet-window timing.
-
-## Existing Endpoint Contract
-
-The app already exposes:
+Use:
 
 ```text
-GET /api/cron/notification-emails
+tasks/task-268-github-actions-notification-email-scheduler.md
 ```
 
-Production URL:
-
-```text
-https://nexus-dash.app/api/cron/notification-emails
-```
-
-Accepted auth headers:
-
-```text
-x-notification-email-dispatch-secret: <NOTIFICATION_EMAIL_DISPATCH_SECRET>
-```
-
-or:
-
-```text
-Authorization: Bearer <NOTIFICATION_EMAIL_DISPATCH_SECRET>
-```
-
-The secret is resolved through `lib/env.server.ts`. Do not print, log, commit,
-or paste the secret.
-
-## Implementation Guidance
-
-1. Confirm the endpoint still passes authorization tests and local smoke.
-2. Provision an Upstash QStash Schedule, or document why an equivalent managed
-   scheduler is being used instead.
-3. Configure it to invoke the production endpoint every 5 minutes.
-4. Send the configured dispatch secret through an HTTP header, preferably
-   `x-notification-email-dispatch-secret`.
-5. Enable provider retry/visibility features, but make app idempotency the
-   primary duplicate-send defense.
-6. Update docs with:
-   - scheduler provider
-   - cadence
-   - target URL
-   - auth header name, not value
-   - ownership and rotation notes
-   - how to pause/disable the schedule
-   - how to inspect scheduler deliveries
-7. Keep GitHub Actions dispatch as manual diagnostic tooling only, or remove it
-   if it is misleading and no longer useful.
-
-## Files To Inspect First
-
-- `agent.md`
-- `tasks/current.md`
-- `tasks/backlog.md`
-- `tasks/task-227-production-grade-notification-email-orchestration.md`
-- `README.md`
-- `docs/runbooks/vercel-env-contract-and-secrets.md`
-- `app/api/cron/notification-emails/route.ts`
-- `lib/env.server.ts`
-- `lib/services/project-notification-email-service.ts`
-- `.github/workflows/notification-email-dispatch.yml`
-- `journal.md` entries for TASK-125, TASK-225, TASK-227, PR #254, PR #262,
-  PR #263, and the production smoke
-
-## Acceptance Criteria
-
-1. Production has a managed scheduler invoking
-   `GET https://nexus-dash.app/api/cron/notification-emails` every 5 minutes.
-2. The scheduler uses the protected dispatch secret without exposing the value
-   in code, logs, docs, GitHub comments, or screenshots.
-3. Manual endpoint invocation remains possible for preview/diagnostic smoke.
-4. GitHub Actions is not the primary production scheduler.
-5. A due notification email group sends automatically without manual endpoint
-   invocation.
-6. Repeated scheduler calls do not produce duplicate emails.
-7. Scheduler delivery failures are observable through the chosen provider.
-8. README, runbook, `journal.md`, `tasks/backlog.md`, and `tasks/current.md`
-   reflect the final operational contract.
-
-## Validation Plan
-
-Local and CI:
-
-- `npm run lint`
-- `npm test`
-- `npm run test:coverage`
-- `npm run build`
-
-Focused:
-
-- `npm test -- --run tests/api/notification-email-dispatch.route.test.ts`
-- `npm test -- --run tests/lib/project-notification-email-service.test.ts`
-
-Production smoke:
-
-1. Create one or more email-eligible notifications for
-   `dorian.agaesse@gmail.com`.
-2. Confirm the notification appears in-app.
-3. Do not manually invoke the dispatcher after the initial setup check.
-4. Wait beyond the debounce window plus one scheduler cadence.
-5. Confirm one grouped email arrives.
-6. Confirm the email links work.
-7. Confirm a later scheduler invocation does not duplicate the email.
-8. Confirm scheduler logs show successful invocations without secret exposure.
-
-## Out Of Scope
-
-- Changing notification grouping semantics.
-- Implementing due-date reminder business logic; that is TASK-226.
-- Changing actor attribution or self-notification rules; that is TASK-265.
-- Adding instant in-app push behavior; that is TASK-263.
+TASK-268 owns the current scheduler implementation, production smoke plan, and
+documentation updates.

--- a/tasks/task-265-notification-actor-attribution-and-self-notification-rules.md
+++ b/tasks/task-265-notification-actor-attribution-and-self-notification-rules.md
@@ -161,6 +161,6 @@ Manual smoke after production deploy:
 ## Out Of Scope
 
 - Adding instant push/SSE/WebSocket updates; that is TASK-263.
-- Changing scheduler activation; that is TASK-228.
+- Changing scheduler activation; that is TASK-268.
 - Implementing due-date reminder business logic; that is TASK-226.
 - Redesigning the notification center UI beyond copy required for attribution.

--- a/tasks/task-268-github-actions-notification-email-scheduler.md
+++ b/tasks/task-268-github-actions-notification-email-scheduler.md
@@ -1,0 +1,82 @@
+# TASK-268 GitHub Actions Notification Email Scheduler
+
+Date: 2026-05-19
+Branch: `feature/task-268-github-actions-notification-email-scheduler`
+
+## Summary
+
+Replace the pending QStash scheduler path with a simpler production bridge:
+GitHub Actions invokes the protected notification email dispatcher every three
+hours. This deliberately downgrades the delivery promise from the original
+TASK-227 one-hour maximum delay target to an early-production periodic digest
+model while preserving the production-grade parts that already exist in the
+app: durable DB-backed email state, idempotent dispatch, protected endpoint
+authorization, recipient/project grouping, provider delivery records, and
+manual smoke support.
+
+## Decision
+
+QStash is abandoned for now. It created too much operational friction for the
+current stage of the project. Vercel remains on Hobby, so Vercel Cron cannot run
+more than once per day. GitHub Actions scheduled dispatch is acceptable as a
+temporary production scheduler because notification email delivery is useful
+even when it is periodic rather than near-real-time.
+
+The production contract becomes:
+
+- Dispatch runs every 3 hours through GitHub Actions.
+- GitHub Actions calls `GET /api/cron/notification-emails`.
+- The workflow sends `x-notification-email-dispatch-secret`.
+- The app remains responsible for idempotency and safe concurrency.
+- Manual workflow dispatch remains available for diagnostics and preview smoke.
+
+## Product Promise
+
+For this bridge, notification email delivery is:
+
+- grouped
+- idempotent
+- protected
+- eventually delivered by scheduled production dispatch
+
+It is not guaranteed to arrive within one hour. The expected practical delivery
+window is the debounce window plus up to one scheduled cadence and any GitHub
+Actions scheduling delay.
+
+## Acceptance Criteria
+
+1. `.github/workflows/notification-email-dispatch.yml` runs on a 3-hour
+   schedule and still supports manual dispatch.
+2. Scheduled dispatch defaults to `https://nexus-dash.app`.
+3. Manual dispatch can still override the target URL for preview or diagnostic
+   runs.
+4. The workflow uses `NOTIFICATION_EMAIL_DISPATCH_SECRET` or `CRON_SECRET`
+   without exposing secret values.
+5. QStash is no longer presented as the active next scheduler task in
+   `tasks/backlog.md`, `tasks/current.md`, README, or runbooks.
+6. TASK-228 is marked superseded by this task rather than left as the active
+   next step.
+7. Documentation clearly states the 3-hour delivery caveat and why it is
+   accepted.
+8. CI and Copilot review complete cleanly.
+
+## Validation Plan
+
+- `git diff --check`
+- Review workflow syntax and documentation for stale QStash-as-next-step
+  language.
+- Let GitHub PR checks run.
+- After merge, confirm the workflow appears with both schedule and manual
+  dispatch triggers.
+- After production deployment, either wait for the next scheduled run or run
+  the workflow manually once against production and verify a successful
+  dispatcher response.
+
+## Out Of Scope
+
+- Implementing QStash or any other managed scheduler.
+- Changing notification email grouping/debounce business logic.
+- Implementing due-date reminders; that remains TASK-226 after scheduler
+  activation.
+- Changing actor attribution or self-notification rules; that remains TASK-265.
+


### PR DESCRIPTION
## Summary
- Replace the active QStash scheduler path with TASK-268, a GitHub Actions 3-hour production bridge for notification email dispatch.
- Add a `schedule` trigger to `.github/workflows/notification-email-dispatch.yml` while keeping manual dispatch and target URL override support.
- Update README, runbook, project docs, task briefs, backlog/current task, and journal to reflect the new delivery caveat and supersede TASK-228.

## Validation
- `git diff --check`
- `npm run lint`
- `npm test -- --run tests/api/notification-email-dispatch.route.test.ts`
- `npm test` with local non-secret test env
- `npm run test:coverage` with local non-secret test env
- `npm run build` with local non-secret build env and `OUTBOUND_EMAIL_DELIVERY_MODE=disabled`

## Notes
- This intentionally downgrades the scheduler promise from the original sub-hour/max-one-hour target to periodic delivery, usually within one 3-hour cadence plus GitHub Actions scheduling delay.
- GitHub Actions dispatch needs `NOTIFICATION_EMAIL_DISPATCH_SECRET` or legacy `CRON_SECRET`; if the GitHub `production` environment is used for secrets, it must allow scheduled jobs to run without manual approval.