### PR TITLE
TASK-312 Hidden project refresh reconciliation

### DIFF
--- a/components/project-live-refresh.tsx
+++ b/components/project-live-refresh.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState, useTransition } from "react";
-import { RefreshCw } from "lucide-react";
 import { useRouter } from "next/navigation";
 
-import { Button } from "@/components/ui/button";
 import {
   dispatchProjectActivityRemoteEvent,
   PROJECT_ACTIVITY_ACK_EVENT,
@@ -454,27 +452,7 @@ export function ProjectLiveRefresh({
     };
   }, [pendingVersion, refreshDashboard]);
 
-  if (!pendingVersion) {
-    return null;
-  }
-
-  return (
-    <div
-      aria-live="polite"
-      className="fixed bottom-4 left-1/2 z-50 flex w-[calc(100%-2rem)] max-w-md -translate-x-1/2 items-center justify-between gap-3 rounded-md border border-border bg-popover px-4 py-3 text-sm text-popover-foreground shadow-lg sm:left-auto sm:right-4 sm:w-auto sm:translate-x-0"
-    >
-      <span>Project updates are ready.</span>
-      <Button
-        type="button"
-        size="sm"
-        onClick={() => refreshDashboard(pendingVersion)}
-        disabled={isRefreshing}
-      >
-        <RefreshCw className="h-4 w-4" />
-        Refresh
-      </Button>
-    </div>
-  );
+  return null;
 }
 
 export const projectLiveRefreshInternals = {

--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,19 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-06-04 - TASK-312 hidden project refresh reconciliation
+
+- Summary: Removed the user-facing project refresh prompt/button while keeping
+  the internal pending-refresh safety path for edit locks and hidden tabs.
+- Evidence: `ProjectLiveRefresh` now renders no UI for pending versions. Focused
+  component coverage was updated so locked remote updates stay invisible and
+  still auto-refresh once the lock clears. `npm test -- --run
+  tests/components/project-live-refresh.test.tsx`, `npm run lint`, local
+  PostgreSQL env `npm test`, local PostgreSQL env `npm run test:coverage`, and
+  local-safe `npm run build` passed. Local-safe `npm run test:e2e` passed 8/8
+  specs after adding the expected local auth origin env. TASK-311 was moved to
+  completed after PR #318 merged.
+
 # 2026-05-31 - TASK-275 performance investigation completed
 
 - Summary: Completed the app action-latency investigation and scoped TASK-276

--- a/project.md
+++ b/project.md
@@ -115,9 +115,8 @@ Source of truth: [`prisma/schema.prisma`](./prisma/schema.prisma)
 
 From `tasks/current.md` + `tasks/backlog.md`:
 
-1. TASK-311: typed realtime events and targeted dashboard reconciliation
-2. TASK-224: agent roadmap access for scoped roadmap phase/event APIs
-3. TASK-263: real-time notification updates for inbox/count awareness
+1. TASK-224: agent roadmap access for scoped roadmap phase/event APIs
+2. TASK-263: real-time notification updates for inbox/count awareness
 
 ## 8. Source-of-Truth Docs
 

--- a/project.md
+++ b/project.md
@@ -115,8 +115,9 @@ Source of truth: [`prisma/schema.prisma`](./prisma/schema.prisma)
 
 From `tasks/current.md` + `tasks/backlog.md`:
 
-1. TASK-224: agent roadmap access for scoped roadmap phase/event APIs
-2. TASK-263: real-time notification updates for inbox/count awareness
+1. TASK-312: hidden project refresh reconciliation
+2. TASK-224: agent roadmap access for scoped roadmap phase/event APIs
+3. TASK-263: real-time notification updates for inbox/count awareness
 
 ## 8. Source-of-Truth Docs
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -6,11 +6,6 @@ Last reviewed: 2026-05-31
 
 ## Pending
 ### Execution Queue (Now / Next)
-- ID: TASK-311
-  Title: Product latency remediation - typed realtime events and targeted dashboard reconciliation
-  Status: Implemented and locally validated on `feature/task-311-product-latency-remediation`; PR workflow pending
-  Rationale: Implement the top-ranked path from TASK-310 by replacing project-level "something changed" refresh behavior with typed project activity events that can update relevant dashboard client state immediately. Task create/update/move, task comment create, and context card create/update/delete should no longer force observers through a broad `router.refresh()` when the change can be safely reconciled locally. Keep the existing version-based live refresh as a safety fallback and add timing marks so actor and observer latency can be measured in local production mode and preview.
-  Dependencies: TASK-310, TASK-309, TASK-308, TASK-276, TASK-263
 - ID: TASK-224
   Title: Agent roadmap access - scoped API contract for roadmap phases and events
   Status: Promoted 2026-05-31
@@ -122,6 +117,16 @@ Last reviewed: 2026-05-31
   Dependencies: TASK-051
 
 ## Completed
+- ID: TASK-312
+  Title: Hidden project refresh reconciliation - remove user-facing refresh prompt
+  Status: Done (2026-06-04, PR pending)
+  Rationale: Removed the visible bottom-right project refresh prompt and manual refresh button while preserving hidden pending-version tracking and automatic refresh once active edit locks or hidden-tab constraints clear. This keeps realtime collaboration machinery out of the user's way.
+  Dependencies: TASK-311, TASK-308
+- ID: TASK-311
+  Title: Product latency remediation - typed realtime events and targeted dashboard reconciliation
+  Status: Done (2026-06-04, merged via PR #318)
+  Rationale: Implemented the top-ranked path from TASK-310 by adding typed project activity events and direct dashboard reconciliation for task, task-comment, and context-card mutations. Final preview validation showed the observer dashboard applying a remote task create 98 ms after API completion, eliminating the prior 4-5 second broad-refresh fallback delay for supported events.
+  Dependencies: TASK-310, TASK-309, TASK-308, TASK-276, TASK-263
 - ID: TASK-310
   Title: Full-stack product performance investigation - user-perceived latency root cause report
   Status: Done (2026-06-04, merged via PR #317)

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,153 +1,65 @@
-# Current Task: TASK-311 Product Latency Remediation
+# Current Task: TASK-312 Hidden Project Refresh Reconciliation
 
 ## Task ID
-TASK-311
+TASK-312
 
 ## Status
-Implementation validated locally and on branch preview
-`feature/task-311-product-latency-remediation`; PR merge workflow in progress.
+Implemented on `feature/task-312-hide-project-refresh-affordance`; PR workflow
+in progress.
 
 ## Source
-- Follow-up implementation task created from TASK-310 after PR #317 merged on
-  2026-06-04.
-- Report: `docs/reports/task-310-performance-investigation.md`.
+- User feedback after TASK-311: the bottom-right "Project updates are ready /
+  Refresh" button exposes internal synchronization machinery and adds
+  unnecessary product noise.
 
 ## Objective
-Make collaboration updates feel production-grade by replacing project-level
-"something changed" refresh behavior with typed project events that can update
-the relevant dashboard client state immediately, while preserving broad route
-refresh as a safe fallback.
+Keep the live project reconciliation safety fallback, but make it invisible to
+users. Remote updates may still be deferred while a user is actively editing or
+the tab is hidden, then auto-apply as soon as the dashboard is safe to refresh.
 
 ## Why This Matters
-TASK-310 reproduced the core latency gap locally: a remote/API task create took
-72 ms wall-clock and `task-create;dur=63.0`, but the already-open observer
-dashboard took 4513 ms to show the new card. That isolates the most urgent
-remaining issue to poll-backed activity propagation plus broad
-`router.refresh()` reconciliation.
+NexusDash should feel collaborative and automatic. A visible manual refresh
+control suggests the user must understand or operate the realtime system, even
+though the app already has enough state to apply pending updates safely once
+editing locks clear.
 
 ## Scope
-- Introduce a typed project activity event contract for supported mutations.
-- Emit typed events for:
-  - task create
-  - task update
-  - task reorder/move
-  - task comment create
-  - context card create/update/delete
-- Reconcile safe remote events directly in dashboard client state:
-  - add/update/move task cards when no edit lock conflicts;
-  - update comment counts and append detail-modal comments when possible;
-  - add/update/remove context cards;
-  - fall back to existing safe live refresh behavior for unknown or unsafe
-    events.
-- Add client timing marks for mutation completion, event receipt, local patch
-  application, and fallback refresh.
-- Add local production-mode measurement for observer-visible latency before and
-  after the implementation.
+- Remove the rendered project-refresh prompt and manual refresh button from
+  `ProjectLiveRefresh`.
+- Preserve hidden pending-version tracking and automatic refresh once locks,
+  hidden-tab state, or in-flight refresh state clear.
+- Update component tests so they assert silent deferral and automatic follow-up
+  refresh behavior.
+- Mark TASK-311 complete in backlog tracking now that PR #318 is merged.
 
 ## Out Of Scope
-- Provisioning a managed realtime provider in this task.
-- Replacing the app database as the source of truth.
-- Notification-center live updates; TASK-263 remains the dedicated task.
-- Presence, typing indicators, live cursors, or collaborative text editing.
-
-## Architecture Direction
-- Keep the existing project activity version as a coarse fallback.
-- Add typed domain events as the primary reconciliation signal.
-- Separate event creation, event publication/streaming, and client
-  reconciliation so a future managed realtime provider can replace the current
-  poll-backed SSE transport without rewriting dashboard state handling.
-- Prefer canonical mutation payloads for safe local patching; use targeted
-  background reads or full refresh only when the payload is incomplete or the
-  local state is unsafe to patch.
+- Changing the typed realtime event contract from TASK-311.
+- Replacing the SSE/fallback transport.
+- Notification-center realtime behavior; TASK-263 remains the dedicated task.
 
 ## Acceptance Criteria
-1. Mutations emit typed project activity events for task create/update/move,
-   task comment create, and context card create/update/delete.
-2. Remote task/context/comment events update an open dashboard without waiting
-   for full `router.refresh()` when the user is not editing the affected
-   entity.
-3. Unknown, unsafe, or schema-incompatible events still fall back to the current
-   safe refresh prompt/auto-refresh behavior.
-4. Observer-visible task create/move/update latency is measured locally and
-   reduced from the TASK-310 baseline of ~4.5 seconds to under 1.5 seconds,
-   with a stretch target under 500 ms after mutation completion in local
-   production mode.
-5. Client timing marks record mutation completion, event receipt, patch
-   application, and fallback refresh.
-6. The implementation keeps a clear path to managed realtime by separating the
-   event contract from the transport.
+1. Users never see the bottom-right project refresh prompt or refresh button.
+2. Remote updates that cannot be applied immediately remain pending internally.
+3. Pending updates still auto-refresh when the dashboard becomes safe.
+4. Existing typed-event patching and fallback-refresh behavior remain covered by
+   tests.
 
 ## Definition Of Done
-- [x] Implementation is committed on `feature/task-311-product-latency-remediation`.
-- [x] Focused tests cover event creation and client reconciliation.
-- [x] Local production-mode browser/API probe records before/after observer
-      latency.
-- [x] `npm run lint`, `npm test`, `npm run test:coverage`, and `npm run build`
-      pass.
-- [x] A branch preview is deployed and validates at least one actor-side flow
-      and one observer-side flow.
-- [x] `tasks/backlog.md`, `tasks/current.md`, `journal.md`, and ADR docs are
-      updated.
-- [ ] A ready PR is opened, checks pass, Copilot feedback is handled, and the
-      PR is merged or ready for maintainer review depending on permissions.
+- [x] `ProjectLiveRefresh` no longer renders user-facing pending-refresh UI.
+- [x] Focused tests cover invisible deferral and automatic pending refresh.
+- [x] `tasks/backlog.md`, `tasks/current.md`, and `journal.md` are updated.
+- [ ] PR is opened, checks pass, Copilot feedback is handled, and the PR is
+      merged.
 
-## Local Validation Evidence
+## Validation Evidence
+- `npm test -- --run tests/components/project-live-refresh.test.tsx` passed 1
+  file / 10 tests.
 - `npm run lint` passed.
-- Local PostgreSQL env `npm test` passed: 115 files passed, 2 skipped; 864
+- Local PostgreSQL env `npm test` passed: 116 files passed, 2 skipped; 866
   tests passed, 2 skipped.
 - Local PostgreSQL env `npm run test:coverage` passed with 91.37% statements,
   81.33% branches, 92.2% functions, and 91.88% lines.
-- Local-safe production env `npm run build` passed after providing the
-  required local `GOOGLE_TOKEN_ENCRYPTION_KEY` placeholder.
-- Local-safe `npm run test:e2e` passed all 8 Playwright specs with
-  `OUTBOUND_EMAIL_DELIVERY_MODE=disabled`; an earlier run with the placeholder
-  Resend key in live mode failed only the password-reset email send path.
-- Local production-mode two-user latency probe on `127.0.0.1:3150`: task
-  create API 119 ms, observer card visible 825 ms after API completion and
-  944 ms after mutation start. Observer marks showed
-  `nexusdash.project-activity.received` followed by
-  `nexusdash.project-activity.patched` 3 ms later, with no console errors.
-- After hardening event writes through `app.record_project_activity_event(...)`,
-  local production-mode probe on `127.0.0.1:3152` passed with task create API
-  54 ms, observer card visible 849 ms after API completion and 904 ms after
-  mutation start. The observer received a typed `task/created` remote event and
-  marked `received` then `patched`.
-- After Copilot review follow-up, event stream cursors use a composite
-  `version`/`createdAt`/`id` cursor and the database event function advances
-  project event versions monotonically under a project-row lock. Typed event
-  failures now fall back to a durable project activity touch before returning a
-  response header version.
-- Review-fix validation passed: `npm run lint`, local PostgreSQL env
-  `npm test` (116 files passed, 2 skipped; 866 tests passed, 2 skipped),
-  `npm run test:coverage` (91.37% statements, 81.33% branches, 92.2%
-  functions, 91.88% lines), and local-safe `npm run test:e2e` (8/8 specs).
-- Local production-mode probe on `127.0.0.1:3154` after the review fixes
-  measured task create API 66 ms, observer card visible 1345 ms after API
-  completion and 1411 ms after mutation start. Observer marks showed
-  `received` then `patched`, and the observer received a typed `task/created`
-  event.
-- Final branch preview `26921567621` initially reproduced the deployed
-  fallback path: task create API 2608 ms, observer visible 2912 ms after API
-  completion, observer marks showed `received` then `fallback-refresh-start`,
-  and no typed remote events were received. Migrations had applied, so the
-  deployed gap was narrowed to runtime access to the new event table under the
-  split migration/runtime database roles.
-- Added an explicit `SELECT, INSERT` runtime grant for
-  `ProjectActivityEvent`; RLS policies remain the authorization boundary.
-- Switched event recording to prefer the Prisma `projectActivityEvent.create`
-  path inside the existing actor RLS transaction after the durable activity
-  touch. The database function remains available as a fallback, but the primary
-  runtime path now uses the same RLS/grant model as the rest of the service
-  layer.
-- Final branch preview run `26922436935` deployed
-  `git_ref=feature/task-311-product-latency-remediation` to
-  `https://nexus-dash-gztb6x1zo-dorian-agaesses-projects.vercel.app`; workflow
-  logs show checkout of
-  `refs/remotes/origin/feature/task-311-product-latency-remediation`.
-- Preview browser probe created two accounts, created a project, invited and
-  accepted an observer member, opened the observer dashboard, and created a
-  task as the actor. Result: task create API 2691 ms, observer card visible 98
-  ms after API completion and 2789 ms after mutation start. Observer marks
-  showed `received` then `patched`, and the observer received a typed
-  `task/created` event. This confirms the previous 4-5s deployed
-  cross-user update delay was caused by fallback refresh, not by client patching.
+- Local-safe production env `npm run build` passed.
+- Local-safe production env `npm run test:e2e` passed 8/8 Playwright specs
+  after providing the expected `NEXTAUTH_URL`/`NEXTAUTH_SECRET` and trusted
+  local origins for the password-reset flow.

--- a/tests/components/project-live-refresh.test.tsx
+++ b/tests/components/project-live-refresh.test.tsx
@@ -329,7 +329,7 @@ describe("ProjectLiveRefresh", () => {
     });
   });
 
-  test("defers refresh while local editing is active and exposes a refresh action", async () => {
+  test("defers refresh invisibly while local editing is active", async () => {
     const { container, root } = createTestRenderer();
     const lock = document.createElement("div");
     lock.setAttribute("data-project-live-refresh-lock", "true");
@@ -350,16 +350,8 @@ describe("ProjectLiveRefresh", () => {
     });
 
     expect(routerRefreshMock).not.toHaveBeenCalled();
-    expect(container.textContent).toContain("Project updates are ready.");
-
-    const refreshButton = Array.from(container.querySelectorAll("button")).find((button) =>
-      button.textContent?.includes("Refresh")
-    );
-    await act(async () => {
-      refreshButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-
-    expect(routerRefreshMock).toHaveBeenCalledTimes(1);
+    expect(container.textContent).not.toContain("Project updates are ready.");
+    expect(container.querySelector("button")).toBeNull();
 
     await act(async () => {
       root.unmount();
@@ -457,7 +449,7 @@ describe("ProjectLiveRefresh", () => {
     });
 
     expect(routerRefreshMock).not.toHaveBeenCalled();
-    expect(container.textContent).toContain("Project updates are ready.");
+    expect(container.textContent).not.toContain("Project updates are ready.");
 
     lock.remove();
 


### PR DESCRIPTION
## Summary
- removes the user-facing `ProjectLiveRefresh` pending-update prompt and manual refresh button
- preserves hidden pending-version tracking so remote updates still auto-refresh when edit locks, hidden-tab state, or in-flight refresh state clear
- updates task tracking by moving TASK-311 to completed and recording TASK-312 validation evidence

## Validation
- `npm test -- --run tests/components/project-live-refresh.test.tsx`
- `npm run lint`
- local PostgreSQL env `npm test`
- local PostgreSQL env `npm run test:coverage`
- local-safe production env `npm run build`
- local-safe production env `npm run test:e2e` with expected local auth origin env

## Notes
This intentionally keeps realtime fallback mechanics internal. Users should not see a project-refresh affordance during normal collaboration; the dashboard applies safe typed events directly or refreshes silently once it is safe to do so.
