### PR TITLE
TASK-307 Implement agent comment identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Implemented today:
   - Roadmap event-first milestone lanes with grouped child events, drag-and-drop regrouping, and target-date planning
   - Kanban board (`Backlog`, `In Progress`, `Blocked`, `Done`)
   - Calendar panel (Google Calendar list/create/update/delete)
+  - Task comments with agent-authored comment attribution through the project
+    credential label and a shared agent avatar
 - Per-user Google Calendar connection and calendar target setting (`/account/settings`)
 - Attachment storage abstraction:
   - `local` provider (filesystem)

--- a/components/kanban-board-types.ts
+++ b/components/kanban-board-types.ts
@@ -7,6 +7,8 @@ export interface TaskPersonSummary {
   avatarSeed: string;
 }
 
+export type TaskCommentAuthorKind = "user" | "agent";
+
 export type ProjectTaskCollaboratorRole = "owner" | "editor" | "viewer";
 
 export interface TaskBlockedFollowUp {
@@ -33,7 +35,12 @@ export interface ProjectEpicOption extends TaskEpicSummary {
   taskCount: number;
 }
 
-export type TaskCommentAuthor = TaskPersonSummary;
+export interface TaskCommentAuthor extends TaskPersonSummary {
+  kind?: TaskCommentAuthorKind;
+  agentCredentialId?: string | null;
+  agentCredentialLabel?: string | null;
+  owner?: TaskPersonSummary | null;
+}
 
 export interface TaskCommentReaction {
   emoji: string;

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -45,6 +45,7 @@ import { TaskDeadlineField } from "@/components/kanban/task-deadline-field";
 import { AttachmentPreviewModal } from "@/components/attachment-preview-modal";
 import { RichTextContent } from "@/components/rich-text-content";
 import { RichTextEditor } from "@/components/rich-text-editor";
+import { AgentAvatar } from "@/components/ui/agent-avatar";
 import { Badge } from "@/components/ui/badge";
 import { AssigneeSelect } from "@/components/ui/assignee-select";
 import { AttachmentLinkComposer } from "@/components/ui/attachment-link-composer";
@@ -1431,12 +1432,20 @@ function TaskReadOnlyContent({
                   className="rounded-xl border border-border/50 bg-background/80 px-3 py-2"
                 >
                   <div className="flex items-start gap-2.5">
-                    <UserAvatar
-                      avatarSeed={comment.author.avatarSeed}
-                      displayName={comment.author.displayName}
-                      className="mt-0.5 h-8 w-8 border-border/70"
-                      decorative
-                    />
+                    {isAgentCommentAuthor(comment.author) ? (
+                      <AgentAvatar
+                        displayName={comment.author.displayName}
+                        className="mt-0.5 h-8 w-8 border-border/70"
+                        decorative
+                      />
+                    ) : (
+                      <UserAvatar
+                        avatarSeed={comment.author.avatarSeed}
+                        displayName={comment.author.displayName}
+                        className="mt-0.5 h-8 w-8 border-border/70"
+                        decorative
+                      />
+                    )}
                     <div className="min-w-0 flex-1">
                       <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
                         <p className="text-sm font-medium">{comment.author.displayName}</p>
@@ -2089,9 +2098,22 @@ function formatTaskCommentTimestamp(createdAt: string): string {
 }
 
 function getCommentIdentityMeta(author: TaskComment["author"]): string | null {
+  if (isAgentCommentAuthor(author)) {
+    const owner = author.owner;
+    if (!owner) {
+      return null;
+    }
+
+    return `via ${owner.usernameTag ?? owner.displayName}`;
+  }
+
   if (!author.usernameTag || author.usernameTag === author.displayName) {
     return null;
   }
 
   return author.usernameTag;
+}
+
+function isAgentCommentAuthor(author: TaskComment["author"]): boolean {
+  return author.kind === "agent";
 }

--- a/components/ui/agent-avatar.tsx
+++ b/components/ui/agent-avatar.tsx
@@ -1,0 +1,30 @@
+import { Bot } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+interface AgentAvatarProps {
+  displayName: string;
+  className?: string;
+  decorative?: boolean;
+}
+
+export function AgentAvatar({
+  displayName,
+  className,
+  decorative = false,
+}: AgentAvatarProps) {
+  return (
+    <span
+      aria-hidden={decorative}
+      aria-label={decorative ? undefined : `${displayName} avatar`}
+      data-agent-avatar="true"
+      role={decorative ? undefined : "img"}
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full border border-border/60 bg-muted text-muted-foreground",
+        className
+      )}
+    >
+      <Bot aria-hidden="true" className="h-2/3 w-2/3" strokeWidth={2.2} />
+    </span>
+  );
+}

--- a/journal.md
+++ b/journal.md
@@ -11,6 +11,12 @@ Use it for important implementation milestones, blockers, validation runs, and r
 - Added a task brief covering current behavior, scope, acceptance criteria,
   definition of done, and implementation notes around preserving the existing
   owner-principal authorization model while adding comment author metadata.
+- Drafted `tasks/current.md` around TASK-307 after investigating the task
+  comment service, comments API route, Prisma `TaskComment` model, task detail
+  comment rendering, and existing agent-aware notification attribution. The
+  selected implementation approach is to keep `authorUserId` as the owner/RLS
+  actor while adding durable nullable agent credential id and label snapshot
+  metadata to comments.
 
 # 2026-05-31 - TASK-306 task comment mention cursor spacing
 

--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,15 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-05-31 - TASK-307 agent comment credential identity
+
+- Created TASK-307 to track dedicated agent credential presentation for task
+  comments: display the credential label with ` (agent)` and use one shared
+  robot-head-like avatar for all agent-authored comments.
+- Added a task brief covering current behavior, scope, acceptance criteria,
+  definition of done, and implementation notes around preserving the existing
+  owner-principal authorization model while adding comment author metadata.
+
 # 2026-05-31 - TASK-306 task comment mention cursor spacing
 
 - Started TASK-306 from GitHub issue #306 on

--- a/journal.md
+++ b/journal.md
@@ -31,6 +31,9 @@ Use it for important implementation milestones, blockers, validation runs, and r
   interaction because localhost PostgreSQL ports 5432/5433 were not reachable;
   `npx prisma migrate deploy` against the same env failed with a schema engine
   connection error.
+- PR #308 remote Quality Gates passed on
+  `102fb63e1b57bbf75f60dede28862d65053b7150`: Quality Core, Playwright E2E
+  Smoke, and Container Image.
 
 # 2026-05-31 - TASK-306 task comment mention cursor spacing
 

--- a/journal.md
+++ b/journal.md
@@ -17,6 +17,20 @@ Use it for important implementation milestones, blockers, validation runs, and r
   selected implementation approach is to keep `authorUserId` as the owner/RLS
   actor while adding durable nullable agent credential id and label snapshot
   metadata to comments.
+- Implemented TASK-307 locally by adding nullable `TaskComment` agent credential
+  metadata, storing a label snapshot on agent-created comments, returning
+  agent-aware comment authors through the comments API, rendering agent comments
+  with a shared local robot-head-like avatar, and updating the agent OpenAPI
+  schema/notes.
+- Focused validation passed: `npx prisma generate`, `npx prisma validate`,
+  task comment route tests, task detail comment rendering tests, agent
+  onboarding docs tests, and `npm run lint`.
+- Full local validation passed for `npm test`, `npm run test:coverage`, and
+  `npm run build` with documented local DB env plus placeholder build-only
+  secrets. Local `npm run test:e2e` rebuilt successfully but failed before app
+  interaction because localhost PostgreSQL ports 5432/5433 were not reachable;
+  `npx prisma migrate deploy` against the same env failed with a schema engine
+  connection error.
 
 # 2026-05-31 - TASK-306 task comment mention cursor spacing
 

--- a/lib/agent-onboarding.ts
+++ b/lib/agent-onboarding.ts
@@ -148,6 +148,9 @@ export const AGENT_API_ENDPOINTS: ReadonlyArray<AgentApiEndpointDefinition> = [
     title: "List task comments",
     description: "List the chronological comment thread for one task.",
     requiredScopes: ["task:read"],
+    notes: [
+      "Agent-authored comments include the credential label in author.displayName.",
+    ],
   },
   {
     tag: "Tasks",
@@ -157,7 +160,10 @@ export const AGENT_API_ENDPOINTS: ReadonlyArray<AgentApiEndpointDefinition> = [
     description: "Append a new plain-text comment to a task discussion thread.",
     requiredScopes: ["task:write"],
     requestContentType: "application/json",
-    notes: ["Task comments are append-only in v1 and preserve line breaks."],
+    notes: [
+      "Task comments are append-only in v1 and preserve line breaks.",
+      "Agent-authored comments are attributed to the credential label with an (agent) suffix.",
+    ],
   },
   {
     tag: "Tasks",
@@ -1317,6 +1323,24 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
             displayName: { type: "string" },
             usernameTag: { type: ["string", "null"] },
             avatarSeed: { type: "string" },
+            kind: { type: "string", enum: ["user", "agent"] },
+            agentCredentialId: { type: ["string", "null"] },
+            agentCredentialLabel: { type: ["string", "null"] },
+            owner: {
+              anyOf: [
+                {
+                  type: "object",
+                  required: ["id", "displayName", "usernameTag", "avatarSeed"],
+                  properties: {
+                    id: { type: "string" },
+                    displayName: { type: "string" },
+                    usernameTag: { type: ["string", "null"] },
+                    avatarSeed: { type: "string" },
+                  },
+                },
+                { type: "null" },
+              ],
+            },
           },
         },
         TaskCommentRecord: {

--- a/lib/services/project-task-comment-service.ts
+++ b/lib/services/project-task-comment-service.ts
@@ -18,6 +18,7 @@ import {
 } from "@/lib/task-person";
 
 const MAX_TASK_COMMENT_LENGTH = 4000;
+const AGENT_COMMENT_AVATAR_SEED = "nexusdash-agent-comment-avatar";
 
 interface ServiceErrorResult {
   ok: false;
@@ -32,7 +33,14 @@ interface ServiceSuccessResult<T> {
 
 type ServiceResult<T> = ServiceSuccessResult<T> | ServiceErrorResult;
 
-export type TaskCommentAuthorSummary = TaskPersonSummary;
+export type TaskCommentAuthorKind = "user" | "agent";
+
+export interface TaskCommentAuthorSummary extends TaskPersonSummary {
+  kind: TaskCommentAuthorKind;
+  agentCredentialId: string | null;
+  agentCredentialLabel: string | null;
+  owner: TaskPersonSummary | null;
+}
 
 export interface TaskCommentSummary {
   id: string;
@@ -111,6 +119,8 @@ function mapTaskComment(input: {
   id: string;
   content: string;
   createdAt: Date;
+  authorAgentCredentialId: string | null;
+  authorAgentCredentialLabel: string | null;
   author: {
     id: string;
     name: string | null;
@@ -120,11 +130,34 @@ function mapTaskComment(input: {
     avatarSeed: string | null;
   };
 }): TaskCommentSummary {
+  const owner = mapTaskPersonSummary(input.author)!;
+  const agentCredentialLabel = normalizeText(input.authorAgentCredentialLabel);
+  const isAgentComment = Boolean(
+    input.authorAgentCredentialId || agentCredentialLabel
+  );
+
   return {
     id: input.id,
     content: input.content,
     createdAt: input.createdAt,
-    author: mapTaskPersonSummary(input.author)!,
+    author: isAgentComment
+      ? {
+          id: input.authorAgentCredentialId ?? input.author.id,
+          kind: "agent",
+          displayName: buildAgentDisplayName(agentCredentialLabel),
+          usernameTag: null,
+          avatarSeed: AGENT_COMMENT_AVATAR_SEED,
+          agentCredentialId: input.authorAgentCredentialId,
+          agentCredentialLabel: agentCredentialLabel || null,
+          owner,
+        }
+      : {
+          ...owner,
+          kind: "user",
+          agentCredentialId: null,
+          agentCredentialLabel: null,
+          owner: null,
+        },
   };
 }
 
@@ -427,6 +460,8 @@ export async function listTaskCommentsForProject(input: {
           id: true,
           content: true,
           createdAt: true,
+          authorAgentCredentialId: true,
+          authorAgentCredentialLabel: true,
           author: {
             select: {
               id: true,
@@ -520,16 +555,33 @@ export async function createTaskCommentForProject(input: {
       }
 
       try {
+        let actorKind: NotificationActorKind = "user";
+        let actorCredentialId: string | null = null;
+        let actorCredentialLabel: string | null = null;
+
+        if (input.agentAccess) {
+          actorKind = "agent";
+          actorCredentialId = input.agentAccess.credentialId;
+          actorCredentialLabel = await resolveAgentCredentialLabel({
+            db,
+            agentAccess: input.agentAccess,
+          });
+        }
+
         const comment = await db.taskComment.create({
           data: {
             taskId: input.taskId,
             authorUserId: actorUserId,
+            authorAgentCredentialId: actorCredentialId,
+            authorAgentCredentialLabel: actorCredentialLabel,
             content,
           },
           select: {
             id: true,
             content: true,
             createdAt: true,
+            authorAgentCredentialId: true,
+            authorAgentCredentialLabel: true,
             author: {
               select: {
                 id: true,
@@ -551,18 +603,9 @@ export async function createTaskCommentForProject(input: {
           comment.author.email ||
           comment.author.username ||
           "Someone";
-        let actorKind: NotificationActorKind = "user";
         let actorDisplayName = authorDisplayName;
-        let actorCredentialId: string | null = null;
-        let actorCredentialLabel: string | null = null;
 
         if (input.agentAccess) {
-          actorKind = "agent";
-          actorCredentialId = input.agentAccess.credentialId;
-          actorCredentialLabel = await resolveAgentCredentialLabel({
-            db,
-            agentAccess: input.agentAccess,
-          });
           actorDisplayName = buildAgentDisplayName(actorCredentialLabel);
         }
 
@@ -615,7 +658,7 @@ export async function createTaskCommentForProject(input: {
 export interface TaskCommentReactionSummary {
   id: string;
   emoji: string;
-  user: TaskCommentAuthorSummary;
+  user: TaskPersonSummary;
   createdAt: Date;
 }
 

--- a/prisma/migrations/20260531110000_task307_agent_comment_identity/migration.sql
+++ b/prisma/migrations/20260531110000_task307_agent_comment_identity/migration.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "TaskComment"
+ADD COLUMN "authorAgentCredentialId" TEXT,
+ADD COLUMN "authorAgentCredentialLabel" VARCHAR(80);
+
+CREATE INDEX "TaskComment_authorAgentCredentialId_idx" ON "TaskComment"("authorAgentCredentialId");
+
+ALTER TABLE "TaskComment"
+ADD CONSTRAINT "TaskComment_authorAgentCredentialId_fkey"
+FOREIGN KEY ("authorAgentCredentialId") REFERENCES "ApiCredential"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -422,18 +422,22 @@ model Task {
 }
 
 model TaskComment {
-  id           String   @id @default(cuid())
-  taskId       String
-  authorUserId String
-  task         Task     @relation(fields: [taskId], references: [id], onDelete: Cascade)
-  author       User     @relation("TaskCommentAuthor", fields: [authorUserId], references: [id], onDelete: Cascade)
-  content      String
-  createdAt    DateTime @default(now())
+  id                         String         @id @default(cuid())
+  taskId                     String
+  authorUserId               String
+  authorAgentCredentialId    String?
+  authorAgentCredentialLabel String?        @db.VarChar(80)
+  task                       Task           @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  author                     User           @relation("TaskCommentAuthor", fields: [authorUserId], references: [id], onDelete: Cascade)
+  authorAgentCredential      ApiCredential? @relation("TaskCommentAgentAuthorCredential", fields: [authorAgentCredentialId], references: [id], onDelete: SetNull)
+  content                    String
+  createdAt                  DateTime       @default(now())
 
   reactions TaskCommentReaction[]
 
   @@index([taskId, createdAt])
   @@index([authorUserId])
+  @@index([authorAgentCredentialId])
 }
 
 model TaskCommentReaction {
@@ -598,6 +602,7 @@ model ApiCredential {
   revokedByUser User?                     @relation("ApiCredentialRevokedBy", fields: [revokedByUserId], references: [id], onDelete: SetNull)
   scopeGrants   ApiCredentialScopeGrant[]
   auditEvents   AuthAuditEvent[]
+  taskComments  TaskComment[]              @relation("TaskCommentAgentAuthorCredential")
 
   @@index([projectId])
   @@index([createdByUserId])

--- a/project.md
+++ b/project.md
@@ -1,6 +1,6 @@
 # NexusDash Project Blueprint (Current State)
 
-Last verified: 2026-05-26
+Last verified: 2026-05-31
 
 ## 1. Vision
 
@@ -31,6 +31,8 @@ NexusDash is a personal/team execution workspace that keeps project planning, de
   - project-scoped, append-only task discussion threads
   - chronological author-attributed comment history in the task detail modal
   - lazy-loaded thread reads with lightweight board-level comment counts
+  - agent-authored comments keep project credential attribution by displaying
+    the credential label with an `(agent)` suffix and a shared agent avatar
 - Project-scoped agent access:
   - owner-managed API credentials in project settings
   - one-time raw API key reveal with rotate/revoke lifecycle
@@ -73,7 +75,8 @@ Current schema includes:
 - Authorization boundaries: `Project.ownerId`, `ProjectMembership` (`owner|editor|viewer`)
 - Agent auth: `ApiCredential`, `ApiCredentialScopeGrant`, `AuthAuditEvent`
 - Domain: `Project`, `RoadmapPhase`, `RoadmapEvent`, `Epic`, `Task`, `Resource` (context cards), `TaskBlockedFollowUp`
-- Collaboration on tasks: `TaskComment`
+- Collaboration on tasks: `TaskComment` with optional agent credential
+  attribution metadata for agent-authored comments
 - Attachments: `TaskAttachment`, `ResourceAttachment` with `uploadedByUserId`
 - Calendar: `GoogleCalendarCredential` (one row per user)
 - Notification email orchestration: `ProjectNotificationEmail` and

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -2,7 +2,7 @@
 
 Use this file to capture tasks discovered during development. Each entry should include: ID, title, rationale, dependencies.
 
-Last reviewed: 2026-05-26
+Last reviewed: 2026-05-31
 
 ## Pending
 ### Execution Queue (Now / Next)
@@ -28,6 +28,12 @@ Last reviewed: 2026-05-26
   Rationale: Redesign the login and home page so they feel like a polished product surface rather than a technical auth form: improve visual hierarchy, copy, branding presence, and call-to-action clarity so new visitors understand the product value at a glance and returning users get a frictionless sign-in experience.
   Dependencies: TASK-045, TASK-059, TASK-083
 ### Deferred (Intentional)
+- ID: TASK-307
+  Title: Agent comment credential identity - label and shared avatar
+  Status: Pending
+  Rationale: Agent-authored comments currently render with the credential owner's identity because task comment rows store the owner user id. Make agent comments visibly attributable to the project agent credential by showing `<credential label> (agent)` and a shared robot-head-like avatar for all agents.
+  Dependencies: TASK-059, TASK-127, TASK-265, TASK-306
+  Brief: `tasks/task-307-agent-comment-credential-identity.md`
 - ID: TASK-224
   Title: Agent roadmap access - scoped API contract for roadmap phases and events
   Status: Pending

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -30,7 +30,7 @@ Last reviewed: 2026-05-31
 ### Deferred (Intentional)
 - ID: TASK-307
   Title: Agent comment credential identity - label and shared avatar
-  Status: Pending
+  Status: Implemented locally - PR/checks pending
   Rationale: Agent-authored comments currently render with the credential owner's identity because task comment rows store the owner user id. Make agent comments visibly attributable to the project agent credential by showing `<credential label> (agent)` and a shared robot-head-like avatar for all agents.
   Dependencies: TASK-059, TASK-127, TASK-265, TASK-306
   Brief: `tasks/task-307-agent-comment-credential-identity.md`

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -30,7 +30,7 @@ Last reviewed: 2026-05-31
 ### Deferred (Intentional)
 - ID: TASK-307
   Title: Agent comment credential identity - label and shared avatar
-  Status: Implemented locally - PR/checks pending
+  Status: Implemented - PR #308 open, remote Quality Gates passed
   Rationale: Agent-authored comments currently render with the credential owner's identity because task comment rows store the owner user id. Make agent comments visibly attributable to the project agent credential by showing `<credential label> (agent)` and a shared robot-head-like avatar for all agents.
   Dependencies: TASK-059, TASK-127, TASK-265, TASK-306
   Brief: `tasks/task-307-agent-comment-credential-identity.md`

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,148 +1,145 @@
-# Current Task: TASK-118 Real-Time Collaboration Updates
+# Current Task: TASK-307 Agent Comment Credential Identity
 
 ## Task ID
-TASK-118
+TASK-307
 
 ## Status
-Implemented - PR #305 open, review follow-up in progress
+Planning - ready for implementation
 
 ## Source
-- `tasks/backlog.md` execution queue, promoted on 2026-05-26 after TASK-274
-  and TASK-133.
-- User report: when two users work on the same project, task movement or task
-  content changes made by one user are invisible to the other user until a
-  manual page refresh.
+- User request on 2026-05-31 after PR #307 merge:
+  agent-authored task comments should show the agent credential label with
+  ` (agent)` and all agents should share the closest available visual to a
+  robot-head avatar.
+- Backlog entry: `tasks/backlog.md`
+- Task brief: `tasks/task-307-agent-comment-credential-identity.md`
 
 ## Objective
-Reduce stale-state and manual-refresh friction during shared project work by
-propagating project activity changes to other open project dashboards
-automatically, while preserving the current Prisma/PostgreSQL architecture,
-service-layer authorization, and Vercel deployment constraints.
+Make task comments authored through project-scoped agent credentials visibly
+attributed to the agent credential, not only to the credential owner, while
+preserving the existing security model where agent requests execute under the
+credential owner's project membership and RLS principal.
 
 ## Investigation Summary
-- Project dashboard data is server-loaded in `app/projects/[projectId]/page.tsx`
-  and section components, then handed to client components such as
-  `KanbanBoard`, `ProjectContextPanel`, `ProjectEpicPanel`, and
-  `ProjectRoadmapPanel`.
-- Client panels keep local state for responsive editing and optimistic updates.
-  They already resync from fresh props when their own tab calls
-  `router.refresh()`.
-- Mutation paths are request/response route handlers. The initiating browser
-  calls `router.refresh()` after successful writes, but other browsers have no
-  subscription, polling, or invalidation signal.
-- Existing ADRs reject a Convex migration for now and require near-term
-  realtime needs to be solved on the current PostgreSQL/Prisma stack first.
-- Vercel/serverless constraints make durable in-process WebSockets a poor fit,
-  and the repo does not currently depend on Supabase Realtime client env.
+- `TaskComment` currently stores `authorUserId` only. The comment author is
+  serialized from the related `User`, so an agent-created comment displays as
+  the credential owner after creation and after reload.
+- Agent assignment and task comment mention notifications already resolve and
+  persist agent-aware actor metadata: `actorKind`, `actorCredentialId`,
+  `actorCredentialLabel`, and display copy like `Build bot (agent)`.
+- `createTaskCommentForProject` already receives `agentAccess` and resolves
+  the credential label for mention notification copy. This is the right place
+  to also persist comment author presentation metadata.
+- `listTaskCommentsForProject` and the comments route return only the human
+  `author` summary today. The UI type `TaskCommentAuthor` is currently a plain
+  `TaskPersonSummary`.
+- The task detail modal renders comments with `UserAvatar` and
+  `comment.author.displayName`, plus an optional username tag. It has no concept
+  of a non-human comment author.
+- Existing generated avatars are seed-based abstract pixel avatars. The request
+  asks for the closest thing available now to a robot head, so the implementation
+  should add a small local shared agent avatar component or data URI rather than
+  relying on a remote asset.
 
 ## Selected Approach
-- Use `Project.updatedAt` as the durable project activity version.
-- Because project RLS only allows owners to update the `Project` row directly,
-  editor/content mutations advance this version through a narrow
-  `app.touch_project_activity(project_id, activity_at)` security-definer
-  function that explicitly validates owner/editor membership before updating
-  `Project.updatedAt`.
-- Touch the project row after successful project-scoped mutations that affect
-  the shared dashboard: tasks, task comments, task attachments, context cards,
-  context attachments, epics, and roadmap phases/events/reorders.
-- Add an authorized project activity endpoint that returns the current activity
-  version for collaborators who can read the project.
-- Add a project dashboard live-refresh client boundary that polls the activity
-  endpoint at a short interval, detects newer activity from other requests, and
-  calls `router.refresh()` when the user is idle.
-- If a local edit dialog/form/drag operation is active, defer the refresh and
-  show a lightweight "updates available" control so remote changes are not
-  allowed to stomp in-progress edits.
-- Keep notification-specific realtime work in TASK-263 aligned with this
-  transport decision instead of adding a parallel realtime stack.
+- Add durable agent-author metadata to task comments while keeping
+  `authorUserId` as the owner/RLS actor:
+  - nullable `authorAgentCredentialId`
+  - nullable `authorAgentCredentialLabel`
+  - relation to `ApiCredential` with `onDelete: SetNull`
+- Store a normalized credential label snapshot when an agent creates a comment.
+  The snapshot keeps historical comment attribution stable if the credential is
+  renamed later. If the credential is later deleted, old comments can still
+  display the stored label.
+- Extend the task comment service summary with an author kind:
+  - human comments map to the current `TaskPersonSummary`.
+  - agent comments map to a dedicated agent author summary using
+    `<label> (agent)` or `Agent` if the label is unavailable.
+- Extend the comments API response and client types in a backward-compatible
+  way so existing comments without agent metadata continue to render as human
+  comments.
+- Render agent-authored comments in the task detail modal with:
+  - display name: `<credential label> (agent)`
+  - meta text pointing to the credential owner's human identity when useful
+  - a shared local robot-head-like avatar for every agent-authored comment
+- Keep mention and assignment notification behavior aligned with the existing
+  TASK-265 actor attribution work. This task should not change notification
+  semantics unless tests expose an inconsistency.
 
 ## Scope
-- Project dashboard live updates for shared project entities:
-  - Kanban tasks: create, update, reorder, archive/unarchive, delete, comments,
-    and attachments.
-  - Context cards: create, update, delete, attachments, and direct upload
-    finalization/cleanup where it changes visible card state.
-  - Epics: create, update, delete, and task rollup refresh after task changes.
-  - Roadmap phases/events: create, update, reorder, move, and delete.
-- A small reusable polling/refresh client layer for project pages.
-- Service-level activity version helpers and focused tests for activity writes
-  and endpoint authorization.
-- Documentation of the transport decision in `adr/decisions.md` because it
-  constrains future notification realtime work.
+- Prisma schema and migration for task comment agent-author metadata.
+- Task comment create/list service mapping and tests.
+- Comments route serialization tests.
+- Client task comment author types.
+- Task detail comment thread rendering for agent vs human authors.
+- Shared local agent avatar visual used by all agent comments.
+- Focused docs updates for the agent API/comment response shape if the public
+  OpenAPI/onboarding schema changes.
 
 ## Out Of Scope
-- WebSocket infrastructure or a new paid realtime provider.
-- Full collaborative conflict resolution or CRDT-style concurrent editing.
-- Presence indicators, live cursors, or per-user active-edit awareness.
-- Google Calendar external event push; calendar panel can keep its existing
-  explicit refresh behavior.
-- Notification center live updates, which remain tracked by TASK-263.
-
-## Implementation Summary
-- Added `GET /api/projects/[projectId]/activity`, authorized through the
-  existing API principal and project access services, returning `{ projectId,
-  version, serverTime }` with `Cache-Control: no-store`.
-- Added `ProjectLiveRefresh` to the project dashboard. It polls the activity
-  endpoint every five seconds, calls `router.refresh()` when the activity
-  version advances, and defers refresh behind a fixed "Project updates are
-  ready" action while a dashboard panel reports local editing/submitting/drag
-  activity.
-- Added live-refresh locks to Kanban, context cards, epics, and roadmap panels
-  so remote refreshes do not interrupt open task/card/epic/roadmap editing,
-  delete confirmations, attachment submissions, or roadmap drag operations.
-- Wired activity touching through task, task comment/reaction, task attachment,
-  context card/attachment, epic, and roadmap mutation services.
-- Added focused coverage for activity touch behavior, activity route
-  serialization/authorization failure handling, live-refresh auto refresh, and
-  deferred refresh.
-
-## Validation Evidence
-- `npm run lint` passed.
-- `DATABASE_URL=postgresql://nexus:nexus@localhost:5432/nexusdash
-  DIRECT_URL=postgresql://nexus:nexus@localhost:5433/nexusdash npm test`
-  passed: 112 files passed, 2 skipped; 843 tests passed, 2 skipped.
-- Same DB env `npm run test:coverage` passed: 91.23% statements, 81.2%
-  branches, 93.42% functions, 91.75% lines.
-- Preview-style build env with distinct `DATABASE_URL`/`DIRECT_URL`,
-  `GOOGLE_TOKEN_ENCRYPTION_KEY`, and `AGENT_TOKEN_SIGNING_SECRET`
-  `npm run build` passed and listed the new
-  `/api/projects/[projectId]/activity` route.
-- `npx prisma validate` passed.
-- PR #305 Quality Gates passed remotely, including Quality Core, Playwright E2E
-  smoke, and container image build.
-- Manual deploy workflow `26689831199` successfully deployed the preview:
-  `https://nexus-dash-3dlunbbgu-dorian-agaesses-projects.vercel.app`.
-- Direct preview browser/API smoke from this shell is blocked by Vercel
-  protection because `VERCEL_AUTOMATION_BYPASS_SECRET` is not available locally;
-  `/api/health/live` and `/` both returned 401 without the bypass header.
-- `npm run db:local:up` is blocked in this workspace because Docker Desktop is
-  not available (`dockerDesktopLinuxEngine` pipe missing), so local Playwright
-  E2E could not be run here. CI Playwright passed, and protected-preview
-  two-session smoke remains the remaining manual validation item.
+- Separate `User` rows or full account records for agents.
+- Per-agent custom avatars.
+- Agent identity changes for task assignment fields, activity metadata, or
+  reactions unless required to keep comments internally consistent.
+- Any change to project membership, RLS, or agent scope enforcement.
+- Deploy preview validation unless the implementation PR or review explicitly
+  asks for browser verification beyond normal CI.
 
 ## Acceptance Criteria
-1. A collaborator viewing an open project dashboard automatically sees task,
-   context-card, epic, and roadmap changes made by another collaborator without
-   manually refreshing the browser.
-2. Live refresh is authorized by project membership and does not expose project
-   activity state to non-members.
-3. Local in-progress edits are protected: remote changes are deferred behind a
-   visible refresh affordance while the user is editing, dragging, or submitting
-   a local mutation.
-4. The implementation preserves optimistic local updates for the actor who made
-   the change.
-5. Tests cover activity version touching, activity endpoint authorization, and
-   live-refresh client behavior for auto-refresh and deferred-refresh cases.
-6. Local validation passes: `npm run lint`, `npm test`, `npm run test:coverage`,
-   `npm run build`, and an E2E or preview smoke for two-session dashboard
-   freshness, or any environment blocker is recorded.
+1. When a project-scoped agent credential creates a task comment, the returned
+   comment and subsequent list/reload response show the credential label
+   followed by ` (agent)`.
+2. All agent-authored comments use the same shared robot-head-like avatar.
+3. Human-authored comments continue to render the existing human display name,
+   username metadata, and generated avatar unchanged.
+4. Agent comment identity survives page refresh, API reload, credential rename,
+   and credential deletion where a label snapshot exists.
+5. Legacy comments without agent metadata remain readable and fall back to the
+   existing human author presentation.
+6. Agent mention notification copy remains consistent with the credential-label
+   attribution already introduced by TASK-265.
+7. Automated tests cover service persistence/mapping, route response shape, and
+   UI rendering for both human and agent comments.
 
 ## Definition Of Done
-- Implementation is committed on `feature/task-118-realtime-collaboration`.
-- `tasks/current.md`, `tasks/backlog.md`, `journal.md`, and
-  `adr/decisions.md` are updated with the selected transport and validation
-  evidence.
-- A ready-for-review PR is opened for TASK-118 and automated feedback is
-  handled.
-- Preview validation is run for the branch if the deploy workflow is available;
-  otherwise the blocker and the local/CI substitute evidence are recorded.
+- A migration and Prisma schema update are committed for task comment
+  agent-author metadata.
+- `createTaskCommentForProject` persists agent credential id/label snapshot
+  when `agentAccess` is present.
+- `listTaskCommentsForProject` returns stable agent author presentation data
+  for old and new comments.
+- The task detail comment thread renders agent comments with
+  `<credential label> (agent)` and the shared robot-head-like avatar.
+- Human comment behavior remains unchanged in tests.
+- Validation baseline passes: `npm run lint`, `npm test`,
+  `npm run test:coverage`, and `npm run build`.
+- PR is opened from a task branch, Copilot review feedback is handled, and the
+  final handoff includes the delivered commit SHA.
+
+## Implementation Plan
+1. Create a feature branch from current `origin/main` after the planning/docs
+   PR is merged or retarget this work onto a feature branch if instructed.
+2. Add the Prisma fields and migration for nullable agent credential metadata on
+   `TaskComment`.
+3. Update task comment service mapping to resolve an explicit comment-author
+   union and store label snapshots during agent comment creation.
+4. Update the comments route, API tests, and any OpenAPI/onboarding schema that
+   documents task comment author shape.
+5. Update client comment types and task detail rendering with a shared
+   robot-head-like agent avatar.
+6. Add or extend component tests for agent comment rendering and route/service
+   tests for persistence, reload, credential rename/delete fallback, and human
+   regression behavior.
+7. Run the full validation baseline and open the implementation PR.
+
+## Open Questions
+- None blocking.
+
+## Assumptions
+- The displayed agent label should be a historical snapshot from comment
+  creation time, not a live credential lookup that changes old comments when a
+  credential is renamed.
+- The robot-head-like avatar can be a local UI component or generated SVG/data
+  URI committed in code, with the same visual for every agent.
+- It is acceptable for the comment's underlying `authorUserId` to remain the
+  credential owner's user id for authorization, audit continuity, and RLS.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,7 +4,7 @@
 TASK-307
 
 ## Status
-Planning - ready for implementation
+Implemented locally - PR/checks pending
 
 ## Source
 - User request on 2026-05-31 after PR #307 merge:
@@ -76,6 +76,22 @@ credential owner's project membership and RLS principal.
 - Focused docs updates for the agent API/comment response shape if the public
   OpenAPI/onboarding schema changes.
 
+## Implementation Summary
+- Added nullable `TaskComment` agent-author metadata:
+  `authorAgentCredentialId` and `authorAgentCredentialLabel`.
+- Kept `authorUserId` as the credential owner's RLS/audit actor while storing a
+  credential label snapshot for agent-authored comments.
+- Updated task comment create/list mapping so agent comments return
+  `<credential label> (agent)`, a shared agent avatar seed, owner metadata, and
+  stable credential metadata after reload.
+- Added a local shared `AgentAvatar` component using the existing icon system,
+  and updated the task detail comment thread to use it for agent-authored
+  comments while keeping human comments on the existing generated avatar path.
+- Updated the agent OpenAPI/onboarding schema and route notes so clients can see
+  the optional agent author metadata on task comment responses.
+- Added route coverage for persisted agent identity and label-snapshot fallback,
+  plus component coverage for agent vs human comment rendering.
+
 ## Out Of Scope
 - Separate `User` rows or full account records for agents.
 - Per-agent custom avatars.
@@ -115,6 +131,27 @@ credential owner's project membership and RLS principal.
   `npm run test:coverage`, and `npm run build`.
 - PR is opened from a task branch, Copilot review feedback is handled, and the
   final handoff includes the delivered commit SHA.
+
+## Validation Evidence
+- `npx prisma generate` passed.
+- `npx prisma validate` passed.
+- `npx vitest run tests/api/task-comments.route.test.ts` passed.
+- `npx vitest run tests/components/task-detail-modal-comments.test.tsx` passed.
+- `npx vitest run tests/api/task-comments.route.test.ts tests/components/task-detail-modal-comments.test.tsx tests/components/agent-onboarding-guide.test.ts tests/app/agent-onboarding-pages.test.ts` passed.
+- `npm run lint` passed.
+- With local DB env (`DATABASE_URL=postgresql://nexus:nexus@localhost:5432/nexusdash`,
+  `DIRECT_URL=postgresql://nexus:nexus@localhost:5433/nexusdash`) `npm test`
+  passed: 113 files passed, 2 skipped; 847 tests passed, 2 skipped.
+- With the same DB env, `npm run test:coverage` passed: 91.43% statements,
+  81.54% branches, 93.42% functions, 91.95% lines.
+- With the same DB env plus placeholder production-only secrets,
+  `npm run build` passed.
+- `npm run test:e2e` rebuilt successfully, then failed before app interaction
+  because the local PostgreSQL ports required by the E2E Prisma helpers were not
+  reachable (`Test-NetConnection` failed for localhost ports 5432 and 5433);
+  `npx prisma migrate deploy` against the same local DB env also failed with a
+  schema engine connection error. Remote PR Quality Gates should provide the
+  Playwright smoke substitute unless a deploy-preview run is requested.
 
 ## Implementation Plan
 1. Create a feature branch from current `origin/main` after the planning/docs

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,7 +4,7 @@
 TASK-307
 
 ## Status
-Implemented locally - PR/checks pending
+Implemented - PR #308 open, remote Quality Gates passed
 
 ## Source
 - User request on 2026-05-31 after PR #307 merge:
@@ -152,6 +152,9 @@ credential owner's project membership and RLS principal.
   `npx prisma migrate deploy` against the same local DB env also failed with a
   schema engine connection error. Remote PR Quality Gates should provide the
   Playwright smoke substitute unless a deploy-preview run is requested.
+- PR #308 remote Quality Gates passed on commit
+  `102fb63e1b57bbf75f60dede28862d65053b7150`: Quality Core, Playwright E2E
+  Smoke, and Container Image.
 
 ## Implementation Plan
 1. Create a feature branch from current `origin/main` after the planning/docs

--- a/tasks/task-307-agent-comment-credential-identity.md
+++ b/tasks/task-307-agent-comment-credential-identity.md
@@ -1,0 +1,71 @@
+# TASK-307 Agent Comment Credential Identity
+
+## Status
+Pending
+
+## Source
+- User request on 2026-05-31 after PR #307 merge.
+
+## Objective
+Render agent-authored task comments with the project agent credential label plus
+` (agent)` and a shared robot-head-style avatar, so agent activity is visibly
+distinct from the credential owner while staying inside the current
+project-scoped agent access model.
+
+## Current Behavior
+- Agent bearer tokens resolve to the credential owner's user id for service and
+  RLS execution.
+- Task comments persist `authorUserId`, so agent-authored comments display as
+  the credential owner in comment threads.
+- Agent assignment and mention notifications already carry `actorKind`,
+  credential id, and credential label metadata for notification copy.
+
+## Scope
+- Task comment persistence and API response changes needed to identify
+  agent-authored comments after reload.
+- Comment thread UI display name logic: `<credential label> (agent)`.
+- Shared agent avatar visual, robot-head-like, used for all agent-authored
+  comments.
+- Backward-compatible behavior for existing comments and human comments.
+- Tests for agent comment create, list, and render behavior.
+
+## Out Of Scope
+- Full separate agent user accounts.
+- Per-agent custom avatars.
+- Changing human comment identity.
+- Agent identity for non-comment surfaces unless needed for consistency with
+  comment notifications.
+
+## Acceptance Criteria
+1. When an agent creates a task comment, the comment thread displays the
+   credential label followed by ` (agent)`.
+2. Agent comments render with the shared robot-head-like avatar; all agents use
+   the same avatar.
+3. Human comments continue to render the human author name and avatar unchanged.
+4. Agent comment identity survives page refresh and comment list API reloads.
+5. Older comments without agent credential metadata remain readable and fall
+   back safely.
+6. Mention and assignment notification copy remains consistent with
+   credential-label agent attribution.
+7. Tests cover API/service persistence and comment UI rendering for agent and
+   human comments.
+
+## Definition Of Done
+- The data model or comment metadata can distinguish agent-authored comments
+  without changing the authorization principal used for agent requests.
+- Task comment create/list routes return enough author presentation data for
+  the UI to render agent identity consistently.
+- The task detail comment thread renders the agent credential label with
+  ` (agent)` and the shared robot-head avatar.
+- Focused automated coverage passes for agent comment author presentation,
+  human comment regression behavior, and legacy comment fallback behavior.
+- Tracking docs and any relevant API/onboarding documentation are updated.
+
+## Implementation Notes
+- Investigate whether to store credential id plus label snapshot on
+  `TaskComment`, or a structured comment-author metadata field. A label snapshot
+  avoids historical comments changing if credentials are renamed.
+- Keep authorization and RLS actor behavior unchanged: agent requests should
+  still execute under the credential owner principal.
+- Prefer a local component or deterministic avatar seed for the shared
+  robot-head avatar; do not depend on remote image assets.

--- a/tasks/task-307-agent-comment-credential-identity.md
+++ b/tasks/task-307-agent-comment-credential-identity.md
@@ -1,7 +1,7 @@
 # TASK-307 Agent Comment Credential Identity
 
 ## Status
-Implemented locally - PR/checks pending
+Implemented - PR #308 open, remote Quality Gates passed
 
 ## Source
 - User request on 2026-05-31 after PR #307 merge.

--- a/tasks/task-307-agent-comment-credential-identity.md
+++ b/tasks/task-307-agent-comment-credential-identity.md
@@ -1,7 +1,7 @@
 # TASK-307 Agent Comment Credential Identity
 
 ## Status
-Pending
+Implemented locally - PR/checks pending
 
 ## Source
 - User request on 2026-05-31 after PR #307 merge.

--- a/tests/api/task-comments.route.test.ts
+++ b/tests/api/task-comments.route.test.ts
@@ -82,6 +82,8 @@ describe("task comments route", () => {
         id: "comment-1",
         content: "First update",
         createdAt: new Date("2026-04-19T09:00:00.000Z"),
+        authorAgentCredentialId: null,
+        authorAgentCredentialLabel: null,
         author: {
           id: "user-1",
           name: "Alice Example",
@@ -95,6 +97,8 @@ describe("task comments route", () => {
         id: "comment-2",
         content: "Second update",
         createdAt: new Date("2026-04-19T10:00:00.000Z"),
+        authorAgentCredentialId: null,
+        authorAgentCredentialLabel: null,
         author: {
           id: "user-2",
           name: null,
@@ -125,6 +129,10 @@ describe("task comments route", () => {
             displayName: "alice",
             usernameTag: "alice#1234",
             avatarSeed: "user-1",
+            kind: "user",
+            agentCredentialId: null,
+            agentCredentialLabel: null,
+            owner: null,
           },
         },
         {
@@ -136,6 +144,10 @@ describe("task comments route", () => {
             displayName: "bob",
             usernameTag: null,
             avatarSeed: "seed-222",
+            kind: "user",
+            agentCredentialId: null,
+            agentCredentialLabel: null,
+            owner: null,
           },
         },
       ],
@@ -149,6 +161,8 @@ describe("task comments route", () => {
         id: true,
         content: true,
         createdAt: true,
+        authorAgentCredentialId: true,
+        authorAgentCredentialLabel: true,
         author: {
           select: {
             id: true,
@@ -160,6 +174,63 @@ describe("task comments route", () => {
           },
         },
       },
+    });
+  });
+
+  test("GET returns persisted agent comment identity", async () => {
+    prismaMock.task.findUnique.mockResolvedValueOnce({
+      id: "task-1",
+      projectId: "project-1",
+    });
+    prismaMock.taskComment.findMany.mockResolvedValueOnce([
+      {
+        id: "comment-agent",
+        content: "Agent update",
+        createdAt: new Date("2026-04-19T09:30:00.000Z"),
+        authorAgentCredentialId: null,
+        authorAgentCredentialLabel: "Build bot",
+        author: {
+          id: "owner-1",
+          name: "Credential Owner",
+          email: "owner@example.com",
+          username: "owner",
+          usernameDiscriminator: "0001",
+          avatarSeed: null,
+        },
+      },
+    ]);
+
+    const response = await GET(
+      new Request(
+        "http://localhost/api/projects/project-1/tasks/task-1/comments"
+      ) as never,
+      { params: Promise.resolve({ projectId: "project-1", taskId: "task-1" }) }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(readJson(response)).resolves.toEqual({
+      comments: [
+        {
+          id: "comment-agent",
+          content: "Agent update",
+          createdAt: "2026-04-19T09:30:00.000Z",
+          author: {
+            id: "owner-1",
+            displayName: "Build bot (agent)",
+            usernameTag: null,
+            avatarSeed: "nexusdash-agent-comment-avatar",
+            kind: "agent",
+            agentCredentialId: null,
+            agentCredentialLabel: "Build bot",
+            owner: {
+              id: "owner-1",
+              displayName: "owner",
+              usernameTag: "owner#0001",
+              avatarSeed: "owner-1",
+            },
+          },
+        },
+      ],
     });
   });
 
@@ -211,6 +282,8 @@ describe("task comments route", () => {
       id: "comment-3",
       content: "Ready for review",
       createdAt: new Date("2026-04-19T11:00:00.000Z"),
+      authorAgentCredentialId: null,
+      authorAgentCredentialLabel: null,
       author: {
         id: "test-user",
         name: "Reviewer",
@@ -246,6 +319,10 @@ describe("task comments route", () => {
           displayName: "reviewer",
           usernameTag: "reviewer#0007",
           avatarSeed: "test-user",
+          kind: "user",
+          agentCredentialId: null,
+          agentCredentialLabel: null,
+          owner: null,
         },
       },
     });
@@ -253,12 +330,16 @@ describe("task comments route", () => {
       data: {
         taskId: "task-1",
         authorUserId: "test-user",
+        authorAgentCredentialId: null,
+        authorAgentCredentialLabel: null,
         content: "Ready for review",
       },
       select: {
         id: true,
         content: true,
         createdAt: true,
+        authorAgentCredentialId: true,
+        authorAgentCredentialLabel: true,
         author: {
           select: {
             id: true,
@@ -319,6 +400,8 @@ describe("task comments route", () => {
       id: "comment-mention",
       content: "Can you check this @owner#0001?",
       createdAt: new Date("2026-04-19T11:30:00.000Z"),
+      authorAgentCredentialId: null,
+      authorAgentCredentialLabel: null,
       author: {
         id: "test-user",
         name: "Reviewer",
@@ -410,6 +493,8 @@ describe("task comments route", () => {
       id: "comment-agent-mention",
       content: "I need @owner#0001 here.",
       createdAt: new Date("2026-04-19T12:15:00.000Z"),
+      authorAgentCredentialId: "credential-1",
+      authorAgentCredentialLabel: "Build bot",
       author: {
         id: "owner-1",
         name: "Owner",
@@ -435,6 +520,33 @@ describe("task comments route", () => {
     );
 
     expect(response.status).toBe(201);
+    await expect(readJson(response)).resolves.toMatchObject({
+      comment: {
+        author: {
+          id: "credential-1",
+          displayName: "Build bot (agent)",
+          usernameTag: null,
+          avatarSeed: "nexusdash-agent-comment-avatar",
+          kind: "agent",
+          agentCredentialId: "credential-1",
+          agentCredentialLabel: "Build bot",
+          owner: {
+            id: "owner-1",
+            displayName: "owner",
+            usernameTag: "owner#0001",
+            avatarSeed: "owner-1",
+          },
+        },
+      },
+    });
+    expect(prismaMock.taskComment.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          authorAgentCredentialId: "credential-1",
+          authorAgentCredentialLabel: "Build bot",
+        }),
+      })
+    );
     expect(prismaMock.notification.createMany).toHaveBeenCalledWith({
       data: [
         expect.objectContaining({
@@ -479,6 +591,8 @@ describe("task comments route", () => {
       id: "comment-self-mention",
       content: "Reminder for @reviewer#0007.",
       createdAt: new Date("2026-04-19T12:30:00.000Z"),
+      authorAgentCredentialId: null,
+      authorAgentCredentialLabel: null,
       author: {
         id: "test-user",
         name: "Reviewer",
@@ -540,6 +654,8 @@ describe("task comments route", () => {
       id: "comment-ambiguous",
       content: "Can @alice check this?",
       createdAt: new Date("2026-04-19T11:45:00.000Z"),
+      authorAgentCredentialId: null,
+      authorAgentCredentialLabel: null,
       author: {
         id: "test-user",
         name: "Reviewer",
@@ -601,6 +717,8 @@ describe("task comments route", () => {
       id: "comment-selected",
       content: "Can @alice check this?",
       createdAt: new Date("2026-04-19T12:00:00.000Z"),
+      authorAgentCredentialId: null,
+      authorAgentCredentialLabel: null,
       author: {
         id: "test-user",
         name: "Reviewer",

--- a/tests/components/task-detail-modal-comments.test.tsx
+++ b/tests/components/task-detail-modal-comments.test.tsx
@@ -1,0 +1,218 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("next/image", async () => {
+  const ReactModule = await import("react");
+
+  return {
+    default: (props: Record<string, unknown>) => {
+      const { unoptimized, ...imageProps } = props;
+      void unoptimized;
+
+      return ReactModule.createElement("img", imageProps);
+    },
+  };
+});
+
+import { TaskDetailModal } from "@/components/kanban/task-detail-modal";
+import type {
+  KanbanTask,
+  TaskComment,
+} from "@/components/kanban-board-types";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const ownerSummary = {
+  id: "owner-1",
+  displayName: "owner",
+  usernameTag: "owner#0001",
+  avatarSeed: "owner-1",
+};
+
+const baseTask: KanbanTask = {
+  id: "task-1",
+  title: "Comment identity",
+  description: null,
+  deadlineDate: null,
+  commentCount: 1,
+  labels: [],
+  blockedFollowUps: [],
+  status: "Backlog",
+  archivedAt: null,
+  attachments: [],
+  relatedTasks: [],
+  epic: null,
+  assignee: null,
+  createdBy: ownerSummary,
+  updatedBy: ownerSummary,
+  createdAt: "2026-05-31T09:00:00.000Z",
+  updatedAt: "2026-05-31T09:00:00.000Z",
+};
+
+function createTestRenderer() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  return {
+    container,
+    root,
+  };
+}
+
+async function renderWithRoot(root: Root, comments: TaskComment[]) {
+  await act(async () => {
+    root.render(
+      <TaskDetailModal
+        projectId="project-1"
+        canEdit={false}
+        isOpen
+        selectedTask={{ ...baseTask, commentCount: comments.length }}
+        isEditMode={false}
+        editTitle=""
+        editLabels={[]}
+        editLabelInput=""
+        editLabelSuggestions={[]}
+        editDescription=""
+        editDeadlineDate=""
+        editEpicId=""
+        editAssigneeUserId=""
+        editRelatedTasks={[]}
+        relatedTaskSearch=""
+        newBlockedFollowUpEntry=""
+        isUpdatingTask={false}
+        taskModalError={null}
+        attachmentError={null}
+        isSubmittingAttachment={false}
+        isArchivingTask={false}
+        isArchivedTask={false}
+        hasPendingAttachmentUploads={false}
+        pendingAttachmentUploads={[]}
+        isLinkComposerOpen={false}
+        linkUrl=""
+        fileInputKey={0}
+        previewAttachment={null}
+        taskComments={comments}
+        taskCommentsError={null}
+        isLoadingTaskComments={false}
+        newTaskComment=""
+        isSubmittingTaskComment={false}
+        onClose={vi.fn()}
+        onActivateEditMode={vi.fn()}
+        onToggleEditMode={vi.fn()}
+        onEditTitleChange={vi.fn()}
+        onEditLabelInputChange={vi.fn()}
+        onAddEditLabel={vi.fn()}
+        onRemoveEditLabel={vi.fn()}
+        onEditDescriptionChange={vi.fn()}
+        onEditDeadlineDateChange={vi.fn()}
+        onEditEpicIdChange={vi.fn()}
+        onEditAssigneeUserIdChange={vi.fn()}
+        onRelatedTaskSearchChange={vi.fn()}
+        onAddRelatedTask={vi.fn()}
+        onRemoveRelatedTask={vi.fn()}
+        availableEpicOptions={[]}
+        availableAssignees={[]}
+        mentionUsers={[]}
+        availableRelatedTaskOptions={[]}
+        onOpenRelatedTask={vi.fn()}
+        onNewBlockedFollowUpEntryChange={vi.fn()}
+        onAddBlockedFollowUpEntry={vi.fn()}
+        onSaveTask={vi.fn()}
+        onQuickEpicChange={vi.fn()}
+        onQuickAssigneeChange={vi.fn()}
+        onToggleLinkComposer={vi.fn()}
+        onLinkUrlChange={vi.fn()}
+        onAddLinkAttachment={vi.fn()}
+        onAddFileAttachment={vi.fn()}
+        onDeleteAttachment={vi.fn()}
+        onPreviewAttachmentChange={vi.fn()}
+        onNewTaskCommentChange={vi.fn()}
+        onSubmitTaskComment={vi.fn()}
+        onMoveTask={vi.fn()}
+        onArchiveTask={vi.fn()}
+        onUnarchiveTask={vi.fn()}
+        onRequestDeleteTask={vi.fn()}
+      />
+    );
+  });
+}
+
+describe("TaskDetailModal comments", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ reactions: [] }),
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.innerHTML = "";
+  });
+
+  test("renders agent-authored comments with credential identity and shared avatar", async () => {
+    const { root } = createTestRenderer();
+
+    await renderWithRoot(root, [
+      {
+        id: "comment-agent",
+        content: "Agent status update",
+        createdAt: "2026-05-31T09:30:00.000Z",
+        reactions: [],
+        author: {
+          id: "credential-1",
+          kind: "agent",
+          displayName: "Build bot (agent)",
+          usernameTag: null,
+          avatarSeed: "nexusdash-agent-comment-avatar",
+          agentCredentialId: "credential-1",
+          agentCredentialLabel: "Build bot",
+          owner: ownerSummary,
+        },
+      },
+    ]);
+
+    expect(document.body.textContent).toContain("Build bot (agent)");
+    expect(document.body.textContent).toContain("via owner#0001");
+    expect(document.body.querySelectorAll("[data-agent-avatar='true']")).toHaveLength(1);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  test("keeps human-authored comments on the generated user avatar path", async () => {
+    const { root } = createTestRenderer();
+
+    await renderWithRoot(root, [
+      {
+        id: "comment-human",
+        content: "Human status update",
+        createdAt: "2026-05-31T09:30:00.000Z",
+        reactions: [],
+        author: {
+          ...ownerSummary,
+          kind: "user",
+          agentCredentialId: null,
+          agentCredentialLabel: null,
+          owner: null,
+        },
+      },
+    ]);
+
+    expect(document.body.textContent).toContain("owner");
+    expect(document.body.querySelectorAll("[data-agent-avatar='true']")).toHaveLength(0);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add nullable task comment metadata for agent credential id and label snapshots while preserving the credential owner as the RLS/user actor.
- Return agent-aware task comment authors from create/list APIs, including `<credential label> (agent)`, owner metadata, and stable fallback behavior after credential deletion.
- Render agent-authored task comments with a shared local robot-head-like avatar and keep human comments on the existing generated avatar path.
- Update agent OpenAPI/onboarding docs plus task tracking docs.

## Validation
- `npx prisma generate`
- `npx prisma validate`
- `npx vitest run tests/api/task-comments.route.test.ts`
- `npx vitest run tests/components/task-detail-modal-comments.test.tsx`
- `npx vitest run tests/api/task-comments.route.test.ts tests/components/task-detail-modal-comments.test.tsx tests/components/agent-onboarding-guide.test.ts tests/app/agent-onboarding-pages.test.ts`
- `npm run lint`
- `DATABASE_URL=postgresql://nexus:nexus@localhost:5432/nexusdash DIRECT_URL=postgresql://nexus:nexus@localhost:5433/nexusdash npm test`
- Same DB env `npm run test:coverage`
- Same DB env plus placeholder build-only secrets `npm run build`
- Remote Quality Gates passed on `feature/task-307-agent-comment-identity`: Quality Core, Playwright E2E Smoke, and Container Image.

## E2E note
- Local `npm run test:e2e` rebuilt successfully, then failed before app interaction because local PostgreSQL ports 5432/5433 were not reachable in this workspace. `npx prisma migrate deploy` against the same local DB env failed with a schema engine connection error. The remote PR Playwright smoke passed.