### PR TITLE
fix: repair notification dispatch workflow yaml

### DIFF
--- a/.github/workflows/notification-email-dispatch.yml
+++ b/.github/workflows/notification-email-dispatch.yml
@@ -95,7 +95,7 @@ jobs:
           } catch {
             console.log("- Parsed summary: `unavailable; dispatcher response was not JSON`");
           }
-NODE
+          NODE
           )"
           {
             echo "## Notification Email Dispatch"


### PR DESCRIPTION
## Summary

- Fix the TASK-273 notification dispatch workflow YAML by indenting the heredoc terminator inside the `run` block.
- This addresses the post-merge workflow-file failure on `main` after PR #288.

## Validation

- `git diff --check`
- GitHub workflow parser will validate on this PR and the follow-up merge push.
