### PR TITLE
TASK-271 Suppress repeated notification digest emails

### DIFF
--- a/journal.md
+++ b/journal.md
@@ -20,9 +20,9 @@ Use it for important implementation milestones, blockers, validation runs, and r
   emails for notifications that had already been emailed but remained unread
   in-app. Created `fix/task-271-notification-email-no-repeat`, added
   `tasks/task-271-notification-email-delivery-deduplication.md`, and tightened
-  `lib/services/project-notification-email-service.ts` so sent/skipped email
-  items cover notification IDs permanently while pending/dispatching groups
-  still use current fingerprints for pre-delivery refreshes.
+  `lib/services/project-notification-email-service.ts` so sent email items
+  cover notification IDs permanently while pending/dispatching groups still use
+  current fingerprints for pre-delivery refreshes.
 
 ### 2026-05-20
 - Type: Execution

--- a/journal.md
+++ b/journal.md
@@ -22,7 +22,9 @@ Use it for important implementation milestones, blockers, validation runs, and r
   `tasks/task-271-notification-email-delivery-deduplication.md`, and tightened
   `lib/services/project-notification-email-service.ts` so sent email items
   cover notification IDs permanently while pending/dispatching groups still use
-  current fingerprints for pre-delivery refreshes.
+  current fingerprints for pre-delivery refreshes. Added a dispatch-time guard
+  so stale pending groups created before the fix are skipped when another sent
+  group already covered their notification IDs.
 
 ### 2026-05-20
 - Type: Execution

--- a/journal.md
+++ b/journal.md
@@ -12,6 +12,18 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ## Recent Entries (Most Relevant)
 
+### 2026-05-21
+- Type: Execution
+- Summary: Started TASK-271 to suppress repeated notification digest emails for
+  already-delivered notifications.
+- Evidence: User reported receiving repeated NexusDash notification reminder
+  emails for notifications that had already been emailed but remained unread
+  in-app. Created `fix/task-271-notification-email-no-repeat`, added
+  `tasks/task-271-notification-email-delivery-deduplication.md`, and tightened
+  `lib/services/project-notification-email-service.ts` so sent/skipped email
+  items cover notification IDs permanently while pending/dispatching groups
+  still use current fingerprints for pre-delivery refreshes.
+
 ### 2026-05-20
 - Type: Execution
 - Summary: Fixed notification email scheduler production target drift.

--- a/lib/services/project-notification-email-service.ts
+++ b/lib/services/project-notification-email-service.ts
@@ -365,7 +365,7 @@ async function isNotificationFingerprintCovered(input: {
           email: {
             kind: input.kind,
             status: {
-              in: ["sent", "skipped"],
+              in: ["sent"],
             },
           },
         },
@@ -606,7 +606,7 @@ async function findUncoveredNotificationEmailCandidates(
           ON email."id" = item."emailId"
         WHERE item."notificationId" = notification."id"
           AND (
-            email."status" IN ('sent', 'skipped')
+            email."status" = 'sent'
             OR (
               email."status" IN ('pending', 'dispatching')
               AND (

--- a/lib/services/project-notification-email-service.ts
+++ b/lib/services/project-notification-email-service.ts
@@ -938,11 +938,57 @@ async function buildInvitationReminderItem(input: {
   };
 }
 
+async function findSentCoveredNotificationIds(input: {
+  kind: NotificationEmailKind;
+  currentGroupId: string;
+  notificationIds: string[];
+}): Promise<Set<string>> {
+  const notificationIds = Array.from(new Set(input.notificationIds));
+  if (notificationIds.length === 0) {
+    return new Set();
+  }
+
+  const rows = await prisma.projectNotificationEmailItem.findMany({
+    where: {
+      notificationId: {
+        in: notificationIds,
+      },
+      emailId: {
+        not: input.currentGroupId,
+      },
+      email: {
+        kind: input.kind,
+        status: "sent",
+      },
+    },
+    select: {
+      notificationId: true,
+    },
+  });
+
+  return new Set(rows.map((row) => row.notificationId));
+}
+
 async function buildPreparedSection(input: {
   group: ClaimedEmailGroup;
   appOrigin: string;
   now: Date;
 }): Promise<PreparedSection | null> {
+  const sentCoveredNotificationIds = await findSentCoveredNotificationIds({
+    kind: input.group.kind,
+    currentGroupId: input.group.id,
+    notificationIds: input.group.items.map((item) => item.notificationId),
+  });
+
+  if (sentCoveredNotificationIds.size > 0) {
+    input.group = {
+      ...input.group,
+      items: input.group.items.filter(
+        (item) => !sentCoveredNotificationIds.has(item.notificationId)
+      ),
+    };
+  }
+
   if (input.group.kind === EMAIL_KIND_PROJECT_DIGEST) {
     return buildActivityItems({
       group: input.group,

--- a/lib/services/project-notification-email-service.ts
+++ b/lib/services/project-notification-email-service.ts
@@ -350,19 +350,42 @@ async function isRecipientVerified(db: DbClient, recipientUserId: string) {
 async function isNotificationFingerprintCovered(input: {
   db: DbClient;
   notificationId: string;
+  notificationUpdatedAt: Date;
   sourceFingerprint: string;
   kind: NotificationEmailKind;
 }): Promise<boolean> {
   const existing = await input.db.projectNotificationEmailItem.findFirst({
     where: {
       notificationId: input.notificationId,
-      sourceFingerprint: input.sourceFingerprint,
       email: {
         kind: input.kind,
-        status: {
-          in: ["pending", "dispatching", "sent", "skipped"],
-        },
       },
+      OR: [
+        {
+          email: {
+            kind: input.kind,
+            status: {
+              in: ["sent", "skipped"],
+            },
+          },
+        },
+        {
+          OR: [
+            {
+              notificationUpdatedAt: input.notificationUpdatedAt,
+            },
+            {
+              sourceFingerprint: input.sourceFingerprint,
+            },
+          ],
+          email: {
+            kind: input.kind,
+            status: {
+              in: ["pending", "dispatching"],
+            },
+          },
+        },
+      ],
     },
     select: {
       id: true,
@@ -440,6 +463,7 @@ export async function enqueueNotificationEmailForNotification(input: {
     await isNotificationFingerprintCovered({
       db: input.db,
       notificationId: input.notification.id,
+      notificationUpdatedAt: input.notification.updatedAt,
       sourceFingerprint: details.sourceFingerprint,
       kind: details.kind,
     })
@@ -581,10 +605,18 @@ async function findUncoveredNotificationEmailCandidates(
         INNER JOIN "ProjectNotificationEmail" email
           ON email."id" = item."emailId"
         WHERE item."notificationId" = notification."id"
-          AND item."sourceFingerprint" =
-            notification."id" || ':' ||
-            to_char(notification."updatedAt", 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
-          AND email."status" IN ('pending', 'dispatching', 'sent', 'skipped')
+          AND (
+            email."status" IN ('sent', 'skipped')
+            OR (
+              email."status" IN ('pending', 'dispatching')
+              AND (
+                item."notificationUpdatedAt" = notification."updatedAt"
+                OR item."sourceFingerprint" =
+                  notification."id" || ':' ||
+                  to_char(notification."updatedAt", 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+              )
+            )
+          )
       )
     ORDER BY notification."updatedAt" ASC, notification."id" ASC
     LIMIT ${limit}

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -4,6 +4,12 @@ Use this file to capture tasks discovered during development. Each entry should 
 
 ## Pending
 ### Execution Queue (Now / Next)
+- ID: TASK-271
+  Title: Notification email delivery deduplication - suppress already-emailed unread notifications
+  Status: Active
+  Rationale: Production showed that unread in-app notifications could produce repeated digest emails on later 3-hour scheduler runs. Email delivery should cover notification IDs once, while in-app read/resolved state remains independent and future distinct notifications remain eligible.
+  Dependencies: TASK-125, TASK-227, TASK-268
+  Brief: `tasks/task-271-notification-email-delivery-deduplication.md`
 - ID: TASK-269
   Title: GitHub Actions workflow cleanup - simplify CI/CD, scheduled jobs, and maintenance automation
   Status: Next

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,84 +1,61 @@
-# Current Task: TASK-269 GitHub Actions Workflow Cleanup
+# Current Task: TASK-271 Notification Email Delivery Deduplication
 
 ## Task ID
-TASK-269
+TASK-271
 
 ## Status
-Queued
+Active
 
 ## Source
-- User request after PR #270, PR #271, and PR #272 merged:
-  add GitHub Actions workflow cleanup to the top of the backlog.
-- `tasks/backlog.md` entry:
-  "GitHub Actions workflow cleanup - simplify CI/CD, scheduled jobs, and
-  maintenance automation."
+- User report after PR #274 merged: production sent repeated notification
+  reminder emails for already-emailed unread notifications.
 - Dedicated brief:
-  `tasks/task-269-github-actions-workflow-cleanup.md`.
+  `tasks/task-271-notification-email-delivery-deduplication.md`.
 
 ## Objective
-Audit and simplify the repository's GitHub Actions workflows so CI, staged
-Vercel deployment, notification email scheduling, dependency security, and
-maintenance automation have clear ownership, minimal duplicated logic, and
-operator-friendly failure modes.
+Prevent already-emailed notifications from being emailed again by later
+scheduled dispatcher runs. Email dispatch should cover notification IDs once,
+while future distinct notifications continue through the existing
+debounce/grouping pipeline.
 
 ## Current Baseline
-- Quality gates, branch-name checks, staged Vercel deploy/promote/rollback,
-  dependency security, Dependabot triage, Copilot repair, and notification
-  email dispatch are all active workflow concerns.
-- TASK-268 intentionally moved notification email scheduling to a GitHub
-  Actions 3-hour production bridge while QStash remains out of the current
-  production path.
-- TASK-132 added deterministic app version metadata injection to the Vercel
-  deploy workflow.
-- TASK-259/TASK-272 tightened database env validation and documentation around
-  Supabase runtime/admin connection shapes.
+- Notification email groups are durable and the scheduler runs every 3 hours.
+- Email sending intentionally does not mark in-app notifications read or
+  resolved.
+- The current coverage logic is fingerprint-sensitive, which is useful for
+  pending refreshes but too strict once an email has already been sent or
+  skipped.
 
 ## Scope
-- Inventory `.github/workflows/**` and document each workflow's owner,
-  trigger, required secrets, permissions, artifacts, and expected operator path.
-- Remove dead, duplicated, or workaround-shaped workflow logic that no longer
-  matches the current production model.
-- Normalize reusable env resolution and summaries where workflows share the
-  same Vercel, metadata, database, or notification-dispatch assumptions.
-- Confirm scheduled jobs have the least practical permissions, explicit
-  failure output, and no accidental dependency on interactive environment
-  approvals.
-- Keep product behavior unchanged unless a workflow bug is found and fixed.
+- Tighten service-layer notification email coverage checks.
+- Add focused regression tests for already-delivered notification IDs.
+- Keep in-app notification read/resolved semantics unchanged.
+- Keep scheduler cadence and workflow behavior unchanged.
 
 ## Acceptance Criteria
-1. Every active GitHub Actions workflow has a clear purpose, trigger set,
-   permissions block, and documented secret/env contract.
-2. Obsolete QStash-era or pre-rotation scheduler/deploy assumptions are removed
-   or explicitly marked historical.
-3. Notification email dispatch, deploy/promote/rollback, quality gates,
-   dependency security, Dependabot triage, and Copilot repair workflows remain
-   functionally covered.
-4. Workflow summaries and failure messages are clear enough for an operator to
-   identify the failing step without reading the whole YAML file.
-5. README/runbook references match the final workflow behavior.
+1. Sent/skipped notification email items suppress future email dispatch by
+   notification ID, even if the notification row is later updated.
+2. Pending/dispatching items still require the current fingerprint or timestamp
+   so pre-send notification refreshes can update the pending group.
+3. Future distinct notification rows remain eligible for email delivery.
+4. Focused service tests cover the delivered/skipped suppression behavior.
 
 ## Definition Of Done
-- Workflow YAML changes are minimal and behavior-preserving except for
-  intentional cleanup fixes.
-- Documentation reflects the final workflow contract.
-- Relevant workflow syntax and local validation pass.
-- The branch is pushed, a PR is opened, Copilot/check feedback is monitored,
-  and the handoff includes the delivered commit SHA.
+- Service changes are minimal and scoped to notification email coverage logic.
+- Tests and relevant validation pass.
+- `tasks/backlog.md`, `tasks/current.md`, and `journal.md` reflect the fix.
+- A PR is opened, Copilot/check feedback is monitored, and the handoff includes
+  delivered commit SHA(s).
 
 ## Validation Plan
 - `git diff --check`
-- `npm run lint` if workflow-adjacent scripts or docs linting are touched.
-- Use `gh workflow view <workflow>` for workflow inspection and, when a manual
-  workflow must be exercised, dispatch it explicitly with `gh workflow run
-  <workflow> --ref <branch>` plus the required fields.
-- Validate YAML through normal PR checks.
-- Monitor PR checks for branch-name, quality gates, and any workflow-specific
-  failures.
+- `npm test -- --run tests/lib/project-notification-email-service.test.ts`
+- `npm run lint`
+- `npm test`
+- `npm run test:coverage`
+- `npm run build`
 
 ## Out Of Scope
-- Replacing the TASK-268 GitHub Actions scheduler bridge with QStash, Vercel
-  Cron, or another managed scheduler.
-- Changing product notification email delivery semantics.
-- Changing Vercel production/staging database credentials or secrets.
-- Redesigning Dependabot/Copilot repair policy unless stale workflow logic makes
-  that necessary.
+- Changing the 3-hour scheduler bridge.
+- Marking in-app notifications read/resolved after email delivery.
+- Changing actor attribution or self-notification behavior from TASK-265.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -23,8 +23,7 @@ debounce/grouping pipeline.
 - Email sending intentionally does not mark in-app notifications read or
   resolved.
 - The current coverage logic is fingerprint-sensitive, which is useful for
-  pending refreshes but too strict once an email has already been sent or
-  skipped.
+  pending refreshes but too strict once an email has already been sent.
 
 ## Scope
 - Tighten service-layer notification email coverage checks.
@@ -33,12 +32,12 @@ debounce/grouping pipeline.
 - Keep scheduler cadence and workflow behavior unchanged.
 
 ## Acceptance Criteria
-1. Sent/skipped notification email items suppress future email dispatch by
-   notification ID, even if the notification row is later updated.
+1. Sent notification email items suppress future email dispatch by notification
+   ID, even if the notification row is later updated.
 2. Pending/dispatching items still require the current fingerprint or timestamp
    so pre-send notification refreshes can update the pending group.
 3. Future distinct notification rows remain eligible for email delivery.
-4. Focused service tests cover the delivered/skipped suppression behavior.
+4. Focused service tests cover the sent-notification suppression behavior.
 
 ## Definition Of Done
 - Service changes are minimal and scoped to notification email coverage logic.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -37,7 +37,9 @@ debounce/grouping pipeline.
 2. Pending/dispatching items still require the current fingerprint or timestamp
    so pre-send notification refreshes can update the pending group.
 3. Future distinct notification rows remain eligible for email delivery.
-4. Focused service tests cover the sent-notification suppression behavior.
+4. Stale pending groups created before the fix are skipped at dispatch time if
+   their notification IDs were already sent by another group.
+5. Focused service tests cover the sent-notification suppression behavior.
 
 ## Definition Of Done
 - Service changes are minimal and scoped to notification email coverage logic.

--- a/tasks/task-271-notification-email-delivery-deduplication.md
+++ b/tasks/task-271-notification-email-delivery-deduplication.md
@@ -14,9 +14,8 @@ notifications remain unread.
   must not mark notifications read or resolved.
 
 ## Acceptance Criteria
-1. Once a project digest or invitation reminder is sent or skipped for a
-   notification, that notification ID is no longer eligible for a future email
-   dispatch.
+1. Once a project digest or invitation reminder is sent for a notification,
+   that notification ID is no longer eligible for a future email dispatch.
 2. Pending or currently dispatching groups still use the current notification
    fingerprint so refreshes before delivery can be folded into the pending
    email.
@@ -24,8 +23,8 @@ notifications remain unread.
 4. The behavior is covered by focused service tests.
 
 ## Definition Of Done
-- The service-level coverage logic distinguishes delivered/skipped items from
+- The service-level coverage logic distinguishes sent items from
   pending/dispatching items.
-- Tests prove delivered/skipped notification IDs are suppressed from future
-  dispatch while pending fingerprints remain current-sensitive.
+- Tests prove sent notification IDs are suppressed from future dispatch while
+  pending fingerprints remain current-sensitive.
 - Relevant validation is run and the branch is opened as a focused PR.

--- a/tasks/task-271-notification-email-delivery-deduplication.md
+++ b/tasks/task-271-notification-email-delivery-deduplication.md
@@ -20,7 +20,9 @@ notifications remain unread.
    fingerprint so refreshes before delivery can be folded into the pending
    email.
 3. Future distinct notifications remain eligible for normal debounce/grouping.
-4. The behavior is covered by focused service tests.
+4. Stale pending groups that were created before the fix do not send if their
+   notifications have already been sent by another group.
+5. The behavior is covered by focused service tests.
 
 ## Definition Of Done
 - The service-level coverage logic distinguishes sent items from

--- a/tasks/task-271-notification-email-delivery-deduplication.md
+++ b/tasks/task-271-notification-email-delivery-deduplication.md
@@ -1,0 +1,31 @@
+# TASK-271: Notification Email Delivery Deduplication
+
+## Objective
+Prevent already-emailed notifications from being emailed again on later
+scheduled dispatcher runs. A notification email should be a delivery event for
+the covered notification IDs, not a recurring reminder while the in-app
+notifications remain unread.
+
+## Context
+- The production scheduler currently runs every 3 hours.
+- Users should receive email for future eligible notifications, not repeated
+  emails for the same unread notifications.
+- In-app notification read/resolved state remains independent: sending email
+  must not mark notifications read or resolved.
+
+## Acceptance Criteria
+1. Once a project digest or invitation reminder is sent or skipped for a
+   notification, that notification ID is no longer eligible for a future email
+   dispatch.
+2. Pending or currently dispatching groups still use the current notification
+   fingerprint so refreshes before delivery can be folded into the pending
+   email.
+3. Future distinct notifications remain eligible for normal debounce/grouping.
+4. The behavior is covered by focused service tests.
+
+## Definition Of Done
+- The service-level coverage logic distinguishes delivered/skipped items from
+  pending/dispatching items.
+- Tests prove delivered/skipped notification IDs are suppressed from future
+  dispatch while pending fingerprints remain current-sensitive.
+- Relevant validation is run and the branch is opened as a focused PR.

--- a/tests/lib/project-notification-email-service.test.ts
+++ b/tests/lib/project-notification-email-service.test.ts
@@ -277,7 +277,7 @@ describe("project-notification-email-service", () => {
     );
   });
 
-  test("does not enqueue a notification fingerprint already sent or skipped", async () => {
+  test("does not enqueue a notification already sent or skipped even if it changed later", async () => {
     prismaMock.projectNotificationEmailItem.findFirst.mockResolvedValueOnce({
       id: "item-1",
     });
@@ -288,6 +288,22 @@ describe("project-notification-email-service", () => {
     });
 
     expect(prismaMock.projectNotificationEmail.create).not.toHaveBeenCalled();
+    expect(prismaMock.projectNotificationEmailItem.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          notificationId: "notification-mention-1",
+          OR: expect.arrayContaining([
+            expect.objectContaining({
+              email: expect.objectContaining({
+                status: {
+                  in: ["sent", "skipped"],
+                },
+              }),
+            }),
+          ]),
+        }),
+      })
+    );
   });
 
   test("creates invitation reminder groups for the six-hour reminder window", async () => {
@@ -409,6 +425,24 @@ describe("project-notification-email-service", () => {
 
     expect(summary.groupsClaimed).toBe(0);
     expect(outboundEmailMock.sendOutboundEmail).not.toHaveBeenCalled();
+  });
+
+  test("reconcile suppresses already-delivered notifications by id", async () => {
+    await dispatchProjectNotificationEmails({
+      appOrigin: "https://preview.nexusdash.test",
+      now,
+    });
+
+    const reconcileQuery = prismaMock.$queryRaw.mock.calls[0]?.[0] as
+      | { strings: string[] }
+      | undefined;
+    const sql = reconcileQuery?.strings.join(" ") ?? "";
+
+    expect(sql).toContain("email.\"status\" IN ('sent', 'skipped')");
+    expect(sql).toContain(
+      "item.\"notificationUpdatedAt\" = notification.\"updatedAt\""
+    );
+    expect(sql).toContain("email.\"status\" IN ('pending', 'dispatching')");
   });
 
   test("releases stale dispatching groups back to pending for retry", async () => {

--- a/tests/lib/project-notification-email-service.test.ts
+++ b/tests/lib/project-notification-email-service.test.ts
@@ -23,6 +23,7 @@ const prismaMock = vi.hoisted(() => ({
     count: vi.fn(),
     create: vi.fn(),
     findFirst: vi.fn(),
+    findMany: vi.fn(),
     update: vi.fn(),
   },
 }));
@@ -210,6 +211,7 @@ describe("project-notification-email-service", () => {
     });
     prismaMock.projectNotificationEmailItem.count.mockResolvedValue(1);
     prismaMock.projectNotificationEmailItem.findFirst.mockResolvedValue(null);
+    prismaMock.projectNotificationEmailItem.findMany.mockResolvedValue([]);
     prismaMock.$queryRaw.mockResolvedValue([]);
     outboundEmailMock.sendOutboundEmail.mockResolvedValue({
       ok: true,
@@ -443,6 +445,49 @@ describe("project-notification-email-service", () => {
       "item.\"notificationUpdatedAt\" = notification.\"updatedAt\""
     );
     expect(sql).toContain("email.\"status\" IN ('pending', 'dispatching')");
+  });
+
+  test("skips stale pending groups whose notifications were already sent elsewhere", async () => {
+    prismaMock.$queryRaw
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: "email-1" }]);
+    prismaMock.projectNotificationEmail.findMany
+      .mockResolvedValueOnce([{ recipientUserId: "user-1" }])
+      .mockResolvedValueOnce([
+        claimedGroup({
+          id: "email-1",
+          projectId: "project-1",
+          projectName: "Alpha",
+          notification: mentionNotification(),
+        }),
+      ]);
+    prismaMock.projectNotificationEmailItem.findMany.mockResolvedValueOnce([
+      {
+        notificationId: "notification-mention-1",
+      },
+    ]);
+
+    const summary = await dispatchProjectNotificationEmails({
+      appOrigin: "https://preview.nexusdash.test",
+      now,
+    });
+
+    expect(summary).toMatchObject({
+      groupsClaimed: 1,
+      recipientEmailsAttempted: 0,
+      recipientEmailsSkipped: 1,
+      groupsSkipped: 1,
+    });
+    expect(outboundEmailMock.sendOutboundEmail).not.toHaveBeenCalled();
+    expect(prismaMock.projectNotificationEmail.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: { in: ["email-1"] } },
+        data: expect.objectContaining({
+          status: "skipped",
+          errorCode: "no-current-eligible-notifications",
+        }),
+      })
+    );
   });
 
   test("releases stale dispatching groups back to pending for retry", async () => {

--- a/tests/lib/project-notification-email-service.test.ts
+++ b/tests/lib/project-notification-email-service.test.ts
@@ -277,7 +277,7 @@ describe("project-notification-email-service", () => {
     );
   });
 
-  test("does not enqueue a notification already sent or skipped even if it changed later", async () => {
+  test("does not enqueue a notification already sent even if it changed later", async () => {
     prismaMock.projectNotificationEmailItem.findFirst.mockResolvedValueOnce({
       id: "item-1",
     });
@@ -296,7 +296,7 @@ describe("project-notification-email-service", () => {
             expect.objectContaining({
               email: expect.objectContaining({
                 status: {
-                  in: ["sent", "skipped"],
+                  in: ["sent"],
                 },
               }),
             }),
@@ -438,7 +438,7 @@ describe("project-notification-email-service", () => {
       | undefined;
     const sql = reconcileQuery?.strings.join(" ") ?? "";
 
-    expect(sql).toContain("email.\"status\" IN ('sent', 'skipped')");
+    expect(sql).toContain("email.\"status\" = 'sent'");
     expect(sql).toContain(
       "item.\"notificationUpdatedAt\" = notification.\"updatedAt\""
     );


### PR DESCRIPTION
## Summary
- Treat sent notification email items as permanent coverage for their notification IDs so unread in-app notifications do not trigger repeat digest emails on later scheduler runs.
- Keep pending/dispatching coverage fingerprint-sensitive so notification refreshes before email delivery can still update the pending group.
- Keep skipped outcomes retryable because some skips can be transient, such as recipient verification/configuration state.
- Add a dispatch-time guard so stale pending groups created before this fix are skipped if their notification IDs were already sent by another group.
- Add TASK-271 tracking docs and focused service regression coverage.

## Validation
- `npm test -- --run tests/lib/project-notification-email-service.test.ts`
- `npm run lint`
- `npm test` with explicit local `DATABASE_URL`/`DIRECT_URL`
- `npm run test:coverage` with explicit local `DATABASE_URL`/`DIRECT_URL`
- `npm run build` with safe local placeholder env
- After Copilot review fix and stale-pending guard: `npm test -- --run tests/lib/project-notification-email-service.test.ts`; `npm run lint`; `npm test`; `npm run test:coverage`; `npm run build`
- Latest PR Quality Gates run `26193722968` passed: Quality Core, Playwright smoke, and Container Image.
- Branch-name check run `26193728794` passed.

## Notes
- The first full `npm test` run failed before code execution because this shell had no `DATABASE_URL`; rerunning with the README local connection string passed.
- `npm run db:local:up` could not start because Docker Desktop was not running locally.