### PR TITLE
TASK-265 Notification actor attribution

### DIFF
--- a/journal.md
+++ b/journal.md
@@ -14,6 +14,31 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ### 2026-05-22
 - Type: Execution
+- Summary: Implemented TASK-265 notification actor attribution and
+  self-notification rules.
+- Evidence: Added explicit actor metadata to task assignment and comment
+  mention notifications, including agent credential id/label and display copy
+  such as `<credential> (agent)` for agent-authored activity. Human
+  self-assignment and self-mention notifications are suppressed, while
+  agent-to-owner notifications remain eligible. Validation passed with
+  `git diff --check`, focused route/email tests, `npm run lint`, full
+  `npm test`, `npm run test:coverage`, and `npm run build` using the local
+  Postgres database and local-only build env.
+
+### 2026-05-22
+- Type: Planning
+- Summary: Started TASK-265 in a dedicated worktree and cleaned stale execution
+  queue entries.
+- Evidence: Fetched current `origin/main` at `522daeb`, created
+  `../nexus_dash_task265` on
+  `feature/task-265-notification-actor-attribution`, moved merged TASK-271
+  (PR #275) and TASK-272 (PR #276) from the execution queue to Completed in
+  `tasks/backlog.md`, promoted TASK-265 to Active, and redrafted
+  `tasks/current.md` with acceptance criteria, definition of done, local
+  prerequisites, validation plan, and review workflow.
+
+### 2026-05-22
+- Type: Execution
 - Summary: Started TASK-272 release version cadence and tagging policy.
 - Evidence: Added `tasks/task-272-release-version-cadence-and-tagging.md`,
   promoted TASK-272 to active in `tasks/backlog.md`, created

--- a/lib/services/notification-service.ts
+++ b/lib/services/notification-service.ts
@@ -91,8 +91,15 @@ export interface TaskCommentMentionNotificationMetadata {
   mentionedUserDisplayName: string;
   authorUsername: string;
   authorDisplayName: string;
+  actorKind: NotificationActorKind;
+  actorUserId: string;
+  actorDisplayName: string;
+  actorCredentialId: string | null;
+  actorCredentialLabel: string | null;
   targetPath: string;
 }
+
+export type NotificationActorKind = "user" | "agent";
 
 export interface TaskAssignmentNotificationMetadata {
   taskId: string;
@@ -101,8 +108,11 @@ export interface TaskAssignmentNotificationMetadata {
   projectName: string;
   assignedUserId: string;
   assignedUserDisplayName: string;
+  actorKind: NotificationActorKind;
   actorUserId: string;
   actorDisplayName: string;
+  actorCredentialId: string | null;
+  actorCredentialLabel: string | null;
   targetPath: string;
 }
 
@@ -774,6 +784,11 @@ export interface TaskCommentMentionNotificationInput {
   mentionedUserDisplayName: string;
   authorUsername: string;
   authorDisplayName: string;
+  actorKind: NotificationActorKind;
+  actorUserId: string;
+  actorDisplayName: string;
+  actorCredentialId: string | null;
+  actorCredentialLabel: string | null;
   targetPath: string;
 }
 
@@ -782,7 +797,7 @@ function buildTaskCommentMentionNotificationContent(
 ) {
   return {
     title: `Mentioned in: ${input.taskTitle}`,
-    body: `${input.authorDisplayName} mentioned you in a comment on ${input.taskTitle}.`,
+    body: `${input.actorDisplayName} mentioned you in a comment on ${input.taskTitle}.`,
     targetPath: input.targetPath,
   };
 }
@@ -801,6 +816,11 @@ function buildTaskCommentMentionMetadata(
     mentionedUserDisplayName: input.mentionedUserDisplayName,
     authorUsername: input.authorUsername,
     authorDisplayName: input.authorDisplayName,
+    actorKind: input.actorKind,
+    actorUserId: input.actorUserId,
+    actorDisplayName: input.actorDisplayName,
+    actorCredentialId: input.actorCredentialId,
+    actorCredentialLabel: input.actorCredentialLabel,
     targetPath: input.targetPath,
   };
 }
@@ -838,6 +858,25 @@ function mapTaskCommentMentionMetadata(
     return null;
   }
 
+  const actorKind =
+    metadata.actorKind === "agent" || metadata.actorKind === "user"
+      ? metadata.actorKind
+      : "user";
+  const actorUserId =
+    typeof metadata.actorUserId === "string" ? metadata.actorUserId : "";
+  const actorDisplayName =
+    typeof metadata.actorDisplayName === "string"
+      ? metadata.actorDisplayName
+      : metadata.authorDisplayName;
+  const actorCredentialId =
+    typeof metadata.actorCredentialId === "string"
+      ? metadata.actorCredentialId
+      : null;
+  const actorCredentialLabel =
+    typeof metadata.actorCredentialLabel === "string"
+      ? metadata.actorCredentialLabel
+      : null;
+
   return {
     commentId: metadata.commentId,
     taskId: metadata.taskId,
@@ -849,6 +888,11 @@ function mapTaskCommentMentionMetadata(
     mentionedUserDisplayName: metadata.mentionedUserDisplayName,
     authorUsername: metadata.authorUsername,
     authorDisplayName: metadata.authorDisplayName,
+    actorKind,
+    actorUserId,
+    actorDisplayName,
+    actorCredentialId,
+    actorCredentialLabel,
     targetPath: metadata.targetPath,
   };
 }
@@ -1003,8 +1047,11 @@ export interface TaskAssignmentNotificationInput {
   projectName: string;
   assignedUserId: string;
   assignedUserDisplayName: string;
+  actorKind: NotificationActorKind;
   actorUserId: string;
   actorDisplayName: string;
+  actorCredentialId: string | null;
+  actorCredentialLabel: string | null;
   targetPath: string;
 }
 
@@ -1028,8 +1075,11 @@ function buildTaskAssignmentMetadata(
     projectName: input.projectName,
     assignedUserId: input.assignedUserId,
     assignedUserDisplayName: input.assignedUserDisplayName,
+    actorKind: input.actorKind,
     actorUserId: input.actorUserId,
     actorDisplayName: input.actorDisplayName,
+    actorCredentialId: input.actorCredentialId,
+    actorCredentialLabel: input.actorCredentialLabel,
     targetPath: input.targetPath,
   };
 }
@@ -1065,6 +1115,19 @@ function mapTaskAssignmentMetadata(
     return null;
   }
 
+  const actorKind =
+    metadata.actorKind === "agent" || metadata.actorKind === "user"
+      ? metadata.actorKind
+      : "user";
+  const actorCredentialId =
+    typeof metadata.actorCredentialId === "string"
+      ? metadata.actorCredentialId
+      : null;
+  const actorCredentialLabel =
+    typeof metadata.actorCredentialLabel === "string"
+      ? metadata.actorCredentialLabel
+      : null;
+
   return {
     taskId: metadata.taskId,
     taskTitle: metadata.taskTitle,
@@ -1072,8 +1135,11 @@ function mapTaskAssignmentMetadata(
     projectName: metadata.projectName,
     assignedUserId: metadata.assignedUserId,
     assignedUserDisplayName: metadata.assignedUserDisplayName,
+    actorKind,
     actorUserId: metadata.actorUserId,
     actorDisplayName: metadata.actorDisplayName,
+    actorCredentialId,
+    actorCredentialLabel,
     targetPath: metadata.targetPath,
   };
 }

--- a/lib/services/project-notification-email-service.ts
+++ b/lib/services/project-notification-email-service.ts
@@ -801,7 +801,8 @@ function buildActivityItems(input: {
 
     const actorDisplayName =
       notification.type === NOTIFICATION_TYPE_TASK_COMMENT_MENTION
-        ? readString(notification.metadata, "authorDisplayName")
+        ? readString(notification.metadata, "actorDisplayName") ||
+          readString(notification.metadata, "authorDisplayName")
         : readString(notification.metadata, "actorDisplayName");
     if (!actorDisplayName) {
       continue;

--- a/lib/services/project-task-comment-service.ts
+++ b/lib/services/project-task-comment-service.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/services/project-access-service";
 import { type DbClient, withActorRlsContext } from "@/lib/services/rls-context";
 import {
+  type NotificationActorKind,
   type TaskCommentMentionNotificationInput,
   createTaskCommentMentionNotification,
 } from "@/lib/services/notification-service";
@@ -77,6 +78,32 @@ function normalizeActorUserId(actorUserId: string | null | undefined): string {
   }
 
   return actorUserId.trim();
+}
+
+function normalizeText(value: string | null | undefined): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function buildAgentDisplayName(label: string | null | undefined): string {
+  const normalizedLabel = normalizeText(label);
+  return normalizedLabel ? `${normalizedLabel} (agent)` : "Agent";
+}
+
+async function resolveAgentCredentialLabel(input: {
+  db: DbClient;
+  agentAccess: AgentProjectAccessContext;
+}): Promise<string | null> {
+  const credential = await input.db.apiCredential.findFirst({
+    where: {
+      id: input.agentAccess.credentialId,
+      projectId: input.agentAccess.projectId,
+    },
+    select: {
+      label: true,
+    },
+  });
+
+  return normalizeText(credential?.label) || null;
 }
 
 function mapTaskComment(input: {
@@ -283,13 +310,16 @@ function buildPendingMentionNotifications(input: {
   actorUserId: string;
   authorDisplayName: string;
   authorUsername: string | null;
+  actorKind: NotificationActorKind;
+  actorDisplayName: string;
+  actorCredentialId: string | null;
+  actorCredentialLabel: string | null;
   commentId: string;
   taskId: string;
   taskTitle: string;
   projectId: string;
   projectName: string;
   mentionedUsers: MentionedProjectMember[];
-  allowActorNotification: boolean;
 }): PendingMentionNotification[] {
   const taskPath =
     `/projects/${encodeURIComponent(input.projectId)}` +
@@ -299,7 +329,7 @@ function buildPendingMentionNotifications(input: {
   return input.mentionedUsers
     .filter(
       (mentionedUser) =>
-        input.allowActorNotification ||
+        input.actorKind === "agent" ||
         mentionedUser.userId !== input.actorUserId
     )
     .map((mentionedUser) => ({
@@ -315,6 +345,11 @@ function buildPendingMentionNotifications(input: {
         mentionedUserDisplayName: mentionedUser.displayName,
         authorUsername: input.authorUsername || "",
         authorDisplayName: input.authorDisplayName,
+        actorKind: input.actorKind,
+        actorUserId: input.actorUserId,
+        actorDisplayName: input.actorDisplayName,
+        actorCredentialId: input.actorCredentialId,
+        actorCredentialLabel: input.actorCredentialLabel,
         targetPath: taskPath,
       },
     }));
@@ -514,17 +549,35 @@ export async function createTaskCommentForProject(input: {
           comment.author.email ||
           comment.author.username ||
           "Someone";
+        let actorKind: NotificationActorKind = "user";
+        let actorDisplayName = authorDisplayName;
+        let actorCredentialId: string | null = null;
+        let actorCredentialLabel: string | null = null;
+
+        if (input.agentAccess) {
+          actorKind = "agent";
+          actorCredentialId = input.agentAccess.credentialId;
+          actorCredentialLabel = await resolveAgentCredentialLabel({
+            db,
+            agentAccess: input.agentAccess,
+          });
+          actorDisplayName = buildAgentDisplayName(actorCredentialLabel);
+        }
+
         const pendingNotifications = buildPendingMentionNotifications({
           actorUserId,
           authorDisplayName,
           authorUsername: comment.author.username,
+          actorKind,
+          actorDisplayName,
+          actorCredentialId,
+          actorCredentialLabel,
           commentId: comment.id,
           taskId: input.taskId,
           taskTitle: task.title,
           projectId: input.projectId,
           projectName: mentionResolution.data.projectName,
           mentionedUsers: mentionResolution.data.mentionedUsers,
-          allowActorNotification: Boolean(input.agentAccess),
         });
 
         return {

--- a/lib/services/project-task-service.ts
+++ b/lib/services/project-task-service.ts
@@ -30,6 +30,7 @@ import {
   type AgentProjectAccessContext,
 } from "@/lib/services/project-access-service";
 import {
+  type NotificationActorKind,
   type TaskAssignmentNotificationInput,
   createTaskAssignmentNotification,
   resolveTaskAssignmentNotifications,
@@ -334,6 +335,28 @@ function buildPersonDisplayName(input: {
   return input.name || input.email || input.username || "Someone";
 }
 
+function buildAgentDisplayName(label: string | null | undefined): string {
+  const normalizedLabel = normalizeText(label);
+  return normalizedLabel ? `${normalizedLabel} (agent)` : "Agent";
+}
+
+async function resolveAgentCredentialLabel(input: {
+  db: DbClient;
+  agentAccess: AgentProjectAccessContext;
+}): Promise<string | null> {
+  const credential = await input.db.apiCredential.findFirst({
+    where: {
+      id: input.agentAccess.credentialId,
+      projectId: input.agentAccess.projectId,
+    },
+    select: {
+      label: true,
+    },
+  });
+
+  return normalizeText(credential?.label) || null;
+}
+
 function shouldNotifyAssignee(input: {
   actorUserId: string;
   assigneeUserId: string | null;
@@ -356,6 +379,7 @@ async function buildTaskAssignmentNotification(input: {
   taskId: string;
   actorUserId: string;
   assigneeUserId: string;
+  agentAccess?: AgentProjectAccessContext;
 }): Promise<PendingTaskAssignmentNotification | null> {
   const task = await input.db.task.findUnique({
     where: { id: input.taskId },
@@ -386,6 +410,21 @@ async function buildTaskAssignmentNotification(input: {
     return null;
   }
 
+  let actorKind: NotificationActorKind = "user";
+  let actorDisplayName = buildPersonDisplayName(task.updatedByUser);
+  let actorCredentialId: string | null = null;
+  let actorCredentialLabel: string | null = null;
+
+  if (input.agentAccess) {
+    actorKind = "agent";
+    actorCredentialId = input.agentAccess.credentialId;
+    actorCredentialLabel = await resolveAgentCredentialLabel({
+      db: input.db,
+      agentAccess: input.agentAccess,
+    });
+    actorDisplayName = buildAgentDisplayName(actorCredentialLabel);
+  }
+
   return {
     recipientUserId: task.assigneeUser.id,
     notification: {
@@ -395,8 +434,11 @@ async function buildTaskAssignmentNotification(input: {
       projectName: task.project.name,
       assignedUserId: task.assigneeUser.id,
       assignedUserDisplayName: buildPersonDisplayName(task.assigneeUser),
+      actorKind,
       actorUserId: input.actorUserId,
-      actorDisplayName: buildPersonDisplayName(task.updatedByUser),
+      actorDisplayName,
+      actorCredentialId,
+      actorCredentialLabel,
       targetPath: buildTaskPath(task.projectId, task.id),
     },
   };
@@ -683,6 +725,7 @@ export async function createTaskForProject(
             taskId: createdTask.id,
             actorUserId,
             assigneeUserId: createdAssigneeUserId,
+            agentAccess: input.agentAccess,
           }),
         });
       }
@@ -1103,6 +1146,7 @@ export async function updateTaskForProject(
             taskId,
             actorUserId: normalizedActorUserId,
             assigneeUserId: updatedAssigneeUserId,
+            agentAccess,
           }),
         });
       }

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -4,30 +4,18 @@ Use this file to capture tasks discovered during development. Each entry should 
 
 ## Pending
 ### Execution Queue (Now / Next)
-- ID: TASK-272
-  Title: Release version cadence and tagging - pre-1.0 product version policy
+- ID: TASK-265
+  Title: Notification actor attribution and self-notification rules
   Status: Active
-  Rationale: TASK-132 fixed the misleading `0.1.0+<commit>` display by separating product version from build revision, but the app now stays on `v0.2.0` until a human explicitly bumps `package.json`. Define and implement a lightweight release policy so pre-1.0 versions move intentionally (`0.2.1`, `0.3.0`, etc.), production deployments can be tied to release notes/tags, and the team has clear criteria for when NexusDash becomes `1.0.0`.
-  Dependencies: TASK-042, TASK-116, TASK-132
-  Brief: `tasks/task-272-release-version-cadence-and-tagging.md`
-- ID: TASK-271
-  Title: Notification email delivery deduplication - suppress already-emailed unread notifications
-  Status: Active
-  Rationale: Production showed that unread in-app notifications could produce repeated digest emails on later 3-hour scheduler runs. Email delivery should cover notification IDs once, while in-app read/resolved state remains independent and future distinct notifications remain eligible.
-  Dependencies: TASK-125, TASK-227, TASK-268
-  Brief: `tasks/task-271-notification-email-delivery-deduplication.md`
+  Rationale: Production email smoke confirmed the digest shape, but agent-authored assignment/mention copy can read as if the human account performed the action (for example `dorian1 assigned you...`) because agent API actions currently reuse the credential owner's actor identity. Tighten notification metadata and email/in-app copy so agent activity is attributed to the agent/system, human activity is attributed to the human actor, and self-notifications are consistently suppressed for human self-assignment/self-mention while remaining allowed for genuine agent-to-user activity.
+  Dependencies: TASK-123, TASK-124, TASK-127, TASK-227, TASK-260
+  Brief: `tasks/task-265-notification-actor-attribution-and-self-notification-rules.md`
 - ID: TASK-269
   Title: GitHub Actions workflow cleanup - simplify CI/CD, scheduled jobs, and maintenance automation
   Status: Next
   Rationale: The repository now has several production-impacting workflows covering quality gates, staged Vercel deploys, notification email dispatch, dependency security, Dependabot triage, and Copilot repair. Recent production work exposed duplicated env handling, scheduler tradeoffs, and deploy/secrets coupling across these workflows. Run a focused cleanup so workflow responsibilities, permissions, env/secrets usage, dispatch inputs, summaries, and failure modes are easier to understand and operate without changing product behavior.
   Dependencies: TASK-042, TASK-116, TASK-132, TASK-268
   Brief: `tasks/task-269-github-actions-workflow-cleanup.md`
-- ID: TASK-265
-  Title: Notification actor attribution and self-notification rules
-  Status: Next
-  Rationale: Production email smoke confirmed the digest shape, but agent-authored assignment/mention copy can read as if the human account performed the action (for example `dorian1 assigned you...`) because agent API actions currently reuse the credential owner's actor identity. Tighten notification metadata and email/in-app copy so agent activity is attributed to the agent/system, human activity is attributed to the human actor, and self-notifications are consistently suppressed for human self-assignment/self-mention while remaining allowed for genuine agent-to-user activity.
-  Dependencies: TASK-123, TASK-124, TASK-127, TASK-227, TASK-260
-  Brief: `tasks/task-265-notification-actor-attribution-and-self-notification-rules.md`
 - ID: TASK-226
   Title: Task due-date email reminders - 3-day deadline warning delivery
   Status: Pending (after TASK-268 scheduler activation)
@@ -155,6 +143,16 @@ Use this file to capture tasks discovered during development. Each entry should 
   Dependencies: TASK-051
 
 ## Completed
+- ID: TASK-272
+  Title: Release version cadence and tagging - pre-1.0 product version policy
+  Status: Done (2026-05-21, merged via PR #276)
+  Rationale: Defined the lightweight pre-1.0 release-version policy, release PR checklist, changelog convention, and helper script so product versions move intentionally while build/revision metadata remains separate.
+  Dependencies: TASK-042, TASK-116, TASK-132
+- ID: TASK-271
+  Title: Notification email delivery deduplication - suppress already-emailed unread notifications
+  Status: Done (2026-05-21, merged via PR #275)
+  Rationale: Suppressed repeated notification digest emails by making sent email items cover notification IDs permanently, while pending/dispatching groups still use current fingerprints for pre-delivery refreshes and future distinct notifications remain eligible.
+  Dependencies: TASK-125, TASK-227, TASK-268
 - ID: TASK-268
   Title: GitHub Actions notification email scheduler - 3-hour production bridge
   Status: Done (2026-05-19, merged via PR #271)

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,62 +1,111 @@
-# Current Task: TASK-271 Notification Email Delivery Deduplication
+# Current Task: TASK-265 Notification Actor Attribution And Self-Notification Rules
 
 ## Task ID
-TASK-271
+TASK-265
 
 ## Status
 Active
 
 ## Source
-- User report after PR #274 merged: production sent repeated notification
-  reminder emails for already-emailed unread notifications.
+- Backlog execution queue item:
+  `tasks/backlog.md`
 - Dedicated brief:
-  `tasks/task-271-notification-email-delivery-deduplication.md`.
+  `tasks/task-265-notification-actor-attribution-and-self-notification-rules.md`
+- Production observation: agent-authored assignment/mention notifications can
+  read as if the credential owner's human account directly performed the
+  action.
 
 ## Objective
-Prevent already-emailed notifications from being emailed again by later
-scheduled dispatcher runs. Email dispatch should cover notification IDs once,
-while future distinct notifications continue through the existing
-debounce/grouping pipeline.
+Make notification creation, in-app copy, and email digest copy distinguish the
+authorization actor from the product notification actor. Human self-actions
+should be suppressed when they would only notify the same human about their own
+assignment or mention, while agent-to-user activity should remain notifiable
+even when the agent credential is owned by the recipient.
 
 ## Current Baseline
-- Notification email groups are durable and the scheduler runs every 3 hours.
-- Email sending intentionally does not mark in-app notifications read or
-  resolved.
-- The current coverage logic is fingerprint-sensitive, which is useful for
-  pending refreshes but too strict once an email has already been sent.
+- Notification email digest grouping is working and in-app notifications remain
+  atomic per action/artifact.
+- Agent API writes currently authorize through the credential owner's user id.
+- Notification producers pass user-centric fields such as actor/user display
+  names, which can make agent-authored activity look human-authored.
+- TASK-271 already fixed repeated email delivery for previously emailed
+  notification IDs; this task must preserve that behavior.
 
 ## Scope
-- Tighten service-layer notification email coverage checks.
-- Add focused regression tests for already-delivered notification IDs.
-- Keep in-app notification read/resolved semantics unchanged.
-- Keep scheduler cadence and workflow behavior unchanged.
+- Trace notification producers for task assignment and comment mentions.
+- Add or thread explicit notification actor identity through service boundaries
+  where agent-authenticated writes can create notifications.
+- Store/use durable metadata that distinguishes human, agent, and system
+  actors without weakening authorization/RLS behavior.
+- Suppress self-notifications only for human actor-to-same-recipient
+  assignment/mention cases.
+- Update in-app notification copy and email digest copy to use the same actor
+  attribution model.
+- Add focused tests for human self suppression, human-to-human delivery,
+  agent-to-owner delivery, and digest copy.
 
 ## Acceptance Criteria
-1. Sent notification email items suppress future email dispatch by notification
-   ID, even if the notification row is later updated.
-2. Pending/dispatching items still require the current fingerprint or timestamp
-   so pre-send notification refreshes can update the pending group.
-3. Future distinct notification rows remain eligible for email delivery.
-4. Stale pending groups created before the fix are skipped at dispatch time if
-   their notification IDs were already sent by another group.
-5. Focused service tests cover the sent-notification suppression behavior.
+1. Human self-assignment does not create an in-app notification or queued email.
+2. Human self-mention does not create an in-app notification or queued email.
+3. Human-to-other-user assignment and mention still create one atomic in-app
+   notification per action.
+4. Agent-to-user assignment and mention create notifications even when the
+   credential owner is the recipient.
+5. Agent-authored notification copy clearly attributes the action to an agent,
+   not to the credential owner's human display name.
+6. Email digest copy uses the same actor attribution as the in-app
+   notification.
+7. Existing TASK-260/TASK-271 behavior remains intact: in-app notifications are
+   atomic, email grouping is in the email orchestration layer, and sent email
+   items suppress repeated dispatch by notification ID.
+8. Tests cover human self suppression, human-to-human delivery,
+   agent-to-owner delivery, and email template copy.
 
 ## Definition Of Done
-- Service changes are minimal and scoped to notification email coverage logic.
-- Tests and relevant validation pass.
-- `tasks/backlog.md`, `tasks/current.md`, and `journal.md` reflect the fix.
-- A PR is opened, Copilot/check feedback is monitored, and the handoff includes
-  delivered commit SHA(s).
+- Service-layer notification rules distinguish authorization actor from
+  notification actor.
+- Routes remain thin and continue delegating authorization-sensitive behavior to
+  services.
+- Relevant unit/service tests pass locally.
+- Full validation passes or any blocker is documented.
+- `tasks/backlog.md`, `tasks/current.md`, and `journal.md` reflect TASK-265
+  progress.
+- A PR is opened from `feature/task-265-notification-actor-attribution`, Copilot
+  and check feedback are monitored, actionable review comments are addressed,
+  and the handoff includes delivered commit SHA(s).
+
+## Local Prerequisites
+- Node.js must satisfy `.node-version` / `package.json` engines.
+- PostgreSQL must be reachable for full Vitest/build validation. The repo-owned
+  local Docker database can be started with `npm run db:local:up`.
+- Runtime env should follow `README.md` and
+  `docs/runbooks/vercel-env-contract-and-secrets.md`; no new secrets are
+  expected for this task.
 
 ## Validation Plan
 - `git diff --check`
-- `npm test -- --run tests/lib/project-notification-email-service.test.ts`
+- Focused tests once touched paths are known, likely:
+  - `npm test -- --run tests/lib/notification-service.test.ts`
+  - `npm test -- --run tests/lib/project-notification-email-service.test.ts`
+  - `npm test -- --run tests/lib/outbound-email-templates.test.ts`
+  - relevant task/comment/agent API tests
 - `npm run lint`
 - `npm test`
 - `npm run test:coverage`
 - `npm run build`
 
+## Deploy/Review Workflow
+- Branch/worktree:
+  `feature/task-265-notification-actor-attribution` at
+  `../nexus_dash_task265`.
+- Open a ready-for-review PR once implementation and local validation are
+  reviewable.
+- Preview validation is not required by default because this is service/copy
+  behavior, but if acceptance depends on deployed UI/email smoke, trigger the
+  Vercel preview workflow with explicit `git_ref` per `agent.md`.
+
 ## Out Of Scope
-- Changing the 3-hour scheduler bridge.
-- Marking in-app notifications read/resolved after email delivery.
-- Changing actor attribution or self-notification behavior from TASK-265.
+- Realtime notification updates; that is TASK-263.
+- Scheduler cadence or activation changes; that is TASK-268/TASK-269.
+- Due-date reminder business logic; that is TASK-226.
+- Redesigning the notification center beyond copy required for attribution.

--- a/tasks/task-265-notification-actor-attribution-and-self-notification-rules.md
+++ b/tasks/task-265-notification-actor-attribution-and-self-notification-rules.md
@@ -1,7 +1,7 @@
 # TASK-265 Notification Actor Attribution And Self-Notification Rules
 
 Date: 2026-05-16
-Branch: `feature/task-265-notification-actor-attribution-self-notification`
+Branch: `feature/task-265-notification-actor-attribution`
 
 ## Summary
 

--- a/tests/api/task-comments.route.test.ts
+++ b/tests/api/task-comments.route.test.ts
@@ -19,6 +19,9 @@ const prismaMock = vi.hoisted(() => ({
     createMany: vi.fn(),
     updateMany: vi.fn(),
   },
+  apiCredential: {
+    findFirst: vi.fn(),
+  },
 }));
 
 const apiGuardMock = vi.hoisted(() => ({
@@ -66,6 +69,7 @@ describe("task comments route", () => {
     prismaMock.notification.findMany.mockResolvedValue([]);
     prismaMock.notification.createMany.mockResolvedValue({ count: 1 });
     prismaMock.notification.updateMany.mockResolvedValue({ count: 1 });
+    prismaMock.apiCredential.findFirst.mockResolvedValue(null);
   });
 
   test("GET returns chronological task comments", async () => {
@@ -382,6 +386,9 @@ describe("task comments route", () => {
       ownerId: "owner-1",
       memberships: [],
     });
+    prismaMock.apiCredential.findFirst.mockResolvedValueOnce({
+      label: "Build bot",
+    });
     prismaMock.task.findUnique.mockResolvedValueOnce({
       id: "task-1",
       title: "Agent mention task",
@@ -432,12 +439,72 @@ describe("task comments route", () => {
       data: [
         expect.objectContaining({
           recipientUserId: "owner-1",
+          body:
+            "Build bot (agent) mentioned you in a comment on Agent mention task.",
           sourceType: "task_comment_mention",
           sourceId: "comment-agent-mention",
+          metadata: expect.objectContaining({
+            authorDisplayName: "Owner",
+            actorKind: "agent",
+            actorUserId: "owner-1",
+            actorDisplayName: "Build bot (agent)",
+            actorCredentialId: "credential-1",
+            actorCredentialLabel: "Build bot",
+          }),
         }),
       ],
       skipDuplicates: true,
     });
+  });
+
+  test("POST does not notify humans when they mention themselves", async () => {
+    prismaMock.task.findUnique.mockResolvedValueOnce({
+      id: "task-1",
+      title: "Self mention task",
+      projectId: "project-1",
+    });
+    prismaMock.project.findUnique.mockResolvedValueOnce({
+      id: "project-1",
+      name: "Test project",
+      owner: {
+        id: "test-user",
+        name: "Reviewer",
+        email: "reviewer@example.com",
+        username: "reviewer",
+        usernameDiscriminator: "0007",
+      },
+      memberships: [],
+    });
+    prismaMock.taskComment.create.mockResolvedValueOnce({
+      id: "comment-self-mention",
+      content: "Reminder for @reviewer#0007.",
+      createdAt: new Date("2026-04-19T12:30:00.000Z"),
+      author: {
+        id: "test-user",
+        name: "Reviewer",
+        email: "reviewer@example.com",
+        username: "reviewer",
+        usernameDiscriminator: "0007",
+        avatarSeed: null,
+      },
+    });
+
+    const response = await POST(
+      new Request(
+        "http://localhost/api/projects/project-1/tasks/task-1/comments",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            content: "Reminder for @reviewer#0007.",
+          }),
+        }
+      ) as never,
+      { params: Promise.resolve({ projectId: "project-1", taskId: "task-1" }) }
+    );
+
+    expect(response.status).toBe(201);
+    expect(prismaMock.notification.createMany).not.toHaveBeenCalled();
   });
 
   test("POST does not notify discriminator-less ambiguous username mentions", async () => {

--- a/tests/api/task-update.route.test.ts
+++ b/tests/api/task-update.route.test.ts
@@ -25,10 +25,23 @@ const prismaMock = vi.hoisted(() => ({
     createMany: vi.fn(),
     updateMany: vi.fn(),
   },
+  apiCredential: {
+    findFirst: vi.fn(),
+  },
+}));
+
+const apiGuardMock = vi.hoisted(() => ({
+  getAgentProjectAccessContext: vi.fn(),
+  requireApiPrincipal: vi.fn(),
 }));
 
 vi.mock("@/lib/prisma", () => ({
   prisma: prismaMock,
+}));
+
+vi.mock("@/lib/auth/api-guard", () => ({
+  getAgentProjectAccessContext: apiGuardMock.getAgentProjectAccessContext,
+  requireApiPrincipal: apiGuardMock.requireApiPrincipal,
 }));
 
 const attachmentStorageMock = vi.hoisted(() => ({
@@ -66,6 +79,16 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
     prismaMock.notification.findMany.mockResolvedValue([]);
     prismaMock.notification.createMany.mockResolvedValue({ count: 1 });
     prismaMock.notification.updateMany.mockResolvedValue({ count: 1 });
+    prismaMock.apiCredential.findFirst.mockResolvedValue(null);
+    apiGuardMock.requireApiPrincipal.mockResolvedValue({
+      ok: true,
+      principal: {
+        kind: "human",
+        actorUserId: "test-user",
+        requestId: "request-1",
+      },
+    });
+    apiGuardMock.getAgentProjectAccessContext.mockReturnValue(undefined);
     attachmentStorageMock.deleteAttachmentFile.mockResolvedValue(undefined);
   });
 
@@ -770,6 +793,214 @@ describe("PATCH /api/projects/:projectId/tasks/:taskId", () => {
     });
   });
 
+  test("does not create assignment notification for human self-assignment", async () => {
+    prismaMock.task.findUnique.mockResolvedValueOnce({
+      id: "t1",
+      projectId: "p1",
+      status: "In Progress",
+      position: 2,
+      archivedAt: null,
+      epicId: null,
+      assigneeUserId: null,
+      outgoingRelations: [],
+      incomingRelations: [],
+    });
+    prismaMock.task.findUnique.mockResolvedValueOnce({
+      id: "t1",
+      title: "Assign myself",
+      label: null,
+      labelsJson: null,
+      description: null,
+      deadlineAt: null,
+      _count: {
+        comments: 0,
+      },
+      blockedNote: null,
+      status: "In Progress",
+      position: 2,
+      archivedAt: null,
+      epic: null,
+      createdAt: new Date("2026-04-18T08:00:00.000Z"),
+      updatedAt: new Date("2026-04-18T09:00:00.000Z"),
+      createdByUser: {
+        id: "user-1",
+        name: "Alice Example",
+        email: "alice@example.com",
+        username: "alice",
+        usernameDiscriminator: "1234",
+        avatarSeed: null,
+      },
+      updatedByUser: {
+        id: "test-user",
+        name: "Reviewer",
+        email: "reviewer@example.com",
+        username: "reviewer",
+        usernameDiscriminator: "0007",
+        avatarSeed: null,
+      },
+      assigneeUser: {
+        id: "test-user",
+        name: "Reviewer",
+        email: "reviewer@example.com",
+        username: "reviewer",
+        usernameDiscriminator: "0007",
+        avatarSeed: null,
+      },
+      outgoingRelations: [],
+      incomingRelations: [],
+      blockedFollowUps: [],
+    });
+
+    const request = new Request("http://localhost/api/projects/p1/tasks/t1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        assigneeUserId: "test-user",
+      }),
+    });
+
+    const response = await PATCH(request as never, taskRouteParams("p1", "t1"));
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.notification.createMany).not.toHaveBeenCalled();
+  });
+
+  test("attributes owner assignment notifications to agent credentials", async () => {
+    apiGuardMock.requireApiPrincipal.mockResolvedValueOnce({
+      ok: true,
+      principal: {
+        kind: "agent",
+        actorUserId: "owner-1",
+        ownerUserId: "owner-1",
+        credentialId: "credential-1",
+        projectId: "p1",
+        scopes: ["task:write"],
+        tokenId: "token-1",
+        requestId: "request-1",
+      },
+    });
+    apiGuardMock.getAgentProjectAccessContext.mockReturnValueOnce({
+      credentialId: "credential-1",
+      projectId: "p1",
+      scopes: ["task:write"],
+    });
+    prismaMock.project.findFirst.mockResolvedValueOnce({
+      ownerId: "owner-1",
+      memberships: [],
+    });
+    prismaMock.apiCredential.findFirst.mockResolvedValueOnce({
+      label: "Build bot",
+    });
+    prismaMock.task.findUnique.mockResolvedValueOnce({
+      id: "t1",
+      projectId: "p1",
+      status: "In Progress",
+      position: 2,
+      archivedAt: null,
+      epicId: null,
+      assigneeUserId: null,
+      outgoingRelations: [],
+      incomingRelations: [],
+    });
+    prismaMock.task.findUnique.mockResolvedValueOnce({
+      id: "t1",
+      title: "Agent assigns owner",
+      label: null,
+      labelsJson: null,
+      description: null,
+      deadlineAt: null,
+      _count: {
+        comments: 0,
+      },
+      blockedNote: null,
+      status: "In Progress",
+      position: 2,
+      archivedAt: null,
+      epic: null,
+      createdAt: new Date("2026-04-18T08:00:00.000Z"),
+      updatedAt: new Date("2026-04-18T09:00:00.000Z"),
+      createdByUser: {
+        id: "owner-1",
+        name: "Owner",
+        email: "owner@example.com",
+        username: "owner",
+        usernameDiscriminator: "0001",
+        avatarSeed: null,
+      },
+      updatedByUser: {
+        id: "owner-1",
+        name: "Owner",
+        email: "owner@example.com",
+        username: "owner",
+        usernameDiscriminator: "0001",
+        avatarSeed: null,
+      },
+      assigneeUser: {
+        id: "owner-1",
+        name: "Owner",
+        email: "owner@example.com",
+        username: "owner",
+        usernameDiscriminator: "0001",
+        avatarSeed: null,
+      },
+      outgoingRelations: [],
+      incomingRelations: [],
+      blockedFollowUps: [],
+    });
+    prismaMock.task.findUnique.mockResolvedValueOnce({
+      id: "t1",
+      title: "Agent assigns owner",
+      projectId: "p1",
+      project: {
+        name: "Nexus",
+      },
+      assigneeUser: {
+        id: "owner-1",
+        name: "Owner",
+        email: "owner@example.com",
+        username: "owner",
+        usernameDiscriminator: "0001",
+        avatarSeed: null,
+      },
+      updatedByUser: {
+        id: "owner-1",
+        name: "Owner",
+        email: "owner@example.com",
+        username: "owner",
+        usernameDiscriminator: "0001",
+        avatarSeed: null,
+      },
+    });
+
+    const request = new Request("http://localhost/api/projects/p1/tasks/t1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        assigneeUserId: "owner-1",
+      }),
+    });
+
+    const response = await PATCH(request as never, taskRouteParams("p1", "t1"));
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.notification.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          recipientUserId: "owner-1",
+          body: "Build bot (agent) assigned you to Agent assigns owner.",
+          metadata: expect.objectContaining({
+            actorKind: "agent",
+            actorUserId: "owner-1",
+            actorDisplayName: "Build bot (agent)",
+            actorCredentialId: "credential-1",
+            actorCredentialLabel: "Build bot",
+          }),
+        }),
+      ],
+      skipDuplicates: true,
+    });
+  });
+
   test("returns 400 when related tasks are invalid", async () => {
     prismaMock.task.findUnique.mockResolvedValueOnce({
       id: "t1",
@@ -1030,6 +1261,15 @@ describe("DELETE /api/projects/:projectId/tasks/:taskId", () => {
       ownerId: "test-user",
       memberships: [],
     });
+    apiGuardMock.requireApiPrincipal.mockResolvedValue({
+      ok: true,
+      principal: {
+        kind: "human",
+        actorUserId: "test-user",
+        requestId: "request-1",
+      },
+    });
+    apiGuardMock.getAgentProjectAccessContext.mockReturnValue(undefined);
     attachmentStorageMock.deleteAttachmentFile.mockResolvedValue(undefined);
   });
 
@@ -1122,6 +1362,15 @@ describe("POST /api/projects/:projectId/tasks/:taskId/archive", () => {
       ownerId: "test-user",
       memberships: [],
     });
+    apiGuardMock.requireApiPrincipal.mockResolvedValue({
+      ok: true,
+      principal: {
+        kind: "human",
+        actorUserId: "test-user",
+        requestId: "request-1",
+      },
+    });
+    apiGuardMock.getAgentProjectAccessContext.mockReturnValue(undefined);
   });
 
   test("archives a done task", async () => {
@@ -1209,6 +1458,15 @@ describe("DELETE /api/projects/:projectId/tasks/:taskId/archive", () => {
       ownerId: "test-user",
       memberships: [],
     });
+    apiGuardMock.requireApiPrincipal.mockResolvedValue({
+      ok: true,
+      principal: {
+        kind: "human",
+        actorUserId: "test-user",
+        requestId: "request-1",
+      },
+    });
+    apiGuardMock.getAgentProjectAccessContext.mockReturnValue(undefined);
   });
 
   test("unarchives an archived done task", async () => {

--- a/tests/lib/project-notification-email-service.test.ts
+++ b/tests/lib/project-notification-email-service.test.ts
@@ -378,6 +378,49 @@ describe("project-notification-email-service", () => {
     );
   });
 
+  test("uses mention actor display name over legacy author display name", async () => {
+    const mention = mentionNotification({
+      metadata: {
+        ...mentionNotification().metadata,
+        authorDisplayName: "Credential Owner",
+        actorDisplayName: "Build bot (agent)",
+      },
+    });
+    prismaMock.$queryRaw
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: "email-1" }]);
+    prismaMock.projectNotificationEmail.findMany
+      .mockResolvedValueOnce([{ recipientUserId: "user-1" }])
+      .mockResolvedValueOnce([
+        claimedGroup({
+          id: "email-1",
+          projectId: "project-1",
+          projectName: "Alpha",
+          notification: mention,
+        }),
+      ]);
+
+    await dispatchProjectNotificationEmails({
+      appOrigin: "https://preview.nexusdash.test",
+      now,
+    });
+
+    expect(outboundEmailMock.sendOutboundEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining(
+          "Build bot (agent) mentioned you on Ship orchestration"
+        ),
+      })
+    );
+    expect(outboundEmailMock.sendOutboundEmail).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining(
+          "Credential Owner mentioned you on Ship orchestration"
+        ),
+      })
+    );
+  });
+
   test("marks provider failures on all groups in the recipient batch", async () => {
     prismaMock.$queryRaw
       .mockResolvedValueOnce([])


### PR DESCRIPTION
## Summary
- Add explicit notification actor metadata for task assignment and comment mention notifications.
- Attribute agent-authored notifications to the agent credential label instead of the credential owner's human display name.
- Suppress human self-assignment and self-mention notifications while keeping agent-to-owner notifications eligible.
- Clean stale completed tasks out of the execution queue and update TASK-265 planning/current-task notes.

## Root Cause
Agent API actions authorize through the credential owner's user id, so notification builders reused that user's display name for assignment and mention copy. That made agent-authored actions look like human-authored self activity.

## Validation
- `git diff --check`
- `npm test -- --run tests/api/task-update.route.test.ts tests/api/task-comments.route.test.ts tests/lib/project-notification-email-service.test.ts`
- `npm run lint`
- `npm test` with local Postgres `DATABASE_URL`/`DIRECT_URL`
- `npm run test:coverage` with local Postgres `DATABASE_URL`/`DIRECT_URL`
- `npm run build` with local Postgres, `OUTBOUND_EMAIL_DELIVERY_MODE=disabled`, and local `AGENT_TOKEN_SIGNING_SECRET`