### PR TITLE
TASK-226 Fix due reminder RLS reconciliation

### DIFF
--- a/journal.md
+++ b/journal.md
@@ -23,6 +23,11 @@ Use it for important implementation milestones, blockers, validation runs, and r
 - Evidence: Due-date reminder reconciliation now scans verified recipients and runs task discovery under each recipient's RLS context, then creates/reuses the reminder notification and queues its email group immediately. Validation passed: focused `npm test -- --run tests/lib/project-notification-email-service.test.ts` (18 tests); `git diff --check`; `npm run lint`; local PostgreSQL env `npm test` (108 files passed, 832 tests passed, 2 skipped); local PostgreSQL env `npm run test:coverage` (91.23% statements, 81.2% branches, 93.42% functions, 91.75% lines); preview-style env `npm run build`.
 
 ### 2026-05-22
+- Type: Execution
+- Summary: TASK-226 addressed Copilot review feedback on verified-recipient scan scale.
+- Evidence: Copilot flagged that due-date reconciliation materialized every verified user before applying the reminder cap. Added paginated recipient scanning with a 100-user batch size, cursor continuation, and early stop once the reminder cap is reached. Follow-up validation passed: focused service tests (19 tests), `git diff --check`, `npm run lint`, local PostgreSQL `npm test` (108 files passed, 833 tests passed, 2 skipped), local PostgreSQL `npm run test:coverage`, and preview-style `npm run build`.
+
+### 2026-05-22
 - Type: Validation
 - Summary: Resolved PR #277 merge conflicts against current `origin/main`.
 - Evidence: Merged `origin/main` at `d5464d8` into

--- a/journal.md
+++ b/journal.md
@@ -13,6 +13,16 @@ Use it for important implementation milestones, blockers, validation runs, and r
 ## Recent Entries (Most Relevant)
 
 ### 2026-05-22
+- Type: Execution
+- Summary: Started TASK-226 production RLS remediation after prod smoke found no due-date reminder candidates.
+- Evidence: Created branch `fix/task-226-due-reminder-rls` in `../nexus_dash_task226` from `origin/main`. Root cause analysis found due-date reminder discovery reading RLS-protected task rows without an actor context and reminder email queueing depending on a later global notification scan. Updated `tasks/current.md` and `tasks/backlog.md` for the focused production fix.
+
+### 2026-05-22
+- Type: Validation
+- Summary: TASK-226 production RLS remediation passed local validation.
+- Evidence: Due-date reminder reconciliation now scans verified recipients and runs task discovery under each recipient's RLS context, then creates/reuses the reminder notification and queues its email group immediately. Validation passed: focused `npm test -- --run tests/lib/project-notification-email-service.test.ts` (18 tests); `git diff --check`; `npm run lint`; local PostgreSQL env `npm test` (108 files passed, 832 tests passed, 2 skipped); local PostgreSQL env `npm run test:coverage` (91.23% statements, 81.2% branches, 93.42% functions, 91.75% lines); preview-style env `npm run build`.
+
+### 2026-05-22
 - Type: Validation
 - Summary: Resolved PR #277 merge conflicts against current `origin/main`.
 - Evidence: Merged `origin/main` at `d5464d8` into

--- a/lib/services/project-notification-email-service.ts
+++ b/lib/services/project-notification-email-service.ts
@@ -676,9 +676,30 @@ async function reconcilePendingNotificationEmailGroups(): Promise<number> {
   return reconciled;
 }
 
+async function findVerifiedTaskDueDateReminderRecipientIds(): Promise<string[]> {
+  const users = await prisma.user.findMany({
+    where: {
+      email: {
+        not: null,
+      },
+      emailVerified: {
+        not: null,
+      },
+    },
+    orderBy: [{ id: "asc" }],
+    select: {
+      id: true,
+    },
+  });
+
+  return users.map((user) => user.id);
+}
+
 async function findTaskDueDateReminderCandidates(input: {
+  db: DbClient;
   now: Date;
   limit: number;
+  recipientUserId: string;
 }): Promise<DueDateReminderCandidate[]> {
   const todayDate = getLocalCalendarDateString(input.now);
   const reminderDate = addCalendarDaysToDateString(
@@ -690,27 +711,27 @@ async function findTaskDueDateReminderCandidates(input: {
     return [];
   }
 
-  return prisma.$queryRaw<DueDateReminderCandidate[]>(Prisma.sql`
+  return input.db.$queryRaw<DueDateReminderCandidate[]>(Prisma.sql`
     WITH eligible_tasks AS (
       SELECT
         task."id" AS "taskId",
         task."title" AS "taskTitle",
         task."projectId" AS "projectId",
         project."name" AS "projectName",
-        COALESCE(task."assigneeUserId", task."createdByUserId") AS "recipientUserId",
+        ${input.recipientUserId} AS "recipientUserId",
         task."deadlineAt" AS "deadlineAt"
       FROM "Task" task
       INNER JOIN "Project" project
         ON project."id" = task."projectId"
-      LEFT JOIN "ProjectMembership" membership
-        ON membership."projectId" = task."projectId"
-       AND membership."userId" = COALESCE(task."assigneeUserId", task."createdByUserId")
       WHERE task."deadlineAt" = CAST(${reminderDate} AS date)
         AND task."status" <> 'Done'
         AND task."archivedAt" IS NULL
         AND (
-          project."ownerId" = COALESCE(task."assigneeUserId", task."createdByUserId")
-          OR membership."userId" IS NOT NULL
+          task."assigneeUserId" = ${input.recipientUserId}
+          OR (
+            task."assigneeUserId" IS NULL
+            AND task."createdByUserId" = ${input.recipientUserId}
+          )
         )
     )
     SELECT
@@ -730,6 +751,18 @@ async function findTaskDueDateReminderCandidates(input: {
           eligible_tasks."taskId" || ':' ||
           eligible_tasks."recipientUserId" || ':' ||
           ${reminderDate}
+        AND (
+          notification."readAt" IS NOT NULL
+          OR notification."resolvedAt" IS NOT NULL
+          OR EXISTS (
+            SELECT 1
+            FROM "ProjectNotificationEmailItem" item
+            INNER JOIN "ProjectNotificationEmail" email
+              ON email."id" = item."emailId"
+            WHERE item."notificationId" = notification."id"
+              AND email."status" IN ('pending', 'dispatching', 'sent')
+          )
+        )
     )
     ORDER BY eligible_tasks."deadlineAt" ASC, eligible_tasks."taskId" ASC
     LIMIT ${input.limit}
@@ -781,25 +814,67 @@ async function createTaskDueDateReminderNotificationForCandidate(input: {
     ],
     skipDuplicates: true,
   });
+
+  const notification = await input.db.notification.findFirst({
+    where: {
+      recipientUserId: input.candidate.recipientUserId,
+      sourceType: NOTIFICATION_SOURCE_TASK_DUE_DATE_REMINDER,
+      sourceId,
+    },
+    select: {
+      id: true,
+      recipientUserId: true,
+      type: true,
+      title: true,
+      body: true,
+      targetPath: true,
+      sourceType: true,
+      sourceId: true,
+      metadata: true,
+      readAt: true,
+      resolvedAt: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+
+  if (!notification) {
+    return;
+  }
+
+  await enqueueNotificationEmailForNotification({
+    db: input.db,
+    notification,
+  });
 }
 
 async function reconcileTaskDueDateReminderNotifications(
   now: Date
 ): Promise<number> {
-  const candidates = await findTaskDueDateReminderCandidates({
-    now,
-    limit: MAX_RECONCILE_DUE_DATE_REMINDERS,
-  });
+  const recipientUserIds = await findVerifiedTaskDueDateReminderRecipientIds();
   let reconciled = 0;
 
-  for (const candidate of candidates) {
-    await withActorRlsContext(candidate.recipientUserId, async (db) => {
-      await createTaskDueDateReminderNotificationForCandidate({
+  for (const recipientUserId of recipientUserIds) {
+    if (reconciled >= MAX_RECONCILE_DUE_DATE_REMINDERS) {
+      break;
+    }
+
+    await withActorRlsContext(recipientUserId, async (db) => {
+      const candidates = await findTaskDueDateReminderCandidates({
         db,
-        candidate,
+        now,
+        recipientUserId,
+        limit: MAX_RECONCILE_DUE_DATE_REMINDERS - reconciled,
       });
+
+      for (const candidate of candidates) {
+        await createTaskDueDateReminderNotificationForCandidate({
+          db,
+          candidate,
+        });
+        reconciled += 1;
+      }
     });
-    reconciled += 1;
   }
 
   return reconciled;

--- a/lib/services/project-notification-email-service.ts
+++ b/lib/services/project-notification-email-service.ts
@@ -34,6 +34,7 @@ const STALE_DISPATCHING_MS = 30 * 60 * 1000;
 const MAX_GROUPS_PER_DISPATCH = 100;
 const MAX_RECONCILE_NOTIFICATIONS = 500;
 const MAX_RECONCILE_DUE_DATE_REMINDERS = 500;
+const VERIFIED_RECIPIENT_SCAN_BATCH_SIZE = 100;
 const MAX_DIGEST_BODY_ITEMS_PER_PROJECT = 12;
 
 type NotificationEmailKind =
@@ -676,7 +677,10 @@ async function reconcilePendingNotificationEmailGroups(): Promise<number> {
   return reconciled;
 }
 
-async function findVerifiedTaskDueDateReminderRecipientIds(): Promise<string[]> {
+async function findVerifiedTaskDueDateReminderRecipientIds(input: {
+  cursorUserId?: string | null;
+  limit: number;
+}): Promise<string[]> {
   const users = await prisma.user.findMany({
     where: {
       email: {
@@ -687,6 +691,15 @@ async function findVerifiedTaskDueDateReminderRecipientIds(): Promise<string[]> 
       },
     },
     orderBy: [{ id: "asc" }],
+    take: input.limit,
+    ...(input.cursorUserId
+      ? {
+          cursor: {
+            id: input.cursorUserId,
+          },
+          skip: 1,
+        }
+      : {}),
     select: {
       id: true,
     },
@@ -851,30 +864,46 @@ async function createTaskDueDateReminderNotificationForCandidate(input: {
 async function reconcileTaskDueDateReminderNotifications(
   now: Date
 ): Promise<number> {
-  const recipientUserIds = await findVerifiedTaskDueDateReminderRecipientIds();
   let reconciled = 0;
+  let cursorUserId: string | null = null;
 
-  for (const recipientUserId of recipientUserIds) {
-    if (reconciled >= MAX_RECONCILE_DUE_DATE_REMINDERS) {
+  while (reconciled < MAX_RECONCILE_DUE_DATE_REMINDERS) {
+    const recipientUserIds = await findVerifiedTaskDueDateReminderRecipientIds({
+      cursorUserId,
+      limit: VERIFIED_RECIPIENT_SCAN_BATCH_SIZE,
+    });
+
+    if (recipientUserIds.length === 0) {
       break;
     }
 
-    await withActorRlsContext(recipientUserId, async (db) => {
-      const candidates = await findTaskDueDateReminderCandidates({
-        db,
-        now,
-        recipientUserId,
-        limit: MAX_RECONCILE_DUE_DATE_REMINDERS - reconciled,
-      });
-
-      for (const candidate of candidates) {
-        await createTaskDueDateReminderNotificationForCandidate({
-          db,
-          candidate,
-        });
-        reconciled += 1;
+    for (const recipientUserId of recipientUserIds) {
+      if (reconciled >= MAX_RECONCILE_DUE_DATE_REMINDERS) {
+        break;
       }
-    });
+
+      await withActorRlsContext(recipientUserId, async (db) => {
+        const candidates = await findTaskDueDateReminderCandidates({
+          db,
+          now,
+          recipientUserId,
+          limit: MAX_RECONCILE_DUE_DATE_REMINDERS - reconciled,
+        });
+
+        for (const candidate of candidates) {
+          await createTaskDueDateReminderNotificationForCandidate({
+            db,
+            candidate,
+          });
+          reconciled += 1;
+        }
+      });
+    }
+
+    cursorUserId = recipientUserIds[recipientUserIds.length - 1] ?? null;
+    if (recipientUserIds.length < VERIFIED_RECIPIENT_SCAN_BATCH_SIZE) {
+      break;
+    }
   }
 
   return reconciled;

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -4,24 +4,18 @@ Use this file to capture tasks discovered during development. Each entry should 
 
 ## Pending
 ### Execution Queue (Now / Next)
-- ID: TASK-265
-  Title: Notification actor attribution and self-notification rules
+- ID: TASK-226
+  Title: Task due-date email reminders - production RLS reconciliation fix
   Status: Active
-  Rationale: Production email smoke confirmed the digest shape, but agent-authored assignment/mention copy can read as if the human account performed the action (for example `dorian1 assigned you...`) because agent API actions currently reuse the credential owner's actor identity. Tighten notification metadata and email/in-app copy so agent activity is attributed to the agent/system, human activity is attributed to the human actor, and self-notifications are consistently suppressed for human self-assignment/self-mention while remaining allowed for genuine agent-to-user activity.
-  Dependencies: TASK-123, TASK-124, TASK-127, TASK-227, TASK-260
-  Brief: `tasks/task-265-notification-actor-attribution-and-self-notification-rules.md`
+  Rationale: Production smoke after TASK-226 promotion created tasks due within three days, but the notification email dispatcher reported `dueDateRemindersReconciled: 0`. Fix reminder discovery and queueing so the scheduler works under production row-level security and still preserves one reminder per task/user/deadline window.
+  Dependencies: TASK-101, TASK-125, TASK-063, TASK-268
+  Brief: `tasks/task-226-task-due-date-email-reminders.md`
 - ID: TASK-269
   Title: GitHub Actions workflow cleanup - simplify CI/CD, scheduled jobs, and maintenance automation
   Status: Next
   Rationale: The repository now has several production-impacting workflows covering quality gates, staged Vercel deploys, notification email dispatch, dependency security, Dependabot triage, and Copilot repair. Recent production work exposed duplicated env handling, scheduler tradeoffs, and deploy/secrets coupling across these workflows. Run a focused cleanup so workflow responsibilities, permissions, env/secrets usage, dispatch inputs, summaries, and failure modes are easier to understand and operate without changing product behavior.
   Dependencies: TASK-042, TASK-116, TASK-132, TASK-268
   Brief: `tasks/task-269-github-actions-workflow-cleanup.md`
-- ID: TASK-226
-  Title: Task due-date email reminders - 3-day deadline warning delivery
-  Status: In Review
-  Rationale: Send task reminder emails when assigned or owned work is three days from its due date, with idempotent delivery tracking and anti-spam semantics so each reminder fires predictably once per task/user deadline window rather than repeating on every app visit.
-  Dependencies: TASK-101, TASK-125, TASK-063, TASK-268
-  Brief: `tasks/task-226-task-due-date-email-reminders.md`
 - ID: TASK-266
   Title: Production pg query deprecation warning cleanup
   Status: Pending
@@ -143,6 +137,11 @@ Use this file to capture tasks discovered during development. Each entry should 
   Dependencies: TASK-051
 
 ## Completed
+- ID: TASK-265
+  Title: Notification actor attribution and self-notification rules
+  Status: Done (2026-05-22, merged via PR #277)
+  Rationale: Agent-authored assignment and mention notifications now carry agent-aware actor metadata and email/in-app copy so agent activity is not misattributed to the credential owner, while human self-notification suppression remains intact.
+  Dependencies: TASK-123, TASK-124, TASK-127, TASK-227, TASK-260
 - ID: TASK-272
   Title: Release version cadence and tagging - pre-1.0 product version policy
   Status: Done (2026-05-21, merged via PR #276)

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -64,7 +64,7 @@ unauthenticated global scan.
 
 ## Validation Evidence
 - `npm test -- --run tests/lib/project-notification-email-service.test.ts`
-  passed: 1 file, 18 tests.
+  passed: 1 file, 19 tests.
 - `git diff --check` passed.
 - `npm run lint` passed.
 - With local PostgreSQL env, `npm test` passed: 108 files passed, 832 tests
@@ -72,6 +72,11 @@ unauthenticated global scan.
 - With local PostgreSQL env, `npm run test:coverage` passed: 91.23%
   statements, 81.2% branches, 93.42% functions, 91.75% lines.
 - With local PostgreSQL and preview-style runtime env, `npm run build` passed.
+- After Copilot review, paginated verified recipient scanning was added.
+  Follow-up validation passed: focused test file, `git diff --check`,
+  `npm run lint`, local PostgreSQL `npm test` (108 files passed, 833 tests
+  passed, 2 skipped), local PostgreSQL `npm run test:coverage`, and
+  preview-style `npm run build`.
 
 ## Out Of Scope
 - Scheduler cadence or GitHub Actions workflow changes.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,98 +1,79 @@
-# Current Task: TASK-226 Task Due-Date Email Reminders
+# Current Task: TASK-226 Due-Date Reminder Production RLS Fix
 
 ## Task ID
 TASK-226
 
 ## Status
-In Review
+Active
 
 ## Source
+- Production smoke after TASK-226/TASK-265 promotion created tasks due within
+  three days, but `GET /api/cron/notification-emails` returned
+  `dueDateRemindersReconciled: 0`.
 - Dedicated brief:
   `tasks/task-226-task-due-date-email-reminders.md`.
-- Scheduler dependency satisfied by TASK-268, which added the GitHub Actions
-  notification-email dispatcher bridge every 3 hours.
 
 ## Objective
-Create durable, idempotent task due-date reminder notifications and route them
-through the existing notification email orchestration so eligible users receive
-one reminder when work is three calendar days from its deadline.
+Restore production due-date reminder reconciliation so the scheduler can find
+eligible tasks under row-level security, create the durable reminder
+notification, and queue the notification email without depending on an
+unauthenticated global scan.
 
-## Implementation Decisions
-- Recipient: send to the task assignee when present; otherwise send to the task
-  creator as the task owner fallback.
-- Access: create no reminder unless that recipient is still the project owner or
-  an active project member.
-- Completion: exclude tasks in `Done` and archived tasks.
-- Deadline window: compare date-only task deadlines to the local calendar date
-  plus `TASK_DEADLINE_SOON_DAYS` (`3`) using the shared task-deadline helpers.
-- Idempotency: use durable notification source
-  `task_due_date_reminder` with source id
-  `<taskId>:<recipientUserId>:<deadlineDate>`, so repeated scheduler runs and
-  changing a deadline away and back to the same date do not create duplicate
-  reminders for the same task/recipient/deadline window.
-- Email path: queue the reminder notification into the existing
-  `ProjectNotificationEmail` project digest pipeline instead of adding a second
-  scheduler or email-only path.
+## Current Baseline
+- The merged TASK-226 implementation scans due tasks through a global raw SQL
+  query.
+- Production RLS hides task rows from that global scan, so due-date candidates
+  are not discovered.
+- The previous due-date reminder creation path also relied on the later global
+  notification reconciliation pass to queue email delivery.
 
 ## Scope
-- Add task due-date reminder notification metadata/content mapping.
-- Reconcile eligible deadline reminders during notification-email dispatch.
-- Include due-date reminder items in the grouped project notification digest
-  email copy.
-- Keep API routes and cron handlers thin.
-- Update docs and tests for the final behavior.
+- Run due-date candidate discovery per verified recipient under that
+  recipient's RLS context.
+- Queue the due-date reminder notification immediately in the same actor
+  context after creation.
+- Preserve existing idempotency: one reminder per task, recipient, and due-date
+  window, with pending/dispatching/sent email coverage suppressing repeats.
+- Add focused regression coverage for the production RLS-shaped behavior.
 
 ## Acceptance Criteria
-1. A task due in three days creates exactly one reminder per eligible recipient
-   for that task/deadline window.
-2. Repeated scheduler/dispatcher calls do not create duplicate reminders or
-   duplicate emails.
-3. Completed or archived tasks do not generate due-date reminders.
-4. Tasks without due dates do not generate due-date reminders.
-5. Users without project access do not receive reminders.
-6. Changing a task deadline is handled deterministically and covered by tests.
-7. Reminder emails use the shared outbound email foundation and existing email
-   delivery observability.
-8. Reminder notification read/unread state stays independent from email delivery
-   side effects.
-9. Tests cover eligibility, idempotency, date-window boundaries, completed task
-   exclusion, provider failure, and scheduler integration.
-10. README, `journal.md`, `tasks/backlog.md`, and this file are updated with the
-    final behavior.
+1. Production scheduler discovery no longer depends on reading RLS-protected
+   task rows without an actor context.
+2. A due task for a verified recipient creates or reuses the due-date reminder
+   notification and queues it into the shared email orchestration.
+3. Repeated scheduler calls do not duplicate pending, dispatching, or sent
+   reminder emails for the same task/recipient/deadline window.
+4. Completed, archived, undated, inaccessible, or unverified-recipient tasks
+   remain ineligible.
+5. Focused tests cover recipient-scoped discovery and immediate email queueing.
 
 ## Definition Of Done
-- Service changes stay inside `lib/services/**` except shared deadline helpers
-  and presentation labels.
-- The protected dispatch endpoint remains a thin adapter.
-- Focused unit/API tests pass for deadline helpers, notification service,
-  notification email orchestration, outbound templates, and the dispatch route.
-- Local validation runs:
-  - `npm run lint`
-  - `npm test`
-  - `npm run test:coverage`
-  - `npm run build`
-- A ready-for-review PR is opened, checks and Copilot review are monitored, and
-  the final handoff includes delivered commit SHA(s).
+- Service and test changes are scoped to TASK-226 reminder reconciliation.
+- `tasks/backlog.md`, `tasks/current.md`, and `journal.md` reflect the
+  production fix.
+- Validation passes or any blocker is documented.
+- A ready-for-review PR is opened, automated checks/review are monitored, and
+  the handoff includes delivered commit SHA(s).
 
 ## Validation Plan
-- `git diff --check`
-- `npm test -- --run tests/lib/task-deadline.test.ts tests/lib/notification-service.test.ts tests/lib/project-notification-email-service.test.ts tests/lib/outbound-email-templates.test.ts tests/api/notification-email-dispatch.route.test.ts`
+- `npm test -- --run tests/lib/project-notification-email-service.test.ts`
 - `npm run lint`
 - `npm test`
 - `npm run test:coverage`
 - `npm run build`
 
 ## Validation Evidence
+- `npm test -- --run tests/lib/project-notification-email-service.test.ts`
+  passed: 1 file, 18 tests.
 - `git diff --check` passed.
-- Focused reminder/email tests passed: 5 files, 45 tests.
 - `npm run lint` passed.
-- `npm test` passed with local PostgreSQL env after migrations: 108 files
-  passed, 827 tests passed, 2 skipped.
-- `npm run test:coverage` passed: 91.23% statements, 81.2% branches, 93.42%
-  functions, 91.75% lines.
-- `npm run build` passed with local runtime placeholder secrets.
+- With local PostgreSQL env, `npm test` passed: 108 files passed, 832 tests
+  passed, 2 skipped.
+- With local PostgreSQL env, `npm run test:coverage` passed: 91.23%
+  statements, 81.2% branches, 93.42% functions, 91.75% lines.
+- With local PostgreSQL and preview-style runtime env, `npm run build` passed.
 
 ## Out Of Scope
-- Scheduler provisioning; TASK-268 owns the active production bridge.
-- Notification actor attribution/self-notification cleanup; TASK-265 owns that.
-- Reminder preference UI, unsubscribe controls, or instant push delivery.
+- Scheduler cadence or GitHub Actions workflow changes.
+- Actor attribution/self-notification changes from TASK-265.
+- Email preference or unsubscribe behavior.

--- a/tests/lib/project-notification-email-service.test.ts
+++ b/tests/lib/project-notification-email-service.test.ts
@@ -8,6 +8,7 @@ const prismaMock = vi.hoisted(() => ({
   },
   notification: {
     createMany: vi.fn(),
+    findFirst: vi.fn(),
     findMany: vi.fn(),
   },
   projectInvitation: {
@@ -220,12 +221,13 @@ function claimedGroup(input: {
 describe("project-notification-email-service", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    prismaMock.user.findMany.mockResolvedValue([]);
+    prismaMock.user.findMany.mockResolvedValue([{ id: "user-1" }]);
     prismaMock.user.findUnique.mockResolvedValue({
       email: "dorian.agaesse@gmail.com",
       emailVerified: new Date("2026-05-01T00:00:00.000Z"),
     });
     prismaMock.notification.createMany.mockResolvedValue({ count: 1 });
+    prismaMock.notification.findFirst.mockResolvedValue(dueDateReminderNotification());
     prismaMock.notification.findMany.mockResolvedValue([]);
     prismaMock.projectInvitation.findFirst.mockResolvedValue({ id: "invite-1" });
     prismaMock.projectNotificationEmail.create.mockResolvedValue({
@@ -431,12 +433,44 @@ describe("project-notification-email-service", () => {
     expect(sql).toContain('task."deadlineAt" = CAST(');
     expect(sql).toContain('task."status" <> \'Done\'');
     expect(sql).toContain('task."archivedAt" IS NULL');
-    expect(sql).toContain('"ProjectMembership" membership');
-    expect(sql).toContain(
-      'COALESCE(task."assigneeUserId", task."createdByUserId")'
-    );
+    expect(sql).toContain('task."assigneeUserId" =');
+    expect(sql).toContain('task."assigneeUserId" IS NULL');
+    expect(sql).toContain('task."createdByUserId" =');
     expect(sql).toContain('notification."sourceType" =');
     expect(sql).toContain('notification."sourceId"');
+    expect(sql).toContain('notification."readAt" IS NOT NULL');
+    expect(sql).toContain('notification."resolvedAt" IS NOT NULL');
+    expect(sql).toContain('"ProjectNotificationEmailItem" item');
+    expect(sql).toContain("email.\"status\" IN ('pending', 'dispatching', 'sent')");
+    expect(prismaMock.user.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          email: { not: null },
+          emailVerified: { not: null },
+        }),
+      })
+    );
+  });
+
+  test("discovers due-date reminders once per verified recipient under recipient context", async () => {
+    prismaMock.user.findMany.mockResolvedValueOnce([
+      { id: "user-1" },
+      { id: "user-2" },
+    ]);
+
+    await dispatchProjectNotificationEmails({
+      appOrigin: "https://preview.nexusdash.test",
+      now,
+    });
+
+    const dueDateQueries = prismaMock.$queryRaw.mock.calls
+      .slice(0, 2)
+      .map((call) => (call[0] as { strings: string[] }).strings.join(" "));
+
+    expect(dueDateQueries).toHaveLength(2);
+    expect(dueDateQueries.every((sql) => sql.includes('FROM "Task" task'))).toBe(
+      true
+    );
   });
 
   test("batches multiple due project groups into one recipient email", async () => {

--- a/tests/lib/project-notification-email-service.test.ts
+++ b/tests/lib/project-notification-email-service.test.ts
@@ -444,6 +444,7 @@ describe("project-notification-email-service", () => {
     expect(sql).toContain("email.\"status\" IN ('pending', 'dispatching', 'sent')");
     expect(prismaMock.user.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
+        take: 100,
         where: expect.objectContaining({
           email: { not: null },
           emailVerified: { not: null },
@@ -470,6 +471,36 @@ describe("project-notification-email-service", () => {
     expect(dueDateQueries).toHaveLength(2);
     expect(dueDateQueries.every((sql) => sql.includes('FROM "Task" task'))).toBe(
       true
+    );
+  });
+
+  test("paginates verified recipient scanning for due-date reminders", async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({
+      id: `user-${String(index).padStart(3, "0")}`,
+    }));
+    prismaMock.user.findMany
+      .mockResolvedValueOnce(firstPage)
+      .mockResolvedValueOnce([]);
+
+    await dispatchProjectNotificationEmails({
+      appOrigin: "https://preview.nexusdash.test",
+      now,
+    });
+
+    expect(prismaMock.user.findMany).toHaveBeenCalledTimes(2);
+    expect(prismaMock.user.findMany).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        take: 100,
+      })
+    );
+    expect(prismaMock.user.findMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        cursor: { id: "user-099" },
+        skip: 1,
+        take: 100,
+      })
     );
   });
 


### PR DESCRIPTION
## Summary
- Run due-date reminder discovery per verified recipient under that recipient's RLS context instead of a global unauthenticated task scan.
- Queue the due-date reminder notification into the project notification email pipeline immediately after creation/reuse.
- Update TASK-226 tracking docs and add regression coverage for recipient-scoped discovery and email queueing.

## Root Cause
Production RLS hid `Task` rows from the global due-date reminder query, so the scheduler found zero candidates. The created reminder path also depended on a later global notification scan to enqueue email delivery.

## Validation
- `npm test -- --run tests/lib/project-notification-email-service.test.ts`
- `git diff --check`
- `npm run lint`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/nexusdash?schema=public DIRECT_URL=... npm test`
- `DATABASE_URL=... DIRECT_URL=... npm run test:coverage`
- Preview-style runtime env + local PostgreSQL: `npm run build`