### PR TITLE
TASK-273 Plan cost-aware notification email scheduling

### DIFF
--- a/adr/decisions.md
+++ b/adr/decisions.md
@@ -16,6 +16,30 @@ Keep UI-only or task-only notes in `journal.md`.
 
 ## Active Decisions
 
+## 2026-05-22 - Keep notification email dispatch app-owned while improving scheduler cadence cost-consciously
+- Status: Proposed
+- Context: TASK-268 intentionally used a no-new-cost GitHub Actions scheduler
+  bridge every 3 hours after QStash setup created operational friction and
+  Vercel Hobby could not provide the desired high-frequency cron behavior.
+  Production smoke for TASK-226/TASK-265 showed the durable email pipeline can
+  reconcile and send, but the coarse scheduler cadence makes notification
+  emails arrive in predictable batches rather than near each group's intended
+  `sendAfterAt`.
+- Decision: Keep NexusDash's durable app-owned notification email queue,
+  idempotency, protected dispatcher, and Resend delivery foundation. Evaluate
+  scheduler improvements separately, starting with a no-new-cost GitHub Actions
+  cadence reduction and treating QStash, Vercel Pro Cron, or a cloud queue as
+  future trigger options rather than replacements for the app-owned queue.
+- Consequences: Near-term work can improve user-visible latency without
+  prematurely buying a platform upgrade or weakening delivery semantics.
+  Scheduler/provider changes should alter only when the dispatcher is invoked,
+  while the application continues owning grouping, duplicate suppression,
+  delivery records, and smoke validation.
+- Links: `tasks/task-273-cost-aware-notification-email-scheduling.md`,
+  `tasks/task-268-github-actions-notification-email-scheduler.md`,
+  `lib/services/project-notification-email-service.ts`,
+  `.github/workflows/notification-email-dispatch.yml`
+
 ## 2026-05-20 - Use app runtime role for Supabase transaction-pooled app traffic
 - Status: Accepted
 - Context: Production and preview validation showed that runtime database

--- a/journal.md
+++ b/journal.md
@@ -13,6 +13,11 @@ Use it for important implementation milestones, blockers, validation runs, and r
 ## Recent Entries (Most Relevant)
 
 ### 2026-05-22
+- Type: Planning
+- Summary: Created TASK-273 for cost-aware notification email scheduling improvements.
+- Evidence: Production smoke after TASK-226/TASK-265 confirmed the durable notification email pipeline can reconcile and send, but user discussion identified the current 3-hour GitHub Actions bridge as too coarse and predictably batched compared with common production notification systems. Added `tasks/task-273-cost-aware-notification-email-scheduling.md`, queued TASK-273 in `tasks/backlog.md`, updated `tasks/current.md`, marked TASK-226 complete after PR #279, and recorded a proposed architecture direction in `adr/decisions.md` to keep the app-owned durable email queue while improving scheduler cadence under cost constraints.
+
+### 2026-05-22
 - Type: Execution
 - Summary: Started TASK-226 production RLS remediation after prod smoke found no due-date reminder candidates.
 - Evidence: Created branch `fix/task-226-due-reminder-rls` in `../nexus_dash_task226` from `origin/main`. Root cause analysis found due-date reminder discovery reading RLS-protected task rows without an actor context and reminder email queueing depending on a later global notification scan. Updated `tasks/current.md` and `tasks/backlog.md` for the focused production fix.

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -4,12 +4,12 @@ Use this file to capture tasks discovered during development. Each entry should 
 
 ## Pending
 ### Execution Queue (Now / Next)
-- ID: TASK-226
-  Title: Task due-date email reminders - production RLS reconciliation fix
+- ID: TASK-273
+  Title: Cost-aware notification email scheduling - industry-aligned delivery cadence
   Status: Active
-  Rationale: Production smoke after TASK-226 promotion created tasks due within three days, but the notification email dispatcher reported `dueDateRemindersReconciled: 0`. Fix reminder discovery and queueing so the scheduler works under production row-level security and still preserves one reminder per task/user/deadline window.
-  Dependencies: TASK-101, TASK-125, TASK-063, TASK-268
-  Brief: `tasks/task-226-task-due-date-email-reminders.md`
+  Rationale: NexusDash now has durable notification email orchestration, but the current free GitHub Actions bridge runs every 3 hours, so emails arrive in coarse and predictable batches rather than near their per-notification `sendAfterAt`. Define and implement a cost-aware scheduling path that better matches common production notification systems without prematurely committing to a paid platform upgrade.
+  Dependencies: TASK-125, TASK-227, TASK-268, TASK-271, TASK-226
+  Brief: `tasks/task-273-cost-aware-notification-email-scheduling.md`
 - ID: TASK-269
   Title: GitHub Actions workflow cleanup - simplify CI/CD, scheduled jobs, and maintenance automation
   Status: Next
@@ -137,6 +137,11 @@ Use this file to capture tasks discovered during development. Each entry should 
   Dependencies: TASK-051
 
 ## Completed
+- ID: TASK-226
+  Title: Task due-date email reminders - production RLS reconciliation fix
+  Status: Done (2026-05-22, merged via PR #279)
+  Rationale: Follow-up production validation showed due-date reminders reconcile correctly; the merged hardening keeps reminder discovery/queueing RLS-safe and paginates verified-recipient scanning so production reminder dispatch stays resilient as data grows.
+  Dependencies: TASK-101, TASK-125, TASK-063, TASK-268
 - ID: TASK-265
   Title: Notification actor attribution and self-notification rules
   Status: Done (2026-05-22, merged via PR #277)

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,84 +1,70 @@
-# Current Task: TASK-226 Due-Date Reminder Production RLS Fix
+# Current Task: TASK-273 Cost-Aware Notification Email Scheduling
 
 ## Task ID
-TASK-226
+TASK-273
 
 ## Status
 Active
 
 ## Source
-- Production smoke after TASK-226/TASK-265 promotion created tasks due within
-  three days, but `GET /api/cron/notification-emails` returned
-  `dueDateRemindersReconciled: 0`.
+- Production smoke and follow-up discussion after TASK-226/TASK-265 email
+  validation.
+- User concern: the current GitHub Actions scheduler sends notification emails
+  only when the workflow runs, currently every 3 hours, so delivery feels
+  coarse and predictably batched compared with common production systems.
 - Dedicated brief:
-  `tasks/task-226-task-due-date-email-reminders.md`.
+  `tasks/task-273-cost-aware-notification-email-scheduling.md`.
 
 ## Objective
-Restore production due-date reminder reconciliation so the scheduler can find
-eligible tasks under row-level security, create the durable reminder
-notification, and queue the notification email without depending on an
-unauthenticated global scan.
+Create an implementation-ready plan for improving notification email delivery
+cadence while respecting cost constraints. The target is an industry-aligned
+model where durable notification/email records keep their app-owned idempotency,
+but dispatch runs close to each item's intended `sendAfterAt` rather than only
+on a coarse 3-hour bridge.
 
 ## Current Baseline
-- The merged TASK-226 implementation scans due tasks through a global raw SQL
-  query.
-- Production RLS hides task rows from that global scan, so due-date candidates
-  are not discovered.
-- The previous due-date reminder creation path also relied on the later global
-  notification reconciliation pass to queue email delivery.
+- TASK-125 provides durable outbound email delivery records.
+- TASK-227/TASK-271 provide durable notification email grouping, idempotency,
+  debounce windows, and duplicate suppression.
+- TASK-268 intentionally chose a no-new-cost GitHub Actions scheduler bridge
+  every 3 hours while Vercel remained on Hobby and QStash activation had
+  operational friction.
+- TASK-226 now creates due-date reminder notifications and queues them into
+  the shared email orchestration.
 
 ## Scope
-- Run due-date candidate discovery per verified recipient under that
-  recipient's RLS context.
-- Queue the due-date reminder notification immediately in the same actor
-  context after creation.
-- Preserve existing idempotency: one reminder per task, recipient, and due-date
-  window, with pending/dispatching/sent email coverage suppressing repeats.
-- Add focused regression coverage for the production RLS-shaped behavior.
+- Compare low/no-cost and low-friction scheduler options.
+- Define target latency by notification kind.
+- Decide a near-term scheduler cadence that improves UX without forcing a paid
+  platform upgrade.
+- Preserve the existing durable email queue, idempotency, delivery records, and
+  app-owned dispatch endpoint.
+- Add implementation guidance for observability, smoke validation, and future
+  migration to a managed scheduler/queue.
 
 ## Acceptance Criteria
-1. Production scheduler discovery no longer depends on reading RLS-protected
-   task rows without an actor context.
-2. A due task for a verified recipient creates or reuses the due-date reminder
-   notification and queues it into the shared email orchestration.
-3. Repeated scheduler calls do not duplicate pending, dispatching, or sent
-   reminder emails for the same task/recipient/deadline window.
-4. Completed, archived, undated, inaccessible, or unverified-recipient tasks
-   remain ineligible.
-5. Focused tests cover recipient-scoped discovery and immediate email queueing.
+1. A dedicated task brief captures current behavior, pain points, industry
+   baseline, cost-aware options, recommendation, and implementation phases.
+2. The backlog places TASK-273 in the execution queue with correct
+   dependencies.
+3. `journal.md` records why the task was created and how it relates to recent
+   production smoke/TASK-226 work.
+4. `adr/decisions.md` records the proposed architectural direction without
+   committing to a paid provider prematurely.
+5. The task can be implemented later without re-discovering the scheduler
+   tradeoffs.
 
 ## Definition Of Done
-- Service and test changes are scoped to TASK-226 reminder reconciliation.
-- `tasks/backlog.md`, `tasks/current.md`, and `journal.md` reflect the
-  production fix.
-- Validation passes or any blocker is documented.
-- A ready-for-review PR is opened, automated checks/review are monitored, and
-  the handoff includes delivered commit SHA(s).
+- Planning docs are committed on a dedicated branch and opened in a PR.
+- No production behavior is changed in this task.
+- Validation confirms the markdown/docs-only change is structurally clean.
 
 ## Validation Plan
-- `npm test -- --run tests/lib/project-notification-email-service.test.ts`
-- `npm run lint`
-- `npm test`
-- `npm run test:coverage`
-- `npm run build`
-
-## Validation Evidence
-- `npm test -- --run tests/lib/project-notification-email-service.test.ts`
-  passed: 1 file, 19 tests.
-- `git diff --check` passed.
-- `npm run lint` passed.
-- With local PostgreSQL env, `npm test` passed: 108 files passed, 832 tests
-  passed, 2 skipped.
-- With local PostgreSQL env, `npm run test:coverage` passed: 91.23%
-  statements, 81.2% branches, 93.42% functions, 91.75% lines.
-- With local PostgreSQL and preview-style runtime env, `npm run build` passed.
-- After Copilot review, paginated verified recipient scanning was added.
-  Follow-up validation passed: focused test file, `git diff --check`,
-  `npm run lint`, local PostgreSQL `npm test` (108 files passed, 833 tests
-  passed, 2 skipped), local PostgreSQL `npm run test:coverage`, and
-  preview-style `npm run build`.
+- `git diff --check`
+- `git status --short`
 
 ## Out Of Scope
-- Scheduler cadence or GitHub Actions workflow changes.
-- Actor attribution/self-notification changes from TASK-265.
-- Email preference or unsubscribe behavior.
+- Changing scheduler cadence in this PR.
+- Buying or configuring a paid scheduler/provider.
+- Implementing notification preferences, unsubscribe controls, bounce webhooks,
+  or realtime in-app updates.

--- a/tasks/task-273-cost-aware-notification-email-scheduling.md
+++ b/tasks/task-273-cost-aware-notification-email-scheduling.md
@@ -1,0 +1,252 @@
+# TASK-273 Cost-Aware Notification Email Scheduling
+
+Date: 2026-05-22
+Branch: `feature/task-273-notification-email-scheduling-strategy`
+
+## Summary
+
+Improve NexusDash notification email scheduling so delivery is closer to common
+production behavior while respecting the current cost constraint.
+
+The app already has the hard parts of a sane notification email system:
+durable notification records, durable email groups, idempotency, delivery
+status, debounce windows, and a protected dispatcher. The weak part is the
+temporary scheduler bridge: GitHub Actions invokes the dispatcher every 3
+hours, so emails tend to arrive in coarse, predictable waves rather than close
+to each group's intended `sendAfterAt`.
+
+## Product Problem
+
+Users expect notification emails to feel timely but not spammy:
+
+- mentions and assignments should not wait several hours once the quiet window
+  expires;
+- due-date reminders should arrive on the intended day in a predictable
+  user-friendly window;
+- grouped digests should preserve batching/debounce behavior but should not be
+  hostage to a 3-hour polling interval;
+- delivery should remain idempotent, observable, and safe under retries.
+
+The current 3-hour bridge is acceptable as an early-production compromise, but
+it does not feel like the industry norm for app notifications.
+
+## Current Baseline
+
+- `Notification` stores durable in-app activity.
+- `ProjectNotificationEmail` and `ProjectNotificationEmailItem` store durable
+  grouped email work.
+- `OutboundEmailDelivery` records provider delivery attempts.
+- `GET /api/cron/notification-emails` reconciles and dispatches due groups.
+- GitHub Actions currently calls that endpoint every 3 hours.
+- TASK-271 prevents already-sent notification IDs from being emailed again.
+- TASK-226 creates due-date reminder notifications and queues them into the
+  shared project notification digest pipeline.
+
+## Industry Baseline
+
+Typical production notification email systems separate three concerns:
+
+1. **Event persistence:** write an activity/notification row immediately when
+   a mention, assignment, invite, or reminder candidate is created.
+2. **Delivery scheduling:** store when the email is allowed to send
+   (`sendAfterAt`, digest window, local-time preference, retry-after, etc.).
+3. **Worker dispatch:** run a queue worker or frequent scheduler that claims
+   due work, sends through the provider, records delivery state, and retries
+   safely.
+
+For NexusDash, the app-owned durable queue already exists. The missing piece is
+a low-latency, cost-aware worker cadence.
+
+## Target Latency Policy
+
+Use latency goals by email kind instead of one global cadence:
+
+- **Project activity digests**: send 0-15 minutes after the quiet window or
+  max-delay window expires.
+- **Task assignment / mention emails**: use the project activity digest path,
+  but keep the total expected delay under 45 minutes in normal conditions.
+- **Task due-date reminders**: reconcile daily eligibility early enough that
+  reminders arrive on the intended local calendar day; exact minute is less
+  critical than reliability and deduplication.
+- **Project invitation reminders**: delayed reminder semantics are acceptable;
+  delivery can be less urgent than mentions/assignments.
+- **Transactional auth/account emails**: remain immediate through the existing
+  outbound email service and are not governed by this scheduler.
+
+## Cost-Aware Options To Evaluate
+
+### Option A: Tighten GitHub Actions Cadence
+
+Run the existing scheduler workflow every 15 or 30 minutes.
+
+Pros:
+- no new provider setup;
+- no direct new platform cost;
+- keeps current protected endpoint and app-owned queue;
+- fastest path to better UX.
+
+Cons:
+- GitHub scheduled workflows are not a hard real-time worker;
+- runs can be delayed, skipped during incidents, or disabled if the repository
+  becomes inactive;
+- still creates visible batch boundaries, though much smaller than 3 hours;
+- not ideal as the long-term production worker if usage grows.
+
+Recommended use:
+- near-term default under the current cost constraint, if GitHub Actions usage
+  remains within acceptable limits.
+
+### Option B: QStash / Managed HTTP Scheduler
+
+Use a managed scheduler to call the existing protected dispatcher more
+frequently, or schedule individual work items.
+
+Pros:
+- closer to app-notification industry practice;
+- retries and scheduling semantics are provider-owned;
+- can often start at low/no cost depending on current pricing and volume;
+- does not require moving off the existing Vercel Hobby app immediately.
+
+Cons:
+- previous activation had operational friction;
+- pricing and limits must be rechecked at implementation time;
+- secrets, retries, and failure visibility need runbook coverage.
+
+Recommended use:
+- preferred long-term low-cost direction if setup friction is resolved and
+  pricing fits.
+
+### Option C: Vercel Pro Cron
+
+Upgrade Vercel and run cron more frequently from the deployment platform.
+
+Pros:
+- operationally simple with the current hosting stack;
+- centralizes app deployment and scheduled execution;
+- less external glue.
+
+Cons:
+- forces a recurring platform upgrade mostly for scheduler cadence;
+- still cron-based rather than a true queue unless paired with app-owned
+  claiming, which NexusDash already has.
+
+Recommended use:
+- reasonable once the app already needs Vercel Pro for multiple reasons; do not
+  choose it solely for this feature under the current cost constraint.
+
+### Option D: Cloud / Queue Worker
+
+Use a cloud-native queue/scheduler such as Cloud Tasks, EventBridge Scheduler,
+SQS, or a similar worker model.
+
+Pros:
+- closest to mature production architecture;
+- strong retry/dead-letter/visibility options;
+- can scale beyond simple cron.
+
+Cons:
+- much more operational surface;
+- more secrets, IAM, deployment, and monitoring work;
+- likely premature for the current project stage.
+
+Recommended use:
+- defer until NexusDash needs broader background-job infrastructure.
+
+## Recommended Path
+
+Implement this in phases:
+
+1. **Near-term no-new-cost improvement**
+   - Reduce GitHub Actions notification scheduler cadence from 3 hours to 30
+     minutes, or 15 minutes if workflow usage remains reasonable.
+   - Keep the protected endpoint and durable queue unchanged.
+   - Add clear workflow summaries showing claimed groups, emails sent/skipped,
+     reminder reconciliation count, and errors.
+   - Add a smoke command/runbook for manually invoking the dispatcher after
+     creating mention/assignment/due-date smoke data.
+
+2. **Latency and observability hardening**
+   - Track scheduler lag: `now - sendAfterAt` for claimed groups.
+   - Log/alert when lag exceeds the target, for example 60 minutes for project
+     activity emails.
+   - Make dispatch summaries easy to inspect from GitHub Actions and server
+     logs.
+   - Ensure the dispatcher remains idempotent under overlapping invocations.
+
+3. **Managed scheduler decision point**
+   - Recheck pricing/limits for QStash, Vercel Cron, and any candidate
+     low-cost scheduler.
+   - Choose a managed path only if 15-30 minute GitHub Actions cadence is still
+     too coarse or unreliable.
+   - Preserve the existing app-owned queue and protected dispatcher so provider
+     migration changes the trigger, not the delivery semantics.
+
+## Implementation Guidance
+
+- Keep persistence access in `lib/services/**`.
+- Keep `/api/cron/notification-emails` as a thin adapter.
+- Do not send emails directly from task/comment mutation routes.
+- Do not mark in-app notifications read/resolved after email delivery.
+- Preserve durable idempotency on:
+  - notification source identity;
+  - email group source/grouping keys;
+  - sent notification ID coverage;
+  - provider delivery records.
+- If cadence changes through GitHub Actions, update:
+  - `.github/workflows/notification-email-dispatch.yml`;
+  - `README.md`;
+  - `docs/runbooks/vercel-env-contract-and-secrets.md`;
+  - `journal.md`.
+- If a managed scheduler is selected, add or update a runbook covering:
+  - secret setup;
+  - retry behavior;
+  - manual dispatch;
+  - failure diagnostics;
+  - smoke validation;
+  - rollback to the GitHub Actions bridge.
+
+## Acceptance Criteria
+
+1. A cost-aware scheduler option is selected with explicit rationale.
+2. Normal project activity emails are dispatched within the selected target
+   latency after their quiet/max-delay window expires.
+3. Due-date reminders still create exactly one reminder per task, recipient,
+   and deadline window.
+4. Duplicate email suppression from TASK-271 remains intact.
+5. Dispatcher summaries expose enough evidence to diagnose scheduler lag.
+6. Production smoke covers:
+   - task assignment from an agent;
+   - task mention from an agent;
+   - task due in exactly three days;
+   - repeated dispatcher invocation without duplicate sends.
+7. Documentation explains the active scheduler cadence and its cost/latency
+   tradeoff.
+
+## Definition Of Done
+
+- Scheduler cadence or provider trigger is updated according to the chosen
+  path.
+- Relevant runbooks and README scheduler text are updated.
+- Local tests covering notification email dispatch still pass.
+- Workflow or provider-level smoke evidence is recorded.
+- The final handoff states the expected email latency and known residual
+  limitations.
+
+## Validation Plan
+
+- `git diff --check`
+- Focused notification email service/route tests.
+- `npm run lint`
+- `npm test`
+- `npm run build`
+- Production or preview smoke against a test project, depending on the chosen
+  scheduler path.
+
+## Out Of Scope
+
+- Replacing Resend as the outbound provider.
+- User notification preference UI.
+- Bounce/suppression webhook handling, unless selected provider behavior
+  requires a minimal compatibility change.
+- Realtime in-app notification delivery.
+- A broad background-job platform rewrite.


### PR DESCRIPTION
## Summary
- Add TASK-273 as the implementation-ready brief for improving notification email scheduling under cost constraints.
- Move TASK-273 into the execution queue and mark TASK-226 complete after PR #279.
- Update `tasks/current.md`, `journal.md`, and `adr/decisions.md` with the proposed architecture direction: keep the app-owned durable email queue, improve scheduler cadence separately, and avoid prematurely committing to a paid provider.

## Why
The current GitHub Actions bridge preserves no-new-cost delivery but runs every 3 hours, which makes notification emails arrive in coarse, predictable batches. TASK-273 captures a practical path toward more industry-aligned delivery latency while respecting current cost constraints.

## Validation
- `git diff --check`
- `git status --short`
