### PR TITLE
TASK-269 Refresh backlog next tasks

### DIFF
--- a/journal.md
+++ b/journal.md
@@ -13,6 +13,17 @@ Use it for important implementation milestones, blockers, validation runs, and r
 ## Recent Entries (Most Relevant)
 
 ### 2026-05-20
+- Type: Planning
+- Summary: Added post-deploy operational and design assessment follow-ups.
+- Evidence: Updated `tasks/backlog.md` to move merged TASK-268 and TASK-132 to
+  completed, added TASK-269 for GitHub Actions workflow cleanup at the top of
+  the execution queue, and added TASK-270 as a product-wide UI/UX design
+  assessment that feeds existing refinement tasks instead of duplicating them.
+  Added dedicated briefs in
+  `tasks/task-269-github-actions-workflow-cleanup.md` and
+  `tasks/task-270-app-ui-ux-design-assessment.md`.
+
+### 2026-05-20
 - Type: Governance
 - Summary: Clarified Supabase runtime/admin connection policy after production
   credential repair.

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -4,12 +4,12 @@ Use this file to capture tasks discovered during development. Each entry should 
 
 ## Pending
 ### Execution Queue (Now / Next)
-- ID: TASK-268
-  Title: GitHub Actions notification email scheduler - 3-hour production bridge
+- ID: TASK-269
+  Title: GitHub Actions workflow cleanup - simplify CI/CD, scheduled jobs, and maintenance automation
   Status: Next
-  Rationale: QStash activation created too much operational friction for the current stage, and Vercel remains on Hobby where Vercel Cron is daily-only. Use the existing protected GitHub Actions dispatcher as a temporary production scheduler bridge every 3 hours, keeping the app-owned durable queue/idempotency guarantees while explicitly downgrading the email delivery promise from sub-hour to periodic digest delivery.
-  Dependencies: TASK-125, TASK-227
-  Brief: `tasks/task-268-github-actions-notification-email-scheduler.md`
+  Rationale: The repository now has several production-impacting workflows covering quality gates, staged Vercel deploys, notification email dispatch, dependency security, Dependabot triage, and Copilot repair. Recent production work exposed duplicated env handling, scheduler tradeoffs, and deploy/secrets coupling across these workflows. Run a focused cleanup so workflow responsibilities, permissions, env/secrets usage, dispatch inputs, summaries, and failure modes are easier to understand and operate without changing product behavior.
+  Dependencies: TASK-042, TASK-116, TASK-132, TASK-268
+  Brief: `tasks/task-269-github-actions-workflow-cleanup.md`
 - ID: TASK-265
   Title: Notification actor attribution and self-notification rules
   Status: Next
@@ -38,11 +38,6 @@ Use this file to capture tasks discovered during development. Each entry should 
   Status: Pending
   Rationale: Make the project roadmap manageable by project-scoped agent tokens so agents can inspect, create, update, move, reorder, and delete roadmap phases/events when they are responsible for project planning. This should be a deliberate agent API contract expansion with dedicated roadmap scopes, OpenAPI/onboarding documentation, credential UI updates, route guard coverage, and smoke tests rather than implicitly folding roadmap permissions into existing project or task scopes.
   Dependencies: TASK-127, TASK-130, TASK-059
-- ID: TASK-132
-  Title: Version update system adjustments - align version metadata, automation, and release communication
-  Status: In review via PR #270
-  Rationale: Review and adjust the app's version update system so version metadata, dependency-update cadence, release notes, deployment visibility, and any user-facing update indicators stay consistent across automated maintenance, manual releases, and future API or agent-facing surfaces.
-  Dependencies: TASK-041, TASK-042, TASK-116
 - ID: TASK-129
   Title: Login/home page UI polish - user-friendly, product-oriented entry experience
   Status: Pending
@@ -88,6 +83,12 @@ Use this file to capture tasks discovered during development. Each entry should 
   Status: Pending
   Rationale: Enable bilingual product usage (French and English) with consistent UI copy, locale routing/state strategy, and fallback behavior; defer implementation until we confirm i18n architecture and translation workflow.
   Dependencies: TASK-047, TASK-060
+- ID: TASK-270
+  Title: App UI/UX design assessment - product-wide heuristic audit and refinement roadmap
+  Status: Pending
+  Rationale: Before another broad polish pass, assess the current app experience across core user journeys, responsive layouts, visual hierarchy, copy, interaction feedback, accessibility basics, and consistency with the intended product tone. The output should be a ranked, evidence-backed design assessment that decides which issues belong in existing UI tasks such as TASK-108/TASK-100/TASK-129 and which need new implementation tasks, instead of mixing assessment and redesign in one large patch.
+  Dependencies: TASK-091, TASK-096, TASK-100, TASK-108, TASK-129
+  Brief: `tasks/task-270-app-ui-ux-design-assessment.md`
 - ID: TASK-108
   Title: Whole-app UI/UX refinement - global interaction, visual, and information-design polish
   Status: Pending
@@ -142,6 +143,16 @@ Use this file to capture tasks discovered during development. Each entry should 
   Dependencies: TASK-051
 
 ## Completed
+- ID: TASK-268
+  Title: GitHub Actions notification email scheduler - 3-hour production bridge
+  Status: Done (2026-05-19, merged via PR #271)
+  Rationale: QStash activation created too much operational friction for the current stage, and Vercel remains on Hobby where Vercel Cron is daily-only. Added the protected GitHub Actions dispatcher as a temporary production scheduler bridge every 3 hours, keeping the app-owned durable queue/idempotency guarantees while explicitly downgrading the email delivery promise from sub-hour to periodic digest delivery.
+  Dependencies: TASK-125, TASK-227
+- ID: TASK-132
+  Title: Version update system adjustments - align version metadata, automation, and release communication
+  Status: Done (2026-05-20, merged via PR #270)
+  Rationale: Aligned app version metadata, dependency-update cadence, deployment visibility, and user-facing version display by making `package.json` the canonical product-version source and passing deterministic build metadata through Vercel deploy workflows.
+  Dependencies: TASK-041, TASK-042, TASK-116
 - ID: TASK-228
   Title: QStash notification email scheduler activation - production cadence and smoke validation
   Status: Superseded (2026-05-19, replaced by TASK-268)

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -68,8 +68,10 @@ operator-friendly failure modes.
 ## Validation Plan
 - `git diff --check`
 - `npm run lint` if workflow-adjacent scripts or docs linting are touched.
-- Use `gh workflow view` / `gh workflow run --dry-run` equivalents where
-  available, or validate YAML through normal PR checks.
+- Use `gh workflow view <workflow>` for workflow inspection and, when a manual
+  workflow must be exercised, dispatch it explicitly with `gh workflow run
+  <workflow> --ref <branch>` plus the required fields.
+- Validate YAML through normal PR checks.
 - Monitor PR checks for branch-name, quality gates, and any workflow-specific
   failures.
 

--- a/tasks/task-269-github-actions-workflow-cleanup.md
+++ b/tasks/task-269-github-actions-workflow-cleanup.md
@@ -55,8 +55,9 @@ is layered onto it.
 ## Validation Plan
 - `git diff --check`
 - `npm run lint` if workflow-adjacent scripts or docs linting are touched.
-- Use `gh workflow view` / `gh workflow run --dry-run` equivalents where
-  available, or validate YAML through the normal PR checks.
+- Use `gh workflow view <workflow>` for workflow inspection and, when a manual
+  workflow must be exercised, dispatch it explicitly with `gh workflow run
+  <workflow> --ref <branch>` plus the required fields.
+- Validate YAML through the normal PR checks.
 - Monitor PR checks for branch-name, quality gates, and any workflow-specific
   failures.
-

--- a/tasks/task-269-github-actions-workflow-cleanup.md
+++ b/tasks/task-269-github-actions-workflow-cleanup.md
@@ -1,19 +1,10 @@
-# Current Task: TASK-269 GitHub Actions Workflow Cleanup
+# TASK-269 GitHub Actions Workflow Cleanup
 
 ## Task ID
 TASK-269
 
 ## Status
-Queued
-
-## Source
-- User request after PR #270, PR #271, and PR #272 merged:
-  add GitHub Actions workflow cleanup to the top of the backlog.
-- `tasks/backlog.md` entry:
-  "GitHub Actions workflow cleanup - simplify CI/CD, scheduled jobs, and
-  maintenance automation."
-- Dedicated brief:
-  `tasks/task-269-github-actions-workflow-cleanup.md`.
+Pending
 
 ## Objective
 Audit and simplify the repository's GitHub Actions workflows so CI, staged
@@ -21,17 +12,14 @@ Vercel deployment, notification email scheduling, dependency security, and
 maintenance automation have clear ownership, minimal duplicated logic, and
 operator-friendly failure modes.
 
-## Current Baseline
-- Quality gates, branch-name checks, staged Vercel deploy/promote/rollback,
-  dependency security, Dependabot triage, Copilot repair, and notification
-  email dispatch are all active workflow concerns.
-- TASK-268 intentionally moved notification email scheduling to a GitHub
-  Actions 3-hour production bridge while QStash remains out of the current
-  production path.
-- TASK-132 added deterministic app version metadata injection to the Vercel
-  deploy workflow.
-- TASK-259/TASK-272 tightened database env validation and documentation around
-  Supabase runtime/admin connection shapes.
+## Rationale
+Recent production work touched several workflows and exposed recurring friction:
+environment variables are resolved in several places, scheduled notification
+dispatch is intentionally a temporary GitHub Actions bridge, staged deployment
+has production safety requirements, and dependency maintenance includes both
+deterministic automation and Copilot-assisted repair. The workflow set is
+powerful, but it needs a focused hygiene pass before more operational behavior
+is layered onto it.
 
 ## Scope
 - Inventory `.github/workflows/**` and document each workflow's owner,
@@ -62,21 +50,13 @@ operator-friendly failure modes.
   intentional cleanup fixes.
 - Documentation reflects the final workflow contract.
 - Relevant workflow syntax and local validation pass.
-- The branch is pushed, a PR is opened, Copilot/check feedback is monitored,
-  and the handoff includes the delivered commit SHA.
+- A PR is opened and CI/Copilot feedback is handled.
 
 ## Validation Plan
 - `git diff --check`
 - `npm run lint` if workflow-adjacent scripts or docs linting are touched.
 - Use `gh workflow view` / `gh workflow run --dry-run` equivalents where
-  available, or validate YAML through normal PR checks.
+  available, or validate YAML through the normal PR checks.
 - Monitor PR checks for branch-name, quality gates, and any workflow-specific
   failures.
 
-## Out Of Scope
-- Replacing the TASK-268 GitHub Actions scheduler bridge with QStash, Vercel
-  Cron, or another managed scheduler.
-- Changing product notification email delivery semantics.
-- Changing Vercel production/staging database credentials or secrets.
-- Redesigning Dependabot/Copilot repair policy unless stale workflow logic makes
-  that necessary.

--- a/tasks/task-270-app-ui-ux-design-assessment.md
+++ b/tasks/task-270-app-ui-ux-design-assessment.md
@@ -1,0 +1,58 @@
+# TASK-270 App UI/UX Design Assessment
+
+## Task ID
+TASK-270
+
+## Status
+Pending
+
+## Objective
+Produce a product-wide UI/UX assessment that identifies the highest-impact
+design, interaction, copy, accessibility, and responsive-layout issues before
+the next implementation-focused refinement pass.
+
+## Rationale
+The backlog already contains implementation tasks for broad UI refinement
+(`TASK-108`), mobile polish (`TASK-100`), and login/home polish (`TASK-129`).
+This task is intentionally assessment-first: it should create a grounded,
+ranked roadmap so future UI work is not a large speculative redesign and does
+not duplicate existing tasks.
+
+## Scope
+- Review core flows:
+  - unauthenticated entry and sign-in/sign-up
+  - projects list and create/edit/delete flows
+  - project dashboard modules
+  - task create/detail/edit/comment flows
+  - notification center and account settings
+  - owner/project sharing and agent access surfaces
+- Assess visual hierarchy, spacing, density, component consistency, copy,
+  feedback states, empty/error/loading states, keyboard/focus behavior,
+  accessibility basics, and mobile ergonomics.
+- Compare findings against existing tasks and decide whether each item belongs
+  in TASK-108, TASK-100, TASK-129, TASK-133, another existing task, or a new
+  follow-up.
+- Avoid implementing UI changes in this task unless the assessment uncovers a
+  tiny critical regression that should be fixed separately.
+
+## Acceptance Criteria
+1. A concise assessment document exists with ranked findings, evidence, impact,
+   and suggested owning task.
+2. Existing UI backlog tasks are cross-referenced instead of duplicated.
+3. Any newly discovered implementation work is added as focused backlog tasks.
+4. The assessment distinguishes product design improvements from bugs,
+   accessibility defects, and responsive-layout issues.
+5. Screenshots or reproducible notes are captured for high-priority findings
+   when practical.
+
+## Definition Of Done
+- Assessment is documented in the repo.
+- `tasks/backlog.md` is updated with any sequencing or new tasks discovered.
+- `journal.md` records the assessment outcome and recommended next steps.
+- A PR is opened for the assessment and backlog changes.
+
+## Validation Plan
+- Manual walkthrough across desktop and mobile-sized viewports.
+- Browser automation or Playwright screenshots if useful for reproducibility.
+- `git diff --check`.
+


### PR DESCRIPTION
## Summary
- Move merged TASK-268 and TASK-132 out of pending tracking and into completed history.
- Add TASK-269 at the top of the execution queue for GitHub Actions workflow cleanup, with a dedicated task brief.
- Add TASK-270 for an app-wide UI/UX design assessment that feeds existing UI refinement tasks instead of duplicating them.
- Refresh `tasks/current.md` so the next session starts from TASK-269 rather than the already-merged TASK-132.
- Record the planning update in `journal.md`.

## Validation
- `git diff --check`