### PR TITLE
Refresh backlog after TASK-266 and TASK-269

### DIFF
--- a/journal.md
+++ b/journal.md
@@ -1686,3 +1686,8 @@ Low-value entries to avoid going forward:
 - Type: Validation
 - Summary: TASK-127 notification follow-up passed focused regression tests, lint, full unit/API tests, build, and local Playwright smoke coverage.
 - Evidence: `npm test -- tests/api/task-comments.route.test.ts tests/api/task-update.route.test.ts tests/lib/notification-service.test.ts` passed (41 tests); `npm test -- tests/lib/project-collaboration-service.test.ts tests/api/project-members-search.route.test.ts` passed (10 tests); `npm run lint` passed; local DB env with `NODE_ENV=test` `npm test` passed (97 files passed, 1 skipped; 748 passed, 1 skipped); local PostgreSQL env `npm run build` passed. Local Playwright with migrated DB passed 7 of 8 specs in the first `npm run test:e2e`; the only failure was password-reset email delivery because `NODE_ENV=production` without `VERCEL_ENV=preview` attempted Resend with a placeholder key. Rerunning `npx playwright test tests/e2e/password-recovery.spec.ts` with `VERCEL_ENV=preview` passed both password recovery specs.
+
+### 2026-05-26
+- Type: Planning
+- Summary: Refreshed backlog state after TASK-269 and TASK-266 were merged, and captured a new deferred performance investigation for app-wide slowness.
+- Evidence: Moved TASK-269 to Completed after PR #292 and TASK-266 to Completed after PR #293. Added TASK-275 as a deferred measurement-first performance investigation/report for slow creation, update, and refresh flows, including backend latency, database/query timing, route refresh behavior, hydration/bundle cost, cache invalidation, optimistic UI opportunities, and ranked implementation recommendations. Promoted TASK-270, TASK-118, and TASK-129 from Deferred into the execution queue after TASK-274 and TASK-133.

--- a/project.md
+++ b/project.md
@@ -1,6 +1,6 @@
 # NexusDash Project Blueprint (Current State)
 
-Last verified: 2026-05-25
+Last verified: 2026-05-26
 
 ## 1. Vision
 
@@ -107,10 +107,13 @@ Source of truth: [`prisma/schema.prisma`](./prisma/schema.prisma)
 
 From `tasks/current.md` + `tasks/backlog.md`:
 
-1. TASK-269: GitHub Actions workflow cleanup and operating inventory
-2. TASK-266: production pg query deprecation warning cleanup
-3. TASK-133: task UI bug fixing - mini scrollbar and edit modal polish
-4. Deferred UX/product follow-ups remain sequenced in `tasks/backlog.md`
+1. TASK-274: Next.js dependency security update to restore the production audit
+2. TASK-133: task UI bug fixing - mini scrollbar and edit modal polish
+3. TASK-270: product-wide UI/UX design assessment
+4. TASK-118: real-time collaboration updates for live project refresh
+5. TASK-129: login/home page UI polish
+6. TASK-275: deferred performance investigation report for slow creation,
+   update, and refresh flows
 
 ## 8. Source-of-Truth Docs
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -2,21 +2,10 @@
 
 Use this file to capture tasks discovered during development. Each entry should include: ID, title, rationale, dependencies.
 
-Last reviewed: 2026-05-25
+Last reviewed: 2026-05-26
 
 ## Pending
 ### Execution Queue (Now / Next)
-- ID: TASK-269
-  Title: GitHub Actions workflow cleanup - simplify CI/CD, scheduled jobs, and maintenance automation
-  Status: Implementation complete - awaiting maintainer review
-  Rationale: The repository now has several production-impacting workflows covering quality gates, staged Vercel deploys, notification email dispatch, dependency security, Dependabot triage, and Copilot repair. Recent production work exposed duplicated env handling, scheduler tradeoffs, production-target safeguards, and deploy/secrets coupling across these workflows. Run a focused cleanup so workflow responsibilities, permissions, env/secrets usage, dispatch inputs, summaries, and failure modes are easier to understand and operate without changing product behavior.
-  Dependencies: TASK-042, TASK-116, TASK-132, TASK-268
-  Brief: `tasks/task-269-github-actions-workflow-cleanup.md`
-- ID: TASK-266
-  Title: Production pg query deprecation warning cleanup
-  Status: Active
-  Rationale: Production smoke logs repeatedly show `Calling client.query() when the client is already executing a query is deprecated and will be removed in pg@9.0` on task creation and notification-email dispatch paths. Identify the Prisma/Postgres adapter or service flow causing overlapping client queries, fix it without weakening transaction/RLS behavior, and validate that production smoke no longer emits the warning.
-  Dependencies: TASK-258, TASK-259
 - ID: TASK-274
   Title: Next.js dependency security update - restore green production audit
   Status: Queued security follow-up
@@ -24,20 +13,31 @@ Last reviewed: 2026-05-25
   Dependencies: TASK-116, TASK-132
 - ID: TASK-133
   Title: Task UI bug fixing - mini scrollbar and edit modal polish
-  Status: Deferred UI follow-up (promoted 2026-05-04; PR #224 partial fix merged)
+  Status: Queued UI follow-up (promoted 2026-05-04; PR #224 partial fix merged)
   Rationale: Fix task UI regressions around the compact scrollbar affordance and task edit modal behavior so dense task surfaces stay usable, visually clean, and predictable during everyday task creation and editing workflows.
   Dependencies: TASK-076, TASK-113
+- ID: TASK-270
+  Title: App UI/UX design assessment - product-wide heuristic audit and refinement roadmap
+  Status: Promoted 2026-05-26
+  Rationale: Before another broad polish pass, assess the current app experience across core user journeys, responsive layouts, visual hierarchy, copy, interaction feedback, accessibility basics, and consistency with the intended product tone. The output should be a ranked, evidence-backed design assessment that decides which issues belong in existing UI tasks such as TASK-108/TASK-100/TASK-129 and which need new implementation tasks, instead of mixing assessment and redesign in one large patch.
+  Dependencies: TASK-091, TASK-096, TASK-100, TASK-108, TASK-129
+  Brief: `tasks/task-270-app-ui-ux-design-assessment.md`
+- ID: TASK-118
+  Title: Real-time collaboration updates - live project refresh for multi-user work
+  Status: Promoted 2026-05-26
+  Rationale: Reduce stale state and manual-refresh friction during shared project work by propagating task, context-card, and related project mutations live across active collaborators, with explicit decisions around subscriptions, optimistic UI, and conflict handling. This should choose the app-wide realtime transport/pattern that notification-specific live updates can reuse.
+  Dependencies: TASK-058, TASK-076, TASK-103
+- ID: TASK-129
+  Title: Login/home page UI polish - user-friendly, product-oriented entry experience
+  Status: Promoted 2026-05-26
+  Rationale: Redesign the login and home page so they feel like a polished product surface rather than a technical auth form: improve visual hierarchy, copy, branding presence, and call-to-action clarity so new visitors understand the product value at a glance and returning users get a frictionless sign-in experience.
+  Dependencies: TASK-045, TASK-059, TASK-083
 ### Deferred (Intentional)
 - ID: TASK-224
   Title: Agent roadmap access - scoped API contract for roadmap phases and events
   Status: Pending
   Rationale: Make the project roadmap manageable by project-scoped agent tokens so agents can inspect, create, update, move, reorder, and delete roadmap phases/events when they are responsible for project planning. This should be a deliberate agent API contract expansion with dedicated roadmap scopes, OpenAPI/onboarding documentation, credential UI updates, route guard coverage, and smoke tests rather than implicitly folding roadmap permissions into existing project or task scopes.
   Dependencies: TASK-127, TASK-130, TASK-059
-- ID: TASK-129
-  Title: Login/home page UI polish - user-friendly, product-oriented entry experience
-  Status: Pending
-  Rationale: Redesign the login and home page so they feel like a polished product surface rather than a technical auth form: improve visual hierarchy, copy, branding presence, and call-to-action clarity so new visitors understand the product value at a glance and returning users get a frictionless sign-in experience.
-  Dependencies: TASK-045, TASK-059, TASK-083
 - ID: TASK-098
   Title: Meeting notes manager - structured project meeting log with participants, topics, decisions, and follow-ups
   Status: Pending
@@ -53,11 +53,6 @@ Last reviewed: 2026-05-25
   Status: Pending
   Rationale: Add a lighter-weight todo list surface for quick checklist-style capture that does not require the full structure of Kanban tasks, giving teams a place for small actionable items, personal punch lists, or short operational checklists that may later connect to richer task flows.
   Dependencies: TASK-076, TASK-079
-- ID: TASK-118
-  Title: Real-time collaboration updates - live project refresh for multi-user work
-  Status: Pending
-  Rationale: Reduce stale state and manual-refresh friction during shared project work by propagating task, context-card, and related project mutations live across active collaborators, with explicit decisions around subscriptions, optimistic UI, and conflict handling. This should choose the app-wide realtime transport/pattern that notification-specific live updates can reuse.
-  Dependencies: TASK-058, TASK-076, TASK-103
 - ID: TASK-263
   Title: Real-time notification updates - live in-app inbox, counts, and awareness
   Status: Pending
@@ -78,12 +73,12 @@ Last reviewed: 2026-05-25
   Status: Pending
   Rationale: Enable bilingual product usage (French and English) with consistent UI copy, locale routing/state strategy, and fallback behavior; defer implementation until we confirm i18n architecture and translation workflow.
   Dependencies: TASK-047, TASK-060
-- ID: TASK-270
-  Title: App UI/UX design assessment - product-wide heuristic audit and refinement roadmap
+- ID: TASK-275
+  Title: App performance investigation report - creation, update, and refresh latency
   Status: Pending
-  Rationale: Before another broad polish pass, assess the current app experience across core user journeys, responsive layouts, visual hierarchy, copy, interaction feedback, accessibility basics, and consistency with the intended product tone. The output should be a ranked, evidence-backed design assessment that decides which issues belong in existing UI tasks such as TASK-108/TASK-100/TASK-129 and which need new implementation tasks, instead of mixing assessment and redesign in one large patch.
-  Dependencies: TASK-091, TASK-096, TASK-100, TASK-108, TASK-129
-  Brief: `tasks/task-270-app-ui-ux-design-assessment.md`
+  Rationale: User preview testing after TASK-266 confirmed the app works functionally, but creation, update, and refresh flows still feel slow across the product. Run a measurement-first performance investigation and produce a report with evidence, root-cause hypotheses, and ranked recommendations to bring the app closer to industry-standard responsiveness. The report should cover request latency, database/query timing, route refresh behavior, client bundle/hydration cost, cache invalidation, optimistic UI opportunities, loading-state ergonomics, and concrete implementation tasks for the highest-impact fixes.
+  Dependencies: TASK-043, TASK-073, TASK-074, TASK-266, TASK-270
+  Brief: `tasks/task-275-app-performance-investigation-report.md`
 - ID: TASK-108
   Title: Whole-app UI/UX refinement - global interaction, visual, and information-design polish
   Status: Pending
@@ -138,6 +133,17 @@ Last reviewed: 2026-05-25
   Dependencies: TASK-051
 
 ## Completed
+- ID: TASK-266
+  Title: Production pg query deprecation warning cleanup
+  Status: Done (2026-05-26, merged via PR #293)
+  Rationale: Serialized Prisma pg transaction-client query calls while preserving pg pool callback and Promise connect overloads, eliminating the pg query-overlap deprecation warning risk without weakening transaction-scoped RLS. Preview testing from the branch confirmed the app still works, remote Quality Gates passed, and the PR was merged after maintainer review.
+  Dependencies: TASK-258, TASK-259
+- ID: TASK-269
+  Title: GitHub Actions workflow cleanup - simplify CI/CD, scheduled jobs, and maintenance automation
+  Status: Done (2026-05-26, merged via PR #292)
+  Rationale: Kept the workflow set intentionally scoped while cleaning contracts, permissions, documentation, and operator guidance for quality gates, Vercel deploys, notification email dispatch, dependency security, Dependabot triage, and Copilot repair.
+  Dependencies: TASK-042, TASK-116, TASK-132, TASK-268
+  Brief: `tasks/task-269-github-actions-workflow-cleanup.md`
 - ID: TASK-273
   Title: Cost-aware notification email scheduling - industry-aligned delivery cadence
   Status: Done (2026-05-25, merged via PR #291)

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,96 +1,53 @@
-# Current Task: TASK-266 Production pg Query Deprecation Warning Cleanup
+# Current Task: TASK-274 Next.js Dependency Security Update
 
 ## Task ID
-TASK-266
+TASK-274
 
 ## Status
-Active
+Queued - next execution candidate
 
 ## Source
-- Backlog execution queue entry for TASK-266.
-- Production smoke evidence captured in `journal.md` on 2026-05-16 after
-  notification digest validation.
-- User direction on 2026-05-26: own TASK-266 end to end from a dedicated
-  worktree, open a PR, handle Copilot review, deploy a branch preview, and test
-  the preview directly.
+- `tasks/backlog.md` execution queue, refreshed on 2026-05-26 after TASK-269
+  and TASK-266 were merged.
+- TASK-269 workflow audit finding: the production dependency audit currently
+  fails because the installed `next` range includes a high-severity advisory.
 
 ## Objective
-Remove the recurring production `pg` warning:
-
-```text
-Calling client.query() when the client is already executing a query is deprecated and will be removed in pg@9.0
-```
-
-The fix must preserve the existing Prisma/PostgreSQL runtime contract, service
-authorization boundaries, and transaction-scoped RLS behavior.
+Restore a green production dependency audit by updating Next.js and any tightly
+coupled framework packages in a focused dependency PR, without mixing in product
+behavior changes.
 
 ## Current Baseline
-- Prisma 7 uses `@prisma/adapter-pg` through `lib/prisma.ts`.
-- Runtime database traffic is expected to use the Supabase transaction pooler in
-  production and preview.
-- Project-scoped mutations run in service-layer RLS transactions via
-  `withActorRlsContext()`, which sets `app.user_id` with `set_config(..., true)`
-  before project data access.
-- Production logs showed the deprecation warning on both task creation and
-  notification-email dispatch paths, indicating overlapping queries are reaching
-  a single `pg` client somewhere in the Prisma/adapter/service flow.
-- TASK-269 has since merged into `main`; this task branch is based on that
-  workflow cleanup and keeps TASK-266 as the active execution scope.
+- TASK-269 and TASK-266 are completed and merged.
+- The execution queue now starts with TASK-274, followed by TASK-133,
+  TASK-270, TASK-118, and TASK-129.
+- TASK-275 has been added to Deferred as a measurement-first performance
+  investigation/report for slow creation, update, and refresh flows.
 
 ## Scope
-- Identify whether the warning comes from the Prisma pg adapter construction or
-  from service code issuing parallel queries on one transaction client.
-- Fix the root cause without weakening RLS, transaction, or authorization
-  guarantees.
-- Add regression coverage around the changed behavior where practical without
-  making the default unit suite depend on external production services.
-- Update task tracking docs and journal evidence.
-- Open a ready PR, monitor checks and Copilot review, and address actionable
-  feedback.
-- Deploy a Vercel preview from
-  `feature/task-266-pg-query-deprecation-cleanup` and validate the task creation
-  / notification dispatch path against that preview.
+- Confirm the current advisory and the minimum safe Next.js version from the
+  local audit output and package metadata.
+- Update Next.js and any required peer/tightly coupled framework dependencies.
+- Regenerate lockfile state intentionally.
+- Run the repository validation baseline appropriate for a framework update.
+- Keep unrelated backlog, UI, and runtime behavior changes out of the dependency
+  PR.
 
 ## Acceptance Criteria
-1. Task creation no longer emits the `client.query()` overlap deprecation
-   warning during preview smoke validation.
-2. Notification-email dispatch no longer emits the same warning during preview
-   smoke validation.
-3. RLS context remains transaction-scoped and actor-bound for project data
-   reads/writes.
-4. The production/preview database connection contract remains aligned with the
-   existing Supabase transaction-pooler guardrails.
-5. Local validation passes for focused coverage, lint, full unit/API tests,
-   coverage, and build, or any environment blocker is recorded in `journal.md`.
-6. The PR remains unmerged for maintainer review.
+1. `npm audit --omit=dev --audit-level=high` passes or any remaining advisory is
+   documented as unrelated/unavoidable.
+2. Next.js and coupled framework packages are updated to a safe compatible
+   version.
+3. Lint, unit/API tests, coverage, build, and E2E smoke are green locally or any
+   environment blocker is recorded.
+4. The dependency PR clearly documents risk, validation, and rollback path.
 
 ## Definition Of Done
-- Root cause is documented in the final PR description and `journal.md`.
-- Code and tests are committed on the TASK-266 branch.
-- Branch is pushed and a ready PR is open.
-- Automated checks and initial Copilot review are handled.
-- A branch-scoped preview deploy completes using explicit `git_ref` evidence.
-- Preview smoke evidence records the preview URL and the absence of the pg
-  warning on the exercised task creation and notification dispatch paths.
-
-## Validation Plan
-- `git diff --check`
-- Focused tests for the changed Prisma/service behavior.
-- `npm run lint`
-- `npm test`
-- `npm run test:coverage`
-- `npm run build`
-- Branch-scoped preview workflow:
-  `gh workflow run deploy-vercel.yml -f action=deploy-preview -f git_ref=feature/task-266-pg-query-deprecation-cleanup`
-- Preview smoke:
-  - `PLAYWRIGHT_BASE_URL=<preview-url> npx playwright test tests/e2e/smoke-project-task-calendar.spec.ts`
-  - protected notification-email dispatch request against the same preview when
-    runtime secrets allow it
-  - runtime log inspection for the `client.query()` warning after smoke traffic
+- Package and lockfile changes are committed on a dedicated TASK-274 branch.
+- Validation evidence is recorded in `journal.md`.
+- The PR is opened ready for review and automated feedback is handled.
 
 ## Out Of Scope
-- Replacing Prisma or PostgreSQL.
-- Changing the notification email scheduler cadence.
-- Weakening RLS policies or bypassing project authorization.
-- Broad notification-email redesign beyond what is needed to remove the pg
-  query overlap warning.
+- Product feature changes.
+- Broad UI polish.
+- Performance remediation beyond dependency-update fallout.

--- a/tasks/task-269-github-actions-workflow-cleanup.md
+++ b/tasks/task-269-github-actions-workflow-cleanup.md
@@ -4,7 +4,7 @@
 TASK-269
 
 ## Status
-Implementation complete - awaiting maintainer review
+Done (2026-05-26, merged via PR #292)
 
 Implementation branch: `chore/task-269-workflow-cleanup`
 

--- a/tasks/task-275-app-performance-investigation-report.md
+++ b/tasks/task-275-app-performance-investigation-report.md
@@ -1,0 +1,62 @@
+# TASK-275 App Performance Investigation Report
+
+## Task ID
+TASK-275
+
+## Status
+Pending
+
+## Objective
+Produce a measurement-backed performance report for the app's slow-feeling
+creation, update, navigation, and refresh flows, then convert the highest-impact
+findings into concrete implementation recommendations.
+
+## Rationale
+Manual preview validation after TASK-266 confirmed the branch works
+functionally, but the application still feels slow during everyday operations.
+The next performance step should be investigation-first so future work improves
+real user-perceived latency rather than guessing at isolated optimizations.
+
+## Scope
+- Measure representative flows:
+  - project creation and project-list refresh
+  - task creation, update, modal open/close, and board refresh
+  - context-card creation/update and dashboard refresh
+  - roadmap/calendar interactions where they materially affect dashboard speed
+  - notification/account surfaces if they affect common navigation latency
+- Capture evidence from browser devtools or browser automation, server logs,
+  request timings, database/query timing, bundle/hydration characteristics, and
+  route refresh behavior.
+- Identify whether slowness is dominated by network round trips, Prisma/query
+  behavior, RLS transaction work, Next.js cache invalidation, full route
+  refreshes, client hydration, oversized payloads, missing optimistic UI, or
+  loading-state ergonomics.
+- Compare observed behavior against practical industry targets for interactive
+  SaaS apps: fast local feedback, low-latency mutations, limited blocking
+  refreshes, stable layout, and responsive loading states.
+- Produce ranked recommendations with expected impact, complexity, risk, and
+  suggested owning follow-up tasks.
+
+## Acceptance Criteria
+1. A performance report exists in the repo with measured evidence for the
+   highest-traffic creation, update, and refresh flows.
+2. The report distinguishes backend latency, database/query cost, frontend
+   rendering/hydration cost, cache/refresh behavior, and perceived-latency UX.
+3. Recommendations are ranked by user impact and implementation complexity.
+4. At least the top three recommendations include concrete suggested
+   implementation tasks or links to existing backlog tasks.
+5. The report explicitly calls out any quick wins versus architectural changes.
+
+## Definition Of Done
+- The report is committed as documentation.
+- `tasks/backlog.md` is updated with any newly discovered implementation tasks
+  or sequencing changes.
+- `journal.md` records the investigation outcome and recommended next steps.
+- The PR is opened for review; no product behavior changes are bundled unless a
+  tiny measurement/instrumentation change is explicitly necessary.
+
+## Validation Plan
+- Manual preview walkthrough with browser timing evidence.
+- Browser automation screenshots or traces where useful.
+- Server/runtime log review around measured flows.
+- `git diff --check`.


### PR DESCRIPTION
## Summary
- move TASK-266 and TASK-269 to Completed after merged PRs #293 and #292
- add TASK-275 as a deferred measurement-first app performance investigation/report for slow creation, update, and refresh flows
- promote TASK-270, TASK-118, and TASK-129 from Deferred into the execution queue, and refresh current/project/journal tracking docs

## Validation
- `git diff --check`
- backlog duplicate-ID check