### PR TITLE
[codex] Move Dependabot schedule to Friday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "friday"
       time: "06:00"
       timezone: "UTC"
     open-pull-requests-limit: 5
@@ -55,7 +55,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "friday"
       time: "06:30"
       timezone: "UTC"
     open-pull-requests-limit: 3


### PR DESCRIPTION
## Summary

Move the weekly Dependabot schedule from Monday to Friday for both configured ecosystems:

- npm updates at 06:00 UTC
- GitHub Actions updates at 06:30 UTC

## Validation

- `git diff --check`