### PR TITLE
TASK-266 serialize pg transaction queries

### DIFF
--- a/journal.md
+++ b/journal.md
@@ -12,6 +12,29 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 ## Recent Entries (Most Relevant)
 
+### 2026-05-26
+- Type: Execution
+- Summary: Started TASK-266 from a dedicated worktree and implemented a
+  transaction-client query serialization guard for Prisma's pg adapter path.
+- Evidence: Created/used `../nexus_dash_task266` on
+  `feature/task-266-pg-query-deprecation-cleanup`, rewrote
+  `tasks/current.md` for TASK-266 acceptance and preview validation, and updated
+  `lib/prisma.ts` to pass Prisma an external `pg.Pool` whose borrowed
+  transaction clients serialize `query()` calls before returning to the
+  adapter. Added focused coverage in
+  `tests/lib/pg-transaction-query-serialization.test.ts`.
+
+### 2026-05-26
+- Type: Validation
+- Summary: TASK-266 local validation passed for the transaction-client query
+  serialization change.
+- Evidence: `git diff --check`; focused
+  `npm test -- --run tests/lib/pg-transaction-query-serialization.test.ts tests/lib/project-notification-email-service.test.ts tests/api/notification-email-dispatch.route.test.ts`
+  (29 tests); `npm run lint`; local PostgreSQL env `npm test` (109 files
+  passed, 2 skipped; 836 passed, 2 skipped); local PostgreSQL env
+  `npm run test:coverage` (91.23% statements, 81.2% branches, 93.42%
+  functions, 91.75% lines); preview-style env `npm run build`.
+
 ### 2026-05-25
 - Type: Execution
 - Summary: Reapplied TASK-273 cost-aware notification email scheduling implementation after rollback.

--- a/journal.md
+++ b/journal.md
@@ -35,6 +35,25 @@ Use it for important implementation milestones, blockers, validation runs, and r
   `npm run test:coverage` (91.23% statements, 81.2% branches, 93.42%
   functions, 91.75% lines); preview-style env `npm run build`.
 
+### 2026-05-26
+- Type: Blocker
+- Summary: TASK-266 remote automation and full preview smoke are blocked by
+  external runtime/dispatch constraints after PR #293 was opened.
+- Evidence: PR #293 is open and mergeable at head
+  `1d4ca2e79d32db1dd10f8df665400955934d9e4a`, but GitHub reported no PR
+  checks and repeated `gh workflow run` / Actions dispatch attempts for
+  `quality-gates.yml`, `check-branch-names.yml`, and `deploy-vercel.yml`
+  returned HTTP 500 `Failed to run workflow dispatch`. Direct Vercel preview
+  deploys from the TASK-266 worktree succeeded, including
+  `https://nexus-dash-8u5ltuc43-dorian-agaesses-projects.vercel.app`, but the
+  deployment using normal preview env reported `/api/health/ready`
+  `database-unreachable`, and the production env pulled from Vercel has empty
+  `DATABASE_URL` / `DIRECT_URL` because DB runtime secrets are injected by the
+  GitHub deploy workflow rather than stored in Vercel preview env. A protected
+  dispatch smoke with outbound delivery disabled therefore cannot be completed
+  until GitHub workflow dispatch recovers or the preview runtime receives the
+  required DB/dispatch secrets through the expected deploy workflow.
+
 ### 2026-05-25
 - Type: Execution
 - Summary: Started TASK-269 GitHub Actions workflow cleanup.

--- a/lib/pg-transaction-query-serialization.ts
+++ b/lib/pg-transaction-query-serialization.ts
@@ -1,0 +1,49 @@
+import type { Pool, PoolClient } from "pg";
+
+const SERIALIZED_QUERY_CLIENT = Symbol.for(
+  "nexusdash.serialized-pg-query-client"
+);
+
+type QueryableClient = Pick<PoolClient, "query"> & {
+  [SERIALIZED_QUERY_CLIENT]?: true;
+};
+
+type QueryFunction = (...args: unknown[]) => unknown;
+
+export function serializePgQueryClient<TClient extends QueryableClient>(
+  client: TClient
+): TClient {
+  if (client[SERIALIZED_QUERY_CLIENT]) {
+    return client;
+  }
+
+  const originalQuery = client.query.bind(client) as QueryFunction;
+  let queue = Promise.resolve();
+
+  client.query = ((...args: unknown[]) => {
+    const result = queue.then(() => originalQuery(...args));
+    queue = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
+  }) as PoolClient["query"];
+
+  Object.defineProperty(client, SERIALIZED_QUERY_CLIENT, {
+    value: true,
+    enumerable: false,
+  });
+
+  return client;
+}
+
+export function installSerializedTransactionQueries(pool: Pool): Pool {
+  const originalConnect = pool.connect.bind(pool) as () => Promise<PoolClient>;
+
+  pool.connect = (async () => {
+    const client = await originalConnect();
+    return serializePgQueryClient(client);
+  }) as Pool["connect"];
+
+  return pool;
+}

--- a/lib/pg-transaction-query-serialization.ts
+++ b/lib/pg-transaction-query-serialization.ts
@@ -38,11 +38,17 @@ export function serializePgQueryClient<TClient extends QueryableClient>(
 }
 
 export function installSerializedTransactionQueries(pool: Pool): Pool {
-  const originalConnect = pool.connect.bind(pool) as () => Promise<PoolClient>;
+  const originalConnect = pool.connect.bind(pool) as Pool["connect"];
 
-  pool.connect = (async () => {
-    const client = await originalConnect();
-    return serializePgQueryClient(client);
+  pool.connect = ((callback?: Parameters<Pool["connect"]>[0]) => {
+    if (typeof callback === "function") {
+      originalConnect((error, client, release) => {
+        callback(error, client ? serializePgQueryClient(client) : client, release);
+      });
+      return;
+    }
+
+    return originalConnect().then((client) => serializePgQueryClient(client));
   }) as Pool["connect"];
 
   return pool;

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,16 +1,22 @@
 import { PrismaClient } from "@prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
 
 import { getPrismaPgRuntimeConnectionString } from "@/lib/env.server";
+import { installSerializedTransactionQueries } from "@/lib/pg-transaction-query-serialization";
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;
 };
 
 function createPrismaClient(): PrismaClient {
-  const adapter = new PrismaPg({
+  // Prisma interactive transactions borrow one pg client. Serialize driver
+  // calls on that client so deep relation reads cannot trigger pg's query
+  // queue deprecation warning while RLS context remains transaction-scoped.
+  const pool = installSerializedTransactionQueries(new Pool({
     connectionString: getPrismaPgRuntimeConnectionString(),
-  });
+  }));
+  const adapter = new PrismaPg(pool, { disposeExternalPool: true });
   return new PrismaClient({ adapter });
 }
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -14,7 +14,7 @@ Last reviewed: 2026-05-25
   Brief: `tasks/task-269-github-actions-workflow-cleanup.md`
 - ID: TASK-266
   Title: Production pg query deprecation warning cleanup
-  Status: Queued operational follow-up
+  Status: Active
   Rationale: Production smoke logs repeatedly show `Calling client.query() when the client is already executing a query is deprecated and will be removed in pg@9.0` on task creation and notification-email dispatch paths. Identify the Prisma/Postgres adapter or service flow causing overlapping client queries, fix it without weakening transaction/RLS behavior, and validate that production smoke no longer emits the warning.
   Dependencies: TASK-258, TASK-259
 - ID: TASK-133

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,90 +1,91 @@
-# Current Task: TASK-273 Cost-Aware Notification Email Scheduling
+# Current Task: TASK-266 Production pg Query Deprecation Warning Cleanup
 
 ## Task ID
-TASK-273
+TASK-266
 
 ## Status
-Implementation complete - awaiting maintainer review
+Active
 
 ## Source
-- Production smoke and follow-up discussion after TASK-226/TASK-265 email
-  validation.
-- Strategy brief merged via PR #280:
-  `tasks/task-273-cost-aware-notification-email-scheduling.md`.
-- User direction on 2026-05-25: proceed with the conservative no-new-cost path
-  without further discussion.
+- Backlog execution queue entry for TASK-266.
+- Production smoke evidence captured in `journal.md` on 2026-05-16 after
+  notification digest validation.
 
 ## Objective
-Improve notification email delivery cadence while preserving the app-owned
-durable queue, idempotent dispatcher, and current cost posture.
+Remove the recurring production `pg` warning:
 
-The selected near-term implementation is a GitHub Actions cadence reduction
-from the previous 3-hour bridge to every 30 minutes, plus scheduler-lag
-evidence in the dispatcher summary and workflow output. This should make
-activity emails arrive closer to each group's intended `sendAfterAt` without
-introducing QStash, Vercel Pro Cron, or a broader queue worker yet.
+```text
+Calling client.query() when the client is already executing a query is deprecated and will be removed in pg@9.0
+```
+
+The fix must preserve the existing Prisma/PostgreSQL runtime contract, service
+authorization boundaries, and transaction-scoped RLS behavior.
 
 ## Current Baseline
-- TASK-125 provides durable outbound email delivery records.
-- TASK-227/TASK-271 provide durable notification email grouping, idempotency,
-  debounce windows, and duplicate suppression.
-- TASK-268 intentionally chose a no-new-cost GitHub Actions scheduler bridge
-  every 3 hours while Vercel remained on Hobby and QStash activation had
-  operational friction; TASK-273 now tightens that bridge to 30 minutes.
-- TASK-226 creates due-date reminder notifications and queues them into the
-  shared email orchestration.
-- TASK-273 PR #280 selected the cost-aware improvement path; this branch
-  implements the first phase.
-- This implementation branch delivers the 30-minute scheduler bridge and
-  scheduler-lag summary evidence for maintainer review before merge.
+- Prisma 7 uses `@prisma/adapter-pg` through `lib/prisma.ts`.
+- Runtime database traffic is expected to use the Supabase transaction pooler in
+  production and preview.
+- Project-scoped mutations run in service-layer RLS transactions via
+  `withActorRlsContext()`, which sets `app.user_id` with `set_config(..., true)`
+  before project data access.
+- Production logs showed the deprecation warning on both task creation and
+  notification-email dispatch paths, indicating overlapping queries are reaching
+  a single `pg` client somewhere in the Prisma/adapter/service flow.
 
 ## Scope
-- Change `.github/workflows/notification-email-dispatch.yml` to run the
-  protected dispatcher every 30 minutes.
-- Keep scheduled runs targeting `https://nexus-dash.app`; keep manual
-  `target_url` override behavior for previews and diagnostics.
-- Add scheduler-lag fields to the dispatcher summary for claimed due groups.
-- Make the GitHub Actions step summary show parsed dispatch metrics in addition
-  to the raw endpoint response.
-- Update README/runbooks/task docs so the active cadence, expected latency, and
-  residual limitations are accurate.
+- Identify whether the warning comes from the Prisma pg adapter construction or
+  from service code issuing parallel queries on one transaction client.
+- Fix the root cause without weakening RLS, transaction, or authorization
+  guarantees.
+- Add regression coverage around the changed behavior where practical without
+  making the default unit suite depend on external production services.
+- Update task tracking docs and journal evidence.
+- Open a ready PR, monitor checks and Copilot review, and address actionable
+  feedback.
+- Deploy a Vercel preview from
+  `feature/task-266-pg-query-deprecation-cleanup` and validate the task creation
+  / notification dispatch path against that preview.
 
 ## Acceptance Criteria
-1. The selected scheduler path is explicit: 30-minute GitHub Actions cadence,
-   no new paid provider, app-owned queue unchanged.
-2. Normal project activity emails are expected within the 30-minute quiet
-   window plus at most one 30-minute scheduler cadence and GitHub scheduling
-   delay under normal conditions.
-3. Due-date reminder reconciliation remains in the protected dispatcher and
-   still preserves one reminder per task, recipient, and deadline date.
-4. Duplicate email suppression from TASK-271 remains unchanged.
-5. Dispatcher summaries expose scheduler-lag evidence for claimed groups.
-6. Workflow summaries expose enough parsed metrics to inspect reconciliation,
-   claim/send outcomes, errors, and scheduler lag without reading raw JSON.
-7. Documentation explains the active cadence, cost/latency tradeoff, manual
-   smoke path, and future managed-scheduler decision point.
+1. Task creation no longer emits the `client.query()` overlap deprecation
+   warning during preview smoke validation.
+2. Notification-email dispatch no longer emits the same warning during preview
+   smoke validation.
+3. RLS context remains transaction-scoped and actor-bound for project data
+   reads/writes.
+4. The production/preview database connection contract remains aligned with the
+   existing Supabase transaction-pooler guardrails.
+5. Local validation passes for focused coverage, lint, full unit/API tests,
+   coverage, and build, or any environment blocker is recorded in `journal.md`.
+6. The PR remains unmerged for maintainer review.
 
 ## Definition Of Done
-- Scheduler cadence is updated to 30 minutes.
-- Dispatcher summary includes scheduler-lag metrics and tests cover them.
-- Relevant README/runbook/task tracking docs are updated.
-- Local focused notification email tests, lint, full tests/coverage, and build
-  pass or any blockers are recorded in `journal.md`.
-- The branch is pushed, a ready PR is opened, and Copilot/check feedback is
-  monitored according to `agent.md`; final merge remains a maintainer decision.
+- Root cause is documented in the final PR description and `journal.md`.
+- Code and tests are committed on the TASK-266 branch.
+- Branch is pushed and a ready PR is open.
+- Automated checks and initial Copilot review are handled.
+- A branch-scoped preview deploy completes using explicit `git_ref` evidence.
+- Preview smoke evidence records the preview URL and the absence of the pg
+  warning on the exercised task creation and notification dispatch paths.
 
 ## Validation Plan
 - `git diff --check`
-- `npm test -- --run tests/lib/project-notification-email-service.test.ts tests/api/notification-email-dispatch.route.test.ts`
+- Focused tests for the changed Prisma/service behavior.
 - `npm run lint`
 - `npm test`
 - `npm run test:coverage`
 - `npm run build`
+- Branch-scoped preview workflow:
+  `gh workflow run deploy-vercel.yml -f action=deploy-preview -f git_ref=feature/task-266-pg-query-deprecation-cleanup`
+- Preview smoke:
+  - `PLAYWRIGHT_BASE_URL=<preview-url> npx playwright test tests/e2e/smoke-project-task-calendar.spec.ts`
+  - protected notification-email dispatch request against the same preview when
+    runtime secrets allow it
+  - runtime log inspection for the `client.query()` warning after smoke traffic
 
 ## Out Of Scope
-- Replacing Resend as the outbound provider.
-- Buying or configuring a paid scheduler/provider.
-- User notification preference UI.
-- Bounce/suppression webhook handling.
-- Realtime in-app notification delivery.
-- A broad background-job platform rewrite.
+- Replacing Prisma or PostgreSQL.
+- Changing the notification email scheduler cadence.
+- Weakening RLS policies or bypassing project authorization.
+- Broad notification-email redesign beyond what is needed to remove the pg
+  query overlap warning.

--- a/tests/lib/pg-transaction-query-serialization.test.ts
+++ b/tests/lib/pg-transaction-query-serialization.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test, vi } from "vitest";
+import type { Pool, PoolClient } from "pg";
 
-import { serializePgQueryClient } from "@/lib/pg-transaction-query-serialization";
+import {
+  installSerializedTransactionQueries,
+  serializePgQueryClient,
+} from "@/lib/pg-transaction-query-serialization";
 
 function createDeferred<TValue>() {
   let resolve!: (value: TValue) => void;
@@ -72,5 +76,51 @@ describe("serializePgQueryClient", () => {
 
     queries.second.resolve("second-result");
     await expect(second).resolves.toBe("second-result");
+  });
+});
+
+describe("installSerializedTransactionQueries", () => {
+  test("preserves pg pool callback-style connect calls", async () => {
+    const firstQuery = createDeferred<string>();
+    const secondQuery = createDeferred<string>();
+    const startedQueries: string[] = [];
+    const client = {
+      query: vi.fn((name: string) => {
+        startedQueries.push(name);
+        return name === "first" ? firstQuery.promise : secondQuery.promise;
+      }),
+    } as unknown as PoolClient;
+    const release = vi.fn();
+    const pool = {
+      connect: vi.fn((callback) => {
+        callback(undefined, client, release);
+      }),
+    } as unknown as Pool;
+
+    installSerializedTransactionQueries(pool);
+
+    await new Promise<void>((resolve, reject) => {
+      pool.connect((error, connectedClient, done) => {
+        if (error || !connectedClient) {
+          reject(error ?? new Error("Expected connected client"));
+          return;
+        }
+
+        const first = connectedClient.query("first");
+        const second = connectedClient.query("second");
+
+        firstQuery.resolve("first-result");
+        secondQuery.resolve("second-result");
+
+        Promise.all([first, second])
+          .then(() => {
+            expect(done).toBe(release);
+            resolve();
+          })
+          .catch(reject);
+      });
+    });
+
+    expect(startedQueries).toEqual(["first", "second"]);
   });
 });

--- a/tests/lib/pg-transaction-query-serialization.test.ts
+++ b/tests/lib/pg-transaction-query-serialization.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { serializePgQueryClient } from "@/lib/pg-transaction-query-serialization";
+
+function createDeferred<TValue>() {
+  let resolve!: (value: TValue) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<TValue>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+}
+
+describe("serializePgQueryClient", () => {
+  test("runs overlapping query calls one at a time", async () => {
+    const startedQueries: string[] = [];
+    const queries = {
+      first: createDeferred<string>(),
+      second: createDeferred<string>(),
+      third: createDeferred<string>(),
+    };
+    const client = {
+      query: vi.fn((name: keyof typeof queries) => {
+        startedQueries.push(name);
+        return queries[name].promise;
+      }),
+    };
+
+    const serializedClient = serializePgQueryClient(client);
+    const first = serializedClient.query("first");
+    const second = serializedClient.query("second");
+    const third = serializedClient.query("third");
+
+    await vi.waitFor(() => expect(startedQueries).toEqual(["first"]));
+
+    queries.first.resolve("first-result");
+    await expect(first).resolves.toBe("first-result");
+    await vi.waitFor(() => expect(startedQueries).toEqual(["first", "second"]));
+
+    queries.second.resolve("second-result");
+    await expect(second).resolves.toBe("second-result");
+    await vi.waitFor(() =>
+      expect(startedQueries).toEqual(["first", "second", "third"])
+    );
+
+    queries.third.resolve("third-result");
+    await expect(third).resolves.toBe("third-result");
+  });
+
+  test("continues the query queue after a query rejects", async () => {
+    const startedQueries: string[] = [];
+    const queries = {
+      first: createDeferred<string>(),
+      second: createDeferred<string>(),
+    };
+    const client = {
+      query: vi.fn((name: keyof typeof queries) => {
+        startedQueries.push(name);
+        return queries[name].promise;
+      }),
+    };
+
+    const serializedClient = serializePgQueryClient(client);
+    const first = serializedClient.query("first");
+    const second = serializedClient.query("second");
+
+    queries.first.reject(new Error("first failed"));
+    await expect(first).rejects.toThrow("first failed");
+    await vi.waitFor(() => expect(startedQueries).toEqual(["first", "second"]));
+
+    queries.second.resolve("second-result");
+    await expect(second).resolves.toBe("second-result");
+  });
+});


### PR DESCRIPTION
﻿## Summary
- add a small pg transaction-client query serialization guard used by the Prisma pg adapter pool
- keep RLS work inside Prisma interactive transactions while preventing overlapping `client.query()` calls from queueing on one borrowed pg client
- refresh TASK-266 tracking docs and add focused unit coverage for ordered query execution and rejection recovery

## Root Cause
Production smoke showed pg's `client.query()` overlap deprecation warning on task creation and notification-email dispatch paths. The risky shape is Prisma interactive transactions: RLS uses one transaction-scoped pg client, and deep Prisma relation reads or accidental parallel transaction work can enqueue multiple driver queries on that single client. pg 8.20 warns for that queue because it will be removed in pg 9.

## Validation
- `git diff --check`
- `npm test -- --run tests/lib/pg-transaction-query-serialization.test.ts tests/lib/project-notification-email-service.test.ts tests/api/notification-email-dispatch.route.test.ts`
- `npm run lint`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/nexusdash?schema=public DIRECT_URL=... NODE_ENV=test npm test`
- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/nexusdash?schema=public DIRECT_URL=... NODE_ENV=test npm run test:coverage`
- preview-style `npm run build` with local placeholder runtime secrets

## Notes
- This PR is ready for review but should not be merged until maintainer approval.
- Remote checks were unstuck by closing/reopening the PR after GitHub failed to create the initial check suites. Preview validation remains expected through the deploy workflow once workflow_dispatch works with the required GitHub-held runtime secrets.
