### PR TITLE
TASK-269 clean up GitHub Actions workflow contracts

### DIFF
--- a/.github/workflows/check-branch-names.yml
+++ b/.github/workflows/check-branch-names.yml
@@ -4,6 +4,8 @@ on:
     types: [opened, edited, synchronize]
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   check-name:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependency-security.yml
+++ b/.github/workflows/dependency-security.yml
@@ -32,15 +32,55 @@ jobs:
         run: npm ci
 
       - name: Audit production dependencies
+        shell: bash
         run: |
           npm audit --omit=dev --audit-level=high --json > npm-audit-prod.json || true
-          node -e "const fs = require('fs'); const audit = JSON.parse(fs.readFileSync('npm-audit-prod.json', 'utf8')); const meta = audit.metadata?.vulnerabilities ?? {}; const highOrCritical = (meta.high ?? 0) + (meta.critical ?? 0); if (highOrCritical > 0) { console.error(`High/Critical production vulnerabilities detected: ${highOrCritical}`); process.exit(1); }"
+          node <<'NODE'
+          const fs = require("fs");
+          const audit = JSON.parse(fs.readFileSync("npm-audit-prod.json", "utf8"));
+          const meta = audit.metadata?.vulnerabilities ?? {};
+          const highOrCritical = (meta.high ?? 0) + (meta.critical ?? 0);
+
+          fs.appendFileSync(
+            process.env.GITHUB_STEP_SUMMARY,
+            [
+              "## Production Dependency Audit",
+              "",
+              `- Critical: \`${meta.critical ?? 0}\``,
+              `- High: \`${meta.high ?? 0}\``,
+              "",
+            ].join("\n")
+          );
+
+          if (highOrCritical > 0) {
+            console.error(
+              `High/Critical production vulnerabilities detected: ${highOrCritical}`
+            );
+            process.exit(1);
+          }
+          NODE
 
       - name: Audit full dependency tree
         if: always()
+        shell: bash
         run: |
           npm audit --json > npm-audit-full.json || true
-          node -e "const fs = require('fs'); const audit = JSON.parse(fs.readFileSync('npm-audit-full.json', 'utf8')); const meta = audit.metadata?.vulnerabilities ?? {}; const lines = [ '## Dependency Security Scan', '', `- Total: ${meta.total ?? 0}`, `- Critical: ${meta.critical ?? 0}`, `- High: ${meta.high ?? 0}`, `- Moderate: ${meta.moderate ?? 0}`, `- Low: ${meta.low ?? 0}` ]; fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join('\\n')}\\n`);"
+          node <<'NODE'
+          const fs = require("fs");
+          const audit = JSON.parse(fs.readFileSync("npm-audit-full.json", "utf8"));
+          const meta = audit.metadata?.vulnerabilities ?? {};
+          const lines = [
+            "## Full Dependency Security Scan",
+            "",
+            `- Total: \`${meta.total ?? 0}\``,
+            `- Critical: \`${meta.critical ?? 0}\``,
+            `- High: \`${meta.high ?? 0}\``,
+            `- Moderate: \`${meta.moderate ?? 0}\``,
+            `- Low: \`${meta.low ?? 0}\``,
+            "",
+          ];
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join("\n"));
+          NODE
 
       - name: Upload audit artifacts
         if: always()

--- a/.github/workflows/notification-email-dispatch.yml
+++ b/.github/workflows/notification-email-dispatch.yml
@@ -12,8 +12,7 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: notification-email-dispatch

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -8,6 +8,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: quality-gates-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/README.md
+++ b/README.md
@@ -366,6 +366,10 @@ Production scheduler decision:
 
 ## CI/CD
 
+The workflow inventory, operator paths, permissions, artifacts, and no-delete
+audit decision are documented in
+[`docs/runbooks/github-actions-workflows.md`](docs/runbooks/github-actions-workflows.md).
+
 ### CI workflows
 
 - `Quality Core (lint, test, coverage, build)`
@@ -375,6 +379,9 @@ Production scheduler decision:
 - `Dependency Security` (scheduled + manual `npm audit` baseline with artifacts)
 - `Notification Email Dispatch Scheduler` (scheduled + manual protected
   dispatch call)
+- `Dependabot Auto Triage` (safe Dependabot lane labeling/approval/merge)
+- `Dependabot Repair Agent` (Copilot-assisted repair PRs for red Dependabot
+  updates)
 
 Branch-name note:
 - human-authored PR branches must use `feature/*`, `fix/*`, `refactor/*`,

--- a/docs/runbooks/github-actions-workflows.md
+++ b/docs/runbooks/github-actions-workflows.md
@@ -1,0 +1,107 @@
+# GitHub Actions Workflows Runbook
+
+This runbook is the operating inventory for the active NexusDash GitHub Actions
+workflows. TASK-269 audited the workflow set and kept all seven workflows
+because each owns a distinct operational lane.
+
+## Inventory
+
+| Workflow | File | Purpose | Triggers | Permissions | Secrets / env | Artifacts / outputs |
+| --- | --- | --- | --- | --- | --- | --- |
+| Check Branch Name | `.github/workflows/check-branch-names.yml` | Enforce branch naming for human and Dependabot PRs. | `pull_request`, `workflow_dispatch` | none | none | check result only |
+| Quality Gates | `.github/workflows/quality-gates.yml` | Run lint, unit/API tests, coverage, build, Playwright smoke, and container-image build. | `pull_request`, `push` to `main`, `workflow_dispatch` | `contents: read` | local CI placeholders for DB/email/agent signing | Playwright report on failure; container image metadata |
+| Deploy Vercel (CD + Rollback) | `.github/workflows/deploy-vercel.yml` | Create staged production deployments after green `main`, and run manual preview deploy, staged deploy, promote, or rollback. | successful `Quality Gates` workflow on `main`, `workflow_dispatch` | `contents: read` | Vercel project/token secrets, database/migration URLs, production runtime secrets, OAuth/R2/email/agent secrets as needed | preview/staged deployment URL artifacts and job summaries |
+| Notification Email Dispatch Scheduler | `.github/workflows/notification-email-dispatch.yml` | Call the protected notification email dispatcher on the active no-new-cost production cadence. | schedule every 30 minutes, `workflow_dispatch` | none | `NOTIFICATION_EMAIL_DISPATCH_SECRET` or legacy `CRON_SECRET` | dispatcher response and parsed summary in job summary |
+| Dependency Security | `.github/workflows/dependency-security.yml` | Run the scheduled/manual npm audit baseline and persist audit JSON. | weekly schedule, `workflow_dispatch` | `contents: read` | none | production/full npm audit JSON |
+| Dependabot Auto Triage | `.github/workflows/dependabot-auto-triage.yml` | Label and approve safe Dependabot lanes, then merge safe green Dependabot PRs. | `pull_request_target` for Dependabot, `workflow_run` after required PR checks | per-job `contents`, `issues`, and `pull-requests` write where needed | `GITHUB_TOKEN` | labels/reviews/merge state; no artifact |
+| Dependabot Repair Agent | `.github/workflows/dependabot-repair-agent.yml` | Scan red Dependabot PRs and use Copilot CLI to open repo-owned repair PRs when possible. | weekly schedule, `workflow_dispatch` | per-job read for scan; write for repair PR creation/status updates | `COPILOT_ACTIONS_TOKEN` to activate Copilot CLI; `GITHUB_TOKEN` | PR comments/branches created by repair script; job summary when skipped |
+
+## Audit Decision
+
+All seven workflows remain necessary:
+
+- Branch policy stays separate from expensive CI so invalid PR branch names fail
+  quickly and clearly.
+- Quality Gates owns product validation and container-build proof.
+- Deploy Vercel owns deploy, promote, and rollback because those actions need
+  production/preview environments and Vercel secrets.
+- Notification Email Dispatch remains separate from deploy because it is an
+  operational scheduler, not a release step.
+- Dependency Security remains separate from Dependabot automation because it is
+  a repository-wide audit baseline with artifacts.
+- Dependabot Auto Triage remains deterministic and bounded to known safe lanes.
+- Dependabot Repair Agent remains separate because it uses Copilot credentials
+  and may create superseding repo-owned PRs, but does not merge them.
+
+No workflow was deleted in TASK-269. The cleanup tightened token permissions for
+workflows that do not need repository access and documented each workflow's
+contract so future cleanup can compare against an explicit baseline.
+
+TASK-269 also fixed the Dependency Security workflow's inline JavaScript shell
+quoting. Recent scheduled failures were partly caused by Bash expanding
+JavaScript template literals before Node could run them; the workflow now uses
+quoted heredocs so future failures represent the audit result itself.
+
+## Operator Paths
+
+### PR Validation
+
+1. Open a non-draft PR from an allowed branch prefix.
+2. Confirm `Check Branch Name` passes.
+3. Confirm `Quality Core`, `E2E Smoke`, and `Container Image` pass.
+4. Review any uploaded Playwright report if E2E fails.
+
+### Preview Deploy
+
+Run `.github/workflows/deploy-vercel.yml` manually:
+
+- `action=deploy-preview`
+- `git_ref=<branch-or-sha>`
+
+Use the `preview-deployment` artifact or job summary URL for preview smoke.
+
+### Staged Production Deploy
+
+Automatic path:
+
+1. Merge to `main`.
+2. Wait for `Quality Gates` on `main`.
+3. `Deploy Vercel (CD + Rollback)` creates a staged production deployment.
+4. Promote the staged URL manually with `action=promote`.
+
+Manual path:
+
+- `action=deploy-production-staged`
+- optional `git_ref=<branch-or-sha>`
+
+Rollback path:
+
+- `action=rollback`
+- `deployment_id_or_url=<known-good-deployment>`
+
+### Notification Email Dispatch
+
+Scheduled production dispatch runs every 30 minutes. Manual dispatch can target
+production or an allowed NexusDash preview URL via `target_url`. The workflow
+summary shows the dispatcher response and parsed send/reconciliation metrics.
+
+### Dependency Maintenance
+
+- `Dependency Security` runs every Monday at 07:00 UTC and can be run manually.
+- Dependabot opens grouped dependency PRs from `.github/dependabot.yml`.
+- `Dependabot Auto Triage` labels safe lanes and merges only safe Dependabot
+  PRs after required checks pass.
+- `Dependabot Repair Agent` runs every Monday at 09:15 UTC. It needs
+  `COPILOT_ACTIONS_TOKEN`; without that secret it records a skip summary.
+
+## Change Rules
+
+- Keep new workflows single-purpose and add them to this inventory in the same
+  PR.
+- Add an explicit `permissions` block. Use `permissions: {}` for workflows that
+  do not need repository token access.
+- Keep deployment-affecting changes aligned with
+  `docs/runbooks/vercel-env-contract-and-secrets.md`.
+- Keep notification scheduler changes aligned with
+  `docs/runbooks/notification-email-dispatch.md`.
+- Do not send production secrets to arbitrary manual-dispatch targets.

--- a/docs/runbooks/notification-email-dispatch.md
+++ b/docs/runbooks/notification-email-dispatch.md
@@ -3,6 +3,9 @@
 This runbook covers the protected notification email dispatcher used by the
 current GitHub Actions production bridge.
 
+For the full GitHub Actions workflow inventory and permissions contract, see
+`docs/runbooks/github-actions-workflows.md`.
+
 ## Dispatcher Contract
 
 - Endpoint: `GET /api/cron/notification-emails`

--- a/docs/runbooks/vercel-env-contract-and-secrets.md
+++ b/docs/runbooks/vercel-env-contract-and-secrets.md
@@ -50,6 +50,10 @@ attempt number.
 Release cadence, pre-1.0 bump rules, changelog expectations, and tag/promotion
 steps are documented in `docs/runbooks/release-versioning.md`.
 
+The GitHub Actions workflow inventory, including deploy workflow triggers,
+permissions, artifacts, and operator paths, is documented in
+`docs/runbooks/github-actions-workflows.md`.
+
 ## Database Runtime
 
 Required for Vercel runtime/deployments:

--- a/journal.md
+++ b/journal.md
@@ -14,6 +14,26 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ### 2026-05-25
 - Type: Execution
+- Summary: Started TASK-269 GitHub Actions workflow cleanup.
+- Evidence: Created `chore/task-269-workflow-cleanup` from `origin/main`, replaced `tasks/current.md` with the TASK-269 execution contract, audited the seven active workflows, and selected a conservative no-delete cleanup focused on least-privilege permissions plus a durable workflow inventory runbook.
+
+### 2026-05-25
+- Type: Execution
+- Summary: Fixed Dependency Security workflow shell quoting during TASK-269 audit.
+- Evidence: `gh workflow view dependency-security.yml` showed repeated scheduled failures. `gh run view 26391151111 --log-failed` showed Bash expanding JavaScript template literals in inline `node -e` snippets (`High/Critical: No such file or directory`, `${meta.total ?? 0}: bad substitution`). Replaced the snippets with quoted Node heredocs so summaries render and future failures reflect actual audit findings.
+
+### 2026-05-25
+- Type: Planning
+- Summary: Added TASK-274 for the current Next.js production audit finding.
+- Evidence: During TASK-269 validation, `npm audit --omit=dev --audit-level=high` failed on a high-severity `next` advisory. Added TASK-274 so the dependency/security update can be handled in a dedicated PR instead of mixing framework upgrades into workflow cleanup.
+
+### 2026-05-25
+- Type: Validation
+- Summary: TASK-269 local validation passed with one expected audit follow-up.
+- Evidence: Workflow YAML parsed with PyYAML for all seven active workflow files. `git diff --check`, `npm run lint`, local PostgreSQL `npm test` (108 files passed, 2 skipped; 834 passed, 2 skipped), local PostgreSQL `npm run test:coverage` (91.23% statements, 81.2% branches, 93.42% functions, 91.75% lines), and placeholder-env `npm run build` passed. `gh workflow view` succeeded for all seven workflows. `npm audit --omit=dev --audit-level=high` still fails on the current `next` advisory and is tracked as TASK-274.
+
+### 2026-05-25
+- Type: Execution
 - Summary: Reapplied TASK-273 cost-aware notification email scheduling implementation after rollback.
 - Evidence: Created `feature/task-273-cost-aware-scheduler-review` from the post-rollback `origin/main`, selected the documented no-new-cost 30-minute GitHub Actions cadence, added dispatcher scheduler-lag metrics, and updated workflow/runbook/project documentation to describe the new cadence and residual GitHub scheduler limitation.
 

--- a/project.md
+++ b/project.md
@@ -1,6 +1,6 @@
 # NexusDash Project Blueprint (Current State)
 
-Last verified: 2026-04-23
+Last verified: 2026-05-25
 
 ## 1. Vision
 
@@ -89,6 +89,8 @@ Source of truth: [`prisma/schema.prisma`](./prisma/schema.prisma)
   - `Quality Core`
   - `E2E Smoke`
   - `Container Image`
+- GitHub Actions workflow inventory is tracked in
+  `docs/runbooks/github-actions-workflows.md`.
 - CD workflow supports:
   - staged production deploy
   - manual preview deploy
@@ -105,10 +107,10 @@ Source of truth: [`prisma/schema.prisma`](./prisma/schema.prisma)
 
 From `tasks/current.md` + `tasks/backlog.md`:
 
-1. TASK-124: comment mentions - project-member @tagging with notification-center delivery
-2. TASK-126: comment reactions - lightweight emoji response system on task threads
-3. TASK-127: API capability audit - confirm every shipped feature remains fully manageable through the API
-4. TASK-131: local validation baseline repair - reproducible container, database, and toolchain setup
+1. TASK-269: GitHub Actions workflow cleanup and operating inventory
+2. TASK-266: production pg query deprecation warning cleanup
+3. TASK-133: task UI bug fixing - mini scrollbar and edit modal polish
+4. Deferred UX/product follow-ups remain sequenced in `tasks/backlog.md`
 
 ## 8. Source-of-Truth Docs
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -8,7 +8,7 @@ Last reviewed: 2026-05-25
 ### Execution Queue (Now / Next)
 - ID: TASK-269
   Title: GitHub Actions workflow cleanup - simplify CI/CD, scheduled jobs, and maintenance automation
-  Status: Next
+  Status: Implementation complete - awaiting maintainer review
   Rationale: The repository now has several production-impacting workflows covering quality gates, staged Vercel deploys, notification email dispatch, dependency security, Dependabot triage, and Copilot repair. Recent production work exposed duplicated env handling, scheduler tradeoffs, production-target safeguards, and deploy/secrets coupling across these workflows. Run a focused cleanup so workflow responsibilities, permissions, env/secrets usage, dispatch inputs, summaries, and failure modes are easier to understand and operate without changing product behavior.
   Dependencies: TASK-042, TASK-116, TASK-132, TASK-268
   Brief: `tasks/task-269-github-actions-workflow-cleanup.md`
@@ -17,6 +17,11 @@ Last reviewed: 2026-05-25
   Status: Queued operational follow-up
   Rationale: Production smoke logs repeatedly show `Calling client.query() when the client is already executing a query is deprecated and will be removed in pg@9.0` on task creation and notification-email dispatch paths. Identify the Prisma/Postgres adapter or service flow causing overlapping client queries, fix it without weakening transaction/RLS behavior, and validate that production smoke no longer emits the warning.
   Dependencies: TASK-258, TASK-259
+- ID: TASK-274
+  Title: Next.js dependency security update - restore green production audit
+  Status: Queued security follow-up
+  Rationale: TASK-269 workflow audit confirmed `npm audit --omit=dev --audit-level=high` currently fails because `next` has a high-severity advisory in the installed range. Handle the framework/security update in its own dependency PR so the workflow cleanup remains behavior-preserving.
+  Dependencies: TASK-116, TASK-132
 - ID: TASK-133
   Title: Task UI bug fixing - mini scrollbar and edit modal polish
   Status: Deferred UI follow-up (promoted 2026-05-04; PR #224 partial fix merged)
@@ -135,7 +140,7 @@ Last reviewed: 2026-05-25
 ## Completed
 - ID: TASK-273
   Title: Cost-aware notification email scheduling - industry-aligned delivery cadence
-  Status: Implementation complete - awaiting maintainer review
+  Status: Done (2026-05-25, merged via PR #291)
   Rationale: Kept the app-owned durable notification email queue and protected dispatcher, reduced the no-new-cost GitHub Actions production bridge from 3 hours to 30 minutes, added scheduler-lag metrics to dispatcher/workflow summaries, and updated runbooks/tracking docs with expected latency and residual GitHub scheduler limitations.
   Dependencies: TASK-125, TASK-227, TASK-268, TASK-271, TASK-226
   Brief: `tasks/task-273-cost-aware-notification-email-scheduling.md`

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,90 +1,102 @@
-# Current Task: TASK-273 Cost-Aware Notification Email Scheduling
+# Current Task: TASK-269 GitHub Actions Workflow Cleanup
 
 ## Task ID
-TASK-273
+TASK-269
 
 ## Status
 Implementation complete - awaiting maintainer review
 
 ## Source
-- Production smoke and follow-up discussion after TASK-226/TASK-265 email
-  validation.
-- Strategy brief merged via PR #280:
-  `tasks/task-273-cost-aware-notification-email-scheduling.md`.
-- User direction on 2026-05-25: proceed with the conservative no-new-cost path
-  without further discussion.
+- Backlog entry:
+  `tasks/task-269-github-actions-workflow-cleanup.md`.
+- User direction on 2026-05-25: own TASK-269 end to end, decide whether the
+  current GitHub Actions workflows are all necessary, clean up what is needed,
+  and execute without waiting for more input.
 
 ## Objective
-Improve notification email delivery cadence while preserving the app-owned
-durable queue, idempotent dispatcher, and current cost posture.
+Audit and simplify the repository's GitHub Actions workflow surface so each
+workflow has a clear owner, trigger, permission boundary, secret/env contract,
+artifact output, and operator path.
 
-The selected near-term implementation is a GitHub Actions cadence reduction
-from the previous 3-hour bridge to every 30 minutes, plus scheduler-lag
-evidence in the dispatcher summary and workflow output. This should make
-activity emails arrive closer to each group's intended `sendAfterAt` without
-introducing QStash, Vercel Pro Cron, or a broader queue worker yet.
+The task should preserve shipped product behavior. Changes should focus on
+workflow hygiene: removing stale assumptions, reducing duplicated shell logic
+where it creates maintenance risk, making failures easier to interpret, and
+aligning README/runbook documentation with the current workflow contract.
 
 ## Current Baseline
-- TASK-125 provides durable outbound email delivery records.
-- TASK-227/TASK-271 provide durable notification email grouping, idempotency,
-  debounce windows, and duplicate suppression.
-- TASK-268 intentionally chose a no-new-cost GitHub Actions scheduler bridge
-  every 3 hours while Vercel remained on Hobby and QStash activation had
-  operational friction; TASK-273 now tightens that bridge to 30 minutes.
-- TASK-226 creates due-date reminder notifications and queues them into the
-  shared email orchestration.
-- TASK-273 PR #280 selected the cost-aware improvement path; this branch
-  implements the first phase.
-- This implementation branch delivers the 30-minute scheduler bridge and
-  scheduler-lag summary evidence for maintainer review before merge.
+- Active workflow files:
+  - `.github/workflows/check-branch-names.yml`
+  - `.github/workflows/quality-gates.yml`
+  - `.github/workflows/deploy-vercel.yml`
+  - `.github/workflows/notification-email-dispatch.yml`
+  - `.github/workflows/dependency-security.yml`
+  - `.github/workflows/dependabot-auto-triage.yml`
+  - `.github/workflows/dependabot-repair-agent.yml`
+- These workflows cover distinct responsibilities today: branch policy,
+  PR/main quality gates, staged Vercel deployment/promote/rollback, the
+  temporary notification email scheduler bridge, dependency audit artifacts,
+  safe Dependabot auto-triage/merge, and Copilot-assisted Dependabot repair.
+- TASK-273 tightened notification email dispatch to a 30-minute GitHub Actions
+  bridge while keeping the app-owned queue and protected dispatcher.
+- Deploy workflow logic currently repeats Vercel secret/env setup and several
+  validation snippets across automatic and manual jobs.
+- `gh workflow view` showed recent `Dependency Security` scheduled failures.
+  Log inspection identified a workflow quoting bug in its inline Node snippets,
+  in addition to any actual audit findings.
+- `npm audit --omit=dev --audit-level=high` still reports a high-severity
+  `next` advisory; the dependency update itself is tracked separately as
+  TASK-274.
 
 ## Scope
-- Change `.github/workflows/notification-email-dispatch.yml` to run the
-  protected dispatcher every 30 minutes.
-- Keep scheduled runs targeting `https://nexus-dash.app`; keep manual
-  `target_url` override behavior for previews and diagnostics.
-- Add scheduler-lag fields to the dispatcher summary for claimed due groups.
-- Make the GitHub Actions step summary show parsed dispatch metrics in addition
-  to the raw endpoint response.
-- Update README/runbooks/task docs so the active cadence, expected latency, and
-  residual limitations are accurate.
+- Inventory all active workflow files and decide whether each workflow remains
+  necessary.
+- Keep workflows with distinct operational ownership; remove or consolidate
+  only if there is clear duplication or dead behavior.
+- Tighten workflow permissions, env validation, summaries, and operator-facing
+  errors where safe.
+- Fix concrete workflow bugs discovered during the audit.
+- Reduce duplicated deploy-workflow shell logic when it lowers maintenance
+  risk without changing deploy/promote/rollback behavior.
+- Update README and runbooks with the final workflow inventory and contracts.
+- Update tracking docs and journal with the TASK-269 decision and validation.
 
 ## Acceptance Criteria
-1. The selected scheduler path is explicit: 30-minute GitHub Actions cadence,
-   no new paid provider, app-owned queue unchanged.
-2. Normal project activity emails are expected within the 30-minute quiet
-   window plus at most one 30-minute scheduler cadence and GitHub scheduling
-   delay under normal conditions.
-3. Due-date reminder reconciliation remains in the protected dispatcher and
-   still preserves one reminder per task, recipient, and deadline date.
-4. Duplicate email suppression from TASK-271 remains unchanged.
-5. Dispatcher summaries expose scheduler-lag evidence for claimed groups.
-6. Workflow summaries expose enough parsed metrics to inspect reconciliation,
-   claim/send outcomes, errors, and scheduler lag without reading raw JSON.
-7. Documentation explains the active cadence, cost/latency tradeoff, manual
-   smoke path, and future managed-scheduler decision point.
+1. Every active workflow has a documented purpose, trigger set, permission
+   boundary, required secrets/env, artifacts, and operator path.
+2. The audit explicitly answers whether each existing workflow is still
+   necessary.
+3. Any cleanup preserves functional coverage for quality gates, branch policy,
+   Vercel deploy/promote/rollback, notification email dispatch, dependency
+   security, Dependabot auto-triage, and Copilot repair.
+4. Workflow YAML has clear failure messages for missing required configuration
+   and emits useful summaries where operators need them.
+5. README/runbook references match the final workflow behavior.
 
 ## Definition Of Done
-- Scheduler cadence is updated to 30 minutes.
-- Dispatcher summary includes scheduler-lag metrics and tests cover them.
-- Relevant README/runbook/task tracking docs are updated.
-- Local focused notification email tests, lint, full tests/coverage, and build
-  pass or any blockers are recorded in `journal.md`.
-- The branch is pushed, a ready PR is opened, and Copilot/check feedback is
-  monitored according to `agent.md`; final merge remains a maintainer decision.
+- `tasks/current.md` is updated before implementation with this execution
+  contract.
+- Workflow YAML cleanup is minimal and behavior-preserving unless a concrete
+  workflow bug is found.
+- Documentation records the workflow inventory and any deliberate no-delete
+  decisions.
+- Local validation passes or any blocker is recorded in `journal.md`.
+- A ready PR is opened, GitHub checks are monitored, and Copilot review
+  feedback is handled; merge remains a maintainer decision.
 
 ## Validation Plan
 - `git diff --check`
-- `npm test -- --run tests/lib/project-notification-email-service.test.ts tests/api/notification-email-dispatch.route.test.ts`
+- Workflow syntax/shape inspection with `gh workflow view` for each active
+  workflow.
 - `npm run lint`
 - `npm test`
 - `npm run test:coverage`
 - `npm run build`
+- PR checks for branch-name, quality gates, and workflow-specific failures.
 
 ## Out Of Scope
-- Replacing Resend as the outbound provider.
-- Buying or configuring a paid scheduler/provider.
-- User notification preference UI.
-- Bounce/suppression webhook handling.
-- Realtime in-app notification delivery.
-- A broad background-job platform rewrite.
+- Product behavior changes.
+- Migrating notification scheduling away from GitHub Actions.
+- Replacing Vercel deployment strategy.
+- Changing Dependabot safe-lane policy beyond clarifying workflow ownership.
+- Upgrading framework/dependency versions to resolve current audit findings;
+  that is TASK-274.

--- a/tasks/task-269-github-actions-workflow-cleanup.md
+++ b/tasks/task-269-github-actions-workflow-cleanup.md
@@ -4,7 +4,9 @@
 TASK-269
 
 ## Status
-Pending
+Implementation complete - awaiting maintainer review
+
+Implementation branch: `chore/task-269-workflow-cleanup`
 
 ## Objective
 Audit and simplify the repository's GitHub Actions workflows so CI, staged
@@ -32,6 +34,19 @@ is layered onto it.
   failure output, and no accidental dependency on interactive environment
   approvals.
 - Keep product behavior unchanged unless a workflow bug is found and fixed.
+
+## Audit Outcome
+
+TASK-269 keeps all seven active workflows because each has distinct ownership:
+branch policy, quality gates, Vercel deploy/promote/rollback, notification
+email dispatch, dependency audit, safe Dependabot auto-triage, and Copilot
+repair. The cleanup target is least-privilege permissions plus a durable
+operator inventory, not workflow deletion.
+
+The audit also found a concrete `dependency-security.yml` bug: inline `node -e`
+snippets used JavaScript template literals inside shell double quotes, so Bash
+expanded backtick and `${...}` fragments before Node executed. The workflow now
+uses quoted heredocs for those summaries and failures.
 
 ## Acceptance Criteria
 1. Every active GitHub Actions workflow has a clear purpose, trigger set,


### PR DESCRIPTION
## Summary

Owns TASK-269 by auditing the active GitHub Actions workflow set, preserving the workflows that still have distinct operational ownership, tightening low-risk permissions, and documenting the workflow contract for operators.

## What changed

- Added `docs/runbooks/github-actions-workflows.md` with the active workflow inventory, purpose, triggers, permissions, secrets/env, artifacts, operator paths, and the no-delete audit decision.
- Kept all seven active workflows because they cover separate lanes: branch policy, quality gates, Vercel deploy/promote/rollback, notification dispatch, dependency audit, Dependabot auto-triage, and Copilot repair.
- Tightened token permissions:
  - `check-branch-names.yml` now uses `permissions: {}`.
  - `notification-email-dispatch.yml` now uses `permissions: {}`.
  - `quality-gates.yml` now declares `contents: read` explicitly.
- Fixed `dependency-security.yml` shell quoting by replacing inline `node -e` template-literal snippets with quoted heredocs, so Bash no longer expands JavaScript before Node runs.
- Updated README, runbooks, project/task tracking, and journal entries.
- Added TASK-274 as a separate follow-up for the current high-severity Next.js production audit finding, so TASK-269 stays workflow-focused.

## Validation

- Parsed all `.github/workflows/*.yml` files with PyYAML.
- `git diff --check`
- `npm run lint`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/nexusdash?schema=public DIRECT_URL=$DATABASE_URL npm test`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/nexusdash?schema=public DIRECT_URL=$DATABASE_URL npm run test:coverage`
- `npm run build` with local placeholder runtime secrets
- `gh workflow view` for all seven active workflows
- `npm audit --omit=dev --audit-level=high` intentionally still fails on the existing `next` advisory; tracked as TASK-274.

## Merge note

I will not merge this PR without maintainer approval.