### PR TITLE
TASK-306 Fix task comment mention cursor spacing

### DIFF
--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -69,7 +69,10 @@ import { UserAvatar } from "@/components/ui/user-avatar";
 import { getEpicColorFromName } from "@/lib/epic";
 import { cn } from "@/lib/utils";
 import { useDismissibleMenu } from "@/lib/hooks/use-dismissible-menu";
-import { renderContentWithMentions, MENTION_HIGHLIGHT_CLASS } from "@/lib/content-with-mentions";
+import {
+  renderContentWithMentions,
+  MENTION_TEXTAREA_MIRROR_HIGHLIGHT_CLASS,
+} from "@/lib/content-with-mentions";
 import {
   parseMentions,
   removeMentionBeforeCursor,
@@ -1489,7 +1492,8 @@ function TaskReadOnlyContent({
                         mentionUsers,
                         hideMentionDiscriminator: true,
                         resolveDisplayUsers: false,
-                        mentionHighlightClassName: MENTION_HIGHLIGHT_CLASS,
+                        mentionHighlightClassName:
+                          MENTION_TEXTAREA_MIRROR_HIGHLIGHT_CLASS,
                       })
                     : null}
                 </div>

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -1271,6 +1271,9 @@ function TaskReadOnlyContent({
       if (!currentTextarea) {
         return;
       }
+      if (currentTextarea.value !== nextValue) {
+        return;
+      }
 
       currentTextarea.focus();
       currentTextarea.setSelectionRange(

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -1246,8 +1246,16 @@ function TaskReadOnlyContent({
       replacement: mentionText,
     });
 
+    const textarea = commentInputRef.current;
     onNewTaskCommentChange(nextValue);
     setCommentCursorPosition(nextCursorPosition);
+    if (textarea) {
+      textarea.value = nextValue;
+      textarea.focus();
+      textarea.setSelectionRange(nextCursorPosition, nextCursorPosition);
+      syncCommentHighlightScroll(textarea);
+    }
+
     const selectedMention = buildCommentMentionSelection(member);
     if (selectedMention) {
       setCommentMentionSelections((previousSelections) =>
@@ -1259,13 +1267,16 @@ function TaskReadOnlyContent({
     }
 
     window.requestAnimationFrame(() => {
-      const textarea = commentInputRef.current;
-      if (!textarea) {
+      const currentTextarea = commentInputRef.current;
+      if (!currentTextarea) {
         return;
       }
 
-      textarea.focus();
-      textarea.setSelectionRange(nextCursorPosition, nextCursorPosition);
+      currentTextarea.focus();
+      currentTextarea.setSelectionRange(
+        nextCursorPosition,
+        nextCursorPosition
+      );
     });
   };
 

--- a/journal.md
+++ b/journal.md
@@ -45,6 +45,22 @@ Use it for important implementation milestones, blockers, validation runs, and r
   the submitted comment article.
 - The next E2E run reached a stale test variable after reopening the task; the
   assertion now checks the comment suffix used by the mention comment flow.
+- PR #307 checks are green on head
+  `987f1fe26f6e5311346801615b8d76f723063914`: branch-name, Quality Core, E2E
+  Smoke, and Container Image all passed.
+- Copilot review completed with one actionable stale-variable comment. The
+  thread was resolved after the current PR diff and green checks confirmed the
+  assertion now uses `taskCommentSuffix`.
+- Preview workflow run `26697364465` was dispatched with
+  `action=deploy-preview` and
+  `git_ref=fix/task-306-mention-cursor-spacing`. Logs show checkout of
+  `refs/remotes/origin/fix/task-306-mention-cursor-spacing` and deployed commit
+  `987f1fe26f6e5311346801615b8d76f723063914`; artifact URL:
+  `https://nexus-dash-as20alnt0-dorian-agaesses-projects.vercel.app`.
+- Playwright request validation against that preview passed using
+  `tmp/project-access-cred.env`: health, agent token exchange, temporary task
+  create, task comment create with `@dorianagaesse`, comment list verification,
+  and cleanup verification with no `task306-preview-mention-*` tasks remaining.
 
 ## Entry Format
 

--- a/journal.md
+++ b/journal.md
@@ -35,6 +35,10 @@ Use it for important implementation milestones, blockers, validation runs, and r
   restoration completed. Tightened the component by imperatively syncing the
   textarea value and selection during mention selection, while keeping the
   animation-frame selection pass as a stabilization step.
+- The next E2E run showed the stabilization frame could still jump the caret
+  after the first characters were typed. Guarded the frame callback so it only
+  restores selection when the textarea still contains the untouched replacement
+  value.
 
 ## Entry Format
 

--- a/journal.md
+++ b/journal.md
@@ -43,6 +43,8 @@ Use it for important implementation milestones, blockers, validation runs, and r
   strict-mode locator because the same mention appeared in the task description,
   card preview, and submitted comment. Scoped the rendered mention assertion to
   the submitted comment article.
+- The next E2E run reached a stale test variable after reopening the task; the
+  assertion now checks the comment suffix used by the mention comment flow.
 
 ## Entry Format
 

--- a/journal.md
+++ b/journal.md
@@ -39,6 +39,10 @@ Use it for important implementation milestones, blockers, validation runs, and r
   after the first characters were typed. Guarded the frame callback so it only
   restores selection when the textarea still contains the untouched replacement
   value.
+- The follow-up E2E run passed the caret/value assertion and only failed on a
+  strict-mode locator because the same mention appeared in the task description,
+  card preview, and submitted comment. Scoped the rendered mention assertion to
+  the submitted comment article.
 
 ## Entry Format
 

--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,34 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-05-31 - TASK-306 task comment mention cursor spacing
+
+- Started TASK-306 from GitHub issue #306 on
+  `fix/task-306-mention-cursor-spacing`.
+- Read `agent.md`, `project.md`, `README.md`, and the issue body. The task
+  requires a matching backlog/current task entry, a focused fix branch, ready PR,
+  Copilot follow-up, branch-ref Vercel preview deploy, and Playwright validation
+  against the preview URL.
+- Initial investigation points to the task comment composer's transparent
+  textarea mirror: the visible mention highlight uses chip padding and medium
+  font weight while the actual caret is owned by the transparent textarea's
+  plain text. That layout mismatch explains why text after a selected mention
+  appears offset and the caret cannot visually reach the end.
+- Implemented a textarea-mirror-specific mention highlight class that removes
+  layout-affecting padding, inline-block display, and font-weight changes while
+  preserving mention highlighting. The read-only mention chip styling remains
+  unchanged.
+- Extended the Playwright smoke task lifecycle flow to select a comment mention,
+  type after it, assert the textarea value/caret end position, submit the
+  comment, and verify a `task_comment_mention` notification row for the
+  mentioned project member.
+- Validation passed: `git diff --check`, `npm run lint`, focused mention/comment
+  tests, full `npm test` with documented DB env, full `npm run test:coverage`
+  with documented DB env, and `npm run build` with documented DB env plus
+  placeholder production-only secrets.
+- Local E2E bootstrap is blocked because Docker Desktop is unavailable:
+  `npm run db:local:up` cannot connect to the `dockerDesktopLinuxEngine` pipe.
+
 ## Entry Format
 
 - `Date`

--- a/journal.md
+++ b/journal.md
@@ -30,6 +30,11 @@ Use it for important implementation milestones, blockers, validation runs, and r
   placeholder production-only secrets.
 - Local E2E bootstrap is blocked because Docker Desktop is unavailable:
   `npm run db:local:up` cannot connect to the `dockerDesktopLinuxEngine` pipe.
+- PR #307 E2E initially failed because the smoke test typed immediately after
+  clicking the autocomplete result, before the deferred animation-frame caret
+  restoration completed. Tightened the component by imperatively syncing the
+  textarea value and selection during mention selection, while keeping the
+  animation-frame selection pass as a stabilization step.
 
 ## Entry Format
 

--- a/lib/content-with-mentions.tsx
+++ b/lib/content-with-mentions.tsx
@@ -16,6 +16,16 @@ export const MENTION_HIGHLIGHT_CLASS =
   "inline-block rounded-md bg-primary/15 px-1 py-0.5 align-baseline font-medium text-primary not-italic";
 
 /**
+ * Mention highlight class for transparent textarea mirrors.
+ *
+ * The browser caret belongs to the invisible textarea, so the visible mirror
+ * must keep the same inline metrics as plain textarea text. Avoid padding,
+ * inline-block, and font-weight changes here.
+ */
+export const MENTION_TEXTAREA_MIRROR_HIGHLIGHT_CLASS =
+  "rounded-sm bg-primary/15 px-0 py-0 font-normal text-primary not-italic";
+
+/**
  * Renders content with @username mentions highlighted.
  * Splits content into segments and wraps mention patterns in styled spans.
  */

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -8,7 +8,7 @@ Last reviewed: 2026-05-26
 ### Execution Queue (Now / Next)
 - ID: TASK-306
   Title: Task comment mention cursor spacing after mention autocomplete
-  Status: In progress
+  Status: Implemented - PR #307 validation green
   Rationale: GitHub issue #306 reports that selecting a mention in the task
     comment composer leaves the visible text, trailing space, and browser caret
     out of sync. Fix the task comment mention editor path without changing

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -6,6 +6,14 @@ Last reviewed: 2026-05-26
 
 ## Pending
 ### Execution Queue (Now / Next)
+- ID: TASK-306
+  Title: Task comment mention cursor spacing after mention autocomplete
+  Status: In progress
+  Rationale: GitHub issue #306 reports that selecting a mention in the task
+    comment composer leaves the visible text, trailing space, and browser caret
+    out of sync. Fix the task comment mention editor path without changing
+    mention search or notification semantics.
+  Dependencies: TASK-076, TASK-123
 - ID: TASK-274
   Title: Next.js dependency security update - restore green production audit
   Status: Implemented - PR validation in progress

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,74 +1,84 @@
-# Current Task: TASK-274 Next.js Dependency Security Update
+# Current Task: TASK-306 Task Comment Mention Cursor Spacing
 
 ## Task ID
-TASK-274
+TASK-306
 
 ## Status
-Implemented - PR validation in progress
+Implemented locally - PR/preview validation pending
 
 ## Source
-- `tasks/backlog.md` execution queue, refreshed on 2026-05-26 after TASK-269
-  and TASK-266 were merged.
-- TASK-269 workflow audit finding: the production dependency audit previously
-  failed because the installed `next` range included a high-severity advisory.
-  On 2026-05-30, the high-severity advisory had cleared from the current npm
-  audit feed, but moderate production advisories remained through Next.js'
-  bundled PostCSS and Prisma's dev-server Hono dependencies.
+- GitHub issue #306: task comment mention cursor spacing after selecting a
+  mention.
+- User report and screenshot from 2026-05-31: after selecting a mention in the
+  task comment composer, the visible spacing and caret position become
+  desynchronized.
 
 ## Objective
-Restore a green production dependency audit by updating or overriding Next.js
-and any tightly coupled framework packages in a focused dependency PR, without
-mixing in product behavior changes.
+Fix the task detail comment composer so selecting a mention inserts a consistent
+trailing separator, preserves predictable caret positioning, and keeps mention
+highlighting/notification behavior intact.
 
-## Current Baseline
-- TASK-269 and TASK-266 are completed and merged.
-- The execution queue now starts with TASK-274, followed by TASK-133,
-  TASK-270, TASK-118, and TASK-129.
-- TASK-275 has been added to Deferred as a measurement-first performance
-  investigation/report for slow creation, update, and refresh flows.
-- `next@16.2.6`, `eslint-config-next@16.2.6`, and `prisma@7.8.0` are already
-  the latest stable versions available to npm on 2026-05-30.
-- The implemented fix uses targeted npm overrides for `next`'s PostCSS
-  dependency and Prisma's `@prisma/dev` Hono dependencies, then regenerates the
-  lockfile from the updated manifest.
+## Investigation Notes
+- The task comment composer uses a transparent textarea layered over a visible
+  rendered mirror from `renderContentWithMentions`.
+- The underlying textarea receives plain text such as `@username ` and owns the
+  actual browser caret.
+- The visible mirror currently reuses the standard mention chip styling, which
+  adds horizontal padding and medium font weight. That makes the visual mention
+  wider than the transparent textarea text, so following text and the caret no
+  longer line up after a selected mention.
 
 ## Scope
-- Confirm the current advisory and the minimum safe Next.js version from the
-  local audit output and package metadata.
-- Update or override Next.js and any required peer/tightly coupled framework
-  dependencies.
-- Regenerate lockfile state intentionally.
-- Run the repository validation baseline appropriate for a framework update.
-- Keep unrelated backlog, UI, and runtime behavior changes out of the dependency
-  PR.
-
-## Validation Notes
-- `npm audit --omit=dev --audit-level=high` passes.
-- `npm audit --omit=dev --audit-level=moderate` passes.
-- `git diff --check`, `npm run lint`, explicit-local-DB `npm test`,
-  explicit-local-DB `npm run test:coverage`, and placeholder-production-env
-  `npm run build` pass locally.
-- `npm run test:e2e` builds successfully but cannot complete Playwright tests
-  because no PostgreSQL server is reachable at `127.0.0.1:5432` and Docker
-  Desktop is unavailable on this machine. Chromium was installed with
-  `npx playwright install chromium`, so the remaining blocker is database
-  availability rather than browser setup.
-
-## Acceptance Criteria
-1. `npm audit --omit=dev --audit-level=high` passes or any remaining advisory is
-   documented as unrelated/unavoidable.
-2. Next.js and coupled framework packages are updated to a safe compatible
-   version.
-3. Lint, unit/API tests, coverage, build, and E2E smoke are green locally or any
-   environment blocker is recorded.
-4. The dependency PR clearly documents risk, validation, and rollback path.
-
-## Definition Of Done
-- Package and lockfile changes are committed on a dedicated TASK-274 branch.
-- Validation evidence is recorded in `journal.md`.
-- The PR is opened ready for review and automated feedback is handled.
+- Task detail modal comment composer mention mirror styling.
+- Mention selection/caret behavior after choosing an autocomplete result.
+- Focused regression tests for the mirror class and comment mention flow.
+- Preview validation against the deployed branch URL with Playwright.
 
 ## Out Of Scope
-- Product feature changes.
-- Broad UI polish.
-- Performance remediation beyond dependency-update fallout.
+- Mention search result behavior.
+- Mention notification service rules, except verifying they still work.
+- Task detail modal redesign.
+- Replacing the textarea/mirror composer with a rich text editor.
+
+## Acceptance Criteria
+1. After selecting a mention in a task comment, the trailing space is represented
+   consistently in the textarea value and visible mirror.
+2. Typing immediately after the mention appears at the same visual position as
+   the caret.
+3. The caret can reach the true end of the comment text with keyboard and mouse
+   navigation.
+4. Mention autocomplete still works in the task comment composer.
+5. Mention notifications still work when a selected mention comment is
+   submitted.
+6. Existing comment creation behavior remains unchanged outside the
+   cursor/spacing fix.
+7. Local validation and preview Playwright validation pass, or any environment
+   blocker is recorded.
+
+## Validation Notes
+- `git diff --check` passed.
+- `npm run lint` passed.
+- Focused tests passed:
+  `npm test -- tests/api/task-comments.route.test.ts tests/components/rich-text-content.test.ts tests/lib/mention.test.ts`.
+- Full test suite passed with documented local DB env:
+  `DATABASE_URL=postgresql://nexus:nexus@localhost:5432/nexusdash` and
+  `DIRECT_URL=postgresql://nexus:nexus@localhost:5433/nexusdash npm test`.
+- Coverage passed with the same DB env:
+  `npm run test:coverage` reported 91.23% statements, 81.2% branches, 93.42%
+  functions, and 91.75% lines.
+- Build passed with the same DB env plus placeholder production-only secrets.
+- Local E2E setup is blocked because Docker Desktop is not available
+  (`dockerDesktopLinuxEngine` pipe missing) when running
+  `npm run db:local:up`.
+- Preview deployment and Playwright validation remain pending.
+
+## Definition Of Done
+- A dedicated `fix/task-306-mention-cursor-spacing` branch contains the fix.
+- `tasks/current.md`, `tasks/backlog.md`, and `journal.md` are updated.
+- A ready-for-review PR is opened for issue #306.
+- Copilot review feedback and CI failures are handled.
+- A Vercel preview deployment is triggered with
+  `git_ref=fix/task-306-mention-cursor-spacing`.
+- Playwright is run against the preview URL, tagging the mention target from
+  `tmp/project-access-cred.env` in the manual flow or equivalent automated
+  setup.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -73,7 +73,9 @@ highlighting/notification behavior intact.
 - PR E2E initially exposed an immediate-type race after autocomplete selection:
   Playwright could type before the next animation frame restored the caret. The
   component now synchronizes the textarea value and selection immediately during
-  mention selection, with the animation frame kept as stabilization.
+  mention selection. The follow-up animation-frame stabilization now aborts if
+  the user has already typed more text, preventing a delayed caret jump from
+  splitting the following word.
 - Preview deployment and Playwright validation remain pending.
 
 ## Definition Of Done

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -70,6 +70,10 @@ highlighting/notification behavior intact.
 - Local E2E setup is blocked because Docker Desktop is not available
   (`dockerDesktopLinuxEngine` pipe missing) when running
   `npm run db:local:up`.
+- PR E2E initially exposed an immediate-type race after autocomplete selection:
+  Playwright could type before the next animation frame restored the caret. The
+  component now synchronizes the textarea value and selection immediately during
+  mention selection, with the animation frame kept as stabilization.
 - Preview deployment and Playwright validation remain pending.
 
 ## Definition Of Done

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,7 +4,7 @@
 TASK-306
 
 ## Status
-Implemented locally - PR/preview validation pending
+Implemented - PR #307 validation green
 
 ## Source
 - GitHub issue #306: task comment mention cursor spacing after selecting a
@@ -76,7 +76,24 @@ highlighting/notification behavior intact.
   mention selection. The follow-up animation-frame stabilization now aborts if
   the user has already typed more text, preventing a delayed caret jump from
   splitting the following word.
-- Preview deployment and Playwright validation remain pending.
+- PR #307 is open and ready for review at head
+  `987f1fe26f6e5311346801615b8d76f723063914`.
+- GitHub Actions passed on PR #307: branch name, Quality Core, E2E Smoke, and
+  Container Image checks.
+- Copilot review completed with one actionable test-variable comment. The fix is
+  included in `987f1fe`, and the review thread is resolved.
+- Vercel preview workflow run `26697364465` was triggered with
+  `action=deploy-preview` and
+  `git_ref=fix/task-306-mention-cursor-spacing`.
+- The workflow logs show the job checked out
+  `refs/remotes/origin/fix/task-306-mention-cursor-spacing` and deployed commit
+  `987f1fe26f6e5311346801615b8d76f723063914`.
+- Preview URL:
+  `https://nexus-dash-as20alnt0-dorian-agaesses-projects.vercel.app`.
+- Playwright request validation against the preview URL passed: health endpoint,
+  agent token exchange, temporary task creation, comment creation with
+  `@dorianagaesse` from `tmp/project-access-cred.env`, comment listing, and
+  cleanup verification showing no `task306-preview-mention-*` tasks remain.
 
 ## Definition Of Done
 - A dedicated `fix/task-306-mention-cursor-spacing` branch contains the fix.

--- a/tests/components/rich-text-content.test.ts
+++ b/tests/components/rich-text-content.test.ts
@@ -9,7 +9,10 @@ import {
   buildEnhancedRichTextHtml,
   RichTextContent,
 } from "@/components/rich-text-content";
-import { renderContentWithMentions } from "@/lib/content-with-mentions";
+import {
+  MENTION_TEXTAREA_MIRROR_HIGHLIGHT_CLASS,
+  renderContentWithMentions,
+} from "@/lib/content-with-mentions";
 import {
   createRichTextCodeBlock,
   createRichTextTokenBlock,
@@ -447,6 +450,36 @@ describe("rich-text-content", () => {
     expect(hiddenDiscriminator?.textContent).toBe("#1234");
     expect(hiddenDiscriminator?.className).toContain("hidden");
     expect(mention?.contains(hiddenDiscriminator)).toBe(false);
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  test("keeps transparent textarea mirror mention highlights text-metric neutral", () => {
+    const { container, root } = createTestRenderer();
+
+    act(() => {
+      root.render(
+        React.createElement(
+          "div",
+          null,
+          renderContentWithMentions("@alice hello", {
+            mentionHighlightClassName: MENTION_TEXTAREA_MIRROR_HIGHLIGHT_CLASS,
+            resolveDisplayUsers: false,
+          })
+        )
+      );
+    });
+
+    const mention = container.querySelector("span");
+    expect(mention?.textContent).toBe("@alice");
+    expect(container.textContent).toBe("@alice hello");
+    expect(mention?.className).toContain("px-0");
+    expect(mention?.className).toContain("py-0");
+    expect(mention?.className).toContain("font-normal");
+    expect(mention?.className).not.toContain("inline-block");
+    expect(mention?.className).not.toContain("font-medium");
 
     act(() => {
       root.unmount();

--- a/tests/e2e/smoke-project-task-calendar.spec.ts
+++ b/tests/e2e/smoke-project-task-calendar.spec.ts
@@ -30,7 +30,7 @@ test.describe("critical UI smoke flows", () => {
     const projectName = uniqueProjectName("smoke-task");
     const createdTaskTitle = uniqueProjectName("task");
     const editedTaskTitle = `${createdTaskTitle}-edited`;
-    const taskComment = `Comment ${uniqueProjectName("note")}`;
+    const taskCommentSuffix = `comment ${uniqueProjectName("note")}`;
     const epicName = uniqueProjectName("epic");
 
     await createProjectFromProjectsPage(page, projectName);
@@ -161,17 +161,47 @@ test.describe("critical UI smoke flows", () => {
     await expect(taskSavedToast).toBeVisible();
     await expect(taskSavedToast).not.toBeVisible({ timeout: 15000 });
 
+    const commentInput = page.getByLabel("Task comment");
+    await commentInput.click();
+    await page.keyboard.type(`@${mentionUsername.slice(0, 8)}`);
+    await expect(
+      page.getByRole("option", { name: new RegExp(mentionUsername) })
+    ).toBeVisible();
+    await page.getByRole("option", { name: new RegExp(mentionUsername) }).click();
+    await page.keyboard.type(taskCommentSuffix);
+
+    const expectedCommentText = `@${mentionUsername} ${taskCommentSuffix}`;
+    await expect(commentInput).toHaveValue(expectedCommentText);
+    await expect
+      .poll(() =>
+        commentInput.evaluate((element) => {
+          const textarea = element as HTMLTextAreaElement;
+          return textarea.selectionStart === textarea.value.length;
+        })
+      )
+      .toBe(true);
+
     const createCommentRequest = page.waitForResponse(
       (response) =>
         response.request().method() === "POST" &&
         /\/comments$/.test(response.url()) &&
         response.ok()
     );
-    await page.getByLabel("Task comment").fill(taskComment);
     await page.getByRole("button", { name: "Add comment" }).click();
     await createCommentRequest;
-    await expect(page.getByText(taskComment)).toBeVisible();
+    await expect(page.getByText(taskCommentSuffix)).toBeVisible();
+    await expect(page.getByText(`@${mentionUsername}`)).toBeVisible();
     await expect(page.getByText("1 comment")).toBeVisible();
+    await expect
+      .poll(async () =>
+        prisma.notification.count({
+          where: {
+            recipientUserId: mentionableUser.id,
+            sourceType: "task_comment_mention",
+          },
+        })
+      )
+      .toBe(1);
 
     await page.getByRole("button", { name: "Task options" }).click();
     await page.getByRole("button", { name: /^Edit$/ }).click();

--- a/tests/e2e/smoke-project-task-calendar.spec.ts
+++ b/tests/e2e/smoke-project-task-calendar.spec.ts
@@ -229,7 +229,7 @@ test.describe("critical UI smoke flows", () => {
 
     await editedTaskCard.click();
     await expect(page.getByRole("button", { name: "Close task" })).toBeVisible();
-    await expect(page.getByText(taskComment)).toBeVisible();
+    await expect(page.getByText(taskCommentSuffix)).toBeVisible();
     await page.getByRole("button", { name: "Close task" }).click();
   });
 

--- a/tests/e2e/smoke-project-task-calendar.spec.ts
+++ b/tests/e2e/smoke-project-task-calendar.spec.ts
@@ -189,8 +189,12 @@ test.describe("critical UI smoke flows", () => {
     );
     await page.getByRole("button", { name: "Add comment" }).click();
     await createCommentRequest;
-    await expect(page.getByText(taskCommentSuffix)).toBeVisible();
-    await expect(page.getByText(`@${mentionUsername}`)).toBeVisible();
+    const submittedComment = page
+      .locator("article")
+      .filter({ hasText: taskCommentSuffix })
+      .last();
+    await expect(submittedComment).toBeVisible();
+    await expect(submittedComment.getByText(`@${mentionUsername}`)).toBeVisible();
     await expect(page.getByText("1 comment")).toBeVisible();
     await expect
       .poll(async () =>


### PR DESCRIPTION
## Summary

Fixes #306.

- Adds a textarea-mirror-specific mention highlight class that keeps the visible task comment mention text metric-neutral.
- Uses that class only in the task comment composer overlay so read-only mention chips keep their existing styling.
- Stabilizes mention selection so the textarea value/caret are updated immediately, while the follow-up animation-frame selection guard will not jump the caret after the user has typed.
- Extends regression coverage for transparent mention mirrors and the task lifecycle Playwright smoke flow to select a comment mention, type after it, assert the caret reaches the true end, submit, and verify the mention notification row.
- Merged current `origin/main` after #305 landed and resolved the tracking-doc conflicts.

## Root Cause

The task comment composer layers a transparent textarea over a rendered mention mirror. The textarea owns the browser caret, but the mirror reused the standard mention chip styling with horizontal padding, `inline-block`, and medium font weight. That made the visible mention wider than the underlying textarea text, so text after the selected mention and the caret drifted apart.

## Validation

- `git diff --check`
- `npm run lint`
- `npm test -- tests/api/task-comments.route.test.ts tests/components/rich-text-content.test.ts tests/lib/mention.test.ts`
- `DATABASE_URL=postgresql://nexus:nexus@localhost:5432/nexusdash DIRECT_URL=postgresql://nexus:nexus@localhost:5433/nexusdash npm test`
- `DATABASE_URL=postgresql://nexus:nexus@localhost:5432/nexusdash DIRECT_URL=postgresql://nexus:nexus@localhost:5433/nexusdash npm run test:coverage`
- `DATABASE_URL=postgresql://nexus:nexus@localhost:5432/nexusdash DIRECT_URL=postgresql://nexus:nexus@localhost:5433/nexusdash GOOGLE_TOKEN_ENCRYPTION_KEY=<placeholder> AGENT_TOKEN_SIGNING_SECRET=<placeholder> npm run build`
- Post-conflict local validation on head `f5eb8d626a237cb1d29efa147ea30d74071c00ed`: `git diff --check`, `npm run lint`, and `DATABASE_URL=postgresql://nexus:nexus@localhost:5432/nexusdash DIRECT_URL=postgresql://nexus:nexus@localhost:5433/nexusdash npm test -- tests/api/task-comments.route.test.ts tests/api/task-update.route.test.ts tests/lib/notification-service.test.ts tests/components/rich-text-content.test.ts tests/lib/mention.test.ts tests/api/project-activity.route.test.ts tests/lib/project-activity-service.test.ts tests/components/project-live-refresh.test.tsx` passed.
- PR #307 checks green on head `f5eb8d626a237cb1d29efa147ea30d74071c00ed`: Check Branch Name, Quality Core, E2E Smoke, and Container Image.
- Copilot review handled: one stale-variable thread was fixed and resolved.

## Preview

- Post-conflict workflow run `26698036362` used `action=deploy-preview` and `git_ref=fix/task-306-mention-cursor-spacing`.
- Checkout log shows `refs/remotes/origin/fix/task-306-mention-cursor-spacing` at `f5eb8d626a237cb1d29efa147ea30d74071c00ed`.
- Preview URL: https://nexus-dash-9z0vztuqb-dorian-agaesses-projects.vercel.app
- Playwright request validation ran against that preview URL using `tmp/project-access-cred.env`: health endpoint, agent token exchange, temporary task creation, comment creation tagging `@dorianagaesse`, comment listing verification, and cleanup verification all passed.

Local E2E bootstrap is blocked because Docker Desktop is not available in this workspace, but CI E2E and preview Playwright validation are green.