### PR TITLE
docs: clean up backlog after TASK-307

### DIFF
--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,15 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-05-31 - Backlog cleanup after TASK-307 merge
+
+- Summary: Refreshed task tracking after the latest merged PRs so the backlog no
+  longer lists completed work as active or deferred.
+- Evidence: Moved TASK-307 to Completed after PR #309, updated TASK-306 as
+  merged via PR #307, moved TASK-118 to Completed after PR #305, reset
+  `tasks/current.md` to no active implementation task, and recorded TASK-307
+  post-merge preview smoke evidence in its task brief.
+
 # 2026-05-31 - TASK-307 agent comment credential identity
 
 - Created TASK-307 to track dedicated agent credential presentation for task
@@ -31,9 +40,9 @@ Use it for important implementation milestones, blockers, validation runs, and r
   interaction because localhost PostgreSQL ports 5432/5433 were not reachable;
   `npx prisma migrate deploy` against the same env failed with a schema engine
   connection error.
-- PR #308 remote Quality Gates passed on
-  `102fb63e1b57bbf75f60dede28862d65053b7150`: Quality Core, Playwright E2E
-  Smoke, and Container Image.
+- Superseded docs-branch PR #308 was closed after the implementation was moved
+  onto `feature/task-307-agent-comment-identity`; PR #309 merged the feature on
+  2026-05-31 after Quality Gates and Copilot review completed.
 
 # 2026-05-31 - TASK-306 task comment mention cursor spacing
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -17,23 +17,12 @@ Last reviewed: 2026-05-31
   Rationale: Before another broad polish pass, assess the current app experience across core user journeys, responsive layouts, visual hierarchy, copy, interaction feedback, accessibility basics, and consistency with the intended product tone. The output should be a ranked, evidence-backed design assessment that decides which issues belong in existing UI tasks such as TASK-108/TASK-100/TASK-129 and which need new implementation tasks, instead of mixing assessment and redesign in one large patch.
   Dependencies: TASK-091, TASK-096, TASK-100, TASK-108, TASK-129
   Brief: `tasks/task-270-app-ui-ux-design-assessment.md`
-- ID: TASK-118
-  Title: Real-time collaboration updates - live project refresh for multi-user work
-  Status: Implemented locally - PR/preview validation pending
-  Rationale: Reduce stale state and manual-refresh friction during shared project work by propagating task, context-card, and related project mutations live across active collaborators, with explicit decisions around subscriptions, optimistic UI, and conflict handling. This should choose the app-wide realtime transport/pattern that notification-specific live updates can reuse.
-  Dependencies: TASK-058, TASK-076, TASK-103
 - ID: TASK-129
   Title: Login/home page UI polish - user-friendly, product-oriented entry experience
   Status: Promoted 2026-05-26
   Rationale: Redesign the login and home page so they feel like a polished product surface rather than a technical auth form: improve visual hierarchy, copy, branding presence, and call-to-action clarity so new visitors understand the product value at a glance and returning users get a frictionless sign-in experience.
   Dependencies: TASK-045, TASK-059, TASK-083
 ### Deferred (Intentional)
-- ID: TASK-307
-  Title: Agent comment credential identity - label and shared avatar
-  Status: Implemented - PR #308 open, remote Quality Gates passed
-  Rationale: Agent-authored comments currently render with the credential owner's identity because task comment rows store the owner user id. Make agent comments visibly attributable to the project agent credential by showing `<credential label> (agent)` and a shared robot-head-like avatar for all agents.
-  Dependencies: TASK-059, TASK-127, TASK-265, TASK-306
-  Brief: `tasks/task-307-agent-comment-credential-identity.md`
 - ID: TASK-224
   Title: Agent roadmap access - scoped API contract for roadmap phases and events
   Status: Pending
@@ -134,15 +123,26 @@ Last reviewed: 2026-05-31
   Dependencies: TASK-051
 
 ## Completed
+- ID: TASK-307
+  Title: Agent comment credential identity - label and shared avatar
+  Status: Done (2026-05-31, merged via PR #309)
+  Rationale: Agent-authored task comments now persist project agent credential metadata and render with `<credential label> (agent)` plus a shared robot-head-like avatar, while preserving the credential owner as the authorization principal. Post-merge preview smoke created three agent-authored comments, assigned two tasks to the validation user, mentioned that user in comments, and verified the deployed API reloads the agent author identity.
+  Dependencies: TASK-059, TASK-127, TASK-265, TASK-306
+  Brief: `tasks/task-307-agent-comment-credential-identity.md`
 - ID: TASK-306
   Title: Task comment mention cursor spacing after mention autocomplete
-  Status: Done (pending merge via PR #307)
+  Status: Done (2026-05-31, merged via PR #307)
   Rationale: Fixed the task comment composer mirror/caret mismatch after
     mention autocomplete by using metric-neutral mirror styling, stabilizing
     selection after mention insertion, and adding regression coverage for
     typing immediately after a selected mention plus mention notification
     creation.
   Dependencies: TASK-076, TASK-123
+- ID: TASK-118
+  Title: Real-time collaboration updates - live project refresh for multi-user work
+  Status: Done (2026-05-31, merged via PR #305)
+  Rationale: Added live project refresh for multi-user work so task, context-card, roadmap, and related dashboard mutations can be observed across active collaborators without manual page refreshes. Remote Quality Gates and branch preview deployment passed before merge.
+  Dependencies: TASK-058, TASK-076, TASK-103
 - ID: TASK-274
   Title: Next.js dependency security update - restore green production audit
   Status: Done (2026-05-30, merged via PR #304)

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,185 +1,22 @@
-# Current Task: TASK-307 Agent Comment Credential Identity
-
-## Task ID
-TASK-307
+# Current Task: None
 
 ## Status
-Implemented - PR #308 open, remote Quality Gates passed
+Idle after TASK-307 completion.
 
-## Source
-- User request on 2026-05-31 after PR #307 merge:
-  agent-authored task comments should show the agent credential label with
-  ` (agent)` and all agents should share the closest available visual to a
-  robot-head avatar.
-- Backlog entry: `tasks/backlog.md`
-- Task brief: `tasks/task-307-agent-comment-credential-identity.md`
+## Last Reviewed
+2026-05-31
 
-## Objective
-Make task comments authored through project-scoped agent credentials visibly
-attributed to the agent credential, not only to the credential owner, while
-preserving the existing security model where agent requests execute under the
-credential owner's project membership and RLS principal.
+## Queue Snapshot
+- Recently completed and now reflected in `tasks/backlog.md`:
+  - TASK-307 merged via PR #309.
+  - TASK-306 merged via PR #307.
+  - TASK-118 merged via PR #305.
+- Next executable queue entries:
+  - TASK-133
+  - TASK-270
+  - TASK-129
 
-## Investigation Summary
-- `TaskComment` currently stores `authorUserId` only. The comment author is
-  serialized from the related `User`, so an agent-created comment displays as
-  the credential owner after creation and after reload.
-- Agent assignment and task comment mention notifications already resolve and
-  persist agent-aware actor metadata: `actorKind`, `actorCredentialId`,
-  `actorCredentialLabel`, and display copy like `Build bot (agent)`.
-- `createTaskCommentForProject` already receives `agentAccess` and resolves
-  the credential label for mention notification copy. This is the right place
-  to also persist comment author presentation metadata.
-- `listTaskCommentsForProject` and the comments route return only the human
-  `author` summary today. The UI type `TaskCommentAuthor` is currently a plain
-  `TaskPersonSummary`.
-- The task detail modal renders comments with `UserAvatar` and
-  `comment.author.displayName`, plus an optional username tag. It has no concept
-  of a non-human comment author.
-- Existing generated avatars are seed-based abstract pixel avatars. The request
-  asks for the closest thing available now to a robot head, so the implementation
-  should add a small local shared agent avatar component or data URI rather than
-  relying on a remote asset.
-
-## Selected Approach
-- Add durable agent-author metadata to task comments while keeping
-  `authorUserId` as the owner/RLS actor:
-  - nullable `authorAgentCredentialId`
-  - nullable `authorAgentCredentialLabel`
-  - relation to `ApiCredential` with `onDelete: SetNull`
-- Store a normalized credential label snapshot when an agent creates a comment.
-  The snapshot keeps historical comment attribution stable if the credential is
-  renamed later. If the credential is later deleted, old comments can still
-  display the stored label.
-- Extend the task comment service summary with an author kind:
-  - human comments map to the current `TaskPersonSummary`.
-  - agent comments map to a dedicated agent author summary using
-    `<label> (agent)` or `Agent` if the label is unavailable.
-- Extend the comments API response and client types in a backward-compatible
-  way so existing comments without agent metadata continue to render as human
-  comments.
-- Render agent-authored comments in the task detail modal with:
-  - display name: `<credential label> (agent)`
-  - meta text pointing to the credential owner's human identity when useful
-  - a shared local robot-head-like avatar for every agent-authored comment
-- Keep mention and assignment notification behavior aligned with the existing
-  TASK-265 actor attribution work. This task should not change notification
-  semantics unless tests expose an inconsistency.
-
-## Scope
-- Prisma schema and migration for task comment agent-author metadata.
-- Task comment create/list service mapping and tests.
-- Comments route serialization tests.
-- Client task comment author types.
-- Task detail comment thread rendering for agent vs human authors.
-- Shared local agent avatar visual used by all agent comments.
-- Focused docs updates for the agent API/comment response shape if the public
-  OpenAPI/onboarding schema changes.
-
-## Implementation Summary
-- Added nullable `TaskComment` agent-author metadata:
-  `authorAgentCredentialId` and `authorAgentCredentialLabel`.
-- Kept `authorUserId` as the credential owner's RLS/audit actor while storing a
-  credential label snapshot for agent-authored comments.
-- Updated task comment create/list mapping so agent comments return
-  `<credential label> (agent)`, a shared agent avatar seed, owner metadata, and
-  stable credential metadata after reload.
-- Added a local shared `AgentAvatar` component using the existing icon system,
-  and updated the task detail comment thread to use it for agent-authored
-  comments while keeping human comments on the existing generated avatar path.
-- Updated the agent OpenAPI/onboarding schema and route notes so clients can see
-  the optional agent author metadata on task comment responses.
-- Added route coverage for persisted agent identity and label-snapshot fallback,
-  plus component coverage for agent vs human comment rendering.
-
-## Out Of Scope
-- Separate `User` rows or full account records for agents.
-- Per-agent custom avatars.
-- Agent identity changes for task assignment fields, activity metadata, or
-  reactions unless required to keep comments internally consistent.
-- Any change to project membership, RLS, or agent scope enforcement.
-- Deploy preview validation unless the implementation PR or review explicitly
-  asks for browser verification beyond normal CI.
-
-## Acceptance Criteria
-1. When a project-scoped agent credential creates a task comment, the returned
-   comment and subsequent list/reload response show the credential label
-   followed by ` (agent)`.
-2. All agent-authored comments use the same shared robot-head-like avatar.
-3. Human-authored comments continue to render the existing human display name,
-   username metadata, and generated avatar unchanged.
-4. Agent comment identity survives page refresh, API reload, credential rename,
-   and credential deletion where a label snapshot exists.
-5. Legacy comments without agent metadata remain readable and fall back to the
-   existing human author presentation.
-6. Agent mention notification copy remains consistent with the credential-label
-   attribution already introduced by TASK-265.
-7. Automated tests cover service persistence/mapping, route response shape, and
-   UI rendering for both human and agent comments.
-
-## Definition Of Done
-- A migration and Prisma schema update are committed for task comment
-  agent-author metadata.
-- `createTaskCommentForProject` persists agent credential id/label snapshot
-  when `agentAccess` is present.
-- `listTaskCommentsForProject` returns stable agent author presentation data
-  for old and new comments.
-- The task detail comment thread renders agent comments with
-  `<credential label> (agent)` and the shared robot-head-like avatar.
-- Human comment behavior remains unchanged in tests.
-- Validation baseline passes: `npm run lint`, `npm test`,
-  `npm run test:coverage`, and `npm run build`.
-- PR is opened from a task branch, Copilot review feedback is handled, and the
-  final handoff includes the delivered commit SHA.
-
-## Validation Evidence
-- `npx prisma generate` passed.
-- `npx prisma validate` passed.
-- `npx vitest run tests/api/task-comments.route.test.ts` passed.
-- `npx vitest run tests/components/task-detail-modal-comments.test.tsx` passed.
-- `npx vitest run tests/api/task-comments.route.test.ts tests/components/task-detail-modal-comments.test.tsx tests/components/agent-onboarding-guide.test.ts tests/app/agent-onboarding-pages.test.ts` passed.
-- `npm run lint` passed.
-- With local DB env (`DATABASE_URL=postgresql://nexus:nexus@localhost:5432/nexusdash`,
-  `DIRECT_URL=postgresql://nexus:nexus@localhost:5433/nexusdash`) `npm test`
-  passed: 113 files passed, 2 skipped; 847 tests passed, 2 skipped.
-- With the same DB env, `npm run test:coverage` passed: 91.43% statements,
-  81.54% branches, 93.42% functions, 91.95% lines.
-- With the same DB env plus placeholder production-only secrets,
-  `npm run build` passed.
-- `npm run test:e2e` rebuilt successfully, then failed before app interaction
-  because the local PostgreSQL ports required by the E2E Prisma helpers were not
-  reachable (`Test-NetConnection` failed for localhost ports 5432 and 5433);
-  `npx prisma migrate deploy` against the same local DB env also failed with a
-  schema engine connection error. Remote PR Quality Gates should provide the
-  Playwright smoke substitute unless a deploy-preview run is requested.
-- PR #308 remote Quality Gates passed on commit
-  `102fb63e1b57bbf75f60dede28862d65053b7150`: Quality Core, Playwright E2E
-  Smoke, and Container Image.
-
-## Implementation Plan
-1. Create a feature branch from current `origin/main` after the planning/docs
-   PR is merged or retarget this work onto a feature branch if instructed.
-2. Add the Prisma fields and migration for nullable agent credential metadata on
-   `TaskComment`.
-3. Update task comment service mapping to resolve an explicit comment-author
-   union and store label snapshots during agent comment creation.
-4. Update the comments route, API tests, and any OpenAPI/onboarding schema that
-   documents task comment author shape.
-5. Update client comment types and task detail rendering with a shared
-   robot-head-like agent avatar.
-6. Add or extend component tests for agent comment rendering and route/service
-   tests for persistence, reload, credential rename/delete fallback, and human
-   regression behavior.
-7. Run the full validation baseline and open the implementation PR.
-
-## Open Questions
-- None blocking.
-
-## Assumptions
-- The displayed agent label should be a historical snapshot from comment
-  creation time, not a live credential lookup that changes old comments when a
-  credential is renamed.
-- The robot-head-like avatar can be a local UI component or generated SVG/data
-  URI committed in code, with the same visual for every agent.
-- It is acceptable for the comment's underlying `authorUserId` to remain the
-  credential owner's user id for authorization, audit continuity, and RLS.
+## Notes
+- Backlog order is workflow-first, not numeric: execution queue first,
+  intentionally deferred work next, and completed work newest-first.
+- No implementation task is currently active in this checkout.

--- a/tasks/task-307-agent-comment-credential-identity.md
+++ b/tasks/task-307-agent-comment-credential-identity.md
@@ -1,10 +1,12 @@
 # TASK-307 Agent Comment Credential Identity
 
 ## Status
-Implemented - PR #308 open, remote Quality Gates passed
+Done - merged via PR #309 on 2026-05-31
 
 ## Source
 - User request on 2026-05-31 after PR #307 merge.
+- Implementation merged through PR #309 after the superseded docs-branch PR #308
+  was closed.
 
 ## Objective
 Render agent-authored task comments with the project agent credential label plus
@@ -60,6 +62,14 @@ project-scoped agent access model.
 - Focused automated coverage passes for agent comment author presentation,
   human comment regression behavior, and legacy comment fallback behavior.
 - Tracking docs and any relevant API/onboarding documentation are updated.
+
+## Validation Evidence
+- PR #309 merged commit `c8c5c47f6ff0c56bff4b44255a6fc2d70cd2c431`
+  after remote Quality Gates passed on the implementation branch.
+- Post-merge preview smoke against the test project created three tasks, assigned
+  two to `dorianagaesse`, mentioned `@dorianagaesse#1987` in three
+  agent-authored comments, and verified comment reloads return
+  `codex_smoke (agent)` with `author.kind: agent`.
 
 ## Implementation Notes
 - Investigate whether to store credential id plus label snapshot on


### PR DESCRIPTION
## Summary
- Move TASK-307, TASK-306, and TASK-118 into Completed with their merged PR references.
- Reset `tasks/current.md` to an idle/no-active-task state and preserve the next execution queue snapshot.
- Record TASK-307 merge and preview-smoke evidence in the task brief and journal.

## Validation
- `git diff --check`