### PR TITLE
Document Supabase runtime and admin DB URL policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,15 @@ Notes:
 For Supabase production/preview:
 
 - `DATABASE_URL`: transaction pooler URL, `*.pooler.supabase.com:6543`, with
-  TLS enabled. For the shared Supabase pooler, the username must include the
-  project ref, for example `postgres.<project-ref>`.
-- `DIRECT_URL`: direct database URL, `db.<project-ref>.supabase.co:5432`, with
-  TLS enabled.
+  TLS enabled. For the shared Supabase pooler, use the least-privilege runtime
+  role and include the project ref in the username, for example
+  `app_runtime.<project-ref>`.
+- `DIRECT_URL` / `MIGRATION_DATABASE_URL`: admin-capable migration connection,
+  never `app_runtime`. Prefer the direct database URL
+  `db.<project-ref>.supabase.co:5432` when the environment can reach it.
+  Supabase direct hosts are IPv6-only by default; if GitHub Actions or Vercel
+  cannot connect to the direct host, use the admin `postgres.<project-ref>`
+  session-pooler URL on `*.pooler.supabase.com:5432`.
 - `SUPABASE_URL`: the matching client API URL,
   `https://<project-ref>.supabase.co`.
 - Prisma runtime automatically adds the compatibility flags needed for the
@@ -405,8 +410,10 @@ Required GitHub secrets:
 - `VERCEL_PROJECT_ID`
 - `NOTIFICATION_EMAIL_DISPATCH_SECRET` or `CRON_SECRET` for scheduled/manual
   notification email dispatch
-- `DATABASE_URL` (runtime connection; Supabase transaction pooler on port `6543`)
-- `DIRECT_URL` (direct database connection; Supabase direct host on port `5432`)
+- `DATABASE_URL` (runtime connection; Supabase `app_runtime` transaction pooler
+  on port `6543`)
+- `DIRECT_URL` (admin-capable migration connection; direct host preferred,
+  admin session-pooler fallback allowed when direct IPv6 is unavailable)
 - `MIGRATION_DATABASE_URL` (admin-capable migration connection; must not be the runtime `DATABASE_URL`)
 - `AGENT_TOKEN_SIGNING_SECRET` (required for production deploys; preview workflow falls back to a placeholder when intentionally unset)
 - Preview deployments still need `AGENT_TOKEN_SIGNING_SECRET` at runtime. GitHub Actions fallback values do not automatically populate Vercel's shared preview runtime unless the deployment explicitly passes them through.

--- a/adr/decisions.md
+++ b/adr/decisions.md
@@ -16,6 +16,27 @@ Keep UI-only or task-only notes in `journal.md`.
 
 ## Active Decisions
 
+## 2026-05-20 - Use app runtime role for Supabase transaction-pooled app traffic
+- Status: Accepted
+- Context: Production and preview validation showed that runtime database
+  traffic must not use the admin `postgres` role, while Supabase direct
+  database hosts may be IPv6-only and therefore unreachable from some GitHub,
+  Vercel, or local execution environments.
+- Decision: Configure `DATABASE_URL` with the least-privilege
+  `app_runtime.<project-ref>` role through the Supabase transaction pooler on
+  port `6543`. Keep `DIRECT_URL` and `MIGRATION_DATABASE_URL` admin-capable and
+  separate from runtime traffic. Prefer Supabase's direct host for admin and
+  migration connections when reachable; use the admin
+  `postgres.<project-ref>` session-pooler URL on port `5432` as the operational
+  fallback when direct IPv6 connectivity is unavailable.
+- Consequences: Runtime traffic preserves forced-RLS defense in depth and avoids
+  serverless session-pool exhaustion. Migration/admin flows remain possible in
+  IPv4-only environments, but operators must treat admin session-pooler usage as
+  a fallback for `DIRECT_URL` / `MIGRATION_DATABASE_URL`, never as a valid
+  runtime `DATABASE_URL` shape.
+- Links: `docs/runbooks/database-connection-hardening.md`,
+  `docs/runbooks/vercel-env-contract-and-secrets.md`, `lib/env.server.ts`
+
 ## 2026-05-07 - Centralize outbound email delivery through durable provider records
 - Status: Accepted
 - Context: TASK-125 needed app-owned transactional email delivery for current

--- a/docs/runbooks/database-connection-hardening.md
+++ b/docs/runbooks/database-connection-hardening.md
@@ -5,8 +5,12 @@ Define a safe and repeatable way to configure, rotate, and verify database
 connections across local dev, CI, and production.
 
 ## Connection Roles
-- `DATABASE_URL`: runtime application traffic (pooled endpoint in production).
-- `DIRECT_URL`: direct admin/migration traffic (non-pooler endpoint).
+- `DATABASE_URL`: runtime application traffic. In hosted Supabase production
+  and preview this must be a least-privilege runtime role through transaction
+  pooling.
+- `DIRECT_URL`: admin/migration traffic. Prefer a direct database endpoint when
+  the execution environment can reach it; use an admin-capable session-pooler
+  endpoint when Supabase's direct host is unreachable from that environment.
 
 In production with remote hosts, these URLs must:
 - target different endpoints
@@ -16,12 +20,23 @@ In production with remote hosts, these URLs must:
 For Supabase production:
 - `DATABASE_URL` must use the Supabase transaction pooler:
   `*.pooler.supabase.com:6543`
-- `DIRECT_URL` must use the direct database endpoint:
-  `db.<project-ref>.supabase.co:5432`
+- `DATABASE_URL` must use the least-privilege runtime database role
+  (`app_runtime.<project-ref>` on the shared pooler in current environments).
+- `DIRECT_URL` and `MIGRATION_DATABASE_URL` must use an admin-capable role such
+  as `postgres`; they must never use `app_runtime`.
+- `DIRECT_URL` should use the direct database endpoint when reachable:
+  `db.<project-ref>.supabase.co:5432`.
+- Supabase direct database hosts are IPv6-only by default unless the project has
+  IPv4 support enabled. GitHub Actions, Vercel, and local machines may be unable
+  to resolve or connect to that host. In those cases, use the admin
+  session-pooler URL (`postgres.<project-ref>` on
+  `*.pooler.supabase.com:5432`) for `DIRECT_URL` and
+  `MIGRATION_DATABASE_URL` instead of weakening `DATABASE_URL`.
 - `DATABASE_URL`, `DIRECT_URL`, and `SUPABASE_URL` must all target the same
   Supabase project ref. On the shared pooler, the project ref is encoded in the
-  username (`postgres.<project-ref>`). On direct/client URLs, it is encoded in
-  the host (`db.<project-ref>.supabase.co` and
+  username (`<role>.<project-ref>`, for example `app_runtime.<project-ref>` or
+  `postgres.<project-ref>`). On direct/client URLs, it is encoded in the host
+  (`db.<project-ref>.supabase.co` and
   `https://<project-ref>.supabase.co`).
 
 Do not use the Supabase session pooler (`*.pooler.supabase.com:5432`) for
@@ -38,8 +53,12 @@ short-lived/serverless application connections.
   - keep ephemeral/local endpoints where possible.
   - avoid production credentials in CI.
 - Production:
-  - transaction-pooled runtime URL in `DATABASE_URL`
-  - direct migration/admin URL in `DIRECT_URL`
+  - transaction-pooled `app_runtime` runtime URL in `DATABASE_URL`
+  - admin-capable migration URL in `DIRECT_URL`
+  - use the direct host for `DIRECT_URL` when IPv6/direct connectivity is
+    available
+  - use the `postgres.<project-ref>` session-pooler URL for `DIRECT_URL` /
+    `MIGRATION_DATABASE_URL` when direct host connectivity is unavailable
   - TLS enabled on both URLs
 
 ## Credential Hygiene
@@ -50,7 +69,8 @@ short-lived/serverless application connections.
 
 ## Rotation Procedure
 1. Create new database credentials in provider console.
-2. Update secret manager values for `DATABASE_URL` and `DIRECT_URL`.
+2. Update secret manager values for `DATABASE_URL`, `DIRECT_URL`, and
+   `MIGRATION_DATABASE_URL` as needed.
 3. Run validation pipeline (`lint`, `test`, `test:coverage`, `build`).
 4. Deploy staged production release.
 5. Validate readiness endpoint and critical app workflows.
@@ -65,15 +85,20 @@ snapshots, preview files, staging files, or old pulled Vercel env caches.
 Use this checklist when production DB routing is suspect:
 
 1. Open the Supabase Production project.
-2. Copy the Production transaction-pooler connection string for `DATABASE_URL`.
+2. Copy the Production transaction-pooler connection string for `DATABASE_URL`
+   and set it to the least-privilege runtime role (`app_runtime.<project-ref>`).
 3. Copy the matching Production direct connection string for `DIRECT_URL` and
-   `MIGRATION_DATABASE_URL`.
+   `MIGRATION_DATABASE_URL` when direct IPv6 connectivity is available.
+   Otherwise copy the admin `postgres.<project-ref>` session-pooler URL on port
+   `5432`.
 4. Confirm the same project ref appears in:
-   - pooler username: `postgres.<project-ref>`
+   - runtime pooler username: `app_runtime.<project-ref>`
+   - admin pooler username, when used: `postgres.<project-ref>`
    - direct host: `db.<project-ref>.supabase.co`
    - client URL: `https://<project-ref>.supabase.co`
 5. Update Vercel Production runtime secrets and GitHub production environment
-   secrets through their secret managers.
+   secrets through their secret managers. Never substitute the admin URL into
+   `DATABASE_URL`.
 6. Deploy a staged production build, promote it, then verify `/api/health/live`
    and an authenticated project list.
 
@@ -83,9 +108,12 @@ recovery unless the operator explicitly authorizes a specific secret operation.
 ## Verification Checklist
 - `validateServerRuntimeConfig()` passes in the target environment.
 - `/api/health/ready` returns healthy status after deploy.
-- Prisma migrations run using `DIRECT_URL`.
+- Prisma migrations run using `DIRECT_URL` / `MIGRATION_DATABASE_URL` with an
+  admin-capable role.
 - Runtime traffic uses Supabase transaction pooling (`DATABASE_URL` on port
-  `6543`) when the database is Supabase.
+  `6543`) and the least-privilege `app_runtime` role when the database is
+  Supabase.
+- `DIRECT_URL` / `MIGRATION_DATABASE_URL` do not use `app_runtime`.
 - Supabase project refs match across `DATABASE_URL`, `DIRECT_URL`, and
   `SUPABASE_URL`.
 - Vercel logs do not show `EMAXCONNSESSION` during representative authenticated

--- a/docs/runbooks/vercel-env-contract-and-secrets.md
+++ b/docs/runbooks/vercel-env-contract-and-secrets.md
@@ -58,13 +58,27 @@ For Supabase-backed Vercel deployments:
 
 - `DATABASE_URL` must be the Supabase transaction pooler URL:
   `*.pooler.supabase.com:6543`.
-- `DIRECT_URL` must be the Supabase direct database URL:
-  `db.<project-ref>.supabase.co:5432`.
+- `DATABASE_URL` must use the least-privilege runtime role
+  (`app_runtime.<project-ref>` on the shared Supabase pooler).
+- `DIRECT_URL` / `MIGRATION_DATABASE_URL` must use an admin-capable role such
+  as `postgres`; they must not use `app_runtime`.
+- `DIRECT_URL` should be the Supabase direct database URL
+  (`db.<project-ref>.supabase.co:5432`) when the deployment environment can
+  reach Supabase direct hosts.
+- Supabase direct hosts are IPv6-only by default unless IPv4 support is enabled.
+  If GitHub Actions or Vercel cannot connect to the direct host, use the admin
+  session-pooler URL (`postgres.<project-ref>` on
+  `*.pooler.supabase.com:5432`) for `DIRECT_URL` and
+  `MIGRATION_DATABASE_URL`.
 - Both values must enforce TLS, for example `?sslmode=require`.
 
 Do not configure `DATABASE_URL` with the Supabase session pooler on port `5432`.
 That shape can exhaust the session pool under normal Vercel/serverless request
 bursts and is rejected by runtime validation.
+
+Do not configure `DATABASE_URL` with the admin `postgres` role. Runtime app
+traffic should stay on `app_runtime` so forced RLS remains meaningful even if a
+service query path regresses.
 
 ## Outbound Email
 
@@ -187,6 +201,10 @@ Important:
   project, not local `.env` snapshots or preview/staging files. The app rejects
   production startup when Supabase project refs differ across `DATABASE_URL`,
   `DIRECT_URL`, and `SUPABASE_URL`.
+- When Supabase direct-host connectivity is unavailable, `DIRECT_URL` may use
+  the admin session pooler on port `5432`. That is an admin/migration fallback,
+  not permission to use session pooling or admin credentials for
+  `DATABASE_URL`.
 - GitHub-managed preview deploys and Vercel-managed preview deployments do not
   get runtime secrets from the same place:
   - `deploy-vercel.yml` can inject preview fallback values into the specific

--- a/journal.md
+++ b/journal.md
@@ -12,6 +12,20 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ## Recent Entries (Most Relevant)
 
+### 2026-05-20
+- Type: Governance
+- Summary: Clarified Supabase runtime/admin connection policy after production
+  credential repair.
+- Evidence: Production and staging role checks confirmed `app_runtime` exists
+  with no superuser/create-role/create-db/RLS-bypass privileges, while
+  `postgres` remains admin-capable. The validated runtime shape is
+  `app_runtime.<project-ref>` through the transaction pooler on port `6543`.
+  Supabase direct-host DNS resolved IPv6-only from local diagnostics, so the
+  docs now allow an admin `postgres.<project-ref>` session-pooler fallback for
+  `DIRECT_URL` / `MIGRATION_DATABASE_URL` when direct connectivity is
+  unavailable, while keeping admin/session-pooler credentials forbidden for
+  `DATABASE_URL`.
+
 ### 2026-05-19
 - Type: Validation
 - Summary: TASK-132 PR #270 branch refreshed against current `main` and

--- a/lib/env.server.ts
+++ b/lib/env.server.ts
@@ -390,6 +390,8 @@ interface ParsedDatabaseConnectionString {
   rawValue: string;
   host: string;
   port: string;
+  username: string;
+  usernameRole: string | null;
   supabaseProjectRef: string | null;
   isLocalHost: boolean;
   isPoolerHost: boolean;
@@ -414,6 +416,15 @@ function extractSupabasePoolerProjectRef(username: string): string | null {
   }
 
   return username.slice(separatorIndex + 1).toLowerCase();
+}
+
+function extractSupabasePoolerRoleName(username: string): string | null {
+  const separatorIndex = username.lastIndexOf(".");
+  if (separatorIndex <= 0) {
+    return null;
+  }
+
+  return username.slice(0, separatorIndex).toLowerCase();
 }
 
 function extractSupabaseClientProjectRef(value: string): string | null {
@@ -464,11 +475,16 @@ function parseDatabaseConnectionString(
   const supabaseProjectRef = isSupabasePoolerHost
     ? extractSupabasePoolerProjectRef(username)
     : extractSupabaseDirectProjectRef(host);
+  const usernameRole = isSupabasePoolerHost
+    ? extractSupabasePoolerRoleName(username)
+    : username.toLowerCase() || null;
 
   return {
     rawValue: value,
     host,
     port,
+    username,
+    usernameRole,
     supabaseProjectRef,
     isLocalHost: isLocalDatabaseHost(host),
     isPoolerHost,
@@ -548,18 +564,21 @@ function assertProductionDatabaseConnectionHardening(
     );
   }
 
-  if (directUrl.isPoolerHost) {
-    throw new Error(
-      "DIRECT_URL must target a direct database endpoint, not a pooler host."
-    );
-  }
-
   if (
     databaseUrl.isSupabasePoolerHost &&
     databaseUrl.port !== SUPABASE_TRANSACTION_POOLER_PORT
   ) {
     throw new Error(
       `DATABASE_URL must use the Supabase transaction pooler port ${SUPABASE_TRANSACTION_POOLER_PORT} in production; port ${SUPABASE_SESSION_POOLER_PORT} is session mode and can exhaust serverless clients.`
+    );
+  }
+
+  if (
+    databaseUrl.isSupabasePoolerHost &&
+    databaseUrl.usernameRole !== "app_runtime"
+  ) {
+    throw new Error(
+      "DATABASE_URL must use the least-privilege app_runtime role for Supabase production runtime traffic."
     );
   }
 
@@ -573,6 +592,24 @@ function assertProductionDatabaseConnectionHardening(
     );
   }
 
+  if (
+    directUrl.isSupabasePoolerHost &&
+    directUrl.port !== SUPABASE_SESSION_POOLER_PORT
+  ) {
+    throw new Error(
+      `DIRECT_URL may use the Supabase admin session-pooler fallback only on port ${SUPABASE_SESSION_POOLER_PORT}.`
+    );
+  }
+
+  if (
+    directUrl.isSupabasePoolerHost &&
+    directUrl.usernameRole === "app_runtime"
+  ) {
+    throw new Error(
+      "DIRECT_URL must use an admin-capable Supabase role, not app_runtime."
+    );
+  }
+
   const isSupabaseConnection =
     databaseUrl.isSupabaseHost && directUrl.isSupabaseHost;
   if (!isSupabaseConnection) {
@@ -582,12 +619,6 @@ function assertProductionDatabaseConnectionHardening(
   if (!databaseUrl.isSupabasePoolerHost) {
     throw new Error(
       "DATABASE_URL must use the Supabase pooler host in production (expected *.pooler.supabase.com)."
-    );
-  }
-
-  if (directUrl.isSupabasePoolerHost) {
-    throw new Error(
-      "DIRECT_URL must use the Supabase direct host in production (for example db.<project-ref>.supabase.co), not the pooler host."
     );
   }
 

--- a/tests/lib/env.server.test.ts
+++ b/tests/lib/env.server.test.ts
@@ -760,20 +760,20 @@ describe("env.server", () => {
     );
   });
 
-  test("fails runtime validation when production direct url points to a pooler host", () => {
+  test("passes runtime validation when supabase direct url uses admin session-pooler fallback", () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv(
       "DATABASE_URL",
-      "postgresql://runtime-user:pwd@pooler.supabase.com:5432/postgres?sslmode=require"
+      "postgresql://app_runtime.project-ref:pwd@aws-1-eu-west-1.pooler.supabase.com:6543/postgres?sslmode=require"
     );
     vi.stubEnv(
       "DIRECT_URL",
-      "postgresql://admin-user:pwd@project.pooler.supabase.com:5432/postgres?sslmode=require"
+      "postgresql://postgres.project-ref:pwd@aws-1-eu-west-1.pooler.supabase.com:5432/postgres?sslmode=require"
     );
+    vi.stubEnv("SUPABASE_URL", "https://project-ref.supabase.co");
+    vi.stubEnv("SUPABASE_PUBLISHABLE_KEY", "pk_test_123");
 
-    expect(() => validateServerRuntimeConfig()).toThrow(
-      "DIRECT_URL must target a direct database endpoint, not a pooler host."
-    );
+    expect(() => validateServerRuntimeConfig()).not.toThrow();
   });
 
   test("fails runtime validation when supabase database url is not a pooler host in production", () => {
@@ -812,7 +812,7 @@ describe("env.server", () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv(
       "DATABASE_URL",
-      "postgresql://postgres.project-ref:pwd@aws-1-eu-west-1.pooler.supabase.com:6543/postgres?sslmode=require"
+      "postgresql://app_runtime.project-ref:pwd@aws-1-eu-west-1.pooler.supabase.com:6543/postgres?sslmode=require"
     );
     vi.stubEnv(
       "DIRECT_URL",
@@ -824,11 +824,27 @@ describe("env.server", () => {
     expect(() => validateServerRuntimeConfig()).not.toThrow();
   });
 
+  test("fails runtime validation when supabase database url uses admin role in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv(
+      "DATABASE_URL",
+      "postgresql://postgres.project-ref:pwd@aws-1-eu-west-1.pooler.supabase.com:6543/postgres?sslmode=require"
+    );
+    vi.stubEnv(
+      "DIRECT_URL",
+      "postgresql://postgres:pwd@db.project-ref.supabase.co:5432/postgres?sslmode=require"
+    );
+
+    expect(() => validateServerRuntimeConfig()).toThrow(
+      "DATABASE_URL must use the least-privilege app_runtime role for Supabase production runtime traffic."
+    );
+  });
+
   test("fails runtime validation when supabase database and direct urls target different projects in production", () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv(
       "DATABASE_URL",
-      "postgresql://postgres.preview-ref:pwd@aws-1-eu-west-1.pooler.supabase.com:6543/postgres?sslmode=require"
+      "postgresql://app_runtime.preview-ref:pwd@aws-1-eu-west-1.pooler.supabase.com:6543/postgres?sslmode=require"
     );
     vi.stubEnv(
       "DIRECT_URL",
@@ -844,7 +860,7 @@ describe("env.server", () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv(
       "DATABASE_URL",
-      "postgresql://postgres.production-ref:pwd@aws-1-eu-west-1.pooler.supabase.com:6543/postgres?sslmode=require"
+      "postgresql://app_runtime.production-ref:pwd@aws-1-eu-west-1.pooler.supabase.com:6543/postgres?sslmode=require"
     );
     vi.stubEnv(
       "DIRECT_URL",
@@ -862,7 +878,7 @@ describe("env.server", () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv(
       "DATABASE_URL",
-      "postgresql://runtime-user:pwd@project.pooler.supabase.com:6543/postgres?sslmode=require"
+      "postgresql://app_runtime.project-ref:pwd@aws-1-eu-west-1.pooler.supabase.com:6543/postgres?sslmode=require"
     );
     vi.stubEnv(
       "DIRECT_URL",
@@ -874,11 +890,43 @@ describe("env.server", () => {
     );
   });
 
+  test("fails runtime validation when supabase direct url uses transaction-pooler fallback", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv(
+      "DATABASE_URL",
+      "postgresql://app_runtime.project-ref:pwd@aws-1-eu-west-1.pooler.supabase.com:6543/postgres?sslmode=require"
+    );
+    vi.stubEnv(
+      "DIRECT_URL",
+      "postgresql://postgres.project-ref:pwd@aws-0-eu-west-1.pooler.supabase.com:6543/postgres?sslmode=require"
+    );
+
+    expect(() => validateServerRuntimeConfig()).toThrow(
+      "DIRECT_URL may use the Supabase admin session-pooler fallback only on port 5432."
+    );
+  });
+
+  test("fails runtime validation when supabase direct url uses app runtime role", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv(
+      "DATABASE_URL",
+      "postgresql://app_runtime.project-ref:pwd@aws-1-eu-west-1.pooler.supabase.com:6543/postgres?sslmode=require"
+    );
+    vi.stubEnv(
+      "DIRECT_URL",
+      "postgresql://app_runtime.project-ref:pwd@aws-1-eu-west-1.pooler.supabase.com:5432/postgres?sslmode=require"
+    );
+
+    expect(() => validateServerRuntimeConfig()).toThrow(
+      "DIRECT_URL must use an admin-capable Supabase role, not app_runtime."
+    );
+  });
+
   test("allows mixed provider endpoints when database is Supabase and direct is non-Supabase", () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv(
       "DATABASE_URL",
-      "postgresql://runtime-user:pwd@project.pooler.supabase.com:6543/postgres?sslmode=require"
+      "postgresql://app_runtime.project-ref:pwd@aws-1-eu-west-1.pooler.supabase.com:6543/postgres?sslmode=require"
     );
     vi.stubEnv(
       "DIRECT_URL",


### PR DESCRIPTION
## Summary
- Clarify that production/preview `DATABASE_URL` must use the least-privilege `app_runtime.<project-ref>` role through Supabase transaction pooling on port `6543`.
- Document that `DIRECT_URL` and `MIGRATION_DATABASE_URL` stay admin-capable, prefer the direct host when reachable, and may use the admin session-pooler URL when Supabase direct IPv6 connectivity is unavailable.
- Align runtime validation with that policy: Supabase runtime traffic must use `app_runtime`, admin session-pooler fallback is allowed only for `DIRECT_URL` on port `5432`, and `app_runtime` is rejected for admin direct URLs.
- Record the policy in the DB runbook, Vercel env runbook, README, ADR log, and journal.

## Validation
- `npm test -- --run tests/lib/env.server.test.ts`
- `npm run lint`
- `npm test`
- `npm run test:coverage`
- `npm run build`
- `git diff --check`