### PR TITLE
TASK-226 Task due-date email reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Implemented today:
 - Project CRUD
 - Project sharing with owner-managed membership/invitation flows, including email-bound invite links
 - In-app notification center for durable unread/read notification review, starting with project invitations
-- Project notification email digests and delayed invitation reminders through the shared outbound email foundation
+- Project notification email digests, delayed invitation reminders, and
+  three-day task due-date reminders through the shared outbound email foundation
 - Project-scoped agent access with owner-managed API credentials, short-lived bearer-token exchange, and audit trail
 - Project dashboard with:
   - Context cards (CRUD + attachments)
@@ -197,6 +198,7 @@ Runbooks:
 
 - `docs/runbooks/vercel-env-contract-and-secrets.md`
 - `docs/runbooks/database-connection-hardening.md`
+- `docs/runbooks/notification-email-dispatch.md`
 - `docs/runbooks/release-versioning.md`
 
 ## Attachments and Storage
@@ -331,12 +333,18 @@ Authorization: Bearer <CRON_SECRET-or-NOTIFICATION_EMAIL_DISPATCH_SECRET>
 
 Notification creation/refreshed paths enqueue durable recipient/project groups.
 Project activity waits for a 30-minute quiet window, but the first unsent
-activity in a group is capped at a 60-minute max delay. Due groups claimed in
-one dispatcher run are batched by recipient, with project sections in one email
-when several projects are ready together. Project invitation reminders are sent
-once after 6 hours when the verified invited user has not opened, accepted,
-declined, or otherwise resolved the invitation notification. Sending email never
-marks notifications read or resolved.
+activity in a group is capped at a 60-minute max delay. Task due-date reminders
+are reconciled by the dispatcher when a task is exactly three local calendar
+days from its date-only deadline. Each reminder creates one durable in-app
+notification per task, recipient, and deadline date, then flows through the same
+recipient/project digest pipeline as other project activity. Reminders target
+the assignee when present, or the task creator when unassigned, and only while
+that recipient still has project access. `Done`, archived, and undated tasks are
+ignored. Due groups claimed in one dispatcher run are batched by recipient, with
+project sections in one email when several projects are ready together. Project
+invitation reminders are sent once after 6 hours when the verified invited user
+has not opened, accepted, declined, or otherwise resolved the invitation
+notification. Sending email never marks notifications read or resolved.
 
 Production scheduler decision:
 

--- a/components/account/notification-center-list.tsx
+++ b/components/account/notification-center-list.tsx
@@ -31,6 +31,12 @@ function getNotificationTypeLabel(notification: NotificationSummary): string {
   if (notification.type === "task_comment_mention") {
     return "Mentioned in comment";
   }
+  if (notification.type === "task_assignment") {
+    return "Task assignment";
+  }
+  if (notification.type === "task_due_date_reminder") {
+    return "Due-date reminder";
+  }
 
   return "Notification";
 }

--- a/docs/runbooks/notification-email-dispatch.md
+++ b/docs/runbooks/notification-email-dispatch.md
@@ -1,0 +1,64 @@
+# Notification Email Dispatch Runbook
+
+This runbook covers the protected notification email dispatcher used by the
+current GitHub Actions production bridge.
+
+## Dispatcher Contract
+
+- Endpoint: `GET /api/cron/notification-emails`
+- Auth header: `x-notification-email-dispatch-secret`
+- Secret source: `NOTIFICATION_EMAIL_DISPATCH_SECRET`, falling back to
+  `CRON_SECRET`
+- Production scheduler: `.github/workflows/notification-email-dispatch.yml`
+  every 3 hours
+- Manual workflow dispatch can target production or a preview URL
+
+The dispatcher reconciles eligible notification sources, queues project email
+groups, claims due groups, and sends recipient-level digest emails with project
+sections. Email delivery never marks in-app notifications read or resolved.
+
+## Due-Date Reminder Behavior
+
+Task due-date reminders are created during dispatcher reconciliation when a task
+is exactly 3 local calendar days from its date-only `deadlineAt`.
+
+Eligibility:
+
+- send to the task assignee when one exists
+- otherwise send to the task creator
+- require that recipient to still be the project owner or a project member
+- skip tasks in `Done`
+- skip archived tasks
+- skip tasks without a deadline
+
+Idempotency key:
+
+```text
+sourceType: task_due_date_reminder
+sourceId: <taskId>:<recipientUserId>:<deadlineDate>
+```
+
+That makes each task, recipient, and deadline date produce at most one reminder
+notification/email window. Moving a task to a different eligible due date creates
+a new window. Moving it away and back to the same date reuses the original
+window.
+
+## Production Smoke Plan
+
+1. Create or identify a production test project visible to the target account.
+2. Create an active task assigned to that account, or leave it unassigned if the
+   account is the task creator.
+3. Set the task due date to exactly 3 local calendar days from the smoke date.
+4. Run the notification email dispatch workflow manually, or wait for the next
+   3-hour scheduled run.
+5. Confirm the dispatcher summary reports due-date reminder reconciliation and
+   that one in-app reminder notification exists.
+6. Let the digest send through the existing email queue and confirm the email
+   includes a concise due-date reminder item.
+7. Re-run the dispatcher for the same task/date and confirm no duplicate
+   reminder notification or sent email is produced.
+8. Mark the in-app notification read and confirm read state remains independent
+   from the recorded email delivery.
+
+Do not print or commit scheduler secrets, Resend provider payloads, or full
+recipient tokens while collecting evidence.

--- a/journal.md
+++ b/journal.md
@@ -24,6 +24,11 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ### 2026-05-22
 - Type: Execution
+- Summary: TASK-226 addressed Copilot review comments on PR #278.
+- Evidence: Changed the due-date reminder eligibility query to compare `deadlineAt` to a bound date-only string cast with `CAST(... AS date)`, avoiding timezone-sensitive timestamp comparison. Canonicalized `createTaskDueDateReminderNotification()` so the validated top-level recipient id overrides stale metadata/source input before create/update. Follow-up validation passed: focused notification/email service tests (2 files, 28 tests), `npm run lint`, local placeholder runtime env `npm run build`, and `git diff --check`.
+
+### 2026-05-22
+- Type: Execution
 - Summary: Started TASK-272 release version cadence and tagging policy.
 - Evidence: Added `tasks/task-272-release-version-cadence-and-tagging.md`,
   promoted TASK-272 to active in `tasks/backlog.md`, created

--- a/journal.md
+++ b/journal.md
@@ -14,6 +14,16 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ### 2026-05-22
 - Type: Execution
+- Summary: TASK-226 started from a dedicated worktree and branch with reminder recipient/idempotency decisions recorded before implementation.
+- Evidence: Created `../nexus_dash_task226` on `feature/task-226-task-due-date-email-reminders` from `origin/main`. Rewrote `tasks/current.md` for TASK-226 and marked the backlog entry active. Decisions: due-date reminders target the current assignee, or the task creator when unassigned; recipients must still have project access; `Done`/archived tasks are excluded; source identity is `task_due_date_reminder` plus `<taskId>:<recipientUserId>:<deadlineDate>`; reminder notifications will feed the existing project notification email digest pipeline.
+
+### 2026-05-22
+- Type: Validation
+- Summary: TASK-226 due-date reminder implementation passed local validation.
+- Evidence: Added `task_due_date_reminder` notification mapping, dispatcher reconciliation for tasks exactly three calendar days from `deadlineAt`, shared project digest email rendering for due-date reminder items, notification center labeling, and documentation/runbook updates. Validation passed: `git diff --check`; focused `npm test -- --run tests/lib/task-deadline.test.ts tests/lib/notification-service.test.ts tests/lib/project-notification-email-service.test.ts tests/lib/outbound-email-templates.test.ts tests/api/notification-email-dispatch.route.test.ts` (5 files, 45 tests); `npm run lint`; local PostgreSQL env `npm test` (108 files passed, 827 tests passed, 2 skipped); `npm run test:coverage` (91.23% statements, 81.2% branches, 93.42% functions, 91.75% lines); local placeholder runtime env `npm run build`.
+
+### 2026-05-22
+- Type: Execution
 - Summary: Started TASK-272 release version cadence and tagging policy.
 - Evidence: Added `tasks/task-272-release-version-cadence-and-tagging.md`,
   promoted TASK-272 to active in `tasks/backlog.md`, created

--- a/lib/services/notification-service.ts
+++ b/lib/services/notification-service.ts
@@ -1435,7 +1435,10 @@ export async function createTaskDueDateReminderNotification(input: {
     await createOrRefreshTaskDueDateReminderNotification({
       db: input.db,
       recipientUserId,
-      notification: input.notification,
+      notification: {
+        ...input.notification,
+        recipientUserId,
+      },
     });
   } catch (error) {
     logServerError("createTaskDueDateReminderNotification", error);

--- a/lib/services/notification-service.ts
+++ b/lib/services/notification-service.ts
@@ -3,6 +3,7 @@ import { Prisma } from "@prisma/client";
 import { logServerError } from "@/lib/observability/logger";
 import { enqueueNotificationEmailForNotification } from "@/lib/services/project-notification-email-service";
 import { type DbClient, withActorRlsContext } from "@/lib/services/rls-context";
+import { formatTaskDeadlineForDisplay } from "@/lib/task-deadline";
 
 const NOTIFICATION_TYPE_PROJECT_INVITATION = "project_invitation";
 const NOTIFICATION_SOURCE_PROJECT_INVITATION = "project_invitation";
@@ -10,6 +11,8 @@ const NOTIFICATION_TYPE_TASK_COMMENT_MENTION = "task_comment_mention";
 const NOTIFICATION_SOURCE_TASK_COMMENT_MENTION = "task_comment_mention";
 const NOTIFICATION_TYPE_TASK_ASSIGNMENT = "task_assignment";
 const NOTIFICATION_SOURCE_TASK_ASSIGNMENT = "task_assignment";
+const NOTIFICATION_TYPE_TASK_DUE_DATE_REMINDER = "task_due_date_reminder";
+const NOTIFICATION_SOURCE_TASK_DUE_DATE_REMINDER = "task_due_date_reminder";
 
 interface ServiceErrorResult {
   ok: false;
@@ -106,10 +109,22 @@ export interface TaskAssignmentNotificationMetadata {
   targetPath: string;
 }
 
+export interface TaskDueDateReminderNotificationMetadata {
+  taskId: string;
+  taskTitle: string;
+  projectId: string;
+  projectName: string;
+  recipientUserId: string;
+  deadlineDate: string;
+  daysUntilDue: number;
+  targetPath: string;
+}
+
 export type NotificationMetadata =
   | ProjectInvitationNotificationMetadata
   | TaskCommentMentionNotificationMetadata
-  | TaskAssignmentNotificationMetadata;
+  | TaskAssignmentNotificationMetadata
+  | TaskDueDateReminderNotificationMetadata;
 
 export interface NotificationSummary {
   id: string;
@@ -211,6 +226,7 @@ function toJsonObject(
     | ProjectInvitationNotificationMetadata
     | TaskCommentMentionNotificationMetadata
     | TaskAssignmentNotificationMetadata
+    | TaskDueDateReminderNotificationMetadata
 ): Prisma.InputJsonObject {
   return metadata as unknown as Prisma.InputJsonObject;
 }
@@ -271,6 +287,8 @@ function mapNotification(
     metadata = mapTaskCommentMentionMetadata(notification.metadata);
   } else if (notification.type === NOTIFICATION_TYPE_TASK_ASSIGNMENT) {
     metadata = mapTaskAssignmentMetadata(notification.metadata);
+  } else if (notification.type === NOTIFICATION_TYPE_TASK_DUE_DATE_REMINDER) {
+    metadata = mapTaskDueDateReminderMetadata(notification.metadata);
   }
 
   return {
@@ -1214,6 +1232,213 @@ export async function resolveTaskAssignmentNotifications(input: {
     });
   } catch (error) {
     logServerError("resolveTaskAssignmentNotifications", error);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Task due-date reminder notifications
+// ---------------------------------------------------------------------------
+
+export interface TaskDueDateReminderNotificationInput {
+  taskId: string;
+  taskTitle: string;
+  projectId: string;
+  projectName: string;
+  recipientUserId: string;
+  deadlineDate: string;
+  daysUntilDue: number;
+  targetPath: string;
+}
+
+function buildTaskDueDateReminderSourceId(
+  input: Pick<
+    TaskDueDateReminderNotificationInput,
+    "taskId" | "recipientUserId" | "deadlineDate"
+  >
+): string {
+  return [input.taskId, input.recipientUserId, input.deadlineDate].join(":");
+}
+
+function buildTaskDueDateReminderNotificationContent(
+  input: TaskDueDateReminderNotificationInput
+) {
+  const dueLabel = formatTaskDeadlineForDisplay(input.deadlineDate, "en-US");
+  const dayLabel =
+    input.daysUntilDue === 1
+      ? "tomorrow"
+      : `in ${input.daysUntilDue} days`;
+
+  return {
+    title: `Due soon: ${input.taskTitle}`,
+    body: `${input.taskTitle} is due ${dayLabel} (${dueLabel}).`,
+    targetPath: input.targetPath,
+  };
+}
+
+function buildTaskDueDateReminderMetadata(
+  input: TaskDueDateReminderNotificationInput
+): TaskDueDateReminderNotificationMetadata {
+  return {
+    taskId: input.taskId,
+    taskTitle: input.taskTitle,
+    projectId: input.projectId,
+    projectName: input.projectName,
+    recipientUserId: input.recipientUserId,
+    deadlineDate: input.deadlineDate,
+    daysUntilDue: input.daysUntilDue,
+    targetPath: input.targetPath,
+  };
+}
+
+function isTaskDueDateReminderMetadata(value: Prisma.JsonValue | null): boolean {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      "deadlineDate" in (value as Record<string, unknown>) &&
+      "daysUntilDue" in (value as Record<string, unknown>)
+  );
+}
+
+function mapTaskDueDateReminderMetadata(
+  value: Prisma.JsonValue | null
+): TaskDueDateReminderNotificationMetadata | null {
+  if (!isTaskDueDateReminderMetadata(value)) {
+    return null;
+  }
+
+  const metadata = value as Record<string, unknown>;
+  if (
+    typeof metadata.taskId !== "string" ||
+    typeof metadata.taskTitle !== "string" ||
+    typeof metadata.projectId !== "string" ||
+    typeof metadata.projectName !== "string" ||
+    typeof metadata.recipientUserId !== "string" ||
+    typeof metadata.deadlineDate !== "string" ||
+    typeof metadata.daysUntilDue !== "number" ||
+    typeof metadata.targetPath !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    taskId: metadata.taskId,
+    taskTitle: metadata.taskTitle,
+    projectId: metadata.projectId,
+    projectName: metadata.projectName,
+    recipientUserId: metadata.recipientUserId,
+    deadlineDate: metadata.deadlineDate,
+    daysUntilDue: metadata.daysUntilDue,
+    targetPath: metadata.targetPath,
+  };
+}
+
+async function createOrRefreshTaskDueDateReminderNotification(input: {
+  db: DbClient;
+  recipientUserId: string;
+  notification: TaskDueDateReminderNotificationInput;
+}) {
+  const content = buildTaskDueDateReminderNotificationContent(input.notification);
+  const metadata = toJsonObject(
+    buildTaskDueDateReminderMetadata(input.notification)
+  );
+  const notificationWhere = {
+    recipientUserId: input.recipientUserId,
+    sourceType: NOTIFICATION_SOURCE_TASK_DUE_DATE_REMINDER,
+    sourceId: buildTaskDueDateReminderSourceId(input.notification),
+  };
+
+  const existingNotifications = await input.db.notification.findMany({
+    where: notificationWhere,
+    take: 1,
+    select: {
+      type: true,
+      title: true,
+      body: true,
+      targetPath: true,
+      metadata: true,
+      resolvedAt: true,
+    },
+  });
+
+  const existingNotification = existingNotifications[0];
+
+  if (!existingNotification) {
+    await input.db.notification.createMany({
+      data: [
+        {
+          recipientUserId: input.recipientUserId,
+          type: NOTIFICATION_TYPE_TASK_DUE_DATE_REMINDER,
+          title: content.title,
+          body: content.body,
+          targetPath: content.targetPath,
+          sourceType: NOTIFICATION_SOURCE_TASK_DUE_DATE_REMINDER,
+          sourceId: notificationWhere.sourceId,
+          metadata,
+        },
+      ],
+      skipDuplicates: true,
+    });
+    await enqueueEmailForNotificationWhere({
+      db: input.db,
+      where: notificationWhere,
+    });
+    return;
+  }
+
+  const metadataUnchanged =
+    JSON.stringify(existingNotification.metadata) === JSON.stringify(metadata);
+  const notificationUnchanged =
+    existingNotification.type === NOTIFICATION_TYPE_TASK_DUE_DATE_REMINDER &&
+    existingNotification.title === content.title &&
+    existingNotification.body === content.body &&
+    existingNotification.targetPath === content.targetPath &&
+    metadataUnchanged &&
+    existingNotification.resolvedAt === null;
+
+  if (notificationUnchanged) {
+    await enqueueEmailForNotificationWhere({
+      db: input.db,
+      where: notificationWhere,
+    });
+    return;
+  }
+
+  await input.db.notification.updateMany({
+    where: notificationWhere,
+    data: {
+      type: NOTIFICATION_TYPE_TASK_DUE_DATE_REMINDER,
+      title: content.title,
+      body: content.body,
+      targetPath: content.targetPath,
+      metadata,
+      resolvedAt: null,
+    },
+  });
+  await enqueueEmailForNotificationWhere({
+    db: input.db,
+    where: notificationWhere,
+  });
+}
+
+export async function createTaskDueDateReminderNotification(input: {
+  db: DbClient;
+  recipientUserId: string | null | undefined;
+  notification: TaskDueDateReminderNotificationInput;
+}): Promise<void> {
+  const recipientUserId = normalizeActorUserId(input.recipientUserId);
+  if (!recipientUserId) {
+    return;
+  }
+
+  try {
+    await createOrRefreshTaskDueDateReminderNotification({
+      db: input.db,
+      recipientUserId,
+      notification: input.notification,
+    });
+  } catch (error) {
+    logServerError("createTaskDueDateReminderNotification", error);
   }
 }
 

--- a/lib/services/project-notification-email-service.ts
+++ b/lib/services/project-notification-email-service.ts
@@ -685,11 +685,8 @@ async function findTaskDueDateReminderCandidates(input: {
     todayDate,
     TASK_DEADLINE_SOON_DAYS
   );
-  const reminderDeadlineAt = reminderDate
-    ? parseTaskDeadlineDateForQuery(reminderDate)
-    : null;
 
-  if (!reminderDate || !reminderDeadlineAt) {
+  if (!reminderDate) {
     return [];
   }
 
@@ -708,7 +705,7 @@ async function findTaskDueDateReminderCandidates(input: {
       LEFT JOIN "ProjectMembership" membership
         ON membership."projectId" = task."projectId"
        AND membership."userId" = COALESCE(task."assigneeUserId", task."createdByUserId")
-      WHERE task."deadlineAt" = ${reminderDeadlineAt}
+      WHERE task."deadlineAt" = CAST(${reminderDate} AS date)
         AND task."status" <> 'Done'
         AND task."archivedAt" IS NULL
         AND (
@@ -737,15 +734,6 @@ async function findTaskDueDateReminderCandidates(input: {
     ORDER BY eligible_tasks."deadlineAt" ASC, eligible_tasks."taskId" ASC
     LIMIT ${input.limit}
   `);
-}
-
-function parseTaskDeadlineDateForQuery(dateOnly: string): Date | null {
-  const formatted = formatTaskDeadlineDate(dateOnly);
-  if (!formatted) {
-    return null;
-  }
-
-  return new Date(`${formatted}T00:00:00.000Z`);
 }
 
 async function createTaskDueDateReminderNotificationForCandidate(input: {

--- a/lib/services/project-notification-email-service.ts
+++ b/lib/services/project-notification-email-service.ts
@@ -11,10 +11,19 @@ import {
   type ProjectNotificationDigestEmailSection,
 } from "@/lib/services/outbound-email-templates";
 import { type DbClient, withActorRlsContext } from "@/lib/services/rls-context";
+import {
+  addCalendarDaysToDateString,
+  formatTaskDeadlineDate,
+  formatTaskDeadlineForDisplay,
+  getLocalCalendarDateString,
+  TASK_DEADLINE_SOON_DAYS,
+} from "@/lib/task-deadline";
 
 const NOTIFICATION_TYPE_PROJECT_INVITATION = "project_invitation";
 const NOTIFICATION_TYPE_TASK_COMMENT_MENTION = "task_comment_mention";
 const NOTIFICATION_TYPE_TASK_ASSIGNMENT = "task_assignment";
+const NOTIFICATION_TYPE_TASK_DUE_DATE_REMINDER = "task_due_date_reminder";
+const NOTIFICATION_SOURCE_TASK_DUE_DATE_REMINDER = "task_due_date_reminder";
 const EMAIL_KIND_PROJECT_DIGEST = "project_digest";
 const EMAIL_KIND_PROJECT_INVITATION_REMINDER = "project_invitation_reminder";
 
@@ -24,6 +33,7 @@ const INVITATION_REMINDER_AFTER_MS = 6 * 60 * 60 * 1000;
 const STALE_DISPATCHING_MS = 30 * 60 * 1000;
 const MAX_GROUPS_PER_DISPATCH = 100;
 const MAX_RECONCILE_NOTIFICATIONS = 500;
+const MAX_RECONCILE_DUE_DATE_REMINDERS = 500;
 const MAX_DIGEST_BODY_ITEMS_PER_PROJECT = 12;
 
 type NotificationEmailKind =
@@ -53,6 +63,15 @@ interface NotificationRecord {
   resolvedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
+}
+
+interface DueDateReminderCandidate {
+  taskId: string;
+  taskTitle: string;
+  projectId: string;
+  projectName: string;
+  recipientUserId: string;
+  deadlineAt: Date;
 }
 
 interface QueueDetails {
@@ -108,6 +127,7 @@ interface PreparedSection {
 }
 
 export interface DispatchProjectNotificationEmailsSummary {
+  dueDateRemindersReconciled: number;
   notificationsReconciled: number;
   groupsClaimed: number;
   recipientEmailsAttempted: number;
@@ -239,6 +259,18 @@ function createActivityGroupingKey(input: {
   ].join(":");
 }
 
+function buildTaskPath(projectId: string, taskId: string): string {
+  return `/projects/${encodeURIComponent(projectId)}?taskId=${encodeURIComponent(taskId)}`;
+}
+
+function createTaskDueDateReminderSourceId(input: {
+  taskId: string;
+  recipientUserId: string;
+  deadlineDate: string;
+}): string {
+  return [input.taskId, input.recipientUserId, input.deadlineDate].join(":");
+}
+
 function createInvitationGroupingKey(input: {
   recipientUserId: string;
   projectId: string;
@@ -268,7 +300,8 @@ function getQueueDetails(notification: NotificationRecord): QueueDetails | null 
 
   if (
     notification.type === NOTIFICATION_TYPE_TASK_COMMENT_MENTION ||
-    notification.type === NOTIFICATION_TYPE_TASK_ASSIGNMENT
+    notification.type === NOTIFICATION_TYPE_TASK_ASSIGNMENT ||
+    notification.type === NOTIFICATION_TYPE_TASK_DUE_DATE_REMINDER
   ) {
     const schedule = calculateActivitySchedule({
       firstPendingNotificationAt: activityAt,
@@ -595,7 +628,8 @@ async function findUncoveredNotificationEmailCandidates(
       AND notification."type" IN (
         ${NOTIFICATION_TYPE_PROJECT_INVITATION},
         ${NOTIFICATION_TYPE_TASK_COMMENT_MENTION},
-        ${NOTIFICATION_TYPE_TASK_ASSIGNMENT}
+        ${NOTIFICATION_TYPE_TASK_ASSIGNMENT},
+        ${NOTIFICATION_TYPE_TASK_DUE_DATE_REMINDER}
       )
       AND recipient."email" IS NOT NULL
       AND recipient."emailVerified" IS NOT NULL
@@ -634,6 +668,147 @@ async function reconcilePendingNotificationEmailGroups(): Promise<number> {
       await enqueueNotificationEmailForNotification({
         db,
         notification,
+      });
+    });
+    reconciled += 1;
+  }
+
+  return reconciled;
+}
+
+async function findTaskDueDateReminderCandidates(input: {
+  now: Date;
+  limit: number;
+}): Promise<DueDateReminderCandidate[]> {
+  const todayDate = getLocalCalendarDateString(input.now);
+  const reminderDate = addCalendarDaysToDateString(
+    todayDate,
+    TASK_DEADLINE_SOON_DAYS
+  );
+  const reminderDeadlineAt = reminderDate
+    ? parseTaskDeadlineDateForQuery(reminderDate)
+    : null;
+
+  if (!reminderDate || !reminderDeadlineAt) {
+    return [];
+  }
+
+  return prisma.$queryRaw<DueDateReminderCandidate[]>(Prisma.sql`
+    WITH eligible_tasks AS (
+      SELECT
+        task."id" AS "taskId",
+        task."title" AS "taskTitle",
+        task."projectId" AS "projectId",
+        project."name" AS "projectName",
+        COALESCE(task."assigneeUserId", task."createdByUserId") AS "recipientUserId",
+        task."deadlineAt" AS "deadlineAt"
+      FROM "Task" task
+      INNER JOIN "Project" project
+        ON project."id" = task."projectId"
+      LEFT JOIN "ProjectMembership" membership
+        ON membership."projectId" = task."projectId"
+       AND membership."userId" = COALESCE(task."assigneeUserId", task."createdByUserId")
+      WHERE task."deadlineAt" = ${reminderDeadlineAt}
+        AND task."status" <> 'Done'
+        AND task."archivedAt" IS NULL
+        AND (
+          project."ownerId" = COALESCE(task."assigneeUserId", task."createdByUserId")
+          OR membership."userId" IS NOT NULL
+        )
+    )
+    SELECT
+      eligible_tasks."taskId",
+      eligible_tasks."taskTitle",
+      eligible_tasks."projectId",
+      eligible_tasks."projectName",
+      eligible_tasks."recipientUserId",
+      eligible_tasks."deadlineAt"
+    FROM eligible_tasks
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM "Notification" notification
+      WHERE notification."recipientUserId" = eligible_tasks."recipientUserId"
+        AND notification."sourceType" = ${NOTIFICATION_SOURCE_TASK_DUE_DATE_REMINDER}
+        AND notification."sourceId" =
+          eligible_tasks."taskId" || ':' ||
+          eligible_tasks."recipientUserId" || ':' ||
+          ${reminderDate}
+    )
+    ORDER BY eligible_tasks."deadlineAt" ASC, eligible_tasks."taskId" ASC
+    LIMIT ${input.limit}
+  `);
+}
+
+function parseTaskDeadlineDateForQuery(dateOnly: string): Date | null {
+  const formatted = formatTaskDeadlineDate(dateOnly);
+  if (!formatted) {
+    return null;
+  }
+
+  return new Date(`${formatted}T00:00:00.000Z`);
+}
+
+async function createTaskDueDateReminderNotificationForCandidate(input: {
+  db: DbClient;
+  candidate: DueDateReminderCandidate;
+}): Promise<void> {
+  const deadlineDate = formatTaskDeadlineDate(input.candidate.deadlineAt);
+  if (!deadlineDate) {
+    return;
+  }
+
+  const sourceId = createTaskDueDateReminderSourceId({
+    taskId: input.candidate.taskId,
+    recipientUserId: input.candidate.recipientUserId,
+    deadlineDate,
+  });
+  const targetPath = buildTaskPath(
+    input.candidate.projectId,
+    input.candidate.taskId
+  );
+  const dueLabel = formatTaskDeadlineForDisplay(deadlineDate, "en-US");
+  const metadata = {
+    taskId: input.candidate.taskId,
+    taskTitle: input.candidate.taskTitle,
+    projectId: input.candidate.projectId,
+    projectName: input.candidate.projectName,
+    recipientUserId: input.candidate.recipientUserId,
+    deadlineDate,
+    daysUntilDue: TASK_DEADLINE_SOON_DAYS,
+    targetPath,
+  } satisfies Prisma.InputJsonObject;
+
+  await input.db.notification.createMany({
+    data: [
+      {
+        recipientUserId: input.candidate.recipientUserId,
+        type: NOTIFICATION_TYPE_TASK_DUE_DATE_REMINDER,
+        title: `Due soon: ${input.candidate.taskTitle}`,
+        body: `${input.candidate.taskTitle} is due in ${TASK_DEADLINE_SOON_DAYS} days (${dueLabel}).`,
+        targetPath,
+        sourceType: NOTIFICATION_SOURCE_TASK_DUE_DATE_REMINDER,
+        sourceId,
+        metadata,
+      },
+    ],
+    skipDuplicates: true,
+  });
+}
+
+async function reconcileTaskDueDateReminderNotifications(
+  now: Date
+): Promise<number> {
+  const candidates = await findTaskDueDateReminderCandidates({
+    now,
+    limit: MAX_RECONCILE_DUE_DATE_REMINDERS,
+  });
+  let reconciled = 0;
+
+  for (const candidate of candidates) {
+    await withActorRlsContext(candidate.recipientUserId, async (db) => {
+      await createTaskDueDateReminderNotificationForCandidate({
+        db,
+        candidate,
       });
     });
     reconciled += 1;
@@ -796,6 +971,31 @@ function buildActivityItems(input: {
     const taskTitle = readString(notification.metadata, "taskTitle");
     const targetPath = readString(notification.metadata, "targetPath");
     if (!taskId || !taskTitle || !targetPath) {
+      continue;
+    }
+
+    if (notification.type === NOTIFICATION_TYPE_TASK_DUE_DATE_REMINDER) {
+      const deadlineDate = readString(notification.metadata, "deadlineDate");
+      const daysUntilDue = notification.metadata.daysUntilDue;
+      if (!deadlineDate || typeof daysUntilDue !== "number") {
+        continue;
+      }
+
+      const dueLabel = formatTaskDeadlineForDisplay(deadlineDate, "en-US");
+      const dayLabel =
+        daysUntilDue === 1 ? "tomorrow" : `in ${daysUntilDue} days`;
+      const key = ["due-date", taskId, deadlineDate].join(":");
+      const existing = collapsed.get(key);
+      if (existing) {
+        existing.count += 1;
+      } else {
+        collapsed.set(key, {
+          label: `Due ${dayLabel}: ${taskTitle} (${dueLabel})`,
+          count: 1,
+          targetPath,
+        });
+      }
+      notificationIds.push(notification.id);
       continue;
     }
 
@@ -1167,6 +1367,7 @@ export async function dispatchProjectNotificationEmails(input: {
   const now = input.now ?? new Date();
   const claimToken = createClaimToken();
   const summary: DispatchProjectNotificationEmailsSummary = {
+    dueDateRemindersReconciled: 0,
     notificationsReconciled: 0,
     groupsClaimed: 0,
     recipientEmailsAttempted: 0,
@@ -1178,6 +1379,14 @@ export async function dispatchProjectNotificationEmails(input: {
     groupsFailed: 0,
     errors: 0,
   };
+
+  try {
+    summary.dueDateRemindersReconciled =
+      await reconcileTaskDueDateReminderNotifications(now);
+  } catch (error) {
+    summary.errors += 1;
+    logServerError("dispatchProjectNotificationEmails.dueDateReminders", error);
+  }
 
   try {
     summary.notificationsReconciled =

--- a/lib/task-deadline.ts
+++ b/lib/task-deadline.ts
@@ -89,6 +89,19 @@ export function getLocalCalendarDateString(now: Date = new Date()): string {
   ].join("-");
 }
 
+export function addCalendarDaysToDateString(
+  dateOnly: string,
+  days: number
+): string | null {
+  const parsed = parseTaskDeadlineDate(dateOnly);
+  if (!parsed || !Number.isInteger(days)) {
+    return null;
+  }
+
+  parsed.setUTCDate(parsed.getUTCDate() + days);
+  return formatTaskDeadlineDate(parsed);
+}
+
 function getDateOnlyUtcTimestamp(value: string): number | null {
   const parsed = parseTaskDeadlineDate(value);
   if (!parsed) {

--- a/project.md
+++ b/project.md
@@ -24,9 +24,9 @@ NexusDash is a personal/team execution workspace that keeps project planning, de
   - unread/read state and resolved lifecycle
   - project invitation delivery, accept/decline actions, and notification-aware account menu counts
   - foundation for future mention and activity producers
-  - DB-backed notification email orchestration for project activity digests and
-    invitation reminders, with recipient/project grouping, debounce timing, and
-    outbound delivery records
+  - DB-backed notification email orchestration for project activity digests,
+    invitation reminders, and three-day task due-date reminders, with
+    recipient/project grouping, debounce timing, and outbound delivery records
 - Task comments:
   - project-scoped, append-only task discussion threads
   - chronological author-attributed comment history in the task detail modal

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -30,7 +30,7 @@ Use this file to capture tasks discovered during development. Each entry should 
   Brief: `tasks/task-265-notification-actor-attribution-and-self-notification-rules.md`
 - ID: TASK-226
   Title: Task due-date email reminders - 3-day deadline warning delivery
-  Status: Pending (after TASK-268 scheduler activation)
+  Status: In Review
   Rationale: Send task reminder emails when assigned or owned work is three days from its due date, with idempotent delivery tracking and anti-spam semantics so each reminder fires predictably once per task/user deadline window rather than repeating on every app visit.
   Dependencies: TASK-101, TASK-125, TASK-063, TASK-268
   Brief: `tasks/task-226-task-due-date-email-reminders.md`

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,62 +1,98 @@
-# Current Task: TASK-271 Notification Email Delivery Deduplication
+# Current Task: TASK-226 Task Due-Date Email Reminders
 
 ## Task ID
-TASK-271
+TASK-226
 
 ## Status
-Active
+In Review
 
 ## Source
-- User report after PR #274 merged: production sent repeated notification
-  reminder emails for already-emailed unread notifications.
 - Dedicated brief:
-  `tasks/task-271-notification-email-delivery-deduplication.md`.
+  `tasks/task-226-task-due-date-email-reminders.md`.
+- Scheduler dependency satisfied by TASK-268, which added the GitHub Actions
+  notification-email dispatcher bridge every 3 hours.
 
 ## Objective
-Prevent already-emailed notifications from being emailed again by later
-scheduled dispatcher runs. Email dispatch should cover notification IDs once,
-while future distinct notifications continue through the existing
-debounce/grouping pipeline.
+Create durable, idempotent task due-date reminder notifications and route them
+through the existing notification email orchestration so eligible users receive
+one reminder when work is three calendar days from its deadline.
 
-## Current Baseline
-- Notification email groups are durable and the scheduler runs every 3 hours.
-- Email sending intentionally does not mark in-app notifications read or
-  resolved.
-- The current coverage logic is fingerprint-sensitive, which is useful for
-  pending refreshes but too strict once an email has already been sent.
+## Implementation Decisions
+- Recipient: send to the task assignee when present; otherwise send to the task
+  creator as the task owner fallback.
+- Access: create no reminder unless that recipient is still the project owner or
+  an active project member.
+- Completion: exclude tasks in `Done` and archived tasks.
+- Deadline window: compare date-only task deadlines to the local calendar date
+  plus `TASK_DEADLINE_SOON_DAYS` (`3`) using the shared task-deadline helpers.
+- Idempotency: use durable notification source
+  `task_due_date_reminder` with source id
+  `<taskId>:<recipientUserId>:<deadlineDate>`, so repeated scheduler runs and
+  changing a deadline away and back to the same date do not create duplicate
+  reminders for the same task/recipient/deadline window.
+- Email path: queue the reminder notification into the existing
+  `ProjectNotificationEmail` project digest pipeline instead of adding a second
+  scheduler or email-only path.
 
 ## Scope
-- Tighten service-layer notification email coverage checks.
-- Add focused regression tests for already-delivered notification IDs.
-- Keep in-app notification read/resolved semantics unchanged.
-- Keep scheduler cadence and workflow behavior unchanged.
+- Add task due-date reminder notification metadata/content mapping.
+- Reconcile eligible deadline reminders during notification-email dispatch.
+- Include due-date reminder items in the grouped project notification digest
+  email copy.
+- Keep API routes and cron handlers thin.
+- Update docs and tests for the final behavior.
 
 ## Acceptance Criteria
-1. Sent notification email items suppress future email dispatch by notification
-   ID, even if the notification row is later updated.
-2. Pending/dispatching items still require the current fingerprint or timestamp
-   so pre-send notification refreshes can update the pending group.
-3. Future distinct notification rows remain eligible for email delivery.
-4. Stale pending groups created before the fix are skipped at dispatch time if
-   their notification IDs were already sent by another group.
-5. Focused service tests cover the sent-notification suppression behavior.
+1. A task due in three days creates exactly one reminder per eligible recipient
+   for that task/deadline window.
+2. Repeated scheduler/dispatcher calls do not create duplicate reminders or
+   duplicate emails.
+3. Completed or archived tasks do not generate due-date reminders.
+4. Tasks without due dates do not generate due-date reminders.
+5. Users without project access do not receive reminders.
+6. Changing a task deadline is handled deterministically and covered by tests.
+7. Reminder emails use the shared outbound email foundation and existing email
+   delivery observability.
+8. Reminder notification read/unread state stays independent from email delivery
+   side effects.
+9. Tests cover eligibility, idempotency, date-window boundaries, completed task
+   exclusion, provider failure, and scheduler integration.
+10. README, `journal.md`, `tasks/backlog.md`, and this file are updated with the
+    final behavior.
 
 ## Definition Of Done
-- Service changes are minimal and scoped to notification email coverage logic.
-- Tests and relevant validation pass.
-- `tasks/backlog.md`, `tasks/current.md`, and `journal.md` reflect the fix.
-- A PR is opened, Copilot/check feedback is monitored, and the handoff includes
-  delivered commit SHA(s).
+- Service changes stay inside `lib/services/**` except shared deadline helpers
+  and presentation labels.
+- The protected dispatch endpoint remains a thin adapter.
+- Focused unit/API tests pass for deadline helpers, notification service,
+  notification email orchestration, outbound templates, and the dispatch route.
+- Local validation runs:
+  - `npm run lint`
+  - `npm test`
+  - `npm run test:coverage`
+  - `npm run build`
+- A ready-for-review PR is opened, checks and Copilot review are monitored, and
+  the final handoff includes delivered commit SHA(s).
 
 ## Validation Plan
 - `git diff --check`
-- `npm test -- --run tests/lib/project-notification-email-service.test.ts`
+- `npm test -- --run tests/lib/task-deadline.test.ts tests/lib/notification-service.test.ts tests/lib/project-notification-email-service.test.ts tests/lib/outbound-email-templates.test.ts tests/api/notification-email-dispatch.route.test.ts`
 - `npm run lint`
 - `npm test`
 - `npm run test:coverage`
 - `npm run build`
 
+## Validation Evidence
+- `git diff --check` passed.
+- Focused reminder/email tests passed: 5 files, 45 tests.
+- `npm run lint` passed.
+- `npm test` passed with local PostgreSQL env after migrations: 108 files
+  passed, 827 tests passed, 2 skipped.
+- `npm run test:coverage` passed: 91.23% statements, 81.2% branches, 93.42%
+  functions, 91.75% lines.
+- `npm run build` passed with local runtime placeholder secrets.
+
 ## Out Of Scope
-- Changing the 3-hour scheduler bridge.
-- Marking in-app notifications read/resolved after email delivery.
-- Changing actor attribution or self-notification behavior from TASK-265.
+- Scheduler provisioning; TASK-268 owns the active production bridge.
+- Notification actor attribution/self-notification cleanup; TASK-265 owns that.
+- Reminder preference UI, unsubscribe controls, or instant push delivery.

--- a/tasks/task-226-task-due-date-email-reminders.md
+++ b/tasks/task-226-task-due-date-email-reminders.md
@@ -182,3 +182,16 @@ Production smoke after merge/deploy:
 - Instant in-app push delivery; that is TASK-263.
 - Reminder preference UI or unsubscribe/suppression preferences unless required
   by a legal/compliance decision.
+
+## Validation Evidence
+
+2026-05-22 implementation evidence:
+
+- `git diff --check`
+- focused reminder/email tests: 5 files, 45 tests
+- `npm run lint`
+- local PostgreSQL env `npm test`: 108 files passed, 827 tests passed, 2
+  skipped
+- `npm run test:coverage`: 91.23% statements, 81.2% branches, 93.42%
+  functions, 91.75% lines
+- local placeholder runtime env `npm run build`

--- a/tests/lib/notification-service.test.ts
+++ b/tests/lib/notification-service.test.ts
@@ -431,7 +431,7 @@ describe("notification-service", () => {
         taskTitle: "Ship reminders",
         projectId: "project-1",
         projectName: "Alpha",
-        recipientUserId: "user-1",
+        recipientUserId: "stale-user",
         deadlineDate: "2026-05-25",
         daysUntilDue: 3,
         targetPath: "/projects/project-1?taskId=task-1",
@@ -446,6 +446,7 @@ describe("notification-service", () => {
           sourceType: "task_due_date_reminder",
           sourceId: "task-1:user-1:2026-05-25",
           metadata: expect.objectContaining({
+            recipientUserId: "user-1",
             deadlineDate: "2026-05-25",
             daysUntilDue: 3,
           }),

--- a/tests/lib/notification-service.test.ts
+++ b/tests/lib/notification-service.test.ts
@@ -12,6 +12,7 @@ const prismaMock = vi.hoisted(() => ({
 }));
 
 const logServerErrorMock = vi.hoisted(() => vi.fn());
+const enqueueEmailMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/prisma", () => ({
   prisma: prismaMock,
@@ -21,8 +22,13 @@ vi.mock("@/lib/observability/logger", () => ({
   logServerError: logServerErrorMock,
 }));
 
+vi.mock("@/lib/services/project-notification-email-service", () => ({
+  enqueueNotificationEmailForNotification: enqueueEmailMock,
+}));
+
 import {
   countUnreadNotificationsForUser,
+  createTaskDueDateReminderNotification,
   getLatestUnreadNotificationForUser,
   listNotificationsForUser,
   markAllNotificationsReadForUser,
@@ -134,6 +140,49 @@ describe("notification-service", () => {
         skipDuplicates: true,
       })
     );
+  });
+
+  test("maps task due-date reminder notifications for the notification center", async () => {
+    prismaMock.notification.findMany
+      .mockResolvedValueOnce([
+        {
+          id: "notification-due-1",
+          type: "task_due_date_reminder",
+          title: "Due soon: Ship reminders",
+          body: "Ship reminders is due in 3 days (May 25, 2026).",
+          targetPath: "/projects/project-1?taskId=task-1",
+          sourceType: "task_due_date_reminder",
+          sourceId: "task-1:user-1:2026-05-25",
+          metadata: {
+            taskId: "task-1",
+            taskTitle: "Ship reminders",
+            projectId: "project-1",
+            projectName: "Alpha",
+            recipientUserId: "user-1",
+            deadlineDate: "2026-05-25",
+            daysUntilDue: 3,
+            targetPath: "/projects/project-1?taskId=task-1",
+          },
+          readAt: null,
+          resolvedAt: null,
+          createdAt: new Date("2026-05-22T08:00:00.000Z"),
+          updatedAt: new Date("2026-05-22T08:00:00.000Z"),
+        },
+      ]);
+
+    const result = await listNotificationsForUser("user-1");
+
+    expect(result.ok).toBe(true);
+    expect(result.ok ? result.data.notifications[0]?.metadata : null).toEqual({
+      taskId: "task-1",
+      taskTitle: "Ship reminders",
+      projectId: "project-1",
+      projectName: "Alpha",
+      recipientUserId: "user-1",
+      deadlineDate: "2026-05-25",
+      daysUntilDue: 3,
+      targetPath: "/projects/project-1?taskId=task-1",
+    });
   });
 
   test("counts unread unresolved notifications after syncing invitations", async () => {
@@ -343,6 +392,70 @@ describe("notification-service", () => {
         resolvedAt: expect.any(Date),
         readAt: expect.any(Date),
       },
+    });
+  });
+
+  test("creates one due-date reminder notification for a task recipient deadline window", async () => {
+    const storedNotification = {
+      id: "notification-due-1",
+      recipientUserId: "user-1",
+      type: "task_due_date_reminder",
+      title: "Due soon: Ship reminders",
+      body: "Ship reminders is due in 3 days (May 25, 2026).",
+      targetPath: "/projects/project-1?taskId=task-1",
+      sourceType: "task_due_date_reminder",
+      sourceId: "task-1:user-1:2026-05-25",
+      metadata: {
+        taskId: "task-1",
+        taskTitle: "Ship reminders",
+        projectId: "project-1",
+        projectName: "Alpha",
+        recipientUserId: "user-1",
+        deadlineDate: "2026-05-25",
+        daysUntilDue: 3,
+        targetPath: "/projects/project-1?taskId=task-1",
+      },
+      readAt: null,
+      resolvedAt: null,
+      createdAt: new Date("2026-05-22T08:00:00.000Z"),
+      updatedAt: new Date("2026-05-22T08:00:00.000Z"),
+    };
+    prismaMock.notification.findMany.mockResolvedValueOnce([]);
+    prismaMock.notification.findFirst.mockResolvedValueOnce(storedNotification);
+
+    await createTaskDueDateReminderNotification({
+      db: prismaMock as never,
+      recipientUserId: "user-1",
+      notification: {
+        taskId: "task-1",
+        taskTitle: "Ship reminders",
+        projectId: "project-1",
+        projectName: "Alpha",
+        recipientUserId: "user-1",
+        deadlineDate: "2026-05-25",
+        daysUntilDue: 3,
+        targetPath: "/projects/project-1?taskId=task-1",
+      },
+    });
+
+    expect(prismaMock.notification.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          recipientUserId: "user-1",
+          type: "task_due_date_reminder",
+          sourceType: "task_due_date_reminder",
+          sourceId: "task-1:user-1:2026-05-25",
+          metadata: expect.objectContaining({
+            deadlineDate: "2026-05-25",
+            daysUntilDue: 3,
+          }),
+        }),
+      ],
+      skipDuplicates: true,
+    });
+    expect(enqueueEmailMock).toHaveBeenCalledWith({
+      db: prismaMock,
+      notification: storedNotification,
     });
   });
 });

--- a/tests/lib/project-notification-email-service.test.ts
+++ b/tests/lib/project-notification-email-service.test.ts
@@ -7,6 +7,7 @@ const prismaMock = vi.hoisted(() => ({
     findUnique: vi.fn(),
   },
   notification: {
+    createMany: vi.fn(),
     findMany: vi.fn(),
   },
   projectInvitation: {
@@ -115,6 +116,34 @@ function assignmentNotification(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function dueDateReminderNotification(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "notification-due-1",
+    recipientUserId: "user-1",
+    type: "task_due_date_reminder",
+    title: "Due soon: Ship reminders",
+    body: "Ship reminders is due in 3 days (May 16, 2026).",
+    targetPath: "/projects/project-1?taskId=task-1",
+    sourceType: "task_due_date_reminder",
+    sourceId: "task-1:user-1:2026-05-16",
+    metadata: {
+      taskId: "task-1",
+      taskTitle: "Ship reminders",
+      projectId: "project-1",
+      projectName: "Alpha",
+      recipientUserId: "user-1",
+      deadlineDate: "2026-05-16",
+      daysUntilDue: 3,
+      targetPath: "/projects/project-1?taskId=task-1",
+    },
+    readAt: null,
+    resolvedAt: null,
+    createdAt: oldDate,
+    updatedAt: oldDate,
+    ...overrides,
+  };
+}
+
 function invitationNotification(overrides: Record<string, unknown> = {}) {
   return {
     id: "notification-invite-1",
@@ -196,6 +225,7 @@ describe("project-notification-email-service", () => {
       email: "dorian.agaesse@gmail.com",
       emailVerified: new Date("2026-05-01T00:00:00.000Z"),
     });
+    prismaMock.notification.createMany.mockResolvedValue({ count: 1 });
     prismaMock.notification.findMany.mockResolvedValue([]);
     prismaMock.projectInvitation.findFirst.mockResolvedValue({ id: "invite-1" });
     prismaMock.projectNotificationEmail.create.mockResolvedValue({
@@ -327,10 +357,93 @@ describe("project-notification-email-service", () => {
     );
   });
 
+  test("ingests due-date reminder notifications into the shared project digest queue", async () => {
+    await enqueueNotificationEmailForNotification({
+      db: prismaMock as never,
+      notification: dueDateReminderNotification(),
+    });
+
+    expect(prismaMock.projectNotificationEmail.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          kind: "project_digest",
+          recipientUserId: "user-1",
+          projectId: "project-1",
+          groupingKey: "project_digest:user-1:project-1",
+          firstPendingNotificationAt: oldDate,
+          latestPendingNotificationAt: oldDate,
+        }),
+      })
+    );
+  });
+
+  test("reconciles tasks due in three days into durable reminder notifications", async () => {
+    prismaMock.$queryRaw
+      .mockResolvedValueOnce([
+        {
+          taskId: "task-1",
+          taskTitle: "Ship reminders",
+          projectId: "project-1",
+          projectName: "Alpha",
+          recipientUserId: "user-1",
+          deadlineAt: new Date("2026-05-16T00:00:00.000Z"),
+        },
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    const summary = await dispatchProjectNotificationEmails({
+      appOrigin: "https://preview.nexusdash.test",
+      now,
+    });
+
+    expect(summary.dueDateRemindersReconciled).toBe(1);
+    expect(prismaMock.notification.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          recipientUserId: "user-1",
+          type: "task_due_date_reminder",
+          title: "Due soon: Ship reminders",
+          sourceType: "task_due_date_reminder",
+          sourceId: "task-1:user-1:2026-05-16",
+          targetPath: "/projects/project-1?taskId=task-1",
+          metadata: expect.objectContaining({
+            deadlineDate: "2026-05-16",
+            daysUntilDue: 3,
+          }),
+        }),
+      ],
+      skipDuplicates: true,
+    });
+  });
+
+  test("uses the eligibility query for due-date reminder access and idempotency", async () => {
+    await dispatchProjectNotificationEmails({
+      appOrigin: "https://preview.nexusdash.test",
+      now,
+    });
+
+    const dueDateQuery = prismaMock.$queryRaw.mock.calls[0]?.[0] as
+      | { strings: string[] }
+      | undefined;
+    const sql = dueDateQuery?.strings.join(" ") ?? "";
+
+    expect(sql).toContain('task."deadlineAt" =');
+    expect(sql).toContain('task."status" <> \'Done\'');
+    expect(sql).toContain('task."archivedAt" IS NULL');
+    expect(sql).toContain('"ProjectMembership" membership');
+    expect(sql).toContain(
+      'COALESCE(task."assigneeUserId", task."createdByUserId")'
+    );
+    expect(sql).toContain('notification."sourceType" =');
+    expect(sql).toContain('notification."sourceId"');
+  });
+
   test("batches multiple due project groups into one recipient email", async () => {
     const mention = mentionNotification();
     const assignment = assignmentNotification();
     prismaMock.$queryRaw
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([
         { id: "email-1" },
@@ -378,8 +491,46 @@ describe("project-notification-email-service", () => {
     );
   });
 
+  test("renders due-date reminder items in recipient digest emails", async () => {
+    prismaMock.$queryRaw
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: "email-1" }]);
+    prismaMock.projectNotificationEmail.findMany
+      .mockResolvedValueOnce([{ recipientUserId: "user-1" }])
+      .mockResolvedValueOnce([
+        claimedGroup({
+          id: "email-1",
+          projectId: "project-1",
+          projectName: "Alpha",
+          notification: dueDateReminderNotification(),
+        }),
+      ]);
+
+    const summary = await dispatchProjectNotificationEmails({
+      appOrigin: "https://preview.nexusdash.test",
+      now,
+    });
+
+    expect(summary).toMatchObject({
+      groupsClaimed: 1,
+      recipientEmailsSent: 1,
+      groupsSent: 1,
+    });
+    expect(outboundEmailMock.sendOutboundEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        templateKey: "project_notification_digest",
+        subject: "1 update for Alpha on NexusDash",
+        text: expect.stringContaining(
+          "Due in 3 days: Ship reminders (May 16, 2026)"
+        ),
+      })
+    );
+  });
+
   test("marks provider failures on all groups in the recipient batch", async () => {
     prismaMock.$queryRaw
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([{ id: "email-1" }]);
     prismaMock.projectNotificationEmail.findMany
@@ -435,7 +586,7 @@ describe("project-notification-email-service", () => {
       now,
     });
 
-    const reconcileQuery = prismaMock.$queryRaw.mock.calls[0]?.[0] as
+    const reconcileQuery = prismaMock.$queryRaw.mock.calls[1]?.[0] as
       | { strings: string[] }
       | undefined;
     const sql = reconcileQuery?.strings.join(" ") ?? "";
@@ -449,6 +600,7 @@ describe("project-notification-email-service", () => {
 
   test("skips stale pending groups whose notifications were already sent elsewhere", async () => {
     prismaMock.$queryRaw
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([{ id: "email-1" }]);
     prismaMock.projectNotificationEmail.findMany
@@ -524,6 +676,7 @@ describe("project-notification-email-service", () => {
       notification: mentionNotification(),
     });
     prismaMock.$queryRaw
+      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([{ id: "email-1" }]);
     prismaMock.projectNotificationEmail.findMany

--- a/tests/lib/project-notification-email-service.test.ts
+++ b/tests/lib/project-notification-email-service.test.ts
@@ -428,7 +428,7 @@ describe("project-notification-email-service", () => {
       | undefined;
     const sql = dueDateQuery?.strings.join(" ") ?? "";
 
-    expect(sql).toContain('task."deadlineAt" =');
+    expect(sql).toContain('task."deadlineAt" = CAST(');
     expect(sql).toContain('task."status" <> \'Done\'');
     expect(sql).toContain('task."archivedAt" IS NULL');
     expect(sql).toContain('"ProjectMembership" membership');

--- a/tests/lib/task-deadline.test.ts
+++ b/tests/lib/task-deadline.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import {
+  addCalendarDaysToDateString,
   formatTaskDeadlineDate,
   formatTaskDeadlineForDisplay,
   getLocalCalendarDateString,
@@ -35,6 +36,11 @@ describe("task-deadline helpers", () => {
     expect(getTaskDeadlineDayDelta("2026-04-20", now)).toBe(0);
     expect(getTaskDeadlineDayDelta("2026-04-22", now)).toBe(2);
     expect(getTaskDeadlineDayDelta("2026-04-18", now)).toBe(-2);
+  });
+
+  test("adds calendar days to date-only strings across month boundaries", () => {
+    expect(addCalendarDaysToDateString("2026-05-29", 3)).toBe("2026-06-01");
+    expect(addCalendarDaysToDateString("2026-02-30", 3)).toBeNull();
   });
 
   test("classifies urgency for active tasks only", () => {


### PR DESCRIPTION
## Summary

Implements TASK-226 task due-date reminder delivery on top of the existing notification email orchestration.

- creates durable `task_due_date_reminder` notifications for tasks exactly three local calendar days from `deadlineAt`
- targets the assignee when present, otherwise the task creator, only while that recipient still has project access
- excludes `Done`, archived, and undated tasks
- uses `<taskId>:<recipientUserId>:<deadlineDate>` as the reminder window source id to keep scheduler runs idempotent
- renders due-date reminder items in the shared project notification digest email path
- updates notification-center labeling, README/project docs, task tracking docs, and the notification email dispatch runbook

## Validation

- `git diff --check`
- `npm test -- --run tests/lib/task-deadline.test.ts tests/lib/notification-service.test.ts tests/lib/project-notification-email-service.test.ts tests/lib/outbound-email-templates.test.ts tests/api/notification-email-dispatch.route.test.ts` (5 files, 45 tests)
- `npm run lint`
- local PostgreSQL env `npm test` (108 files passed, 827 tests passed, 2 skipped)
- local PostgreSQL env `npm run test:coverage` (91.23% statements, 81.2% branches, 93.42% functions, 91.75% lines)
- local placeholder runtime env `npm run build`

Delivered commit: `9047deb4ac112a5e930d1eb4b577c759815ec62b`