### PR TITLE
TASK-309 Realtime event-stream foundation

### DIFF
--- a/adr/decisions.md
+++ b/adr/decisions.md
@@ -16,6 +16,28 @@ Keep UI-only or task-only notes in `journal.md`.
 
 ## Active Decisions
 
+## 2026-06-03 - Prefer SSE as the first realtime transport for project activity
+- Status: Accepted
+- Context: TASK-308 made live collaboration safer but still relied on browser
+  polling. NexusDash needs state-of-the-art collaboration freshness, but the
+  current product requirement is server-to-client invalidation for project
+  dashboards rather than bidirectional presence, cursors, or collaborative text
+  editing.
+- Decision: Add an authenticated server-sent events route for project activity
+  updates and make dashboards prefer it when `EventSource` is available. Keep
+  the existing activity endpoint and adaptive polling as the fallback for
+  unsupported browsers, stream establishment failures, and project-scoped agent
+  clients. Defer managed realtime providers until product requirements include
+  larger fanout, presence, or stronger provider-backed delivery guarantees.
+- Consequences: Open dashboards receive project activity versions through a
+  standard HTTP streaming transport while mutation services continue to use the
+  same durable `Project.updatedAt` version contract. The stream backend still
+  reads from PostgreSQL, so a future Supabase Realtime, Ably, Pusher, or
+  Liveblocks integration can replace the stream source without changing
+  dashboard mutation acknowledgements.
+- Links: `tasks/current.md`, `components/project-live-refresh.tsx`,
+  `app/api/projects/[projectId]/activity/stream/route.ts`
+
 ## 2026-06-01 - Use client-side activity acknowledgements for live project refresh
 - Status: Accepted
 - Context: TASK-276 made dashboard mutations local-first, but the existing

--- a/app/api/projects/[projectId]/activity/stream/route.ts
+++ b/app/api/projects/[projectId]/activity/stream/route.ts
@@ -1,0 +1,199 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import {
+  getAgentProjectAccessContext,
+  requireApiPrincipal,
+} from "@/lib/auth/api-guard";
+import {
+  encodeServerSentEvent,
+  sleepWithAbort,
+} from "@/lib/realtime/server-sent-events";
+import { getProjectActivitySnapshot } from "@/lib/services/project-activity-service";
+import { requireAgentProjectScopes } from "@/lib/services/project-access-service";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 300;
+
+const PROJECT_ACTIVITY_STREAM_EVENT = "project-activity";
+const PROJECT_ACTIVITY_STREAM_RETRY_MS = 2_000;
+const PROJECT_ACTIVITY_STREAM_POLL_INTERVAL_MS = 1_000;
+const PROJECT_ACTIVITY_STREAM_HEARTBEAT_INTERVAL_MS = 15_000;
+const PROJECT_ACTIVITY_STREAM_MAX_DURATION_MS = 280_000;
+
+interface ProjectActivityStreamPayload {
+  projectId: string;
+  version: string;
+  serverTime: string;
+}
+
+function isNewerVersion(nextVersion: string, currentVersion: string): boolean {
+  return Date.parse(nextVersion) > Date.parse(currentVersion);
+}
+
+function createActivityPayload(input: {
+  projectId: string;
+  version: Date;
+}): ProjectActivityStreamPayload {
+  return {
+    projectId: input.projectId,
+    version: input.version.toISOString(),
+    serverTime: new Date().toISOString(),
+  };
+}
+
+function streamHeaders(): HeadersInit {
+  return {
+    "Cache-Control": "no-store, no-transform",
+    Connection: "keep-alive",
+    "Content-Type": "text/event-stream; charset=utf-8",
+    "X-Accel-Buffering": "no",
+  };
+}
+
+export async function GET(
+  request: NextRequest,
+  props: { params: Promise<{ projectId: string }> }
+) {
+  const params = await props.params;
+  const principalResult = await requireApiPrincipal(request);
+  if (!principalResult.ok) {
+    return principalResult.response;
+  }
+
+  const agentAccess = getAgentProjectAccessContext(principalResult.principal);
+  const agentScopeAccess = requireAgentProjectScopes({
+    agentAccess,
+    projectId: params.projectId,
+    requiredScopes: ["project:read"],
+  });
+  if (!agentScopeAccess.ok) {
+    return NextResponse.json(
+      { error: agentScopeAccess.error },
+      {
+        status: agentScopeAccess.status,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      }
+    );
+  }
+
+  const initialSnapshot = await getProjectActivitySnapshot({
+    actorUserId: principalResult.principal.actorUserId,
+    projectId: params.projectId,
+  });
+
+  if (!initialSnapshot.ok) {
+    return NextResponse.json(
+      { error: initialSnapshot.error },
+      {
+        status: initialSnapshot.status,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      }
+    );
+  }
+
+  const encoder = new TextEncoder();
+  let streamCancelled = false;
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      let lastVersion = initialSnapshot.data.version.toISOString();
+      let lastHeartbeatAt = Date.now();
+      const closeAt = Date.now() + PROJECT_ACTIVITY_STREAM_MAX_DURATION_MS;
+
+      function enqueueEvent(input: {
+        event?: string;
+        id?: string;
+        data?: unknown;
+        comment?: string;
+        retry?: number;
+      }) {
+        if (streamCancelled) {
+          return;
+        }
+
+        controller.enqueue(encoder.encode(encodeServerSentEvent(input)));
+      }
+
+      enqueueEvent({
+        event: PROJECT_ACTIVITY_STREAM_EVENT,
+        id: lastVersion,
+        retry: PROJECT_ACTIVITY_STREAM_RETRY_MS,
+        data: createActivityPayload(initialSnapshot.data),
+      });
+
+      while (
+        !streamCancelled &&
+        !request.signal.aborted &&
+        Date.now() < closeAt
+      ) {
+        try {
+          await sleepWithAbort(
+            PROJECT_ACTIVITY_STREAM_POLL_INTERVAL_MS,
+            request.signal
+          );
+        } catch (error) {
+          if ((error as { name?: string }).name === "AbortError") {
+            break;
+          }
+
+          throw error;
+        }
+
+        const snapshot = await getProjectActivitySnapshot({
+          actorUserId: principalResult.principal.actorUserId,
+          projectId: params.projectId,
+        });
+
+        if (!snapshot.ok) {
+          enqueueEvent({
+            event: "error",
+            data: {
+              error: snapshot.error,
+              status: snapshot.status,
+            },
+          });
+          break;
+        }
+
+        const nextVersion = snapshot.data.version.toISOString();
+        if (isNewerVersion(nextVersion, lastVersion)) {
+          lastVersion = nextVersion;
+          lastHeartbeatAt = Date.now();
+          enqueueEvent({
+            event: PROJECT_ACTIVITY_STREAM_EVENT,
+            id: lastVersion,
+            data: createActivityPayload(snapshot.data),
+          });
+          continue;
+        }
+
+        if (Date.now() - lastHeartbeatAt >= PROJECT_ACTIVITY_STREAM_HEARTBEAT_INTERVAL_MS) {
+          lastHeartbeatAt = Date.now();
+          enqueueEvent({ comment: "heartbeat" });
+        }
+      }
+
+      if (!streamCancelled) {
+        controller.close();
+      }
+    },
+    cancel() {
+      streamCancelled = true;
+    },
+  });
+
+  return new Response(stream, {
+    headers: streamHeaders(),
+  });
+}
+
+export const projectActivityStreamRouteInternals = {
+  createActivityPayload,
+  encodeServerSentEvent,
+  isNewerVersion,
+  PROJECT_ACTIVITY_STREAM_EVENT,
+};

--- a/components/project-live-refresh.tsx
+++ b/components/project-live-refresh.tsx
@@ -20,6 +20,7 @@ interface ProjectLiveRefreshProps {
   projectId: string;
   initialVersion: string;
   pollIntervalMs?: number;
+  streamEnabled?: boolean;
 }
 
 interface ProjectActivityResponse {
@@ -43,6 +44,13 @@ function resolveNextPollIntervalMs(activePollIntervalMs: number): number {
   }
 
   return activePollIntervalMs;
+}
+
+function canUseActivityStream(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.EventSource === "function"
+  );
 }
 
 function hasRefreshLock(): boolean {
@@ -76,9 +84,13 @@ export function ProjectLiveRefresh({
   projectId,
   initialVersion,
   pollIntervalMs = DEFAULT_ACTIVE_POLL_INTERVAL_MS,
+  streamEnabled = true,
 }: ProjectLiveRefreshProps) {
   const router = useRouter();
   const [pendingVersion, setPendingVersion] = useState<string | null>(null);
+  const [isPollingFallbackActive, setIsPollingFallbackActive] = useState(
+    () => !streamEnabled || !canUseActivityStream()
+  );
   const [isRefreshing, startRefreshTransition] = useTransition();
   const knownVersionRef = useRef(initialVersion);
   const pendingVersionRef = useRef<string | null>(null);
@@ -150,6 +162,38 @@ export function ProjectLiveRefresh({
     refreshDashboard(deferred);
   }, [refreshDashboard]);
 
+  const handleActivitySnapshot = useCallback(
+    (payload: ProjectActivityResponse) => {
+      if (payload.projectId !== projectId || !payload.version) {
+        return;
+      }
+
+      if (!isNewerVersion(payload.version, knownVersionRef.current)) {
+        return;
+      }
+
+      if (localMutationCountRef.current > 0) {
+        const locallyDeferredVersion = locallyDeferredVersionRef.current;
+        if (
+          !locallyDeferredVersion ||
+          isNewerVersion(payload.version, locallyDeferredVersion)
+        ) {
+          locallyDeferredVersionRef.current = payload.version;
+        }
+        return;
+      }
+
+      if (hasRefreshLock() || isRefreshingRef.current) {
+        pendingVersionRef.current = payload.version;
+        setPendingVersion(payload.version);
+        return;
+      }
+
+      refreshDashboard(payload.version);
+    },
+    [projectId, refreshDashboard]
+  );
+
   useEffect(() => {
     function handleProjectActivityAcknowledgement(event: Event) {
       const detail = (event as CustomEvent<ProjectActivityAcknowledgementDetail>)
@@ -213,6 +257,64 @@ export function ProjectLiveRefresh({
   }, [applyLocallyDeferredVersion, projectId]);
 
   useEffect(() => {
+    setIsPollingFallbackActive(!streamEnabled || !canUseActivityStream());
+  }, [streamEnabled]);
+
+  useEffect(() => {
+    if (!streamEnabled || !canUseActivityStream()) {
+      return;
+    }
+
+    let opened = false;
+    const eventSource = new window.EventSource(
+      `/api/projects/${encodeURIComponent(projectId)}/activity/stream`
+    );
+
+    function handleOpen() {
+      opened = true;
+      setIsPollingFallbackActive(false);
+    }
+
+    function handleProjectActivity(event: MessageEvent<string>) {
+      try {
+        handleActivitySnapshot(JSON.parse(event.data) as ProjectActivityResponse);
+      } catch (error) {
+        console.warn("[ProjectLiveRefresh.streamActivity]", error);
+      }
+    }
+
+    function handleError() {
+      if (opened) {
+        return;
+      }
+
+      eventSource.close();
+      setIsPollingFallbackActive(true);
+    }
+
+    eventSource.addEventListener("open", handleOpen);
+    eventSource.addEventListener(
+      "project-activity",
+      handleProjectActivity as EventListener
+    );
+    eventSource.addEventListener("error", handleError);
+
+    return () => {
+      eventSource.removeEventListener("open", handleOpen);
+      eventSource.removeEventListener(
+        "project-activity",
+        handleProjectActivity as EventListener
+      );
+      eventSource.removeEventListener("error", handleError);
+      eventSource.close();
+    };
+  }, [handleActivitySnapshot, projectId, streamEnabled]);
+
+  useEffect(() => {
+    if (!isPollingFallbackActive) {
+      return;
+    }
+
     let cancelled = false;
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
     let controller: AbortController | null = null;
@@ -266,32 +368,7 @@ export function ProjectLiveRefresh({
         }
 
         const payload = (await response.json()) as ProjectActivityResponse;
-        if (payload.projectId !== projectId || !payload.version) {
-          return;
-        }
-
-        if (!isNewerVersion(payload.version, knownVersionRef.current)) {
-          return;
-        }
-
-        if (localMutationCountRef.current > 0) {
-          const locallyDeferredVersion = locallyDeferredVersionRef.current;
-          if (
-            !locallyDeferredVersion ||
-            isNewerVersion(payload.version, locallyDeferredVersion)
-          ) {
-            locallyDeferredVersionRef.current = payload.version;
-          }
-          return;
-        }
-
-        if (hasRefreshLock() || isRefreshingRef.current) {
-          pendingVersionRef.current = payload.version;
-          setPendingVersion(payload.version);
-          return;
-        }
-
-        refreshDashboard(payload.version);
+        handleActivitySnapshot(payload);
       } catch (error) {
         if ((error as { name?: string }).name === "AbortError") {
           return;
@@ -322,7 +399,7 @@ export function ProjectLiveRefresh({
       document.removeEventListener("visibilitychange", requestImmediatePoll);
       window.removeEventListener("focus", requestImmediatePoll);
     };
-  }, [pollIntervalMs, projectId, refreshDashboard]);
+  }, [handleActivitySnapshot, isPollingFallbackActive, pollIntervalMs, projectId]);
 
   useEffect(() => {
     function refreshWhenVisible() {
@@ -386,6 +463,7 @@ export function ProjectLiveRefresh({
 }
 
 export const projectLiveRefreshInternals = {
+  canUseActivityStream,
   hasRefreshLock,
   isNewerVersion,
   parseVersion,

--- a/journal.md
+++ b/journal.md
@@ -1943,3 +1943,23 @@ Low-value entries to avoid going forward:
 - Type: Validation
 - Summary: TASK-308 adaptive polling follow-up passed the local quality baseline.
 - Evidence: `npm run lint` passed. Local PostgreSQL env `npm test` passed (113 files passed, 2 skipped; 854 passed, 2 skipped). Local PostgreSQL env `npm run test:coverage` passed with 91.32% statements, 81.33% branches, 92.2% functions, and 91.83% lines. Preview-style env `npm run build` passed after supplying the local-safe Google token encryption placeholder required by the current `.env` OAuth group. Local-safe preview env `npm run test:e2e` with `VERCEL_ENV=preview` passed all 8 Playwright specs; an earlier run without `VERCEL_ENV=preview` failed the password-reset smoke because the placeholder Resend key was treated as live delivery.
+
+### 2026-06-03
+- Type: Execution
+- Summary: TASK-309 started after TASK-308 / PR #315 merged and chose SSE as the first durable realtime transport.
+- Evidence: PR #315 merged as `7ac91ad`. Created `feature/task-309-realtime-event-stream`, added TASK-309 to the execution queue, rewrote `tasks/current.md`, and recorded the architecture decision to prefer authenticated server-sent events for project activity while keeping adaptive polling for unsupported browsers, stream failures, and agent/API clients.
+
+### 2026-06-03
+- Type: Execution
+- Summary: TASK-309 implemented the project activity SSE foundation.
+- Evidence: Added `/api/projects/:projectId/activity/stream` with `text/event-stream` project-activity events carrying the existing `{ projectId, version, serverTime }` contract, heartbeat support, and bounded Vercel function duration. Updated `ProjectLiveRefresh` to prefer `EventSource`, retain local mutation acknowledgement/edit-lock behavior, and fall back to adaptive polling when the stream cannot open.
+
+### 2026-06-03
+- Type: Validation
+- Summary: TASK-309 focused realtime stream tests passed.
+- Evidence: `npm test -- --run tests/components/project-live-refresh.test.tsx tests/api/project-activity-stream.route.test.ts` passed 2 files / 11 tests covering stream selection, stream fallback, existing polling behavior, and SSE route formatting/authorization failure handling.
+
+### 2026-06-03
+- Type: Validation
+- Summary: TASK-309 local validation baseline passed.
+- Evidence: `npm run lint` passed. Local PostgreSQL env `npm test` passed (114 files passed, 2 skipped; 858 passed, 2 skipped). Local PostgreSQL env `npm run test:coverage` passed with 91.32% statements, 81.33% branches, 92.2% functions, and 91.83% lines. Preview-style env `npm run build` passed and included `/api/projects/[projectId]/activity/stream` in the route manifest. Local-safe preview env `npm run test:e2e` with `VERCEL_ENV=preview` passed all 8 Playwright specs.

--- a/journal.md
+++ b/journal.md
@@ -1963,3 +1963,8 @@ Low-value entries to avoid going forward:
 - Type: Validation
 - Summary: TASK-309 local validation baseline passed.
 - Evidence: `npm run lint` passed. Local PostgreSQL env `npm test` passed (114 files passed, 2 skipped; 858 passed, 2 skipped). Local PostgreSQL env `npm run test:coverage` passed with 91.32% statements, 81.33% branches, 92.2% functions, and 91.83% lines. Preview-style env `npm run build` passed and included `/api/projects/[projectId]/activity/stream` in the route manifest. Local-safe preview env `npm run test:e2e` with `VERCEL_ENV=preview` passed all 8 Playwright specs.
+
+### 2026-06-03
+- Type: Validation
+- Summary: TASK-309 Copilot review fix passed focused and broad local validation.
+- Evidence: Copilot identified that `sleepWithAbort` removed no abort listener after normal timeout resolution. Fixed the listener cleanup and added `tests/lib/server-sent-events.test.ts`. Focused `npm test -- --run tests/lib/server-sent-events.test.ts tests/components/project-live-refresh.test.tsx tests/api/project-activity-stream.route.test.ts` passed 3 files / 14 tests. `npm run lint` passed. Local PostgreSQL env `npm test` passed (115 files passed, 2 skipped; 861 passed, 2 skipped).

--- a/lib/realtime/server-sent-events.ts
+++ b/lib/realtime/server-sent-events.ts
@@ -50,15 +50,16 @@ export function sleepWithAbort(
   }
 
   return new Promise((resolve, reject) => {
-    const timeoutId = setTimeout(resolve, delayMs);
+    function handleAbort() {
+      clearTimeout(timeoutId);
+      reject(new DOMException("Aborted", "AbortError"));
+    }
 
-    signal.addEventListener(
-      "abort",
-      () => {
-        clearTimeout(timeoutId);
-        reject(new DOMException("Aborted", "AbortError"));
-      },
-      { once: true }
-    );
+    const timeoutId = setTimeout(() => {
+      signal.removeEventListener("abort", handleAbort);
+      resolve();
+    }, delayMs);
+
+    signal.addEventListener("abort", handleAbort, { once: true });
   });
 }

--- a/lib/realtime/server-sent-events.ts
+++ b/lib/realtime/server-sent-events.ts
@@ -1,0 +1,64 @@
+export interface ServerSentEventInput {
+  event?: string;
+  id?: string;
+  retry?: number;
+  data?: unknown;
+  comment?: string;
+}
+
+function sanitizeServerSentEventField(value: string): string {
+  return value.replace(/[\r\n]/g, "");
+}
+
+export function encodeServerSentEvent(input: ServerSentEventInput): string {
+  const lines: string[] = [];
+
+  if (input.comment) {
+    lines.push(`: ${input.comment.replace(/\r?\n/g, "\n: ")}`);
+  }
+
+  if (input.retry != null) {
+    lines.push(`retry: ${Math.max(0, Math.floor(input.retry))}`);
+  }
+
+  if (input.id) {
+    lines.push(`id: ${sanitizeServerSentEventField(input.id)}`);
+  }
+
+  if (input.event) {
+    lines.push(`event: ${sanitizeServerSentEventField(input.event)}`);
+  }
+
+  if (input.data !== undefined) {
+    const serialized =
+      typeof input.data === "string" ? input.data : JSON.stringify(input.data);
+    for (const line of serialized.split(/\r?\n/)) {
+      lines.push(`data: ${line}`);
+    }
+  }
+
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+export function sleepWithAbort(
+  delayMs: number,
+  signal: AbortSignal
+): Promise<void> {
+  if (signal.aborted) {
+    return Promise.reject(new DOMException("Aborted", "AbortError"));
+  }
+
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(resolve, delayMs);
+
+    signal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timeoutId);
+        reject(new DOMException("Aborted", "AbortError"));
+      },
+      { once: true }
+    );
+  });
+}

--- a/project.md
+++ b/project.md
@@ -19,10 +19,9 @@ NexusDash is a personal/team execution workspace that keeps project planning, de
   - Kanban board (`Backlog`, `In Progress`, `Blocked`, `Done`) with reorder, deadline/comment visibility, task epic links, and task detail modal
   - Project epics registry with dedicated epic CRUD, automatic status/progress, and linked-task rollups
   - Google Calendar panel (read/create/update/delete events when connected)
-  - Adaptive polling-backed live project refresh that auto-applies remote
-    collaboration updates when safe, checks active dashboards on a low-latency
-    cadence, backs off hidden tabs, and acknowledges local dashboard mutations
-    to avoid self-refresh prompts
+  - Server-sent-events-backed live project refresh that auto-applies remote
+    collaboration updates when safe, keeps adaptive polling as a fallback,
+    and acknowledges local dashboard mutations to avoid self-refresh prompts
 - Notification center:
   - durable per-user in-app inbox at `/account/notifications`
   - unread/read state and resolved lifecycle

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -6,6 +6,11 @@ Last reviewed: 2026-05-31
 
 ## Pending
 ### Execution Queue (Now / Next)
+- ID: TASK-309
+  Title: Realtime event-stream foundation - SSE transport for collaboration freshness
+  Status: In progress on `feature/task-309-realtime-event-stream`
+  Rationale: Move NexusDash collaboration freshness beyond browser polling by introducing an authenticated server-sent events transport for project activity updates, while retaining adaptive polling as a fallback. SSE is the best near-term fit because the current product needs server-to-client invalidation events for project dashboards and notification freshness, not bidirectional presence or collaborative text editing. The implementation should preserve the existing activity-version contract from TASK-308, avoid an external vendor dependency until scale/presence requirements justify one, document the managed realtime tradeoff, and leave a clean path to swap the stream backend for Supabase Realtime, Ably, Pusher, or Liveblocks later.
+  Dependencies: TASK-118, TASK-263, TASK-308
 - ID: TASK-224
   Title: Agent roadmap access - scoped API contract for roadmap phases and events
   Status: Promoted 2026-05-31

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,81 +1,91 @@
-# Current Task: TASK-308 Smart Live Project Refresh
+# Current Task: TASK-309 Realtime Event-Stream Foundation
 
 ## Task ID
-TASK-308
+TASK-309
 
 ## Status
-In progress on `feature/task-308-smart-live-refresh`.
+In progress on `feature/task-309-realtime-event-stream`.
 
 ## Source
-- User request on 2026-05-31 after TASK-276 / PR #314:
-  the bottom-right project refresh affordance should not become routine friction
-  for collaboration; remote updates should arrive automatically when safe, and
-  local/self-originated changes should not ask the user to refresh their own
-  work.
-- Backlog entry: `tasks/backlog.md` / TASK-308.
+- User request on 2026-06-03 after TASK-308 / PR #315:
+  decide whether polling is the right long-term solution, merge the current PR,
+  create the durable realtime task, choose the best solution for NexusDash, and
+  implement it in a new PR.
+- Backlog entry: `tasks/backlog.md` / TASK-309.
 
 ## Objective
-Improve the TASK-118 live project refresh layer so project dashboard
-collaboration feels automatic and interruption-aware: local mutations are
-acknowledged by the active tab, remote collaborator or agent updates refresh the
-dashboard when the user is idle, and the manual refresh prompt appears only as a
-safety affordance while editing or modal state could be disrupted.
+Move project collaboration freshness toward a state-of-the-art realtime
+architecture by adding an authenticated server-sent events transport for project
+activity updates while preserving the TASK-308 activity-version contract and
+adaptive polling fallback.
+
+## Architecture Decision
+Use SSE as the first durable realtime transport for NexusDash project activity.
+
+Rationale:
+- Current collaboration freshness is server-to-client invalidation: the app
+  needs to tell open dashboards that project state changed.
+- WebSockets are more operationally complex and are better justified by
+  bidirectional features such as presence, live cursors, or collaborative text
+  editing.
+- Managed realtime providers such as Supabase Realtime, Ably, Pusher, or
+  Liveblocks remain the likely next step when fanout, presence, or vendor-backed
+  delivery guarantees become product requirements.
+- SSE fits the existing Next.js/Vercel route-handler model, preserves cookie
+  authentication, works with the current PostgreSQL source of truth, and can
+  reuse the same project activity version snapshots already emitted by
+  mutation acknowledgements.
 
 ## Scope
-- Keep the existing lightweight activity endpoint and polling fallback.
-- Add a small client-side project activity acknowledgement contract for
-  successful local mutations.
-- Use an adaptive activity polling cadence so active project dashboards check
-  for remote collaborator changes quickly, while background tabs back off and
-  focus/visibility changes wake the checker immediately.
-- Make the live refresh controller auto-apply deferred remote updates as soon as
-  the refresh lock clears, without requiring a focus change or manual click.
-- Wire acknowledgement into high-frequency project dashboard mutations covered
-  by TASK-276: task create/update/reorder/delete/archive, comment create,
-  context-card create/update/delete, and comparable local-first flows.
-- Preserve editing safety: dialogs, focused inputs, contenteditable surfaces, and
-  explicit project live-refresh locks still defer route refresh.
-- Add focused tests for local acknowledgement, automatic refresh, and deferred
-  refresh behavior.
+- Add a project activity SSE route under the existing project activity API
+  surface.
+- Stream structured `project-activity` events that contain the same
+  `{ projectId, version, serverTime }` shape as the polling endpoint.
+- Keep the current polling endpoint and adaptive client polling as a fallback
+  for unsupported browsers, stream failures, and agent/API clients.
+- Update `ProjectLiveRefresh` to prefer SSE when available, fall back to
+  polling when the stream cannot be established, and preserve the existing
+  local acknowledgement/edit-lock safety semantics.
+- Document the SSE-vs-managed-realtime decision and future provider swap path.
+- Add focused route and component tests for stream event formatting, fallback,
+  and refresh behavior.
+
+## Out Of Scope
+- Presence, typing indicators, cursors, or collaborative document editing.
+- External realtime vendor provisioning.
+- Notification-center realtime implementation. TASK-263 remains the dedicated
+  task for live notification rows/counts/banner behavior; this task should leave
+  a compatible transport pattern for it.
 
 ## Acceptance Criteria
-1. A successful local project mutation advances/acknowledges the live-refresh
-   version for the active tab so the bottom-right refresh prompt is not shown
-   for the user's own saved action.
-2. A remote activity version newer than the known local version triggers
-   `router.refresh()` automatically when no refresh lock is active.
-3. Active visible project dashboards check for remote activity on a low-latency
-   cadence, and focus/visibility changes trigger an immediate check instead of
-   waiting for the next scheduled poll.
-4. If a remote update arrives while a form, modal, contenteditable, or explicit
-   live-refresh lock is active, the prompt is shown as a safety affordance.
-5. Once that lock clears, the pending remote update is applied automatically
-   without requiring the user to switch tabs, focus the window, or click Refresh.
-6. The live-refresh contract remains compatible with project-scoped agent
-   polling via `/api/projects/:projectId/activity`.
-7. Focused automated tests cover acknowledgement, active polling cadence,
-   focus-triggered checks, and lock-release behavior.
+1. Project dashboards prefer an authenticated SSE activity stream when
+   `EventSource` is available.
+2. SSE emits project activity versions in the same logical contract as
+   `/api/projects/:projectId/activity`.
+3. Remote stream events trigger the same safe auto-refresh behavior as polling:
+   idle dashboards refresh automatically, while edit/modal/contenteditable locks
+   defer with the manual affordance.
+4. Local mutation acknowledgements still suppress self-refresh prompts.
+5. If SSE is unavailable or fails before opening, the dashboard falls back to
+   adaptive polling.
+6. Agent/API consumers can continue using the polling activity endpoint without
+   behavioral change.
+7. Tests cover the SSE route and client stream/fallback behavior.
 
 ## Definition Of Done
 - [x] Implementation is committed on the dedicated feature branch.
-- [x] Focused tests cover the live-refresh controller and client
-      acknowledgement behavior.
+- [x] Focused tests cover the realtime stream route and client stream/fallback
+      behavior.
 - [x] `npm run lint`, `npm test`, `npm run test:coverage`, and `npm run build`
       pass.
-- [x] UI-impacting behavior is smoke-tested with Playwright locally or against a
-      branch preview.
-- [x] `tasks/backlog.md`, `tasks/current.md`, and `journal.md` are updated.
-- [ ] A ready-for-review PR is opened, automated checks pass, and Copilot review
-      feedback is handled.
+- [x] UI-impacting behavior is smoke-tested locally or against a branch preview.
+- [x] `tasks/backlog.md`, `tasks/current.md`, `journal.md`, and
+      `adr/decisions.md` are updated.
+- [ ] A ready-for-review PR is opened, automated checks pass, Copilot review
+      feedback is handled, and preview evidence is recorded if deployed.
 
 ## Notes
-- TASK-276 removed many success-path route refreshes and made local mutation
-  feedback immediate. TASK-308 builds on that by keeping the cross-tab/project
-  activity watcher from treating those local writes as unknown remote changes.
-- The current transport is intentionally still polling-based. A future realtime
-  transport can reuse the same acknowledgement semantics.
-- Active visible dashboards now poll the lightweight activity endpoint every
-  2 seconds by default; hidden tabs back off to reduce background traffic.
-- Preview deployment run `26727186276` checked out
-  `feature/task-308-smart-live-refresh` and produced
-  `https://nexus-dash-q4cso7uob-dorian-agaesses-projects.vercel.app`.
+- PR #315 merged TASK-308 as `7ac91ad` before this branch started.
+- SSE is intentionally a transport upgrade, not a full collaboration-provider
+  migration. The client boundary should make a later managed provider swap
+  possible without rewriting mutation services.

--- a/tests/api/project-activity-stream.route.test.ts
+++ b/tests/api/project-activity-stream.route.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const apiGuardMock = vi.hoisted(() => ({
+  getAgentProjectAccessContext: vi.fn(),
+  requireApiPrincipal: vi.fn(),
+}));
+
+const projectAccessServiceMock = vi.hoisted(() => ({
+  requireAgentProjectScopes: vi.fn(),
+}));
+
+const projectActivityServiceMock = vi.hoisted(() => ({
+  getProjectActivitySnapshot: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/api-guard", () => ({
+  getAgentProjectAccessContext: apiGuardMock.getAgentProjectAccessContext,
+  requireApiPrincipal: apiGuardMock.requireApiPrincipal,
+}));
+
+vi.mock("@/lib/services/project-access-service", () => ({
+  requireAgentProjectScopes: projectAccessServiceMock.requireAgentProjectScopes,
+}));
+
+vi.mock("@/lib/services/project-activity-service", () => ({
+  getProjectActivitySnapshot: projectActivityServiceMock.getProjectActivitySnapshot,
+}));
+
+import { GET as streamProjectActivity } from "@/app/api/projects/[projectId]/activity/stream/route";
+
+function projectParams(projectId: string) {
+  return { params: Promise.resolve({ projectId }) };
+}
+
+async function readFirstChunk(response: Response): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    throw new Error("missing-response-body");
+  }
+
+  const { value } = await reader.read();
+  await reader.cancel();
+  return new TextDecoder().decode(value);
+}
+
+describe("project activity stream route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiGuardMock.requireApiPrincipal.mockResolvedValue({
+      ok: true,
+      principal: {
+        kind: "human",
+        actorUserId: "user-1",
+        requestId: "request-1",
+      },
+    });
+    apiGuardMock.getAgentProjectAccessContext.mockReturnValue(undefined);
+    projectAccessServiceMock.requireAgentProjectScopes.mockReturnValue({ ok: true });
+  });
+
+  test("streams the authorized project activity version as an SSE event", async () => {
+    projectActivityServiceMock.getProjectActivitySnapshot.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        projectId: "project-1",
+        version: new Date("2026-05-30T10:00:00.000Z"),
+      },
+    });
+
+    const response = await streamProjectActivity(
+      new Request("http://localhost/api/projects/project-1/activity/stream") as never,
+      projectParams("project-1")
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    expect(response.headers.get("cache-control")).toBe("no-store, no-transform");
+
+    const chunk = await readFirstChunk(response);
+    expect(chunk).toContain("retry: 2000");
+    expect(chunk).toContain("id: 2026-05-30T10:00:00.000Z");
+    expect(chunk).toContain("event: project-activity");
+    expect(chunk).toContain('"projectId":"project-1"');
+    expect(chunk).toContain('"version":"2026-05-30T10:00:00.000Z"');
+    expect(projectActivityServiceMock.getProjectActivitySnapshot).toHaveBeenCalledWith({
+      actorUserId: "user-1",
+      projectId: "project-1",
+    });
+  });
+
+  test("returns service authorization failures before opening the stream", async () => {
+    projectActivityServiceMock.getProjectActivitySnapshot.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      error: "forbidden",
+    });
+
+    const response = await streamProjectActivity(
+      new Request("http://localhost/api/projects/project-1/activity/stream") as never,
+      projectParams("project-1")
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "forbidden" });
+  });
+});

--- a/tests/components/project-live-refresh.test.tsx
+++ b/tests/components/project-live-refresh.test.tsx
@@ -50,10 +50,61 @@ function mockActivityVersion(version: string) {
   });
 }
 
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  readonly url: string;
+  closed = false;
+  private listeners = new Map<string, Set<EventListener>>();
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? new Set<EventListener>();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: EventListener) {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  close() {
+    this.closed = true;
+  }
+
+  emit(type: string, event: Event) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+
+  open() {
+    this.emit("open", new Event("open"));
+  }
+
+  error() {
+    this.emit("error", new Event("error"));
+  }
+
+  projectActivity(payload: unknown) {
+    this.emit(
+      "project-activity",
+      new MessageEvent("project-activity", {
+        data: JSON.stringify(payload),
+      }) as unknown as Event
+    );
+  }
+}
+
 describe("ProjectLiveRefresh", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
+    MockEventSource.instances = [];
     vi.stubGlobal("fetch", fetchMock);
   });
 
@@ -61,6 +112,81 @@ describe("ProjectLiveRefresh", () => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
     document.body.innerHTML = "";
+  });
+
+  test("uses the project activity stream when EventSource is available", async () => {
+    vi.stubGlobal("EventSource", MockEventSource);
+    const { root } = createTestRenderer();
+
+    await renderWithRoot(
+      root,
+      React.createElement(ProjectLiveRefresh, {
+        projectId: "project-1",
+        initialVersion: "2026-05-30T10:00:00.000Z",
+        pollIntervalMs: 50,
+      })
+    );
+
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0]?.url).toBe(
+      "/api/projects/project-1/activity/stream"
+    );
+
+    await act(async () => {
+      MockEventSource.instances[0]?.open();
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      MockEventSource.instances[0]?.projectActivity({
+        projectId: "project-1",
+        version: "2026-05-30T10:01:00.000Z",
+        serverTime: "2026-05-30T10:01:00.000Z",
+      });
+    });
+
+    expect(routerRefreshMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      root.unmount();
+    });
+
+    expect(MockEventSource.instances[0]?.closed).toBe(true);
+  });
+
+  test("falls back to adaptive polling when the activity stream fails before opening", async () => {
+    vi.stubGlobal("EventSource", MockEventSource);
+    const { root } = createTestRenderer();
+
+    await renderWithRoot(
+      root,
+      React.createElement(ProjectLiveRefresh, {
+        projectId: "project-1",
+        initialVersion: "2026-05-30T10:00:00.000Z",
+        pollIntervalMs: 50,
+      })
+    );
+
+    mockActivityVersion("2026-05-30T10:01:00.000Z");
+
+    await act(async () => {
+      MockEventSource.instances[0]?.error();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    expect(MockEventSource.instances[0]?.closed).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(routerRefreshMock).toHaveBeenCalled();
+
+    await act(async () => {
+      root.unmount();
+    });
   });
 
   test("refreshes the dashboard when project activity advances", async () => {
@@ -131,6 +257,7 @@ describe("ProjectLiveRefresh", () => {
         projectId: "project-1",
         initialVersion: "2026-05-30T10:00:00.000Z",
         pollIntervalMs: 5000,
+        streamEnabled: false,
       })
     );
 
@@ -139,7 +266,10 @@ describe("ProjectLiveRefresh", () => {
       await vi.advanceTimersByTimeAsync(0);
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith("/api/projects/project-1/activity", {
+      cache: "no-store",
+      signal: expect.any(AbortSignal),
+    });
     expect(routerRefreshMock).toHaveBeenCalledTimes(1);
 
     await act(async () => {

--- a/tests/lib/server-sent-events.test.ts
+++ b/tests/lib/server-sent-events.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import {
+  encodeServerSentEvent,
+  sleepWithAbort,
+} from "@/lib/realtime/server-sent-events";
+
+function createInspectableAbortSignal() {
+  const listeners = new Set<EventListener>();
+  const signal = {
+    aborted: false,
+    addEventListener: vi.fn(
+      (_type: string, listener: EventListener) => {
+        listeners.add(listener);
+      }
+    ),
+    removeEventListener: vi.fn(
+      (_type: string, listener: EventListener) => {
+        listeners.delete(listener);
+      }
+    ),
+  } as unknown as AbortSignal;
+
+  return {
+    listeners,
+    signal,
+    abort() {
+      for (const listener of Array.from(listeners)) {
+        listener(new Event("abort"));
+      }
+    },
+  };
+}
+
+describe("server-sent-events", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("encodes named JSON events", () => {
+    expect(
+      encodeServerSentEvent({
+        event: "project-activity",
+        id: "2026-06-03T00:00:00.000Z",
+        retry: 2000,
+        data: { projectId: "project-1" },
+      })
+    ).toBe(
+      [
+        "retry: 2000",
+        "id: 2026-06-03T00:00:00.000Z",
+        "event: project-activity",
+        'data: {"projectId":"project-1"}',
+        "",
+        "",
+      ].join("\n")
+    );
+  });
+
+  test("cleans up abort listeners when sleep resolves", async () => {
+    vi.useFakeTimers();
+    const abort = createInspectableAbortSignal();
+
+    const promise = sleepWithAbort(50, abort.signal);
+    expect(abort.listeners.size).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(50);
+    await expect(promise).resolves.toBeUndefined();
+    expect(abort.listeners.size).toBe(0);
+    expect(abort.signal.removeEventListener).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects when the signal aborts", async () => {
+    vi.useFakeTimers();
+    const abort = createInspectableAbortSignal();
+
+    const promise = sleepWithAbort(50, abort.signal);
+    abort.abort();
+
+    await expect(promise).rejects.toMatchObject({ name: "AbortError" });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds TASK-309 as the realtime event-stream foundation for NexusDash collaboration freshness.
- Introduces an authenticated `/api/projects/:projectId/activity/stream` SSE endpoint that emits the existing project activity version contract.
- Updates `ProjectLiveRefresh` to prefer `EventSource`, preserve TASK-308 local acknowledgement/edit-lock safety, and fall back to adaptive polling when streaming is unavailable or cannot open.
- Records the architecture decision: SSE first for one-way invalidation, managed realtime provider later when presence/fanout/bidirectional collaboration requirements justify it.

## Why

Polling was a pragmatic bridge, but NexusDash should move toward realtime practices. SSE is the best fit for the current product shape because project dashboards need server-to-client invalidation, not WebSocket-style bidirectional collaboration yet.

## Validation

- `npm test -- --run tests/components/project-live-refresh.test.tsx tests/api/project-activity-stream.route.test.ts`
- `npm run lint`
- Local PostgreSQL env `npm test`
- Local PostgreSQL env `npm run test:coverage`
- Preview-style env `npm run build`
- Local-safe preview env `npm run test:e2e` with `VERCEL_ENV=preview`