### PR TITLE
TASK-272 release version cadence and tagging policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+Product releases use SemVer-style pre-1.0 versioning. Keep build identity
+separate from product version: release entries describe `v0.x.y`, while commit
+SHA, deployment URL, and workflow run belong in release evidence.
+
+## Unreleased
+
+- Define each release entry before the release PR is merged.
+
+## v0.2.0 - 2026-05-20
+
+- Made `package.json` the canonical product-version source.
+- Changed the app metadata pill to show a clean product version instead of
+  appending commit SHA build metadata to the visible label.
+- Kept commit SHA, runtime environment, and repository URL as diagnostic
+  deployment metadata.
+- Updated Vercel deploy workflows to inject `APP_VERSION`, `APP_ENV`,
+  `COMMIT_SHA`, and `APP_REPOSITORY_URL` from the checked-out ref.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Runbooks:
 
 - `docs/runbooks/vercel-env-contract-and-secrets.md`
 - `docs/runbooks/database-connection-hardening.md`
+- `docs/runbooks/release-versioning.md`
 
 ## Attachments and Storage
 
@@ -255,6 +256,7 @@ npm run db:migrate
 npm run db:local:up
 npm run db:local:down
 npm run db:local:reset
+npm run release:version -- patch --dry-run
 npm run validate:local
 ```
 
@@ -372,6 +374,13 @@ Branch-name note:
 intentionally change the product version must update both `package.json` and
 `package-lock.json`; Dependabot maintenance PRs must not bump the product
 version by themselves.
+
+Product versions move through intentional release PRs, not every production
+deployment. While NexusDash is pre-1.0, use patch bumps such as `0.2.1` for
+bugfix and operational releases, minor bumps such as `0.3.0` for meaningful
+product capability milestones, and reserve `1.0.0` for the first stable product
+baseline. The detailed checklist lives in
+[`docs/runbooks/release-versioning.md`](docs/runbooks/release-versioning.md).
 
 The running app displays only the clean product version, for example `v0.2.0`.
 Build revision and runtime environment are kept as diagnostic metadata so

--- a/docs/runbooks/release-versioning.md
+++ b/docs/runbooks/release-versioning.md
@@ -1,0 +1,93 @@
+# Release Versioning Runbook
+
+This runbook defines how NexusDash product versions move, how release evidence
+is captured, and when the app should graduate from `0.x.y` to `1.0.0`.
+
+## Principles
+
+- `package.json` is the canonical product-version source.
+- `package-lock.json` must match `package.json` for every release PR.
+- The app displays the clean product version, for example `v0.2.1`.
+- Commit SHA, deployment URL, workflow run, and environment are build/revision
+  evidence. Do not append them to the user-facing version label.
+- Routine task, dependency, workflow, or documentation PRs do not automatically
+  bump the product version. Version bumps happen in intentional release PRs.
+
+## Pre-1.0 Bump Rules
+
+Use `0.x.y` while NexusDash is still before its first stable product baseline.
+
+- Patch: bump `0.2.0` to `0.2.1` for bug fixes, operational corrections,
+  small copy/UI polish, and low-risk improvements.
+- Minor: bump `0.2.1` to `0.3.0` for meaningful user-facing capabilities,
+  workflow changes, or a planned batch of feature work.
+- Hold steady: do not bump for Dependabot PRs, routine CI cleanup, runbook-only
+  clarifications, or task-tracking updates unless they are part of a release.
+- Major: reserve `1.0.0` for the first stable product baseline.
+
+## 1.0.0 Readiness
+
+Move to `1.0.0` when the team is ready to preserve the core product contract:
+
+- Authentication and account flows are stable.
+- Project/task collaboration workflows are reliable enough for everyday use.
+- Data safety, tenant boundaries, and forced RLS behavior have been validated.
+- Notification behavior has predictable in-app and email semantics.
+- Production deploy, staged promotion, rollback, and secret/env operations are
+  documented and repeatable.
+- Known breaking workflow or schema changes are either resolved or explicitly
+  accepted as post-1.0 migration work.
+
+## Release PR Checklist
+
+1. Decide the next product version using the bump rules above.
+2. Run the helper in dry-run mode:
+
+   ```bash
+   npm run release:version -- patch --dry-run
+   ```
+
+3. Apply the selected bump:
+
+   ```bash
+   npm run release:version -- patch
+   ```
+
+   Use `minor`, `major`, or an explicit version such as `0.3.0` when needed.
+
+4. Add or update the matching entry in `CHANGELOG.md`.
+5. Keep the release PR focused on release metadata, release notes, and any
+   small release-only documentation updates.
+6. Validate:
+
+   ```bash
+   git diff --check
+   npm run lint
+   ```
+
+7. After the PR merges, create the matching git tag, for example:
+
+   ```bash
+   git tag v0.2.1
+   git push origin v0.2.1
+   ```
+
+8. Confirm the staged-production deployment summary reports the intended
+   `APP_VERSION` and short revision before promotion.
+9. Promote the staged deployment intentionally, or roll it back if validation
+   fails.
+
+## Release Evidence
+
+Each production release should be traceable to:
+
+- product version, for example `v0.2.1`
+- release PR
+- git tag
+- merge commit SHA
+- staged-production deployment URL or ID
+- workflow run that produced the deployment
+- promotion or rollback decision
+
+This evidence can live in the release PR, `CHANGELOG.md`, or a dated file under
+`docs/releases/` if a release needs more detail than the changelog entry.

--- a/docs/runbooks/vercel-env-contract-and-secrets.md
+++ b/docs/runbooks/vercel-env-contract-and-secrets.md
@@ -47,6 +47,9 @@ in Vercel. If `APP_VERSION` is set by hand, it must match the intended release
 version from source control rather than a dependency-update or deployment
 attempt number.
 
+Release cadence, pre-1.0 bump rules, changelog expectations, and tag/promotion
+steps are documented in `docs/runbooks/release-versioning.md`.
+
 ## Database Runtime
 
 Required for Vercel runtime/deployments:

--- a/journal.md
+++ b/journal.md
@@ -12,6 +12,15 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ## Recent Entries (Most Relevant)
 
+### 2026-05-22
+- Type: Execution
+- Summary: Started TASK-272 release version cadence and tagging policy.
+- Evidence: Added `tasks/task-272-release-version-cadence-and-tagging.md`,
+  promoted TASK-272 to active in `tasks/backlog.md`, created
+  `docs/runbooks/release-versioning.md`, seeded `CHANGELOG.md`, and added the
+  `npm run release:version` helper for dry-run and intentional
+  `package.json`/`package-lock.json` product-version bumps.
+
 ### 2026-05-21
 - Type: Execution
 - Summary: Started TASK-271 to suppress repeated notification digest emails for

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "db:local:up": "docker compose up -d --wait postgres",
     "db:local:down": "docker compose stop postgres",
     "db:local:reset": "node scripts/local-db-reset.mjs",
+    "release:version": "node scripts/release-version.mjs",
     "validate:local": "node scripts/local-validation.mjs"
   },
   "dependencies": {

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -82,11 +82,17 @@ function runNpmVersion(targetVersion) {
 
 const args = process.argv.slice(2);
 const dryRun = args.includes("--dry-run");
+const wantsHelp = args.includes("--help") || args.includes("-h");
 const positional = args.filter((arg) => arg !== "--dry-run");
 
-if (positional.length !== 1 || positional[0] === "--help" || positional[0] === "-h") {
+if (wantsHelp) {
   usage();
-  process.exit(positional[0] === "--help" || positional[0] === "-h" ? 0 : 1);
+  process.exit(0);
+}
+
+if (positional.length !== 1) {
+  usage();
+  process.exit(1);
 }
 
 try {

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import process from "node:process";
+
+const VERSION_PATTERN = /^v?(\d+)\.(\d+)\.(\d+)$/;
+const BUMP_TYPES = new Set(["patch", "minor", "major"]);
+
+function usage() {
+  console.log(`Usage:
+  npm run release:version -- <patch|minor|major|x.y.z> [--dry-run]
+
+Examples:
+  npm run release:version -- patch --dry-run
+  npm run release:version -- minor
+  npm run release:version -- 1.0.0`);
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function parseVersion(rawVersion) {
+  const match = String(rawVersion ?? "").match(VERSION_PATTERN);
+  if (!match) {
+    throw new Error(`Invalid product version: ${rawVersion}`);
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+function formatVersion(version) {
+  return `${version.major}.${version.minor}.${version.patch}`;
+}
+
+function compareVersions(left, right) {
+  for (const key of ["major", "minor", "patch"]) {
+    if (left[key] !== right[key]) {
+      return left[key] - right[key];
+    }
+  }
+
+  return 0;
+}
+
+function bumpVersion(current, bumpType) {
+  switch (bumpType) {
+    case "patch":
+      return { ...current, patch: current.patch + 1 };
+    case "minor":
+      return { major: current.major, minor: current.minor + 1, patch: 0 };
+    case "major":
+      return { major: current.major + 1, minor: 0, patch: 0 };
+    default:
+      return parseVersion(bumpType);
+  }
+}
+
+function runNpmVersion(targetVersion) {
+  const command = process.platform === "win32" ? "npm.cmd" : "npm";
+  const result = spawnSync(command, [
+    "version",
+    targetVersion,
+    "--no-git-tag-version",
+  ], {
+    stdio: "inherit",
+  });
+
+  if (result.error) {
+    throw new Error(`npm version failed to start: ${result.error.message}`);
+  }
+
+  if (result.status !== 0) {
+    const status = result.status ?? result.signal ?? "unknown";
+    throw new Error(`npm version failed with status ${status}.`);
+  }
+}
+
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const positional = args.filter((arg) => arg !== "--dry-run");
+
+if (positional.length !== 1 || positional[0] === "--help" || positional[0] === "-h") {
+  usage();
+  process.exit(positional[0] === "--help" || positional[0] === "-h" ? 0 : 1);
+}
+
+try {
+  const requested = positional[0];
+  if (!BUMP_TYPES.has(requested) && !VERSION_PATTERN.test(requested)) {
+    throw new Error(`Expected patch, minor, major, or x.y.z; received ${requested}.`);
+  }
+
+  const packageJson = readJson("package.json");
+  const packageLock = readJson("package-lock.json");
+  const current = parseVersion(packageJson.version);
+  const lockVersion = parseVersion(packageLock.version);
+  const rootLockVersion = parseVersion(packageLock.packages?.[""]?.version);
+
+  if (
+    compareVersions(current, lockVersion) !== 0 ||
+    compareVersions(current, rootLockVersion) !== 0
+  ) {
+    throw new Error(
+      "package.json and package-lock.json versions differ. Resolve that before preparing a release."
+    );
+  }
+
+  const target = bumpVersion(current, requested);
+  if (compareVersions(target, current) <= 0) {
+    throw new Error(
+      `Target version ${formatVersion(target)} must be greater than current version ${formatVersion(current)}.`
+    );
+  }
+
+  const targetVersion = formatVersion(target);
+  console.log(`[release-version] Current product version: ${formatVersion(current)}`);
+  console.log(`[release-version] Target product version: ${targetVersion}`);
+  console.log(`[release-version] Tag to create after merge: v${targetVersion}`);
+
+  if (dryRun) {
+    console.log("[release-version] Dry run only; package files were not changed.");
+  } else {
+    runNpmVersion(targetVersion);
+    console.log(
+      "[release-version] Updated package.json and package-lock.json. Add release notes before opening the release PR."
+    );
+  }
+} catch (error) {
+  console.error(error instanceof Error ? `[release-version] ${error.message}` : error);
+  process.exit(1);
+}

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -4,6 +4,12 @@ Use this file to capture tasks discovered during development. Each entry should 
 
 ## Pending
 ### Execution Queue (Now / Next)
+- ID: TASK-272
+  Title: Release version cadence and tagging - pre-1.0 product version policy
+  Status: Active
+  Rationale: TASK-132 fixed the misleading `0.1.0+<commit>` display by separating product version from build revision, but the app now stays on `v0.2.0` until a human explicitly bumps `package.json`. Define and implement a lightweight release policy so pre-1.0 versions move intentionally (`0.2.1`, `0.3.0`, etc.), production deployments can be tied to release notes/tags, and the team has clear criteria for when NexusDash becomes `1.0.0`.
+  Dependencies: TASK-042, TASK-116, TASK-132
+  Brief: `tasks/task-272-release-version-cadence-and-tagging.md`
 - ID: TASK-271
   Title: Notification email delivery deduplication - suppress already-emailed unread notifications
   Status: Active

--- a/tasks/task-272-release-version-cadence-and-tagging.md
+++ b/tasks/task-272-release-version-cadence-and-tagging.md
@@ -1,0 +1,114 @@
+# TASK-272 Release Version Cadence and Tagging
+
+## Task ID
+TASK-272
+
+## Status
+Active
+
+## Objective
+Turn the TASK-132 app metadata cleanup into an operational release-version
+model. NexusDash should keep showing a clean product version, but that version
+must move intentionally through pre-1.0 releases and be tied to release notes,
+git tags, and staged-production deployment evidence.
+
+## Context
+TASK-132 made `package.json` the canonical product-version source and changed
+the app metadata pill to display only the clean version, such as `v0.2.0`.
+Commit SHA and environment are now diagnostic metadata instead of being appended
+to the visible version.
+
+That fixed the misleading `0.1.0+<commit>` behavior, but it left the release
+cadence undefined. As a result, every production deployment continues to show
+`v0.2.0` until a release PR manually updates `package.json` and
+`package-lock.json`.
+
+## Current Behavior
+- `package.json` and `package-lock.json` currently declare version `0.2.0`.
+- Deploy workflows inject `APP_VERSION` from the checked-out `package.json`.
+- The app strips SemVer build metadata from the visible label.
+- No release tag or changelog process currently decides when `0.2.0` becomes
+  `0.2.1`, `0.3.0`, or eventually `1.0.0`.
+
+## Proposed Release Policy
+Use SemVer-style pre-1.0 versioning for the product version:
+
+- `0.x.y` means NexusDash is still before its first stable product baseline.
+- Bump `0.2.y` for bug fixes, operational corrections, copy polish, and small
+  low-risk improvements shipped after `0.2.0`.
+- Bump to `0.3.0`, `0.4.0`, etc. for meaningful product capability milestones
+  or batches of user-facing workflow changes.
+- Do not bump the product version for every dependency update, CI cleanup, or
+  routine task PR unless that PR is intentionally part of a release.
+- Move to `1.0.0` only when the core product contract is stable enough to
+  preserve: authentication/account flows, project/task collaboration, data
+  safety, notification behavior, deploy/rollback path, and supportable user
+  expectations.
+
+Keep build identity separate:
+
+- Product version: `v0.2.1`, `v0.3.0`, `v1.0.0`.
+- Build/revision: commit SHA, deployment ID, workflow run, or timestamp.
+- User-facing app label remains the product version.
+- Operator-facing release evidence includes the short commit SHA and deployed
+  Vercel target.
+
+## Scope
+- Add or update release documentation that defines:
+  - pre-1.0 bump rules
+  - `1.0.0` readiness criteria
+  - release PR checklist
+  - post-merge tagging and staged-production promotion steps
+  - rollback expectations
+- Add a release-notes/changelog convention, either:
+  - a root `CHANGELOG.md`, or
+  - dated files under `docs/releases/`
+- Decide whether release PRs should use plain `npm version <patch|minor>
+  --no-git-tag-version` or a small repo script that updates both
+  `package.json` and `package-lock.json`.
+- Ensure docs distinguish normal task PRs, Dependabot PRs, and release PRs.
+- Keep the existing TASK-132 metadata display behavior unless a small
+  operator-facing improvement is clearly useful.
+
+## Acceptance Criteria
+1. The repo documents exactly when to bump `0.x.y` patch/minor versions and
+   when to hold the version steady.
+2. The repo documents concrete readiness criteria for the first `1.0.0`
+   release.
+3. A release PR checklist exists and includes:
+   - bump `package.json`
+   - bump `package-lock.json`
+   - add release notes/changelog entry
+   - verify metadata in the staged deployment summary
+   - create or plan the matching git tag
+   - promote or roll back the staged deployment intentionally
+4. Dependabot and routine maintenance PRs are explicitly excluded from product
+   version bumps unless they are part of a release PR.
+5. The release process preserves the TASK-132 separation between product
+   version and build revision.
+
+## Implementation Notes
+- Prefer lightweight process over heavy release automation for this stage.
+- If adding a script, keep it simple and non-destructive. A likely shape is a
+  helper that runs `npm version patch --no-git-tag-version` or
+  `npm version minor --no-git-tag-version`, then leaves the release notes and
+  commit/tag workflow to the release PR author.
+- Consider a first release example:
+  - `0.2.1` for the next bugfix/operational release after TASK-271.
+  - `0.3.0` for the next meaningful product capability batch.
+- Do not reintroduce visible labels like `v0.2.1+abc123`; keep commit identity
+  in diagnostic/operator metadata.
+
+## Definition Of Done
+- `README.md` and/or a dedicated runbook explains the release-version policy.
+- Release notes/changelog convention exists.
+- `tasks/backlog.md` points to this brief.
+- Any helper script, if added, is documented and covered by basic validation.
+- The implementation is opened as a focused PR.
+
+## Validation Plan
+- `git diff --check`
+- `npm run lint` if code or scripts are touched.
+- Run any newly added release helper in a non-committing/dry-run form if it has
+  one, or validate the documented command manually without leaving unintended
+  version changes.


### PR DESCRIPTION
## Summary
- Add TASK-272 backlog entry and implementation brief for release version cadence and tagging.
- Add a release-versioning runbook with pre-1.0 bump rules, 1.0 readiness criteria, release PR checklist, tag/promotion steps, and release evidence expectations.
- Seed `CHANGELOG.md` with the `v0.2.0` release metadata context.
- Add `npm run release:version` helper for dry-run and intentional `package.json` / `package-lock.json` version bumps.

## Validation
- `npm run release:version -- patch --dry-run`
- `git diff --cached --check`
- `npm run lint`

## Notes
- The helper dry-run currently resolves the next patch release as `0.2.1` and does not mutate package files.
- The visible app version behavior from TASK-132 remains unchanged; commit/build identity stays diagnostic metadata.