### PR TITLE
fix: roll back TASK-273 scheduler changes

### DIFF
--- a/.github/workflows/notification-email-dispatch.yml
+++ b/.github/workflows/notification-email-dispatch.yml
@@ -3,8 +3,8 @@ name: Notification Email Dispatch Scheduler
 on:
   schedule:
     # Temporary production bridge while Vercel remains on Hobby and QStash is not
-    # in use. Run away from the top and half hour to reduce GitHub schedule delay.
-    - cron: "17,47 * * * *"
+    # in use. Run away from the top of the hour to reduce GitHub schedule delay.
+    - cron: "17 */3 * * *"
   workflow_dispatch:
     inputs:
       target_url:
@@ -66,49 +66,12 @@ jobs:
           set -e
 
           echo "$response"
-          parsed_summary="$(RESPONSE_JSON="$response" node <<'NODE'
-          const raw = process.env.RESPONSE_JSON ?? "";
-          try {
-            const payload = JSON.parse(raw);
-            const summary = payload.summary ?? {};
-            const line = (label, key) => {
-              const value = Object.prototype.hasOwnProperty.call(summary, key)
-                ? summary[key]
-                : "n/a";
-              return `- ${label}: \`${value}\``;
-            };
-
-            console.log(line("Due-date reminders reconciled", "dueDateRemindersReconciled"));
-            console.log(line("Notifications reconciled", "notificationsReconciled"));
-            console.log(line("Groups claimed", "groupsClaimed"));
-            console.log(line("Scheduler lag groups measured", "schedulerLagGroupsMeasured"));
-            console.log(line("Max scheduler lag minutes", "schedulerLagMaxMinutes"));
-            console.log(line("Average scheduler lag minutes", "schedulerLagAverageMinutes"));
-            console.log(line("Recipient emails attempted", "recipientEmailsAttempted"));
-            console.log(line("Recipient emails sent", "recipientEmailsSent"));
-            console.log(line("Recipient emails skipped", "recipientEmailsSkipped"));
-            console.log(line("Recipient emails failed", "recipientEmailsFailed"));
-            console.log(line("Groups sent", "groupsSent"));
-            console.log(line("Groups skipped", "groupsSkipped"));
-            console.log(line("Groups failed", "groupsFailed"));
-            console.log(line("Errors", "errors"));
-          } catch {
-            console.log("- Parsed summary: `unavailable; dispatcher response was not JSON`");
-          }
-          NODE
-          )"
           {
             echo "## Notification Email Dispatch"
             echo
             echo "- Trigger: \`${{ github.event_name }}\`"
-            echo "- Scheduled cadence: \`30 minutes\`"
             echo "- Target origin: \`$dispatch_origin\`"
             echo "- Curl exit code: \`$curl_status\`"
-            echo
-            echo "### Parsed Summary"
-            echo
-            echo "$parsed_summary"
-            echo
             echo "- Response/output:"
             echo
             echo '```text'

--- a/README.md
+++ b/README.md
@@ -348,17 +348,12 @@ notification. Sending email never marks notifications read or resolved.
 
 Production scheduler decision:
 
-- Current production bridge: GitHub Actions invokes this endpoint every 30 minutes
+- Current production bridge: GitHub Actions invokes this endpoint every 3 hours
   through `.github/workflows/notification-email-dispatch.yml`.
 - This is an accepted early-production tradeoff while Vercel remains on Hobby
   and no managed scheduler is in use. It preserves durable app-owned queueing
-  and idempotent dispatch. It improves the previous 3-hour bridge while still
-  depending on GitHub scheduled workflow reliability rather than a hard
-  real-time worker.
-- Expected project-activity email timing is the 30-minute quiet window plus at
-  most one 30-minute scheduler cadence and normal GitHub scheduling delay.
-  Dispatcher summaries include scheduler-lag metrics for claimed groups so
-  operators can see when due work waited beyond its `sendAfterAt`.
+  and idempotent dispatch, but it does not satisfy the original one-hour
+  max-delay delivery target.
 - Manual workflow dispatch remains available for preview validation and
   diagnostics by overriding the target URL.
 - Future preferred path: Vercel Cron or a managed HTTP scheduler with

--- a/adr/decisions.md
+++ b/adr/decisions.md
@@ -17,7 +17,7 @@ Keep UI-only or task-only notes in `journal.md`.
 ## Active Decisions
 
 ## 2026-05-22 - Keep notification email dispatch app-owned while improving scheduler cadence cost-consciously
-- Status: Accepted
+- Status: Proposed
 - Context: TASK-268 intentionally used a no-new-cost GitHub Actions scheduler
   bridge every 3 hours after QStash setup created operational friction and
   Vercel Hobby could not provide the desired high-frequency cron behavior.
@@ -26,15 +26,13 @@ Keep UI-only or task-only notes in `journal.md`.
   emails arrive in predictable batches rather than near each group's intended
   `sendAfterAt`.
 - Decision: Keep NexusDash's durable app-owned notification email queue,
-  idempotency, protected dispatcher, and Resend delivery foundation. Reduce the
-  GitHub Actions production bridge to a 30-minute cadence as the first
-  no-new-cost improvement, and treat QStash, Vercel Pro Cron, or a cloud queue
-  as future trigger options rather than replacements for the app-owned queue.
+  idempotency, protected dispatcher, and Resend delivery foundation. Evaluate
+  scheduler improvements separately, starting with a no-new-cost GitHub Actions
+  cadence reduction and treating QStash, Vercel Pro Cron, or a cloud queue as
+  future trigger options rather than replacements for the app-owned queue.
 - Consequences: Near-term work can improve user-visible latency without
-  prematurely buying a platform upgrade or weakening delivery semantics. The
-  app now reports scheduler-lag metrics for claimed groups, but GitHub
-  scheduled workflows remain best-effort rather than hard real-time. Future
-  scheduler/provider changes should alter only when the dispatcher is invoked,
+  prematurely buying a platform upgrade or weakening delivery semantics.
+  Scheduler/provider changes should alter only when the dispatcher is invoked,
   while the application continues owning grouping, duplicate suppression,
   delivery records, and smoke validation.
 - Links: `tasks/task-273-cost-aware-notification-email-scheduling.md`,

--- a/docs/runbooks/notification-email-dispatch.md
+++ b/docs/runbooks/notification-email-dispatch.md
@@ -10,35 +10,12 @@ current GitHub Actions production bridge.
 - Secret source: `NOTIFICATION_EMAIL_DISPATCH_SECRET`, falling back to
   `CRON_SECRET`
 - Production scheduler: `.github/workflows/notification-email-dispatch.yml`
-  every 30 minutes
+  every 3 hours
 - Manual workflow dispatch can target production or a preview URL
 
 The dispatcher reconciles eligible notification sources, queues project email
 groups, claims due groups, and sends recipient-level digest emails with project
 sections. Email delivery never marks in-app notifications read or resolved.
-Each successful dispatcher response includes scheduler-lag metrics for claimed
-groups so operators can compare actual claim time with each group's
-`sendAfterAt`.
-
-## Active Cadence
-
-The current no-new-cost production path is a 30-minute GitHub Actions schedule.
-It keeps NexusDash on the app-owned durable email queue while reducing the
-previous 3-hour batching effect.
-
-Expected timing:
-
-- project activity waits for the 30-minute quiet window, capped by the existing
-  60-minute max-delay window;
-- once a group is due, the scheduler should normally claim it within one
-  30-minute cadence plus normal GitHub scheduling delay;
-- task due-date reminders are reconciled on each dispatcher run, so they remain
-  reliable for same-day delivery without promising an exact minute.
-
-Residual limitation: GitHub scheduled workflows are still a best-effort trigger,
-not a hard real-time queue worker. If scheduler lag becomes unacceptable,
-TASK-273's future decision point is to move the trigger to QStash, Vercel Pro
-Cron, or another managed scheduler while keeping the same dispatcher.
 
 ## Due-Date Reminder Behavior
 
@@ -73,11 +50,9 @@ window.
    account is the task creator.
 3. Set the task due date to exactly 3 local calendar days from the smoke date.
 4. Run the notification email dispatch workflow manually, or wait for the next
-   30-minute scheduled run.
+   3-hour scheduled run.
 5. Confirm the dispatcher summary reports due-date reminder reconciliation and
-   that one in-app reminder notification exists. In the workflow summary, also
-   review `Scheduler lag groups measured`, `Max scheduler lag minutes`, and
-   `Average scheduler lag minutes`.
+   that one in-app reminder notification exists.
 6. Let the digest send through the existing email queue and confirm the email
    includes a concise due-date reminder item.
 7. Re-run the dispatcher for the same task/date and confirm no duplicate

--- a/docs/runbooks/vercel-env-contract-and-secrets.md
+++ b/docs/runbooks/vercel-env-contract-and-secrets.md
@@ -131,16 +131,12 @@ the invitation notification.
 
 Scheduler decision:
 
-- Current production bridge: GitHub Actions invokes this endpoint every 30 minutes
+- Current production bridge: GitHub Actions invokes this endpoint every 3 hours
   through `.github/workflows/notification-email-dispatch.yml`.
 - This bridge uses the existing durable app queue, protected endpoint, and
-  idempotent dispatcher. It improves the previous 3-hour bridge without adding
-  a paid scheduler/provider. Expected project-activity email delivery is the
-  quiet window plus at most one 30-minute scheduler cadence and normal GitHub
-  Actions scheduling delay.
-- Dispatcher responses and workflow summaries include scheduler-lag metrics for
-  claimed groups so operators can see how long due work waited after
-  `sendAfterAt`.
+  idempotent dispatcher. It intentionally does not satisfy the original
+  one-hour max-delay delivery target; expected delivery is periodic, usually
+  within one scheduler cadence plus GitHub Actions scheduling delay.
 - Manual GitHub Actions dispatch remains available for preview validation and
   diagnostics by overriding the target URL.
 - Future preferred path: Vercel Cron or a managed HTTP scheduler with

--- a/journal.md
+++ b/journal.md
@@ -13,21 +13,6 @@ Use it for important implementation milestones, blockers, validation runs, and r
 ## Recent Entries (Most Relevant)
 
 ### 2026-05-25
-- Type: Execution
-- Summary: Started TASK-273 cost-aware notification email scheduling implementation.
-- Evidence: Created `feature/task-273-cost-aware-scheduler` from `origin/main`, updated `tasks/current.md` from the planning-only contract to the implementation contract, selected the documented no-new-cost 30-minute GitHub Actions cadence, added dispatcher scheduler-lag metrics, and updated workflow/runbook/project documentation to describe the new cadence and residual GitHub scheduler limitation.
-
-### 2026-05-25
-- Type: Validation
-- Summary: TASK-273 local validation passed after using the explicit local PostgreSQL env.
-- Evidence: Focused notification email tests passed (`npm test -- --run tests/lib/project-notification-email-service.test.ts tests/api/notification-email-dispatch.route.test.ts`, 26 tests). `npm run lint` and `git diff --check` passed. Plain `npm test` and `npm run test:coverage` initially failed because Vitest does not load `.env` and `DATABASE_URL` was unset; Docker Compose local Postgres could not bind because port 5432 was already allocated, but the documented local PostgreSQL URL was reachable and `npm run db:migrate` showed no pending migrations. With explicit `DATABASE_URL`/`DIRECT_URL`, `npm test` passed (108 files passed, 2 skipped; 833 passed, 2 skipped), `npm run test:coverage` passed (91.23% statements, 81.2% branches, 93.42% functions, 91.75% lines), and `npm run build` passed with safe local placeholder runtime secrets.
-
-### 2026-05-25
-- Type: Validation
-- Summary: TASK-273 PR #288 passed automated review and CI.
-- Evidence: Opened PR #288 from `feature/task-273-cost-aware-scheduler`; Copilot reviewed all 13 changed files and generated no comments. GitHub checks passed: Check Branch Name, Quality Core, E2E Smoke, and Container Image.
-
-### 2026-05-25
 - Type: Planning
 - Summary: Reviewed and refreshed the backlog after the TASK-273 planning merge.
 - Evidence: Updated `tasks/backlog.md` with a 2026-05-25 review stamp, clarified that TASK-273's strategy brief merged via PR #280 while implementation remains pending, queued TASK-269 after scheduler work unless deferred, labeled TASK-266/TASK-133 as follow-ups, and corrected stale completed PR statuses for TASK-104 and TASK-127.

--- a/lib/services/project-notification-email-service.ts
+++ b/lib/services/project-notification-email-service.ts
@@ -131,9 +131,6 @@ export interface DispatchProjectNotificationEmailsSummary {
   dueDateRemindersReconciled: number;
   notificationsReconciled: number;
   groupsClaimed: number;
-  schedulerLagGroupsMeasured: number;
-  schedulerLagMaxMinutes: number;
-  schedulerLagAverageMinutes: number;
   recipientEmailsAttempted: number;
   recipientEmailsSent: number;
   recipientEmailsSkipped: number;
@@ -150,19 +147,6 @@ function maxDate(left: Date, right: Date): Date {
 
 function minDate(left: Date, right: Date): Date {
   return left.getTime() <= right.getTime() ? left : right;
-}
-
-function roundMetric(value: number): number {
-  return Math.round(value * 100) / 100;
-}
-
-function calculateSchedulerLagMinutes(input: {
-  now: Date;
-  sendAfterAt: Date;
-}): number {
-  return roundMetric(
-    Math.max(0, input.now.getTime() - input.sendAfterAt.getTime()) / 60_000
-  );
 }
 
 function isJsonObject(value: Prisma.JsonValue | null): value is Prisma.JsonObject {
@@ -1475,14 +1459,10 @@ export async function dispatchProjectNotificationEmails(input: {
   const appOrigin = normalizeAppOrigin(input.appOrigin);
   const now = input.now ?? new Date();
   const claimToken = createClaimToken();
-  let schedulerLagTotalMinutes = 0;
   const summary: DispatchProjectNotificationEmailsSummary = {
     dueDateRemindersReconciled: 0,
     notificationsReconciled: 0,
     groupsClaimed: 0,
-    schedulerLagGroupsMeasured: 0,
-    schedulerLagMaxMinutes: 0,
-    schedulerLagAverageMinutes: 0,
     recipientEmailsAttempted: 0,
     recipientEmailsSent: 0,
     recipientEmailsSkipped: 0,
@@ -1533,19 +1513,6 @@ export async function dispatchProjectNotificationEmails(input: {
         continue;
       }
 
-      for (const group of groups) {
-        const lagMinutes = calculateSchedulerLagMinutes({
-          now,
-          sendAfterAt: group.sendAfterAt,
-        });
-        schedulerLagTotalMinutes += lagMinutes;
-        summary.schedulerLagGroupsMeasured += 1;
-        summary.schedulerLagMaxMinutes = Math.max(
-          summary.schedulerLagMaxMinutes,
-          lagMinutes
-        );
-      }
-
       const outcome = await dispatchRecipientBatch({
         recipient,
         groups,
@@ -1574,12 +1541,6 @@ export async function dispatchProjectNotificationEmails(input: {
         recipientUserId,
       });
     }
-  }
-
-  if (summary.schedulerLagGroupsMeasured > 0) {
-    summary.schedulerLagAverageMinutes = roundMetric(
-      schedulerLagTotalMinutes / summary.schedulerLagGroupsMeasured
-    );
   }
 
   logServerInfo(

--- a/project.md
+++ b/project.md
@@ -60,10 +60,9 @@ NexusDash is a personal/team execution workspace that keeps project planning, de
 - Testing: Vitest + Playwright
 - Runtime/deploy: Docker, GitHub Actions, Vercel CLI staged production deploy/promotion/rollback
 - Notification email scheduling: GitHub Actions currently invokes the protected
-  dispatcher every 30 minutes as an early-production bridge while Vercel remains
+  dispatcher every 3 hours as an early-production bridge while Vercel remains
   on Hobby and no managed scheduler is in use. This keeps grouped email
-  delivery active with app-owned idempotency, while still depending on GitHub
-  scheduled workflow reliability rather than a hard real-time worker.
+  delivery active but does not provide the original sub-hour delivery target.
 
 ## 4. Data Model Snapshot
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -6,9 +6,15 @@ Last reviewed: 2026-05-25
 
 ## Pending
 ### Execution Queue (Now / Next)
+- ID: TASK-273
+  Title: Cost-aware notification email scheduling - industry-aligned delivery cadence
+  Status: Next (strategy brief merged via PR #280; implementation pending)
+  Rationale: NexusDash now has durable notification email orchestration, but the current free GitHub Actions bridge runs every 3 hours, so emails arrive in coarse and predictable batches rather than near their per-notification `sendAfterAt`. The merged strategy brief recommends a cost-aware implementation path that preserves the app-owned durable queue while improving scheduler cadence and observability without prematurely committing to a paid platform upgrade.
+  Dependencies: TASK-125, TASK-227, TASK-268, TASK-271, TASK-226
+  Brief: `tasks/task-273-cost-aware-notification-email-scheduling.md`
 - ID: TASK-269
   Title: GitHub Actions workflow cleanup - simplify CI/CD, scheduled jobs, and maintenance automation
-  Status: Next
+  Status: Queued (after TASK-273 unless scheduler work is deferred)
   Rationale: The repository now has several production-impacting workflows covering quality gates, staged Vercel deploys, notification email dispatch, dependency security, Dependabot triage, and Copilot repair. Recent production work exposed duplicated env handling, scheduler tradeoffs, production-target safeguards, and deploy/secrets coupling across these workflows. Run a focused cleanup so workflow responsibilities, permissions, env/secrets usage, dispatch inputs, summaries, and failure modes are easier to understand and operate without changing product behavior.
   Dependencies: TASK-042, TASK-116, TASK-132, TASK-268
   Brief: `tasks/task-269-github-actions-workflow-cleanup.md`
@@ -133,12 +139,6 @@ Last reviewed: 2026-05-25
   Dependencies: TASK-051
 
 ## Completed
-- ID: TASK-273
-  Title: Cost-aware notification email scheduling - industry-aligned delivery cadence
-  Status: Done (2026-05-25, PR #288)
-  Rationale: Kept the app-owned durable notification email queue and protected dispatcher, reduced the no-new-cost GitHub Actions production bridge from 3 hours to 30 minutes, added scheduler-lag metrics to dispatcher/workflow summaries, and updated runbooks/tracking docs with expected latency and residual GitHub scheduler limitations.
-  Dependencies: TASK-125, TASK-227, TASK-268, TASK-271, TASK-226
-  Brief: `tasks/task-273-cost-aware-notification-email-scheduling.md`
 - ID: TASK-226
   Title: Task due-date email reminders - production RLS reconciliation fix
   Status: Done (2026-05-22, merged via PR #279)

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,25 +4,23 @@
 TASK-273
 
 ## Status
-Done (PR #288)
+Active
 
 ## Source
 - Production smoke and follow-up discussion after TASK-226/TASK-265 email
   validation.
-- Strategy brief merged via PR #280:
+- User concern: the current GitHub Actions scheduler sends notification emails
+  only when the workflow runs, currently every 3 hours, so delivery feels
+  coarse and predictably batched compared with common production systems.
+- Dedicated brief:
   `tasks/task-273-cost-aware-notification-email-scheduling.md`.
-- User direction on 2026-05-25: proceed with the conservative no-new-cost path
-  without further discussion.
 
 ## Objective
-Improve notification email delivery cadence while preserving the app-owned
-durable queue, idempotent dispatcher, and current cost posture.
-
-The selected near-term implementation is a GitHub Actions cadence reduction
-from the previous 3-hour bridge to every 30 minutes, plus scheduler-lag
-evidence in the dispatcher summary and workflow output. This should make
-activity emails arrive closer to each group's intended `sendAfterAt` without
-introducing QStash, Vercel Pro Cron, or a broader queue worker yet.
+Create an implementation-ready plan for improving notification email delivery
+cadence while respecting cost constraints. The target is an industry-aligned
+model where durable notification/email records keep their app-owned idempotency,
+but dispatch runs close to each item's intended `sendAfterAt` rather than only
+on a coarse 3-hour bridge.
 
 ## Current Baseline
 - TASK-125 provides durable outbound email delivery records.
@@ -30,62 +28,43 @@ introducing QStash, Vercel Pro Cron, or a broader queue worker yet.
   debounce windows, and duplicate suppression.
 - TASK-268 intentionally chose a no-new-cost GitHub Actions scheduler bridge
   every 3 hours while Vercel remained on Hobby and QStash activation had
-  operational friction; TASK-273 now tightens that bridge to 30 minutes.
-- TASK-226 creates due-date reminder notifications and queues them into the
-  shared email orchestration.
-- TASK-273 PR #280 selected the cost-aware improvement path; this branch
-  implements the first phase.
-- PR #288 delivered the 30-minute scheduler bridge and scheduler-lag summary
-  evidence.
+  operational friction.
+- TASK-226 now creates due-date reminder notifications and queues them into
+  the shared email orchestration.
 
 ## Scope
-- Change `.github/workflows/notification-email-dispatch.yml` to run the
-  protected dispatcher every 30 minutes.
-- Keep scheduled runs targeting `https://nexus-dash.app`; keep manual
-  `target_url` override behavior for previews and diagnostics.
-- Add scheduler-lag fields to the dispatcher summary for claimed due groups.
-- Make the GitHub Actions step summary show parsed dispatch metrics in addition
-  to the raw endpoint response.
-- Update README/runbooks/task docs so the active cadence, expected latency, and
-  residual limitations are accurate.
+- Compare low/no-cost and low-friction scheduler options.
+- Define target latency by notification kind.
+- Decide a near-term scheduler cadence that improves UX without forcing a paid
+  platform upgrade.
+- Preserve the existing durable email queue, idempotency, delivery records, and
+  app-owned dispatch endpoint.
+- Add implementation guidance for observability, smoke validation, and future
+  migration to a managed scheduler/queue.
 
 ## Acceptance Criteria
-1. The selected scheduler path is explicit: 30-minute GitHub Actions cadence,
-   no new paid provider, app-owned queue unchanged.
-2. Normal project activity emails are expected within the 30-minute quiet
-   window plus at most one 30-minute scheduler cadence and GitHub scheduling
-   delay under normal conditions.
-3. Due-date reminder reconciliation remains in the protected dispatcher and
-   still preserves one reminder per task, recipient, and deadline date.
-4. Duplicate email suppression from TASK-271 remains unchanged.
-5. Dispatcher summaries expose scheduler-lag evidence for claimed groups.
-6. Workflow summaries expose enough parsed metrics to inspect reconciliation,
-   claim/send outcomes, errors, and scheduler lag without reading raw JSON.
-7. Documentation explains the active cadence, cost/latency tradeoff, manual
-   smoke path, and future managed-scheduler decision point.
+1. A dedicated task brief captures current behavior, pain points, industry
+   baseline, cost-aware options, recommendation, and implementation phases.
+2. The backlog places TASK-273 in the execution queue with correct
+   dependencies.
+3. `journal.md` records why the task was created and how it relates to recent
+   production smoke/TASK-226 work.
+4. `adr/decisions.md` records the proposed architectural direction without
+   committing to a paid provider prematurely.
+5. The task can be implemented later without re-discovering the scheduler
+   tradeoffs.
 
 ## Definition Of Done
-- Scheduler cadence is updated to 30 minutes. Done in PR #288.
-- Dispatcher summary includes scheduler-lag metrics and tests cover them. Done
-  in PR #288.
-- Relevant README/runbook/task tracking docs are updated. Done in PR #288.
-- Local focused notification email tests, lint, full tests/coverage, and build
-  pass or any blockers are recorded. Done in `journal.md`.
-- The branch is pushed, a ready PR is opened, and Copilot/check feedback is
-  monitored according to `agent.md`. Done for PR #288.
+- Planning docs are committed on a dedicated branch and opened in a PR.
+- No production behavior is changed in this task.
+- Validation confirms the markdown/docs-only change is structurally clean.
 
 ## Validation Plan
 - `git diff --check`
-- `npm test -- --run tests/lib/project-notification-email-service.test.ts tests/api/notification-email-dispatch.route.test.ts`
-- `npm run lint`
-- `npm test`
-- `npm run test:coverage`
-- `npm run build`
+- `git status --short`
 
 ## Out Of Scope
-- Replacing Resend as the outbound provider.
+- Changing scheduler cadence in this PR.
 - Buying or configuring a paid scheduler/provider.
-- User notification preference UI.
-- Bounce/suppression webhook handling.
-- Realtime in-app notification delivery.
-- A broad background-job platform rewrite.
+- Implementing notification preferences, unsubscribe controls, bounce webhooks,
+  or realtime in-app updates.

--- a/tasks/task-271-notification-email-delivery-deduplication.md
+++ b/tasks/task-271-notification-email-delivery-deduplication.md
@@ -7,9 +7,7 @@ the covered notification IDs, not a recurring reminder while the in-app
 notifications remain unread.
 
 ## Context
-- At implementation time, the production scheduler ran every 3 hours. TASK-273
-  later tightened the bridge to 30 minutes without changing the duplicate
-  suppression contract.
+- The production scheduler currently runs every 3 hours.
 - Users should receive email for future eligible notifications, not repeated
   emails for the same unread notifications.
 - In-app notification read/resolved state remains independent: sending email

--- a/tasks/task-273-cost-aware-notification-email-scheduling.md
+++ b/tasks/task-273-cost-aware-notification-email-scheduling.md
@@ -3,8 +3,6 @@
 Date: 2026-05-22
 Branch: `feature/task-273-notification-email-scheduling-strategy`
 
-Implementation branch: `feature/task-273-cost-aware-scheduler`
-
 ## Summary
 
 Improve NexusDash notification email scheduling so delivery is closer to common
@@ -32,21 +30,6 @@ Users expect notification emails to feel timely but not spammy:
 The current 3-hour bridge is acceptable as an early-production compromise, but
 it does not feel like the industry norm for app notifications.
 
-## Selected Implementation
-
-The first implementation phase keeps GitHub Actions as the no-new-cost trigger
-and reduces the production schedule to every 30 minutes. This is the
-conservative path because it materially reduces batching without introducing a
-new provider, paid Vercel plan, or queue-worker platform.
-
-The app-owned durable email queue remains the source of truth. The scheduler
-only decides when to call `GET /api/cron/notification-emails`; grouping,
-deduplication, due-date reconciliation, dispatch claims, and outbound delivery
-records stay in the application.
-
-Dispatcher summaries now include scheduler-lag metrics for claimed groups so
-operators can compare actual claim time with each group's `sendAfterAt`.
-
 ## Current Baseline
 
 - `Notification` stores durable in-app activity.
@@ -54,8 +37,7 @@ operators can compare actual claim time with each group's `sendAfterAt`.
   grouped email work.
 - `OutboundEmailDelivery` records provider delivery attempts.
 - `GET /api/cron/notification-emails` reconciles and dispatches due groups.
-- Before TASK-273 implementation, GitHub Actions called that endpoint every 3
-  hours.
+- GitHub Actions currently calls that endpoint every 3 hours.
 - TASK-271 prevents already-sent notification IDs from being emailed again.
 - TASK-226 creates due-date reminder notifications and queues them into the
   shared project notification digest pipeline.

--- a/tests/lib/project-notification-email-service.test.ts
+++ b/tests/lib/project-notification-email-service.test.ts
@@ -538,9 +538,6 @@ describe("project-notification-email-service", () => {
 
     expect(summary).toMatchObject({
       groupsClaimed: 2,
-      schedulerLagGroupsMeasured: 2,
-      schedulerLagMaxMinutes: 30,
-      schedulerLagAverageMinutes: 30,
       recipientEmailsAttempted: 1,
       recipientEmailsSent: 1,
       groupsSent: 2,
@@ -582,9 +579,6 @@ describe("project-notification-email-service", () => {
 
     expect(summary).toMatchObject({
       groupsClaimed: 1,
-      schedulerLagGroupsMeasured: 1,
-      schedulerLagMaxMinutes: 30,
-      schedulerLagAverageMinutes: 30,
       recipientEmailsSent: 1,
       groupsSent: 1,
     });
@@ -692,9 +686,6 @@ describe("project-notification-email-service", () => {
     });
 
     expect(summary.groupsClaimed).toBe(0);
-    expect(summary.schedulerLagGroupsMeasured).toBe(0);
-    expect(summary.schedulerLagMaxMinutes).toBe(0);
-    expect(summary.schedulerLagAverageMinutes).toBe(0);
     expect(outboundEmailMock.sendOutboundEmail).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

This rollback reverts the TASK-273 feature merge and its follow-up workflow YAML hotfix so the feature can be reviewed before any production behavior change remains on `main`.

Reverted commits:
- `f26ddd7` - TASK-273 tighten notification email scheduler cadence (#288)
- `f5c24dc` - fix: repair notification dispatch workflow yaml (#289)

## Impact

- Restores the notification email dispatcher schedule to the prior 3-hour cadence.
- Removes the TASK-273 scheduler-lag summary fields and related tests.
- Restores docs/task tracking to the pre-implementation state where TASK-273 is still pending implementation.

## Validation

- `git diff --cached --check`
- `npm test -- --run tests/lib/project-notification-email-service.test.ts tests/api/notification-email-dispatch.route.test.ts`

I will not merge this PR. It is opened for maintainer review and approval.