### PR TITLE
docs: complete task 275 performance investigation

### DIFF
--- a/docs/reports/task-275-performance-investigation.md
+++ b/docs/reports/task-275-performance-investigation.md
@@ -12,10 +12,11 @@ user sees the final state.
 
 Local service timing against Docker Postgres showed task/comment/context
 mutations in the 15-30 ms range, with full-board reorder at 113.9 ms for a
-41-task board. That does not model Vercel network, RSC render, browser work, or
-remote database latency, but it strongly suggests the several-second perceived
-delay is mostly caused by server-confirmed UI, oversized refresh boundaries, and
-route refresh churn rather than a single slow CRUD query.
+41-task board. Local Playwright browser timing against `next start` showed the
+same split from the user's perspective: task create took 4.7 seconds from submit
+to card visible even though direct service creation took 22.1 ms. That strongly
+points to server-confirmed UI, oversized refresh boundaries, and route refresh
+churn rather than a single slow CRUD query.
 
 Preview API timing could not be completed with the current
 `tmp/project-access-cred.env` credential because `/api/auth/agent/token`
@@ -45,6 +46,29 @@ Environment: local Docker Postgres, migrations applied with
 
 Raw sample was written to `.tmp/task-275-service-benchmark.json` during the
 investigation; `.tmp` is intentionally not committed.
+
+### Local Browser Probe
+
+Environment: Playwright Chromium against local `next start` and Docker Postgres
+after `npm run build`. This measures click/submit to visible UI completion.
+
+| Flow | Local browser timing |
+| --- | ---: |
+| `project.create.submit_to_visible` | 519.9 ms |
+| `dashboard.open.project_to_kanban_visible` | 414.7 ms |
+| `task.create.submit_to_card_visible` | 4696.2 ms |
+| `task.comment.submit_to_visible` | 226.8 ms |
+| `context.create.submit_to_card_visible` | 376.0 ms |
+
+Raw sample was written to `.tmp/task-275-browser-benchmark.json` during the
+investigation; `.tmp` is intentionally not committed.
+
+The standout is task creation: the browser waits almost 4.7 seconds to see the
+new card even though the local create-task service path measured 22.1 ms. The
+task create client closes the modal, posts the form, receives only `taskId`, and
+then depends on `router.refresh()` to fetch/render the card. This is direct
+measured evidence that perceived latency is dominated by refresh/render
+orchestration for at least one high-traffic flow.
 
 ### Client Mutation Paths
 
@@ -91,23 +115,21 @@ investigation; `.tmp` is intentionally not committed.
    but the current transport invalidates by full dashboard refresh rather than
    applying scoped patches.
 
-## Recommendations For TASK-276
+## Ranked Recommendations For TASK-276
 
-1. Make high-traffic mutations locally responsive first:
-   task create, task update, task assignment/epic update, comments, context card
-   create/update/delete, and project list create/update.
-2. Replace mutation-completion `router.refresh()` calls with local cache updates
-   plus debounced background reconciliation. Keep refresh as a fallback, not the
-   primary success path.
-3. Return complete mutation payloads where needed. Task create should return a
-   board-ready task payload, not only `taskId`.
-4. Change reorder persistence to send only the moved task and affected ordering
-   window, or at least update only rows whose status/position changed.
-5. Move stale done-task archival out of the kanban read path into a scheduled or
-   explicit maintenance path.
-6. Add lightweight observability before and after remediation: client
-   performance marks for click-to-visible-update and server timing for the
-   mutation and refresh endpoints.
+| Rank | Recommendation | Class | Impact | Complexity | Risk | Production durability | Evidence |
+| ---: | --- | --- | --- | --- | --- | --- | --- |
+| 1 | Make task creation insert a board-ready local card immediately, with pending/error reconciliation. Return a full task payload from `POST /tasks` instead of only `taskId`. | Quick win with durable API shape | Very high | Medium | Medium | High | Browser task create was 4696.2 ms while service create was 22.1 ms. |
+| 2 | Replace mutation-completion `router.refresh()` calls in task update, quick assignment/epic update, comments, and context-card mutations with local state updates plus debounced background reconciliation. | Architectural cleanup, can ship flow-by-flow | Very high | Medium-high | Medium | High | Code paths call `router.refresh()` after narrow mutations; comments/context are already able to render returned payloads locally. |
+| 3 | Add click-to-visible client performance marks and server timing for mutation endpoints and route refreshes. | Quick win | High | Low | Low | High | Current evidence required temporary probes; TASK-276 needs preview before/after numbers and regression visibility. |
+| 4 | Reduce kanban reorder payload/persistence to changed rows or the affected ordering window. | Architectural cleanup | Medium-high | Medium | Medium | High | Full-board reorder updated 41 rows locally and took 113.9 ms; cost grows linearly with board size and remote latency. |
+| 5 | Bound dashboard refresh work by splitting or caching server-rendered data so a task/comment/context mutation does not reload unrelated sections. | Architectural cleanup | Medium-high | High | Medium-high | High | Current route refresh can re-run summary counts, context, epics, kanban metadata, roadmap/calendar sections, and live refresh. |
+| 6 | Move stale done-task archival out of `listProjectKanbanTasks()` and into scheduled or explicit maintenance. | Durability cleanup | Medium | Medium | Low-medium | High | Read paths currently perform maintenance writes before returning kanban data. |
+
+Recommended implementation order: ship ranks 1-3 first because they directly
+target the observed several-second task-create UX and create measurement
+guardrails. Then handle reorder and dashboard refresh architecture with the new
+instrumentation in place.
 
 ## Validation Targets
 

--- a/docs/reports/task-275-performance-investigation.md
+++ b/docs/reports/task-275-performance-investigation.md
@@ -12,17 +12,23 @@ user sees the final state.
 
 Local service timing against Docker Postgres showed task/comment/context
 mutations in the 15-30 ms range, with full-board reorder at 113.9 ms for a
-41-task board. Local Playwright browser timing against `next start` showed the
-same split from the user's perspective: task create took 4.7 seconds from submit
-to card visible even though direct service creation took 22.1 ms. That strongly
-points to server-confirmed UI, oversized refresh boundaries, and route refresh
-churn rather than a single slow CRUD query.
+41-task board. Protected preview API timing through `vercel curl` showed the
+same backend flows taking roughly 1.0-2.4 seconds once deployed. Local
+Playwright browser timing against `next start` showed task create taking 4.7
+seconds from submit to card visible even though direct service creation took
+22.1 ms.
 
-Preview API timing could not be completed with the current
-`tmp/project-access-cred.env` credential because `/api/auth/agent/token`
-returned `401 {"error":"invalid-api-key"}`. This report therefore treats local
-service timings as backend separation evidence and code-path review as the
-primary UX evidence.
+The performance problem is therefore layered:
+
+- local service logic is not inherently multi-second;
+- deployed preview API calls are already seconds-level;
+- browser UX adds more delay by waiting on server confirmation and broad route
+  refreshes before the user sees state changes.
+
+Direct unauthenticated `curl`/`fetch` calls to the preview initially returned
+`401 Authentication Required` from Vercel deployment protection, before the app
+route was reached. The credential itself exchanged successfully when the same
+request was made through Vercel-authenticated access.
 
 ## Evidence
 
@@ -70,6 +76,39 @@ then depends on `router.refresh()` to fetch/render the card. This is direct
 measured evidence that perceived latency is dominated by refresh/render
 orchestration for at least one high-traffic flow.
 
+### Protected Preview API Probe
+
+Environment: branch/main preview protected by Vercel authentication. Direct
+HTTP calls returned Vercel's `Authentication Required` page, so the probe used
+`vercel curl` and curl `time_total` to measure the protected preview request
+after Vercel-authenticated access. The probe exchanged the new agent credential,
+then exercised project read, activity read, task list/create/comment/update,
+context list/create/update, and full-board reorder.
+
+Warm repeat sample:
+
+| Flow | Preview API timing | Status |
+| --- | ---: | ---: |
+| `agent.token.exchange` | 1021.0 ms | 200 |
+| `project.get` | 1535.1 ms | 200 |
+| `activity.get` | 1079.5 ms | 200 |
+| `tasks.list.before` | 1898.1 ms | 200 |
+| `task.create` | 2442.1 ms | 201 |
+| `task.comment.create` | 1533.7 ms | 201 |
+| `task.update.patch` | 2152.4 ms | 200 |
+| `context.list.before` | 1012.8 ms | 200 |
+| `context.create` | 1279.7 ms | 201 |
+| `context.update.patch` | 1223.8 ms | 200 |
+| `tasks.list.after` | 1776.0 ms | 200 |
+| `task.reorder.full_board` | 1551.3 ms | 200 |
+
+The first successful protected-preview run was similar: task create 2622.0 ms,
+task update 2409.5 ms, task list 2213.8 ms, and token exchange 1439.1 ms.
+
+This materially changes remediation priority: TASK-276 should not only make UI
+updates optimistic; it should also instrument and reduce deployed API latency,
+especially task create/update/list paths.
+
 ### Client Mutation Paths
 
 - Task drag/drop is locally optimistic: `components/kanban-board.tsx` updates
@@ -109,9 +148,13 @@ orchestration for at least one high-traffic flow.
    the background.
 3. Full-board reorder payload and persistence. Dragging one task sends the whole
    board shape and updates all supplied rows, which grows with board size.
-4. Dashboard reads are relatively wide. A refresh reloads summary counts,
+4. Deployed preview API calls are seconds-level even for small payloads. Task
+   create/update/list timings are much higher on preview than local service
+   timings, so network/runtime/database/RLS/serverless overhead needs direct
+   instrumentation.
+5. Dashboard reads are relatively wide. A refresh reloads summary counts,
    context, epics, kanban metadata, and other Suspense sections.
-5. Live refresh is route-refresh based. TASK-118 fixed stale multi-user state,
+6. Live refresh is route-refresh based. TASK-118 fixed stale multi-user state,
    but the current transport invalidates by full dashboard refresh rather than
    applying scoped patches.
 
@@ -119,17 +162,18 @@ orchestration for at least one high-traffic flow.
 
 | Rank | Recommendation | Class | Impact | Complexity | Risk | Production durability | Evidence |
 | ---: | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Make task creation insert a board-ready local card immediately, with pending/error reconciliation. Return a full task payload from `POST /tasks` instead of only `taskId`. | Quick win with durable API shape | Very high | Medium | Medium | High | Browser task create was 4696.2 ms while service create was 22.1 ms. |
-| 2 | Replace mutation-completion `router.refresh()` calls in task update, quick assignment/epic update, comments, and context-card mutations with local state updates plus debounced background reconciliation. | Architectural cleanup, can ship flow-by-flow | Very high | Medium-high | Medium | High | Code paths call `router.refresh()` after narrow mutations; comments/context are already able to render returned payloads locally. |
-| 3 | Add click-to-visible client performance marks and server timing for mutation endpoints and route refreshes. | Quick win | High | Low | Low | High | Current evidence required temporary probes; TASK-276 needs preview before/after numbers and regression visibility. |
-| 4 | Reduce kanban reorder payload/persistence to changed rows or the affected ordering window. | Architectural cleanup | Medium-high | Medium | Medium | High | Full-board reorder updated 41 rows locally and took 113.9 ms; cost grows linearly with board size and remote latency. |
-| 5 | Bound dashboard refresh work by splitting or caching server-rendered data so a task/comment/context mutation does not reload unrelated sections. | Architectural cleanup | Medium-high | High | Medium-high | High | Current route refresh can re-run summary counts, context, epics, kanban metadata, roadmap/calendar sections, and live refresh. |
-| 6 | Move stale done-task archival out of `listProjectKanbanTasks()` and into scheduled or explicit maintenance. | Durability cleanup | Medium | Medium | Low-medium | High | Read paths currently perform maintenance writes before returning kanban data. |
+| 1 | Make task creation insert a board-ready local card immediately, with pending/error reconciliation. Return a full task payload from `POST /tasks` instead of only `taskId`. | Quick win with durable API shape | Very high | Medium | Medium | High | Browser task create was 4696.2 ms while local service create was 22.1 ms and preview API create was 2442.1 ms. |
+| 2 | Add production-safe server timing and request instrumentation around deployed API routes, DB/RLS work, and route refreshes. | Quick win / observability foundation | Very high | Low-medium | Low | High | Preview API timings are already 1.0-2.4 seconds; TASK-276 needs to distinguish network, serverless, query, RLS, and render costs. |
+| 3 | Replace mutation-completion `router.refresh()` calls in task update, quick assignment/epic update, comments, and context-card mutations with local state updates plus debounced background reconciliation. | Architectural cleanup, can ship flow-by-flow | Very high | Medium-high | Medium | High | Code paths call `router.refresh()` after narrow mutations; comments/context are already able to render returned payloads locally. |
+| 4 | Investigate and reduce deployed task API latency, starting with task create/update/list query paths and project activity touch/RLS overhead. | Backend performance cleanup | High | Medium-high | Medium | High | Preview task create was 2442.1 ms, update 2152.4 ms, and list 1776-1898 ms versus local service timings below 31 ms for create/update and 18.9 ms for list. |
+| 5 | Reduce kanban reorder payload/persistence to changed rows or the affected ordering window. | Architectural cleanup | Medium-high | Medium | Medium | High | Full-board reorder updated 41 rows locally in 113.9 ms and took 1551.3 ms on preview; cost grows with board size and remote latency. |
+| 6 | Bound dashboard refresh work by splitting or caching server-rendered data so a task/comment/context mutation does not reload unrelated sections. | Architectural cleanup | Medium-high | High | Medium-high | High | Current route refresh can re-run summary counts, context, epics, kanban metadata, roadmap/calendar sections, and live refresh. |
+| 7 | Move stale done-task archival out of `listProjectKanbanTasks()` and into scheduled or explicit maintenance. | Durability cleanup | Medium | Medium | Low-medium | High | Read paths currently perform maintenance writes before returning kanban data. |
 
-Recommended implementation order: ship ranks 1-3 first because they directly
-target the observed several-second task-create UX and create measurement
-guardrails. Then handle reorder and dashboard refresh architecture with the new
-instrumentation in place.
+Recommended implementation order: ship ranks 1-2 first so users see immediate
+feedback and the team has real timing visibility. Then reduce refreshes and
+deployed task API latency in parallel, because both contribute materially to the
+observed delay.
 
 ## Validation Targets
 
@@ -150,7 +194,9 @@ clear rollback/error states when persistence fails.
 
 ## Open Risk
 
-The invalid preview agent credential blocked production-like API timings. Before
-TASK-276 final validation, refresh the preview credential or validate with a
-signed-in browser session on the branch preview so before/after numbers cover
-real Vercel network, server rendering, and database behavior.
+The preview is protected by Vercel authentication. Direct unauthenticated agent
+API calls fail before reaching the app, so preview automation must use
+`vercel curl`, a Vercel protection bypass secret, or an authenticated browser
+session. TASK-276 should include one of those access paths in its validation
+plan so before/after timings cover real Vercel network, server rendering, and
+database behavior.

--- a/docs/reports/task-275-performance-investigation.md
+++ b/docs/reports/task-275-performance-investigation.md
@@ -1,0 +1,134 @@
+# TASK-275 Performance Investigation
+
+Date: 2026-05-31
+Branch: `feature/task-275-performance-investigation`
+
+## Executive Summary
+
+The dominant cause of the slow-feeling UX is not one obviously multi-second
+business service. It is the mutation UX architecture: many common actions wait
+for a network mutation and then trigger a broad `router.refresh()` before the
+user sees the final state.
+
+Local service timing against Docker Postgres showed task/comment/context
+mutations in the 15-30 ms range, with full-board reorder at 113.9 ms for a
+41-task board. That does not model Vercel network, RSC render, browser work, or
+remote database latency, but it strongly suggests the several-second perceived
+delay is mostly caused by server-confirmed UI, oversized refresh boundaries, and
+route refresh churn rather than a single slow CRUD query.
+
+Preview API timing could not be completed with the current
+`tmp/project-access-cred.env` credential because `/api/auth/agent/token`
+returned `401 {"error":"invalid-api-key"}`. This report therefore treats local
+service timings as backend separation evidence and code-path review as the
+primary UX evidence.
+
+## Evidence
+
+### Local Service Probe
+
+Environment: local Docker Postgres, migrations applied with
+`npm run db:local:up` and `npm run db:migrate`. Probe seeded one project with
+40 tasks and measured service calls directly.
+
+| Flow | Local service timing |
+| --- | ---: |
+| `project.summary` | 26.6 ms |
+| `kanban.list.40_tasks` | 18.9 ms |
+| `task.create` | 22.1 ms |
+| `task.update.patch` | 30.2 ms |
+| `task.comment.create` | 29.4 ms |
+| `task.reorder.full_board_41_updates` | 113.9 ms |
+| `context.list.empty` | 7.4 ms |
+| `context.create` | 29.0 ms |
+| `context.update.patch` | 15.4 ms |
+
+Raw sample was written to `.tmp/task-275-service-benchmark.json` during the
+investigation; `.tmp` is intentionally not committed.
+
+### Client Mutation Paths
+
+- Task drag/drop is locally optimistic: `components/kanban-board.tsx` updates
+  `columns` before persisting. However, persistence posts every column/task ID
+  via `buildPersistPayload()` and calls `router.refresh()` after success.
+- Task create closes the modal immediately, but the new card does not enter
+  local board state. It appears only after `router.refresh()`.
+- Task edit, quick assignment/epic updates, and comments wait for `PATCH` or
+  `POST`, then apply local state, then call `router.refresh()`.
+- Context card create closes the modal immediately but only inserts the returned
+  card after the server responds, then refreshes the full project route.
+- Project create/update use Server Actions with `revalidatePath()` and redirect,
+  so the project list waits on the server action/navigation path.
+- Live project refresh polls every 5 seconds and also calls `router.refresh()`
+  when a newer activity version is seen, adding more full-route refresh pressure.
+
+### Server/Query Paths
+
+- `getProjectSummaryById()` performs the project lookup plus multiple counts for
+  dashboard stats on route render.
+- `KanbanBoardSection` loads tasks, collaborators, and epics together for every
+  board render.
+- `listProjectKanbanTasks()` calls `archiveStaleDoneTasks()` on reads and loads
+  task counts, attachments, blocked follow-ups, related tasks, creator/updater,
+  assignee, and epic metadata.
+- `reorderProjectTasks()` updates every task ID supplied by the client. Because
+  the client sends all columns, a single drag can become N task updates.
+- Every mutation touches project activity, which is correct for collaboration
+  but also means every action becomes visible to the live-refresh poller.
+
+## Root Causes
+
+1. Missing optimistic or immediate local state for create/update/comment flows.
+   The user-visible state often changes only after server confirmation.
+2. Broad route refresh after narrow mutations. Small actions refresh the project
+   dashboard instead of updating the relevant client cache and reconciling in
+   the background.
+3. Full-board reorder payload and persistence. Dragging one task sends the whole
+   board shape and updates all supplied rows, which grows with board size.
+4. Dashboard reads are relatively wide. A refresh reloads summary counts,
+   context, epics, kanban metadata, and other Suspense sections.
+5. Live refresh is route-refresh based. TASK-118 fixed stale multi-user state,
+   but the current transport invalidates by full dashboard refresh rather than
+   applying scoped patches.
+
+## Recommendations For TASK-276
+
+1. Make high-traffic mutations locally responsive first:
+   task create, task update, task assignment/epic update, comments, context card
+   create/update/delete, and project list create/update.
+2. Replace mutation-completion `router.refresh()` calls with local cache updates
+   plus debounced background reconciliation. Keep refresh as a fallback, not the
+   primary success path.
+3. Return complete mutation payloads where needed. Task create should return a
+   board-ready task payload, not only `taskId`.
+4. Change reorder persistence to send only the moved task and affected ordering
+   window, or at least update only rows whose status/position changed.
+5. Move stale done-task archival out of the kanban read path into a scheduled or
+   explicit maintenance path.
+6. Add lightweight observability before and after remediation: client
+   performance marks for click-to-visible-update and server timing for the
+   mutation and refresh endpoints.
+
+## Validation Targets
+
+TASK-276 should measure these before and after on preview or production-like
+data:
+
+- Create task: click submit to card visible.
+- Add comment: click add to comment visible and count incremented.
+- Quick assignee/epic update: menu click to visible metadata update.
+- Drag task between columns: mouse up to card visible in target column, plus
+  background persistence completion.
+- Create context card: submit to card visible.
+- Create/update project: submit to project visible/updated in list.
+
+The target product behavior is immediate visible feedback under 100 ms for safe
+local mutations, with server reconciliation completing in the background and
+clear rollback/error states when persistence fails.
+
+## Open Risk
+
+The invalid preview agent credential blocked production-like API timings. Before
+TASK-276 final validation, refresh the preview credential or validate with a
+signed-in browser session on the branch preview so before/after numbers cover
+real Vercel network, server rendering, and database behavior.

--- a/docs/reports/task-275-performance-investigation.md
+++ b/docs/reports/task-275-performance-investigation.md
@@ -12,11 +12,11 @@ user sees the final state.
 
 Local service timing against Docker Postgres showed task/comment/context
 mutations in the 15-30 ms range, with full-board reorder at 113.9 ms for a
-41-task board. Protected preview API timing through `vercel curl` showed the
-same backend flows taking roughly 1.0-2.4 seconds once deployed. Local
-Playwright browser timing against `next start` showed task create taking 4.7
-seconds from submit to card visible even though direct service creation took
-22.1 ms.
+41-task board. Direct preview API timing after disabling Vercel deployment
+protection showed the same backend flows taking roughly 0.9-2.3 seconds once
+deployed. Local Playwright browser timing against `next start` showed task
+create taking 4.7 seconds from submit to card visible even though direct service
+creation took 22.1 ms.
 
 The performance problem is therefore layered:
 
@@ -25,10 +25,11 @@ The performance problem is therefore layered:
 - browser UX adds more delay by waiting on server confirmation and broad route
   refreshes before the user sees state changes.
 
-Direct unauthenticated `curl`/`fetch` calls to the preview initially returned
+Earlier direct `curl`/`fetch` calls to the preview returned
 `401 Authentication Required` from Vercel deployment protection, before the app
-route was reached. The credential itself exchanged successfully when the same
-request was made through Vercel-authenticated access.
+route was reached. After protection was disabled, the same credential exchanged
+successfully through direct HTTP and the benchmark ran without Vercel CLI
+access.
 
 ## Evidence
 
@@ -109,6 +110,32 @@ This materially changes remediation priority: TASK-276 should not only make UI
 updates optimistic; it should also instrument and reduce deployed API latency,
 especially task create/update/list paths.
 
+### Direct Preview API Probe
+
+Environment: same preview after Vercel deployment protection was disabled. This
+probe used the agent API key directly from `tmp/project-access-cred.env` and
+sampled most routes five times.
+
+| Flow | Count | p50 | p95 | Status |
+| --- | ---: | ---: | ---: | ---: |
+| `health.live` | 1 | 590.9 ms | 590.9 ms | 200 |
+| `agent.token.exchange` | 1 | 986.0 ms | 986.0 ms | 200 |
+| `project.get` | 5 | 1412.5 ms | 1509.5 ms | 200 |
+| `activity.get` | 5 | 953.8 ms | 957.4 ms | 200 |
+| `tasks.list` | 5 | 1603.6 ms | 1604.2 ms | 200 |
+| `task.create` | 5 | 2316.9 ms | 2419.0 ms | 201 |
+| `task.comment.create` | 5 | 1496.3 ms | 1520.9 ms | 201 |
+| `task.update.patch` | 5 | 2029.4 ms | 2035.2 ms | 200 |
+| `task.reorder.move` | 5 | 1109.2 ms | 1126.4 ms | 200 |
+| `context.list` | 5 | 888.9 ms | 889.2 ms | 200 |
+| `context.create` | 5 | 1170.5 ms | 1175.8 ms | 201 |
+| `context.update.patch` | 5 | 1179.8 ms | 1182.4 ms | 200 |
+
+This confirms the deployed API layer remains seconds-level without Vercel
+deployment protection in front. The issue is not only browser refresh behavior:
+the preview runtime/database/request path also needs direct timing
+instrumentation and optimization.
+
 ### Client Mutation Paths
 
 - Task drag/drop is locally optimistic: `components/kanban-board.tsx` updates
@@ -162,11 +189,11 @@ especially task create/update/list paths.
 
 | Rank | Recommendation | Class | Impact | Complexity | Risk | Production durability | Evidence |
 | ---: | --- | --- | --- | --- | --- | --- | --- |
-| 1 | Make task creation insert a board-ready local card immediately, with pending/error reconciliation. Return a full task payload from `POST /tasks` instead of only `taskId`. | Quick win with durable API shape | Very high | Medium | Medium | High | Browser task create was 4696.2 ms while local service create was 22.1 ms and preview API create was 2442.1 ms. |
-| 2 | Add production-safe server timing and request instrumentation around deployed API routes, DB/RLS work, and route refreshes. | Quick win / observability foundation | Very high | Low-medium | Low | High | Preview API timings are already 1.0-2.4 seconds; TASK-276 needs to distinguish network, serverless, query, RLS, and render costs. |
+| 1 | Make task creation insert a board-ready local card immediately, with pending/error reconciliation. Return a full task payload from `POST /tasks` instead of only `taskId`. | Quick win with durable API shape | Very high | Medium | Medium | High | Browser task create was 4696.2 ms while local service create was 22.1 ms and direct preview API create p50 was 2316.9 ms. |
+| 2 | Add production-safe server timing and request instrumentation around deployed API routes, DB/RLS work, and route refreshes. | Quick win / observability foundation | Very high | Low-medium | Low | High | Direct preview API timings are already 0.9-2.3 seconds; TASK-276 needs to distinguish network, serverless, query, RLS, and render costs. |
 | 3 | Replace mutation-completion `router.refresh()` calls in task update, quick assignment/epic update, comments, and context-card mutations with local state updates plus debounced background reconciliation. | Architectural cleanup, can ship flow-by-flow | Very high | Medium-high | Medium | High | Code paths call `router.refresh()` after narrow mutations; comments/context are already able to render returned payloads locally. |
-| 4 | Investigate and reduce deployed task API latency, starting with task create/update/list query paths and project activity touch/RLS overhead. | Backend performance cleanup | High | Medium-high | Medium | High | Preview task create was 2442.1 ms, update 2152.4 ms, and list 1776-1898 ms versus local service timings below 31 ms for create/update and 18.9 ms for list. |
-| 5 | Reduce kanban reorder payload/persistence to changed rows or the affected ordering window. | Architectural cleanup | Medium-high | Medium | Medium | High | Full-board reorder updated 41 rows locally in 113.9 ms and took 1551.3 ms on preview; cost grows with board size and remote latency. |
+| 4 | Investigate and reduce deployed task API latency, starting with task create/update/list query paths and project activity touch/RLS overhead. | Backend performance cleanup | High | Medium-high | Medium | High | Direct preview task create p50 was 2316.9 ms, update p50 was 2029.4 ms, and list p50 was 1603.6 ms versus local service timings below 31 ms for create/update and 18.9 ms for list. |
+| 5 | Reduce kanban reorder payload/persistence to changed rows or the affected ordering window. | Architectural cleanup | Medium-high | Medium | Medium | High | Full-board reorder updated 41 rows locally in 113.9 ms and direct preview reorder p50 was 1109.2 ms; cost grows with board size and remote latency. |
 | 6 | Bound dashboard refresh work by splitting or caching server-rendered data so a task/comment/context mutation does not reload unrelated sections. | Architectural cleanup | Medium-high | High | Medium-high | High | Current route refresh can re-run summary counts, context, epics, kanban metadata, roadmap/calendar sections, and live refresh. |
 | 7 | Move stale done-task archival out of `listProjectKanbanTasks()` and into scheduled or explicit maintenance. | Durability cleanup | Medium | Medium | Low-medium | High | Read paths currently perform maintenance writes before returning kanban data. |
 

--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,22 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-05-31 - TASK-275 performance investigation completed
+
+- Summary: Completed the app action-latency investigation and scoped TASK-276
+  remediation around immediate local feedback, bounded refresh work, and
+  before/after preview validation.
+- Evidence: Added `docs/reports/task-275-performance-investigation.md`. Local
+  Docker Postgres service probe showed core task/comment/context mutations in
+  the 15-30 ms range, while full-board reorder took 113.9 ms for a 41-task
+  board. Code review found common flows gated by server confirmation plus broad
+  `router.refresh()` calls; task creation, comments, task edits, context-card
+  mutations, and project Server Actions all rely on refresh/navigation for
+  visible completion. Preview agent API timing was blocked because the
+  credential in `tmp/project-access-cred.env` returned `invalid-api-key`, so
+  TASK-276 now requires refreshed preview or signed-in browser before/after
+  timings.
+
 # 2026-05-31 - TASK-275/TASK-276 performance task split
 
 - Summary: Split app performance work into investigation and implementation so

--- a/journal.md
+++ b/journal.md
@@ -11,13 +11,15 @@ Use it for important implementation milestones, blockers, validation runs, and r
 - Evidence: Added `docs/reports/task-275-performance-investigation.md`. Local
   Docker Postgres service probe showed core task/comment/context mutations in
   the 15-30 ms range, while full-board reorder took 113.9 ms for a 41-task
-  board. Code review found common flows gated by server confirmation plus broad
-  `router.refresh()` calls; task creation, comments, task edits, context-card
-  mutations, and project Server Actions all rely on refresh/navigation for
-  visible completion. Preview agent API timing was blocked because the
-  credential in `tmp/project-access-cred.env` returned `invalid-api-key`, so
-  TASK-276 now requires refreshed preview or signed-in browser before/after
-  timings.
+  board. Local Playwright timing against `next start` showed task creation at
+  4696.2 ms from submit to visible card, despite direct service creation
+  measuring 22.1 ms. Code review found common flows gated by server
+  confirmation plus broad `router.refresh()` calls; task creation, comments,
+  task edits, context-card mutations, and project Server Actions all rely on
+  refresh/navigation for visible completion. Preview agent API timing was
+  blocked because the credential in `tmp/project-access-cred.env` returned
+  `invalid-api-key`, so TASK-276 now requires refreshed preview or signed-in
+  browser before/after timings.
 
 # 2026-05-31 - TASK-275/TASK-276 performance task split
 

--- a/journal.md
+++ b/journal.md
@@ -11,15 +11,18 @@ Use it for important implementation milestones, blockers, validation runs, and r
 - Evidence: Added `docs/reports/task-275-performance-investigation.md`. Local
   Docker Postgres service probe showed core task/comment/context mutations in
   the 15-30 ms range, while full-board reorder took 113.9 ms for a 41-task
-  board. Local Playwright timing against `next start` showed task creation at
-  4696.2 ms from submit to visible card, despite direct service creation
+  board. Protected preview API probing via `vercel curl` exchanged the new
+  credential successfully and measured task create at 2442.1 ms, task update at
+  2152.4 ms, task list at 1776-1898 ms, and full-board reorder at 1551.3 ms on a
+  warm repeat. Local Playwright timing against `next start` showed task creation
+  at 4696.2 ms from submit to visible card, despite direct service creation
   measuring 22.1 ms. Code review found common flows gated by server
   confirmation plus broad `router.refresh()` calls; task creation, comments,
   task edits, context-card mutations, and project Server Actions all rely on
-  refresh/navigation for visible completion. Preview agent API timing was
-  blocked because the credential in `tmp/project-access-cred.env` returned
-  `invalid-api-key`, so TASK-276 now requires refreshed preview or signed-in
-  browser before/after timings.
+  refresh/navigation for visible completion. Direct preview API calls were
+  blocked by Vercel deployment protection before reaching the app, so TASK-276
+  validation needs `vercel curl`, a Vercel bypass secret, or an authenticated
+  browser session.
 
 # 2026-05-31 - TASK-275/TASK-276 performance task split
 

--- a/journal.md
+++ b/journal.md
@@ -19,10 +19,11 @@ Use it for important implementation milestones, blockers, validation runs, and r
   measuring 22.1 ms. Code review found common flows gated by server
   confirmation plus broad `router.refresh()` calls; task creation, comments,
   task edits, context-card mutations, and project Server Actions all rely on
-  refresh/navigation for visible completion. Direct preview API calls were
-  blocked by Vercel deployment protection before reaching the app, so TASK-276
-  validation needs `vercel curl`, a Vercel bypass secret, or an authenticated
-  browser session.
+  refresh/navigation for visible completion. After Vercel deployment protection
+  was disabled, direct preview API timings remained seconds-level: task create
+  p50 2316.9 ms, task update p50 2029.4 ms, task list p50 1603.6 ms, and reorder
+  p50 1109.2 ms. The earlier direct 401 was Vercel protection, not the app
+  credential.
 
 # 2026-05-31 - TASK-275/TASK-276 performance task split
 

--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,16 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-05-31 - TASK-275/TASK-276 performance task split
+
+- Summary: Split app performance work into investigation and implementation so
+  remediation can be evidence-led while still targeting durable production-grade
+  fixes for several-second action latency.
+- Evidence: Promoted TASK-275 to the top of the execution queue as the
+  measurement/root-cause investigation, created TASK-276 for implementation,
+  updated `tasks/current.md` for TASK-275, and created
+  `feature/task-275-performance-investigation` from current `origin/main`.
+
 # 2026-05-31 - Backlog cleanup after TASK-307 merge
 
 - Summary: Refreshed task tracking after the latest merged PRs so the backlog no

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -6,6 +6,18 @@ Last reviewed: 2026-05-31
 
 ## Pending
 ### Execution Queue (Now / Next)
+- ID: TASK-275
+  Title: App performance investigation - action latency root-cause analysis
+  Status: Promoted 2026-05-31
+  Rationale: Everyday creation, update, and refresh actions currently take several seconds in production-like usage. Run a deep, measurement-first investigation across browser, API, database, cache/refresh, and perceived-latency layers so the remediation work is grounded in evidence rather than isolated guesses.
+  Dependencies: TASK-043, TASK-073, TASK-074, TASK-118, TASK-266
+  Brief: `tasks/task-275-app-performance-investigation-report.md`
+- ID: TASK-276
+  Title: App performance remediation - production-grade action latency fixes
+  Status: Queued behind TASK-275
+  Rationale: Implement durable, production-ready fixes for the root causes identified by TASK-275 so common app actions feel responsive by industry-standard SaaS expectations. The implementation should prioritize user-perceived speed, low-latency mutations, bounded refresh work, efficient data loading, and safe observability that keeps performance regressions detectable.
+  Dependencies: TASK-275, TASK-043, TASK-073, TASK-074, TASK-118, TASK-266
+  Brief: `tasks/task-276-app-performance-remediation.md`
 - ID: TASK-133
   Title: Task UI bug fixing - mini scrollbar and edit modal polish
   Status: Queued UI follow-up (promoted 2026-05-04; PR #224 partial fix merged)
@@ -63,12 +75,6 @@ Last reviewed: 2026-05-31
   Status: Pending
   Rationale: Enable bilingual product usage (French and English) with consistent UI copy, locale routing/state strategy, and fallback behavior; defer implementation until we confirm i18n architecture and translation workflow.
   Dependencies: TASK-047, TASK-060
-- ID: TASK-275
-  Title: App performance investigation report - creation, update, and refresh latency
-  Status: Pending
-  Rationale: User preview testing after TASK-266 confirmed the app works functionally, but creation, update, and refresh flows still feel slow across the product. Run a measurement-first performance investigation and produce a report with evidence, root-cause hypotheses, and ranked recommendations to bring the app closer to industry-standard responsiveness. The report should cover request latency, database/query timing, route refresh behavior, client bundle/hydration cost, cache invalidation, optimistic UI opportunities, loading-state ergonomics, and concrete implementation tasks for the highest-impact fixes.
-  Dependencies: TASK-043, TASK-073, TASK-074, TASK-266, TASK-270
-  Brief: `tasks/task-275-app-performance-investigation-report.md`
 - ID: TASK-108
   Title: Whole-app UI/UX refinement - global interaction, visual, and information-design polish
   Status: Pending

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -8,13 +8,14 @@ Last reviewed: 2026-05-31
 ### Execution Queue (Now / Next)
 - ID: TASK-275
   Title: App performance investigation - action latency root-cause analysis
-  Status: Promoted 2026-05-31
+  Status: Investigation complete on branch; pending review
   Rationale: Everyday creation, update, and refresh actions currently take several seconds in production-like usage. Run a deep, measurement-first investigation across browser, API, database, cache/refresh, and perceived-latency layers so the remediation work is grounded in evidence rather than isolated guesses.
   Dependencies: TASK-043, TASK-073, TASK-074, TASK-118, TASK-266
   Brief: `tasks/task-275-app-performance-investigation-report.md`
+  Report: `docs/reports/task-275-performance-investigation.md`
 - ID: TASK-276
   Title: App performance remediation - production-grade action latency fixes
-  Status: Queued behind TASK-275
+  Status: Queued; scoped by TASK-275 findings
   Rationale: Implement durable, production-ready fixes for the root causes identified by TASK-275 so common app actions feel responsive by industry-standard SaaS expectations. The implementation should prioritize user-perceived speed, low-latency mutations, bounded refresh work, efficient data loading, and safe observability that keeps performance regressions detectable.
   Dependencies: TASK-275, TASK-043, TASK-073, TASK-074, TASK-118, TASK-266
   Brief: `tasks/task-276-app-performance-remediation.md`

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -58,6 +58,8 @@ execute.
   `router.refresh()` calls, not a single obviously multi-second service method.
 - Local Docker Postgres probe showed task/comment/context mutation services in
   the 15-30 ms range; full-board reorder was 113.9 ms for a 41-task board.
+- Local Playwright browser probe showed task creation at 4696.2 ms from submit
+  to visible card, compared with 22.1 ms for direct service creation.
 - Preview agent API timing was blocked because the provided key now returns
   `invalid-api-key`; TASK-276 needs refreshed preview access or signed-in
   browser validation for before/after timing.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,7 +4,8 @@
 TASK-275
 
 ## Status
-Ready to start on `feature/task-275-performance-investigation`
+Investigation complete on `feature/task-275-performance-investigation`;
+awaiting PR review/merge.
 
 ## Source
 - User request on 2026-05-31:
@@ -43,14 +44,27 @@ execute.
 5. TASK-276 has a concrete implementation plan for the first remediation set.
 
 ## Definition Of Done
-- Measurement evidence is captured from preview, production-equivalent, or local
-  runs with clear environment notes.
-- The investigation report is committed.
-- TASK-276 is updated with implementation scope, validation targets, and risk
-  notes.
-- `journal.md` records findings and next steps.
-- `git diff --check` passes.
+- [x] Measurement evidence is captured from preview, production-equivalent, or
+  local runs with clear environment notes.
+- [x] The investigation report is committed.
+- [x] TASK-276 is updated with implementation scope, validation targets, and
+  risk notes.
+- [x] `journal.md` records findings and next steps.
+- [x] `git diff --check` passes.
+
+## Findings
+- Report: `docs/reports/task-275-performance-investigation.md`
+- Main cause: common actions are visibly gated by server confirmation and broad
+  `router.refresh()` calls, not a single obviously multi-second service method.
+- Local Docker Postgres probe showed task/comment/context mutation services in
+  the 15-30 ms range; full-board reorder was 113.9 ms for a 41-task board.
+- Preview agent API timing was blocked because the provided key now returns
+  `invalid-api-key`; TASK-276 needs refreshed preview access or signed-in
+  browser validation for before/after timing.
 
 ## Open Questions
 - Which deployment/environment should be treated as the primary performance
   baseline if preview and production differ materially?
+- Should TASK-276 use a small state/cache helper inside the current components
+  first, or introduce a broader client data layer such as SWR for mutation
+  reconciliation?

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -61,11 +61,13 @@ execute.
 - Protected preview API probe via `vercel curl` showed task create at 2442.1 ms,
   task update at 2152.4 ms, task list at 1776-1898 ms, and full-board reorder
   at 1551.3 ms on a warm repeat.
+- Direct preview API after disabling Vercel deployment protection still showed
+  seconds-level timings: task create p50 2316.9 ms, task update p50 2029.4 ms,
+  task list p50 1603.6 ms, and reorder p50 1109.2 ms.
 - Local Playwright browser probe showed task creation at 4696.2 ms from submit
   to visible card, compared with 22.1 ms for direct service creation.
-- Direct preview API calls were blocked by Vercel deployment protection, not by
-  the agent credential. Vercel-authenticated access exchanged the credential
-  successfully.
+- The earlier direct 401 was Vercel deployment protection, not the agent
+  credential. After disabling protection, direct token exchange succeeded.
 
 ## Open Questions
 - Which deployment/environment should be treated as the primary performance

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -58,11 +58,14 @@ execute.
   `router.refresh()` calls, not a single obviously multi-second service method.
 - Local Docker Postgres probe showed task/comment/context mutation services in
   the 15-30 ms range; full-board reorder was 113.9 ms for a 41-task board.
+- Protected preview API probe via `vercel curl` showed task create at 2442.1 ms,
+  task update at 2152.4 ms, task list at 1776-1898 ms, and full-board reorder
+  at 1551.3 ms on a warm repeat.
 - Local Playwright browser probe showed task creation at 4696.2 ms from submit
   to visible card, compared with 22.1 ms for direct service creation.
-- Preview agent API timing was blocked because the provided key now returns
-  `invalid-api-key`; TASK-276 needs refreshed preview access or signed-in
-  browser validation for before/after timing.
+- Direct preview API calls were blocked by Vercel deployment protection, not by
+  the agent credential. Vercel-authenticated access exchanged the credential
+  successfully.
 
 ## Open Questions
 - Which deployment/environment should be treated as the primary performance

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,22 +1,56 @@
-# Current Task: None
+# Current Task: TASK-275 App Performance Investigation
+
+## Task ID
+TASK-275
 
 ## Status
-Idle after TASK-307 completion.
+Ready to start on `feature/task-275-performance-investigation`
 
-## Last Reviewed
-2026-05-31
+## Source
+- User request on 2026-05-31:
+  common app actions currently take several seconds and need a deep
+  investigation followed by durable, production-ready remediation.
+- Backlog entry: `tasks/backlog.md`
+- Task brief: `tasks/task-275-app-performance-investigation-report.md`
+- Follow-up implementation task: `tasks/task-276-app-performance-remediation.md`
 
-## Queue Snapshot
-- Recently completed and now reflected in `tasks/backlog.md`:
-  - TASK-307 merged via PR #309.
-  - TASK-306 merged via PR #307.
-  - TASK-118 merged via PR #305.
-- Next executable queue entries:
-  - TASK-133
-  - TASK-270
-  - TASK-129
+## Objective
+Measure and explain the app's slow-feeling creation, update, navigation, and
+refresh flows, then produce the concrete implementation plan that TASK-276 will
+execute.
 
-## Notes
-- Backlog order is workflow-first, not numeric: execution queue first,
-  intentionally deferred work next, and completed work newest-first.
-- No implementation task is currently active in this checkout.
+## Scope
+- Capture timing evidence across browser, API, database/query, server render,
+  cache/refresh, client hydration/rendering, and perceived-latency layers.
+- Focus on everyday flows where actions currently take several seconds:
+  project creation/list refresh, task creation/update/assignment/comment/board
+  refresh, context-card creation/update/dashboard refresh, and any roadmap or
+  calendar interactions that materially affect dashboard speed.
+- Identify whether the dominant causes are backend latency, database/RLS work,
+  network round trips, route refreshes, cache invalidation, oversized payloads,
+  client rendering/hydration, missing optimistic UI, or loading-state ergonomics.
+- Update TASK-276 with the evidence-backed remediation scope.
+
+## Acceptance Criteria
+1. A performance report exists in the repo with measured evidence for the
+   highest-traffic slow flows.
+2. The report separates backend/API, database/query, render/hydration,
+   cache/refresh, network, and perceived-UX costs.
+3. The investigation identifies the dominant root causes behind several-second
+   actions.
+4. Recommendations are ranked by impact, complexity, risk, and production
+   durability.
+5. TASK-276 has a concrete implementation plan for the first remediation set.
+
+## Definition Of Done
+- Measurement evidence is captured from preview, production-equivalent, or local
+  runs with clear environment notes.
+- The investigation report is committed.
+- TASK-276 is updated with implementation scope, validation targets, and risk
+  notes.
+- `journal.md` records findings and next steps.
+- `git diff --check` passes.
+
+## Open Questions
+- Which deployment/environment should be treated as the primary performance
+  baseline if preview and production differ materially?

--- a/tasks/task-275-app-performance-investigation-report.md
+++ b/tasks/task-275-app-performance-investigation-report.md
@@ -1,21 +1,21 @@
-# TASK-275 App Performance Investigation Report
+# TASK-275 App Performance Investigation
 
 ## Task ID
 TASK-275
 
 ## Status
-Pending
+Promoted 2026-05-31
 
 ## Objective
 Produce a measurement-backed performance report for the app's slow-feeling
-creation, update, navigation, and refresh flows, then convert the highest-impact
-findings into concrete implementation recommendations.
+creation, update, navigation, and refresh flows, then turn the findings into a
+concrete remediation plan for TASK-276.
 
 ## Rationale
-Manual preview validation after TASK-266 confirmed the branch works
-functionally, but the application still feels slow during everyday operations.
-The next performance step should be investigation-first so future work improves
-real user-perceived latency rather than guessing at isolated optimizations.
+Manual preview and production-like usage confirm the application works
+functionally, but common actions still take several seconds. The next step must
+be investigation-first so the durable remediation work improves real
+user-perceived latency rather than guessing at isolated optimizations.
 
 ## Scope
 - Measure representative flows:
@@ -34,23 +34,36 @@ real user-perceived latency rather than guessing at isolated optimizations.
 - Compare observed behavior against practical industry targets for interactive
   SaaS apps: fast local feedback, low-latency mutations, limited blocking
   refreshes, stable layout, and responsive loading states.
-- Produce ranked recommendations with expected impact, complexity, risk, and
-  suggested owning follow-up tasks.
+- Produce a ranked remediation plan for TASK-276 with expected impact,
+  complexity, risk, validation approach, and sequencing.
+
+## Out Of Scope
+- Broad product redesign unrelated to action latency.
+- Large behavior changes before the root causes are measured.
+- Bundling the full remediation implementation into this investigation task.
+- Introducing observability vendors or paid infrastructure without an explicit
+  decision.
 
 ## Acceptance Criteria
 1. A performance report exists in the repo with measured evidence for the
    highest-traffic creation, update, and refresh flows.
 2. The report distinguishes backend latency, database/query cost, frontend
    rendering/hydration cost, cache/refresh behavior, and perceived-latency UX.
-3. Recommendations are ranked by user impact and implementation complexity.
-4. At least the top three recommendations include concrete suggested
-   implementation tasks or links to existing backlog tasks.
-5. The report explicitly calls out any quick wins versus architectural changes.
+3. The investigation identifies whether several-second actions are dominated by
+   network, database, server rendering, cache invalidation, route refresh,
+   client hydration/rendering, missing optimistic UI, or loading-state
+   ergonomics.
+4. Recommendations are ranked by user impact, implementation complexity, risk,
+   and expected production durability.
+5. TASK-276 has a concrete implementation plan with the first fix set,
+   validation targets, and rollback/risk notes.
+6. The report explicitly calls out any quick wins versus architectural changes.
 
 ## Definition Of Done
 - The report is committed as documentation.
-- `tasks/backlog.md` is updated with any newly discovered implementation tasks
-  or sequencing changes.
+- TASK-276 is updated, if needed, with the implementation scope discovered by
+  the investigation.
+- `tasks/backlog.md` and `tasks/current.md` are updated with sequencing changes.
 - `journal.md` records the investigation outcome and recommended next steps.
 - The PR is opened for review; no product behavior changes are bundled unless a
   tiny measurement/instrumentation change is explicitly necessary.
@@ -59,4 +72,6 @@ real user-perceived latency rather than guessing at isolated optimizations.
 - Manual preview walkthrough with browser timing evidence.
 - Browser automation screenshots or traces where useful.
 - Server/runtime log review around measured flows.
+- API timing probes for representative project/task/context-card operations.
+- Database/query timing analysis where available.
 - `git diff --check`.

--- a/tasks/task-276-app-performance-remediation.md
+++ b/tasks/task-276-app-performance-remediation.md
@@ -24,11 +24,15 @@ feel responsive by modern SaaS standards.
 - Local service timings did not show inherently multi-second mutation services:
   task/comment/context mutations were 15-30 ms locally, while full-board reorder
   was 113.9 ms for a 41-task board.
+- Protected preview API timings are materially slower: warm repeat timings were
+  2442.1 ms for task create, 2152.4 ms for task update, 1776-1898 ms for task
+  list, and 1551.3 ms for full-board reorder via `vercel curl`.
 - Local Playwright timing showed task creation at 4696.2 ms from submit to card
   visible, despite direct service creation measuring 22.1 ms.
-- Preview agent API timing was blocked by an invalid API key in
-  `tmp/project-access-cred.env`; TASK-276 must capture preview/browser
-  before/after timings with refreshed access or signed-in browser validation.
+- Direct unauthenticated preview API calls are blocked by Vercel deployment
+  protection before reaching the app. TASK-276 preview validation must use
+  `vercel curl`, a Vercel protection bypass secret, or an authenticated browser
+  session.
 
 ## Scope
 - Implement the highest-impact fixes from the TASK-275 report.
@@ -52,6 +56,9 @@ feel responsive by modern SaaS standards.
   scheduled, explicit, or otherwise non-read-path maintenance workflow.
 - Add lightweight production-safe timing hooks for click-to-visible-update and
   server mutation/refresh duration.
+- Investigate and reduce deployed API latency in the task create/update/list
+  paths, including query shape, RLS transaction overhead, project activity touch,
+  serverless/runtime behavior, and database connection path.
 - Preserve authorization, RLS, realtime collaboration, and notification
   semantics.
 

--- a/tasks/task-276-app-performance-remediation.md
+++ b/tasks/task-276-app-performance-remediation.md
@@ -1,0 +1,74 @@
+# TASK-276 App Performance Remediation
+
+## Task ID
+TASK-276
+
+## Status
+Queued behind TASK-275
+
+## Objective
+Implement durable, production-ready performance fixes for the several-second
+action latency identified by TASK-275, with emphasis on user-perceived speed,
+low-latency mutations, bounded refresh work, and regression visibility.
+
+## Rationale
+Investigation and implementation should be separate so remediation can be
+evidence-led. Once TASK-275 identifies the dominant latency sources, this task
+owns the production fix set and validation needed to make everyday app actions
+feel responsive by modern SaaS standards.
+
+## Scope
+- Implement the highest-impact fixes from the TASK-275 report.
+- Reduce blocking work in common flows:
+  - project creation and project-list refresh
+  - task creation, update, assignment, comment, and board refresh
+  - context-card creation/update and dashboard refresh
+  - roadmap/calendar interactions if TASK-275 identifies them as material
+- Prefer durable patterns over one-off patches:
+  - efficient service/query boundaries
+  - narrower payloads and refreshes
+  - optimistic or immediate local feedback where safe
+  - sensible cache invalidation/revalidation behavior
+  - loading states that communicate progress without blocking unrelated work
+  - lightweight production-safe timing/observability hooks when needed
+- Preserve authorization, RLS, realtime collaboration, and notification
+  semantics.
+
+## Out Of Scope
+- Cosmetic redesign not tied to performance.
+- Paid infrastructure changes without an explicit decision.
+- Replacing the app architecture wholesale unless TASK-275 proves it is
+  necessary and the change is explicitly approved.
+
+## Acceptance Criteria
+1. The implemented fix set maps directly to measured TASK-275 findings.
+2. Representative common actions are measurably faster on preview or production-
+   equivalent validation data.
+3. User-perceived latency improves through faster local feedback, reduced
+   blocking refreshes, or both.
+4. Data correctness, authorization, RLS, realtime updates, and notification
+   behavior remain intact.
+5. Automated tests cover changed service/API/client behavior.
+6. Preview validation records before/after timing evidence for the targeted
+   flows.
+7. The final handoff documents residual performance risks and any follow-up
+   tasks.
+
+## Definition Of Done
+- The TASK-275 report is complete and linked from this task.
+- The selected remediation scope is implemented on a dedicated feature branch.
+- Focused tests and the full validation baseline pass.
+- Branch-ref preview deployment is validated with timing evidence.
+- `tasks/backlog.md`, `tasks/current.md`, and `journal.md` reflect completion
+  state and any follow-up work.
+- A PR is opened for review, Copilot feedback is handled, and merge-readiness is
+  based on both automated checks and preview performance evidence.
+
+## Validation Plan
+- Focused unit/API/component tests for touched behavior.
+- `npm run lint`
+- `npm test`
+- `npm run test:coverage`
+- `npm run build`
+- Relevant Playwright smoke or targeted preview automation.
+- Branch-ref Vercel preview validation with before/after timing comparison.

--- a/tasks/task-276-app-performance-remediation.md
+++ b/tasks/task-276-app-performance-remediation.md
@@ -24,6 +24,8 @@ feel responsive by modern SaaS standards.
 - Local service timings did not show inherently multi-second mutation services:
   task/comment/context mutations were 15-30 ms locally, while full-board reorder
   was 113.9 ms for a 41-task board.
+- Local Playwright timing showed task creation at 4696.2 ms from submit to card
+  visible, despite direct service creation measuring 22.1 ms.
 - Preview agent API timing was blocked by an invalid API key in
   `tmp/project-access-cred.env`; TASK-276 must capture preview/browser
   before/after timings with refreshed access or signed-in browser validation.

--- a/tasks/task-276-app-performance-remediation.md
+++ b/tasks/task-276-app-performance-remediation.md
@@ -27,12 +27,14 @@ feel responsive by modern SaaS standards.
 - Protected preview API timings are materially slower: warm repeat timings were
   2442.1 ms for task create, 2152.4 ms for task update, 1776-1898 ms for task
   list, and 1551.3 ms for full-board reorder via `vercel curl`.
+- Direct preview API timings after disabling Vercel deployment protection remain
+  seconds-level: p50 2316.9 ms for task create, 2029.4 ms for task update,
+  1603.6 ms for task list, and 1109.2 ms for reorder.
 - Local Playwright timing showed task creation at 4696.2 ms from submit to card
   visible, despite direct service creation measuring 22.1 ms.
-- Direct unauthenticated preview API calls are blocked by Vercel deployment
-  protection before reaching the app. TASK-276 preview validation must use
+- When Vercel deployment protection is enabled, preview validation must use
   `vercel curl`, a Vercel protection bypass secret, or an authenticated browser
-  session.
+  session; otherwise direct API calls hit Vercel auth before app code.
 
 ## Scope
 - Implement the highest-impact fixes from the TASK-275 report.

--- a/tasks/task-276-app-performance-remediation.md
+++ b/tasks/task-276-app-performance-remediation.md
@@ -17,20 +17,39 @@ evidence-led. Once TASK-275 identifies the dominant latency sources, this task
 owns the production fix set and validation needed to make everyday app actions
 feel responsive by modern SaaS standards.
 
+## TASK-275 Findings
+- Report: `docs/reports/task-275-performance-investigation.md`
+- Dominant cause: user-visible state changes are often gated on server
+  confirmation plus broad `router.refresh()` calls.
+- Local service timings did not show inherently multi-second mutation services:
+  task/comment/context mutations were 15-30 ms locally, while full-board reorder
+  was 113.9 ms for a 41-task board.
+- Preview agent API timing was blocked by an invalid API key in
+  `tmp/project-access-cred.env`; TASK-276 must capture preview/browser
+  before/after timings with refreshed access or signed-in browser validation.
+
 ## Scope
 - Implement the highest-impact fixes from the TASK-275 report.
-- Reduce blocking work in common flows:
-  - project creation and project-list refresh
-  - task creation, update, assignment, comment, and board refresh
-  - context-card creation/update and dashboard refresh
-  - roadmap/calendar interactions if TASK-275 identifies them as material
-- Prefer durable patterns over one-off patches:
-  - efficient service/query boundaries
-  - narrower payloads and refreshes
-  - optimistic or immediate local feedback where safe
-  - sensible cache invalidation/revalidation behavior
-  - loading states that communicate progress without blocking unrelated work
-  - lightweight production-safe timing/observability hooks when needed
+- Prioritize immediate local feedback for:
+  - task create
+  - task update/save
+  - quick task assignee and epic updates
+  - task comment create and comment count increment
+  - kanban drag/drop persistence
+  - context-card create/update/delete
+  - project create/update list feedback
+- Replace mutation-completion `router.refresh()` calls with local state/cache
+  updates plus debounced background reconciliation. Full route refresh should be
+  a fallback for consistency recovery, not the primary success path.
+- Return complete mutation payloads where needed. In particular, task creation
+  should return a board-ready task payload instead of only `taskId`.
+- Reduce kanban reorder work by sending and persisting only the moved task and
+  affected ordering window, or by detecting changed rows server-side before
+  issuing updates.
+- Move stale done-task archival out of `listProjectKanbanTasks()` into a
+  scheduled, explicit, or otherwise non-read-path maintenance workflow.
+- Add lightweight production-safe timing hooks for click-to-visible-update and
+  server mutation/refresh duration.
 - Preserve authorization, RLS, realtime collaboration, and notification
   semantics.
 
@@ -54,6 +73,16 @@ feel responsive by modern SaaS standards.
 7. The final handoff documents residual performance risks and any follow-up
    tasks.
 
+## Target Behaviors
+- Safe local UI feedback appears within 100 ms for create/update/comment/move
+  flows, with clear pending state while the server persists.
+- Persistence failures roll back or reconcile the affected item only and show an
+  actionable error.
+- Successful mutations do not visibly blank, reflow, or reload unrelated
+  dashboard sections.
+- Multi-user live refresh still surfaces remote changes without interrupting
+  active editing or causing avoidable full-dashboard churn.
+
 ## Definition Of Done
 - The TASK-275 report is complete and linked from this task.
 - The selected remediation scope is implemented on a dedicated feature branch.
@@ -65,10 +94,17 @@ feel responsive by modern SaaS standards.
   based on both automated checks and preview performance evidence.
 
 ## Validation Plan
-- Focused unit/API/component tests for touched behavior.
+- Focused unit/API/component tests for touched behavior, especially optimistic
+  success, rollback, and background reconciliation paths.
 - `npm run lint`
 - `npm test`
 - `npm run test:coverage`
 - `npm run build`
-- Relevant Playwright smoke or targeted preview automation.
+- Relevant Playwright smoke or targeted preview automation covering:
+  - create task: submit to card visible
+  - add comment: submit to comment visible and count incremented
+  - quick assignee/epic update: click to visible metadata update
+  - drag task between columns: mouse up to target-column visible update
+  - create context card: submit to card visible
+  - create/update project: submit to list visible/updated
 - Branch-ref Vercel preview validation with before/after timing comparison.


### PR DESCRIPTION
## Summary
- Adds the TASK-275 performance investigation report with local service, local browser, protected-preview API, and direct-preview API timing evidence.
- Updates TASK-276 with the concrete remediation scope, ranked recommendations, target behaviors, and preview validation plan.
- Refreshes current/backlog/journal task tracking for the investigation handoff.

## Findings
- Common app actions are layered slow: local service logic is fast, deployed preview API calls are already seconds-level, and UI refresh/server-confirmation adds more delay on top.
- Local Docker Postgres service timings were 15-30 ms for task/comment/context mutations; full-board reorder took 113.9 ms for 41 task updates.
- Direct preview API timings after disabling Vercel deployment protection: task create p50 2316.9 ms, task update p50 2029.4 ms, task list p50 1603.6 ms, reorder p50 1109.2 ms.
- Local Playwright timing against `next start` showed task creation at 4696.2 ms from submit to card visible, despite direct service creation measuring 22.1 ms.
- The earlier direct 401 was Vercel deployment protection before app code, not an invalid app credential. The new credential exchanges successfully with direct HTTP now that protection is disabled.

## Validation
- `npm run db:local:up`
- local migrations via `npm run db:migrate`
- temporary local Vitest service probe passed and wrote timing data to `.tmp/task-275-service-benchmark.json`
- `npm run build`
- temporary local Playwright benchmark passed and wrote timing data to `.tmp/task-275-browser-benchmark.json`
- protected preview API benchmark via `vercel curl` passed and wrote timing data to `.tmp/task-275-preview-vercel-curl-benchmark.json`
- direct preview API benchmark passed and wrote timing data to `.tmp/task-275-api-timings.json`
- `git diff --check`

## Review
- Addressed and resolved both Copilot comments in `9425ab2`.

## Notes
This is the investigation/report PR only. The implementation work remains queued in TASK-276.