### PR TITLE
TASK-263 Real-time notification updates

### DIFF
--- a/adr/decisions.md
+++ b/adr/decisions.md
@@ -16,6 +16,28 @@ Keep UI-only or task-only notes in `journal.md`.
 
 ## Active Decisions
 
+## 2026-06-04 - Use account-scoped SSE snapshots for in-app notification freshness
+- Status: Accepted
+- Context: TASK-263 needs invitation, assignment, mention, and future
+  notification rows to appear in active sessions without navigation or manual
+  refresh, while email notification delivery must remain grouped and debounced.
+- Decision: Keep `Notification` as the source of truth and add an
+  authenticated account-scoped realtime snapshot contract containing version,
+  unread count, and latest unread title. A single client-side chrome component
+  prefers an SSE stream and falls back to adaptive polling; account menu counts,
+  account notification links, awareness banners, and the notification center
+  subscribe to that browser state. The notification center refetches full rows
+  through the existing account notifications API when the snapshot version
+  changes.
+- Consequences: The app gains live in-app notification freshness without adding
+  a second realtime provider or changing email digest behavior. Persistent SSE
+  connections mean E2E tests must wait for UI readiness rather than
+  `networkidle`. The stream reconciles project invitations on the initial
+  snapshot, then uses read-only snapshot polling for steady-state updates.
+- Links: `tasks/current.md`, `lib/services/notification-service.ts`,
+  `components/notification-live-updates.tsx`,
+  `app/api/account/notifications/stream/route.ts`
+
 ## 2026-06-04 - Use typed project activity events for targeted dashboard reconciliation
 - Status: Accepted
 - Context: TASK-310 showed that local mutation APIs were fast while observers

--- a/app/account/layout.tsx
+++ b/app/account/layout.tsx
@@ -1,5 +1,8 @@
 import { NotificationAwarenessBanner } from "@/components/notification-awareness-banner";
 import { requireVerifiedSessionUserIdFromServer } from "@/lib/auth/server-guard";
+import { logServerError } from "@/lib/observability/logger";
+import { getNotificationRealtimeSnapshotForUser } from "@/lib/services/notification-service";
+import type { NotificationRealtimeSnapshot } from "@/lib/notification-realtime-types";
 
 export const dynamic = "force-dynamic";
 
@@ -9,11 +12,26 @@ export default async function AccountLayout({
   children: React.ReactNode;
 }) {
   const actorUserId = await requireVerifiedSessionUserIdFromServer();
+  let notificationSnapshot: NotificationRealtimeSnapshot = {
+    version: new Date(0).toISOString(),
+    unreadCount: 0,
+    latestUnreadNotification: null,
+    serverTime: new Date().toISOString(),
+  };
+
+  try {
+    const result = await getNotificationRealtimeSnapshotForUser(actorUserId);
+    if (result.ok) {
+      notificationSnapshot = result.data;
+    }
+  } catch (error) {
+    logServerError("AccountLayout.getNotificationRealtimeSnapshotForUser", error);
+  }
 
   return (
     <>
       <div className="container pt-6">
-        <NotificationAwarenessBanner actorUserId={actorUserId} />
+        <NotificationAwarenessBanner initialSnapshot={notificationSnapshot} />
       </div>
       {children}
     </>

--- a/app/account/layout.tsx
+++ b/app/account/layout.tsx
@@ -1,8 +1,6 @@
 import { NotificationAwarenessBanner } from "@/components/notification-awareness-banner";
 import { requireVerifiedSessionUserIdFromServer } from "@/lib/auth/server-guard";
-import { logServerError } from "@/lib/observability/logger";
-import { getNotificationRealtimeSnapshotForUser } from "@/lib/services/notification-service";
-import type { NotificationRealtimeSnapshot } from "@/lib/notification-realtime-types";
+import { getInitialNotificationRealtimeSnapshotForUser } from "@/lib/notification-realtime-server";
 
 export const dynamic = "force-dynamic";
 
@@ -12,21 +10,8 @@ export default async function AccountLayout({
   children: React.ReactNode;
 }) {
   const actorUserId = await requireVerifiedSessionUserIdFromServer();
-  let notificationSnapshot: NotificationRealtimeSnapshot = {
-    version: new Date(0).toISOString(),
-    unreadCount: 0,
-    latestUnreadNotification: null,
-    serverTime: new Date().toISOString(),
-  };
-
-  try {
-    const result = await getNotificationRealtimeSnapshotForUser(actorUserId);
-    if (result.ok) {
-      notificationSnapshot = result.data;
-    }
-  } catch (error) {
-    logServerError("AccountLayout.getNotificationRealtimeSnapshotForUser", error);
-  }
+  const notificationSnapshot =
+    await getInitialNotificationRealtimeSnapshotForUser(actorUserId);
 
   return (
     <>

--- a/app/account/notifications/page.tsx
+++ b/app/account/notifications/page.tsx
@@ -9,9 +9,11 @@ import { Button } from "@/components/ui/button";
 import { requireVerifiedSessionUserIdFromServer } from "@/lib/auth/server-guard";
 import { logServerError } from "@/lib/observability/logger";
 import {
+  getNotificationRealtimeSnapshotForUser,
   listNotificationsForUser,
   type NotificationSummary,
 } from "@/lib/services/notification-service";
+import type { NotificationRealtimeSnapshot } from "@/lib/notification-realtime-types";
 
 import {
   acceptNotificationInvitationAction,
@@ -74,13 +76,26 @@ export default async function AccountNotificationsPage({
   const error = readQueryValue(resolvedSearchParams?.error);
 
   let notifications: NotificationSummary[] = [];
+  let notificationSnapshot: NotificationRealtimeSnapshot = {
+    version: new Date(0).toISOString(),
+    unreadCount: 0,
+    latestUnreadNotification: null,
+    serverTime: new Date().toISOString(),
+  };
   let listError: string | null = null;
   try {
-    const result = await listNotificationsForUser(actorUserId);
-    if (result.ok) {
-      notifications = result.data.notifications;
+    const [listResult, snapshotResult] = await Promise.all([
+      listNotificationsForUser(actorUserId),
+      getNotificationRealtimeSnapshotForUser(actorUserId),
+    ]);
+    if (listResult.ok) {
+      notifications = listResult.data.notifications;
     } else {
-      listError = result.error;
+      listError = listResult.error;
+    }
+
+    if (snapshotResult.ok) {
+      notificationSnapshot = snapshotResult.data;
     }
   } catch (loadError) {
     logServerError("AccountNotificationsPage.listNotificationsForUser", loadError);
@@ -124,6 +139,7 @@ export default async function AccountNotificationsPage({
 
         <NotificationCenterList
           notifications={notifications}
+          initialSnapshot={notificationSnapshot}
           onMarkRead={markNotificationReadAction}
           onMarkUnread={markNotificationUnreadAction}
           onMarkAllRead={markAllNotificationsReadAction}

--- a/app/account/notifications/page.tsx
+++ b/app/account/notifications/page.tsx
@@ -7,13 +7,13 @@ import { AutoDismissingAlert } from "@/components/auto-dismissing-alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { requireVerifiedSessionUserIdFromServer } from "@/lib/auth/server-guard";
+import { getInitialNotificationRealtimeSnapshotForUser } from "@/lib/notification-realtime-server";
+import type { NotificationRealtimeSnapshot } from "@/lib/notification-realtime-types";
 import { logServerError } from "@/lib/observability/logger";
 import {
-  getNotificationRealtimeSnapshotForUser,
   listNotificationsForUser,
   type NotificationSummary,
 } from "@/lib/services/notification-service";
-import type { NotificationRealtimeSnapshot } from "@/lib/notification-realtime-types";
 
 import {
   acceptNotificationInvitationAction,
@@ -86,7 +86,7 @@ export default async function AccountNotificationsPage({
   try {
     const [listResult, snapshotResult] = await Promise.all([
       listNotificationsForUser(actorUserId),
-      getNotificationRealtimeSnapshotForUser(actorUserId),
+      getInitialNotificationRealtimeSnapshotForUser(actorUserId),
     ]);
     if (listResult.ok) {
       notifications = listResult.data.notifications;
@@ -94,9 +94,7 @@ export default async function AccountNotificationsPage({
       listError = listResult.error;
     }
 
-    if (snapshotResult.ok) {
-      notificationSnapshot = snapshotResult.data;
-    }
+    notificationSnapshot = snapshotResult;
   } catch (loadError) {
     logServerError("AccountNotificationsPage.listNotificationsForUser", loadError);
     listError = "notifications-list-failed";

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
 import { unstable_noStore as noStore } from "next/cache";
 import { notFound } from "next/navigation";
-import { ArrowLeft, Bell, Settings } from "lucide-react";
+import { ArrowLeft, Settings } from "lucide-react";
 
+import { AccountNotificationsLink } from "@/components/account-notifications-link";
 import { AutoDismissingAlert } from "@/components/auto-dismissing-alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -15,7 +16,8 @@ import {
   MAX_USERNAME_LENGTH,
   MIN_USERNAME_LENGTH,
 } from "@/lib/services/account-security-policy";
-import { countUnreadNotificationsForUser } from "@/lib/services/notification-service";
+import type { NotificationRealtimeSnapshot } from "@/lib/notification-realtime-types";
+import { getNotificationRealtimeSnapshotForUser } from "@/lib/services/notification-service";
 import { getAccountProfile } from "@/lib/services/account-profile-service";
 
 import {
@@ -93,9 +95,17 @@ export default async function AccountProfilePage({
     notFound();
   }
 
-  let unreadNotificationCount = 0;
+  let notificationSnapshot: NotificationRealtimeSnapshot = {
+    version: new Date(0).toISOString(),
+    unreadCount: 0,
+    latestUnreadNotification: null,
+    serverTime: new Date().toISOString(),
+  };
   try {
-    unreadNotificationCount = await countUnreadNotificationsForUser(actorUserId);
+    const result = await getNotificationRealtimeSnapshotForUser(actorUserId);
+    if (result.ok) {
+      notificationSnapshot = result.data;
+    }
   } catch {
     // Non-critical, ignore count fetch failure
   }
@@ -116,21 +126,7 @@ export default async function AccountProfilePage({
             </Link>
           </Button>
           <div className="flex items-center gap-2">
-            <Button
-              asChild
-              variant="outline"
-              className="relative rounded-full border-border/60 px-3 py-1.5 text-sm font-medium text-muted-foreground hover:border-border hover:text-foreground"
-            >
-              <Link href="/account/notifications">
-                <Bell className="h-4 w-4" />
-                Notifications
-                {unreadNotificationCount > 0 ? (
-                  <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-[10px] font-medium text-white">
-                    {unreadNotificationCount > 9 ? "9+" : unreadNotificationCount}
-                  </span>
-                ) : null}
-              </Link>
-            </Button>
+            <AccountNotificationsLink initialSnapshot={notificationSnapshot} />
             <Button
               asChild
               variant="outline"

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -16,8 +16,7 @@ import {
   MAX_USERNAME_LENGTH,
   MIN_USERNAME_LENGTH,
 } from "@/lib/services/account-security-policy";
-import type { NotificationRealtimeSnapshot } from "@/lib/notification-realtime-types";
-import { getNotificationRealtimeSnapshotForUser } from "@/lib/services/notification-service";
+import { getInitialNotificationRealtimeSnapshotForUser } from "@/lib/notification-realtime-server";
 import { getAccountProfile } from "@/lib/services/account-profile-service";
 
 import {
@@ -95,20 +94,8 @@ export default async function AccountProfilePage({
     notFound();
   }
 
-  let notificationSnapshot: NotificationRealtimeSnapshot = {
-    version: new Date(0).toISOString(),
-    unreadCount: 0,
-    latestUnreadNotification: null,
-    serverTime: new Date().toISOString(),
-  };
-  try {
-    const result = await getNotificationRealtimeSnapshotForUser(actorUserId);
-    if (result.ok) {
-      notificationSnapshot = result.data;
-    }
-  } catch {
-    // Non-critical, ignore count fetch failure
-  }
+  const notificationSnapshot =
+    await getInitialNotificationRealtimeSnapshotForUser(actorUserId);
 
   const status = readQueryValue(resolvedSearchParams?.status);
   const error = readQueryValue(resolvedSearchParams?.error);

--- a/app/api/account/notifications/stream/route.ts
+++ b/app/api/account/notifications/stream/route.ts
@@ -1,0 +1,163 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireAuthenticatedApiUser } from "@/lib/auth/api-guard";
+import {
+  encodeServerSentEvent,
+  sleepWithAbort,
+} from "@/lib/realtime/server-sent-events";
+import type { NotificationRealtimeSnapshot } from "@/lib/notification-realtime-types";
+import { getNotificationRealtimeSnapshotForUser } from "@/lib/services/notification-service";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 300;
+
+const NOTIFICATION_STREAM_EVENT = "notification-snapshot";
+const NOTIFICATION_STREAM_RETRY_MS = 2_000;
+const NOTIFICATION_STREAM_POLL_INTERVAL_MS = 1_000;
+const NOTIFICATION_STREAM_HEARTBEAT_INTERVAL_MS = 15_000;
+const NOTIFICATION_STREAM_MAX_DURATION_MS = 280_000;
+
+function streamHeaders(): HeadersInit {
+  return {
+    "Cache-Control": "no-store, no-transform",
+    Connection: "keep-alive",
+    "Content-Type": "text/event-stream; charset=utf-8",
+    "X-Accel-Buffering": "no",
+  };
+}
+
+function isSnapshotChanged(
+  next: NotificationRealtimeSnapshot,
+  previous: NotificationRealtimeSnapshot
+): boolean {
+  return (
+    next.version !== previous.version ||
+    next.unreadCount !== previous.unreadCount ||
+    next.latestUnreadNotification?.title !==
+      previous.latestUnreadNotification?.title
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const authenticatedUser = await requireAuthenticatedApiUser(request);
+  if (!authenticatedUser.ok) {
+    return authenticatedUser.response;
+  }
+
+  const initialSnapshot = await getNotificationRealtimeSnapshotForUser(
+    authenticatedUser.userId
+  );
+  if (!initialSnapshot.ok) {
+    return NextResponse.json(
+      { error: initialSnapshot.error },
+      {
+        status: initialSnapshot.status,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      }
+    );
+  }
+
+  const encoder = new TextEncoder();
+  let streamCancelled = false;
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      let lastSnapshot = initialSnapshot.data;
+      let lastHeartbeatAt = Date.now();
+      const closeAt = Date.now() + NOTIFICATION_STREAM_MAX_DURATION_MS;
+
+      function enqueueEvent(input: {
+        event?: string;
+        id?: string;
+        data?: unknown;
+        comment?: string;
+        retry?: number;
+      }) {
+        if (streamCancelled) {
+          return;
+        }
+
+        controller.enqueue(encoder.encode(encodeServerSentEvent(input)));
+      }
+
+      enqueueEvent({
+        event: NOTIFICATION_STREAM_EVENT,
+        id: lastSnapshot.version,
+        retry: NOTIFICATION_STREAM_RETRY_MS,
+        data: lastSnapshot,
+      });
+
+      while (
+        !streamCancelled &&
+        !request.signal.aborted &&
+        Date.now() < closeAt
+      ) {
+        try {
+          await sleepWithAbort(
+            NOTIFICATION_STREAM_POLL_INTERVAL_MS,
+            request.signal
+          );
+        } catch (error) {
+          if ((error as { name?: string }).name === "AbortError") {
+            break;
+          }
+
+          throw error;
+        }
+
+        const snapshot = await getNotificationRealtimeSnapshotForUser(
+          authenticatedUser.userId,
+          { syncProjectInvitations: false }
+        );
+        if (!snapshot.ok) {
+          enqueueEvent({
+            event: "error",
+            data: {
+              error: snapshot.error,
+              status: snapshot.status,
+            },
+          });
+          break;
+        }
+
+        if (isSnapshotChanged(snapshot.data, lastSnapshot)) {
+          lastSnapshot = snapshot.data;
+          lastHeartbeatAt = Date.now();
+          enqueueEvent({
+            event: NOTIFICATION_STREAM_EVENT,
+            id: lastSnapshot.version,
+            data: lastSnapshot,
+          });
+          continue;
+        }
+
+        if (
+          Date.now() - lastHeartbeatAt >=
+          NOTIFICATION_STREAM_HEARTBEAT_INTERVAL_MS
+        ) {
+          lastHeartbeatAt = Date.now();
+          enqueueEvent({ comment: "heartbeat" });
+        }
+      }
+
+      if (!streamCancelled) {
+        controller.close();
+      }
+    },
+    cancel() {
+      streamCancelled = true;
+    },
+  });
+
+  return new Response(stream, {
+    headers: streamHeaders(),
+  });
+}
+
+export const notificationStreamRouteInternals = {
+  encodeServerSentEvent,
+  isSnapshotChanged,
+  NOTIFICATION_STREAM_EVENT,
+};

--- a/app/api/account/notifications/summary/route.ts
+++ b/app/api/account/notifications/summary/route.ts
@@ -15,7 +15,15 @@ export async function GET(request: NextRequest) {
     authenticatedUser.userId
   );
   if (!result.ok) {
-    return NextResponse.json({ error: result.error }, { status: result.status });
+    return NextResponse.json(
+      { error: result.error },
+      {
+        status: result.status,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      }
+    );
   }
 
   return NextResponse.json(result.data, {

--- a/app/api/account/notifications/summary/route.ts
+++ b/app/api/account/notifications/summary/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { requireAuthenticatedApiUser } from "@/lib/auth/api-guard";
+import { getNotificationRealtimeSnapshotForUser } from "@/lib/services/notification-service";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  const authenticatedUser = await requireAuthenticatedApiUser(request);
+  if (!authenticatedUser.ok) {
+    return authenticatedUser.response;
+  }
+
+  const result = await getNotificationRealtimeSnapshotForUser(
+    authenticatedUser.userId
+  );
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json(result.data, {
+    status: result.status,
+    headers: {
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/app/projects/layout.tsx
+++ b/app/projects/layout.tsx
@@ -1,5 +1,8 @@
 import { NotificationAwarenessBanner } from "@/components/notification-awareness-banner";
 import { requireVerifiedSessionUserIdFromServer } from "@/lib/auth/server-guard";
+import { logServerError } from "@/lib/observability/logger";
+import { getNotificationRealtimeSnapshotForUser } from "@/lib/services/notification-service";
+import type { NotificationRealtimeSnapshot } from "@/lib/notification-realtime-types";
 
 export const dynamic = "force-dynamic";
 
@@ -9,11 +12,26 @@ export default async function ProjectsLayout({
   children: React.ReactNode;
 }) {
   const actorUserId = await requireVerifiedSessionUserIdFromServer();
+  let notificationSnapshot: NotificationRealtimeSnapshot = {
+    version: new Date(0).toISOString(),
+    unreadCount: 0,
+    latestUnreadNotification: null,
+    serverTime: new Date().toISOString(),
+  };
+
+  try {
+    const result = await getNotificationRealtimeSnapshotForUser(actorUserId);
+    if (result.ok) {
+      notificationSnapshot = result.data;
+    }
+  } catch (error) {
+    logServerError("ProjectsLayout.getNotificationRealtimeSnapshotForUser", error);
+  }
 
   return (
     <>
       <div className="container pt-6">
-        <NotificationAwarenessBanner actorUserId={actorUserId} />
+        <NotificationAwarenessBanner initialSnapshot={notificationSnapshot} />
       </div>
       {children}
     </>

--- a/app/projects/layout.tsx
+++ b/app/projects/layout.tsx
@@ -1,8 +1,6 @@
 import { NotificationAwarenessBanner } from "@/components/notification-awareness-banner";
 import { requireVerifiedSessionUserIdFromServer } from "@/lib/auth/server-guard";
-import { logServerError } from "@/lib/observability/logger";
-import { getNotificationRealtimeSnapshotForUser } from "@/lib/services/notification-service";
-import type { NotificationRealtimeSnapshot } from "@/lib/notification-realtime-types";
+import { getInitialNotificationRealtimeSnapshotForUser } from "@/lib/notification-realtime-server";
 
 export const dynamic = "force-dynamic";
 
@@ -12,21 +10,8 @@ export default async function ProjectsLayout({
   children: React.ReactNode;
 }) {
   const actorUserId = await requireVerifiedSessionUserIdFromServer();
-  let notificationSnapshot: NotificationRealtimeSnapshot = {
-    version: new Date(0).toISOString(),
-    unreadCount: 0,
-    latestUnreadNotification: null,
-    serverTime: new Date().toISOString(),
-  };
-
-  try {
-    const result = await getNotificationRealtimeSnapshotForUser(actorUserId);
-    if (result.ok) {
-      notificationSnapshot = result.data;
-    }
-  } catch (error) {
-    logServerError("ProjectsLayout.getNotificationRealtimeSnapshotForUser", error);
-  }
+  const notificationSnapshot =
+    await getInitialNotificationRealtimeSnapshotForUser(actorUserId);
 
   return (
     <>

--- a/components/account-menu.tsx
+++ b/components/account-menu.tsx
@@ -1,19 +1,20 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Bell, CircleUserRound, LogOut, Settings } from "lucide-react";
 
 import { UserAvatar } from "@/components/ui/user-avatar";
 import { Button } from "@/components/ui/button";
 import { useDismissibleMenu } from "@/lib/hooks/use-dismissible-menu";
+import { useNotificationRealtimeSnapshot } from "@/lib/notification-realtime-client";
 
 interface AccountMenuProps {
   isAuthenticated: boolean;
   displayName: string | null;
   usernameTag: string | null;
   avatarSeed: string | null;
-  unreadNotificationCount: number;
+  initialUnreadNotificationCount: number;
 }
 
 export function AccountMenu({
@@ -21,10 +22,23 @@ export function AccountMenu({
   displayName,
   usernameTag,
   avatarSeed,
-  unreadNotificationCount,
+  initialUnreadNotificationCount,
 }: AccountMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useDismissibleMenu<HTMLDivElement>(isOpen, () => setIsOpen(false));
+  const initialNotificationSnapshot = useMemo(
+    () => ({
+      version: new Date(0).toISOString(),
+      unreadCount: initialUnreadNotificationCount,
+      latestUnreadNotification: null,
+      serverTime: new Date().toISOString(),
+    }),
+    [initialUnreadNotificationCount]
+  );
+  const notificationSnapshot = useNotificationRealtimeSnapshot(
+    initialNotificationSnapshot
+  );
+  const unreadNotificationCount = notificationSnapshot.unreadCount;
 
   if (!isAuthenticated) {
     return null;

--- a/components/account-notifications-link.tsx
+++ b/components/account-notifications-link.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import Link from "next/link";
+import { Bell } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { useNotificationRealtimeSnapshot } from "@/lib/notification-realtime-client";
+import type { NotificationRealtimeSnapshot } from "@/lib/notification-realtime-types";
+
+interface AccountNotificationsLinkProps {
+  initialSnapshot: NotificationRealtimeSnapshot;
+}
+
+export function AccountNotificationsLink({
+  initialSnapshot,
+}: AccountNotificationsLinkProps) {
+  const snapshot = useNotificationRealtimeSnapshot(initialSnapshot);
+  const unreadNotificationCount = snapshot.unreadCount;
+
+  return (
+    <Button
+      asChild
+      variant="outline"
+      className="relative rounded-full border-border/60 px-3 py-1.5 text-sm font-medium text-muted-foreground hover:border-border hover:text-foreground"
+    >
+      <Link href="/account/notifications">
+        <Bell className="h-4 w-4" />
+        Notifications
+        {unreadNotificationCount > 0 ? (
+          <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-[10px] font-medium text-white">
+            {unreadNotificationCount > 9 ? "9+" : unreadNotificationCount}
+          </span>
+        ) : null}
+      </Link>
+    </Button>
+  );
+}

--- a/components/account/notification-center-list.tsx
+++ b/components/account/notification-center-list.tsx
@@ -1,12 +1,18 @@
+"use client";
+
 import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
 import { Bell, Check, ExternalLink, MailPlus, RotateCcw } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { useNotificationRealtimeSnapshot } from "@/lib/notification-realtime-client";
+import type { NotificationRealtimeSnapshot } from "@/lib/notification-realtime-types";
 import type { NotificationSummary } from "@/lib/services/notification-service";
 
 interface NotificationCenterListProps {
   notifications: NotificationSummary[];
+  initialSnapshot: NotificationRealtimeSnapshot;
   onMarkRead: (formData: FormData) => void | Promise<void>;
   onMarkUnread: (formData: FormData) => void | Promise<void>;
   onMarkAllRead: () => void | Promise<void>;
@@ -53,13 +59,70 @@ function isProjectInvitationMetadata(
 
 export function NotificationCenterList({
   notifications,
+  initialSnapshot,
   onMarkRead,
   onMarkUnread,
   onMarkAllRead,
   onAcceptInvitation,
   onDeclineInvitation,
 }: NotificationCenterListProps) {
-  const unreadCount = notifications.filter((notification) => !notification.readAt).length;
+  const [visibleNotifications, setVisibleNotifications] =
+    useState(notifications);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const snapshot = useNotificationRealtimeSnapshot(initialSnapshot);
+  const lastLoadedVersionRef = useRef(initialSnapshot.version);
+  const unreadCount = visibleNotifications.filter(
+    (notification) => !notification.readAt
+  ).length;
+
+  useEffect(() => {
+    setVisibleNotifications(notifications);
+  }, [notifications]);
+
+  useEffect(() => {
+    if (snapshot.version === lastLoadedVersionRef.current) {
+      return;
+    }
+
+    const controller = new AbortController();
+    let isActive = true;
+    setIsRefreshing(true);
+    void (async () => {
+      try {
+        const response = await fetch("/api/account/notifications", {
+          cache: "no-store",
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          return;
+        }
+
+        const payload = (await response.json()) as {
+          notifications?: NotificationSummary[];
+        };
+        if (isActive) {
+          setVisibleNotifications(payload.notifications ?? []);
+          lastLoadedVersionRef.current = snapshot.version;
+        }
+      } catch (error) {
+        if ((error as { name?: string }).name === "AbortError") {
+          return;
+        }
+
+        console.warn("[NotificationCenterList.refresh]", error);
+      } finally {
+        if (isActive) {
+          setIsRefreshing(false);
+        }
+      }
+    })();
+
+    return () => {
+      isActive = false;
+      controller.abort();
+    };
+  }, [snapshot.version]);
 
   return (
     <section className="space-y-4">
@@ -78,20 +141,24 @@ export function NotificationCenterList({
         </div>
 
         <form action={onMarkAllRead}>
-          <Button type="submit" variant="outline" disabled={unreadCount === 0}>
+          <Button
+            type="submit"
+            variant="outline"
+            disabled={unreadCount === 0 || isRefreshing}
+          >
             <Check className="h-4 w-4" />
             Mark all read
           </Button>
         </form>
       </div>
 
-      {notifications.length === 0 ? (
+      {visibleNotifications.length === 0 ? (
         <div className="rounded-xl border border-dashed border-border/70 bg-muted/20 px-5 py-8 text-sm text-muted-foreground">
           No active notifications.
         </div>
       ) : (
         <div className="space-y-3">
-          {notifications.map((notification) => {
+          {visibleNotifications.map((notification) => {
             const isUnread = !notification.readAt;
             const metadata = notification.metadata;
             const isInvitation = isProjectInvitationMetadata(metadata);

--- a/components/notification-awareness-banner.tsx
+++ b/components/notification-awareness-banner.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Link from "next/link";
+
 import { AutoDismissingAlert } from "@/components/auto-dismissing-alert";
 import { useNotificationRealtimeSnapshot } from "@/lib/notification-realtime-client";
 import type { NotificationRealtimeSnapshot } from "@/lib/notification-realtime-types";
@@ -24,12 +26,12 @@ export function NotificationAwarenessBanner({
       message={
         <>
           {latestNotification.title}{" "}
-          <a
+          <Link
             href="/account/notifications"
             className="font-medium underline underline-offset-4"
           >
             Review notifications
-          </a>
+          </Link>
         </>
       }
       className="rounded-md border border-sky-500/40 bg-sky-500/10 px-4 py-3 text-sm text-sky-700 dark:text-sky-200"

--- a/components/notification-awareness-banner.tsx
+++ b/components/notification-awareness-banner.tsx
@@ -1,51 +1,35 @@
-import Link from "next/link";
-import { unstable_noStore as noStore } from "next/cache";
+"use client";
 
 import { AutoDismissingAlert } from "@/components/auto-dismissing-alert";
-import { logServerError } from "@/lib/observability/logger";
-import { getLatestUnreadNotificationForUser } from "@/lib/services/notification-service";
+import { useNotificationRealtimeSnapshot } from "@/lib/notification-realtime-client";
+import type { NotificationRealtimeSnapshot } from "@/lib/notification-realtime-types";
 
 interface NotificationAwarenessBannerProps {
-  actorUserId: string;
+  initialSnapshot: NotificationRealtimeSnapshot;
 }
 
-export async function NotificationAwarenessBanner({
-  actorUserId,
+export function NotificationAwarenessBanner({
+  initialSnapshot,
 }: NotificationAwarenessBannerProps) {
-  noStore();
-  const result = await (async () => {
-    try {
-      return await getLatestUnreadNotificationForUser(actorUserId);
-    } catch (error) {
-      logServerError(
-        "NotificationAwarenessBanner.getLatestUnreadNotificationForUser",
-        error
-      );
-      return null;
-    }
-  })();
+  const snapshot = useNotificationRealtimeSnapshot(initialSnapshot);
+  const latestNotification = snapshot.latestUnreadNotification;
 
-  if (!result?.ok) {
+  if (!latestNotification || snapshot.unreadCount === 0) {
     return null;
   }
-
-  if (!result.data.notification) {
-    return null;
-  }
-
-  const latestNotification = result.data.notification;
 
   return (
     <AutoDismissingAlert
+      key={`${snapshot.version}:${latestNotification.title}`}
       message={
         <>
           {latestNotification.title}{" "}
-          <Link
+          <a
             href="/account/notifications"
             className="font-medium underline underline-offset-4"
           >
             Review notifications
-          </Link>
+          </a>
         </>
       }
       className="rounded-md border border-sky-500/40 bg-sky-500/10 px-4 py-3 text-sm text-sky-700 dark:text-sky-200"

--- a/components/notification-live-updates.tsx
+++ b/components/notification-live-updates.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  publishNotificationRealtimeSnapshot,
+} from "@/lib/notification-realtime-client";
+import type { NotificationRealtimeSnapshot } from "@/lib/notification-realtime-types";
+
+const DEFAULT_ACTIVE_POLL_INTERVAL_MS = 2000;
+const BACKGROUND_POLL_INTERVAL_MS = 15000;
+
+interface NotificationLiveUpdatesProps {
+  initialSnapshot: NotificationRealtimeSnapshot;
+  pollIntervalMs?: number;
+  streamEnabled?: boolean;
+}
+
+function canUseNotificationStream(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.EventSource === "function"
+  );
+}
+
+function resolveNextPollIntervalMs(activePollIntervalMs: number): number {
+  if (typeof document !== "undefined" && document.hidden) {
+    return Math.max(BACKGROUND_POLL_INTERVAL_MS, activePollIntervalMs * 4);
+  }
+
+  return activePollIntervalMs;
+}
+
+function isSnapshotChanged(
+  next: NotificationRealtimeSnapshot,
+  previous: NotificationRealtimeSnapshot
+): boolean {
+  return (
+    next.version !== previous.version ||
+    next.unreadCount !== previous.unreadCount ||
+    next.latestUnreadNotification?.title !==
+      previous.latestUnreadNotification?.title
+  );
+}
+
+export function NotificationLiveUpdates({
+  initialSnapshot,
+  pollIntervalMs = DEFAULT_ACTIVE_POLL_INTERVAL_MS,
+  streamEnabled = true,
+}: NotificationLiveUpdatesProps) {
+  const [isPollingFallbackActive, setIsPollingFallbackActive] = useState(
+    () => !streamEnabled || !canUseNotificationStream()
+  );
+  const knownSnapshotRef = useRef(initialSnapshot);
+
+  const handleSnapshot = useCallback((snapshot: NotificationRealtimeSnapshot) => {
+    if (!isSnapshotChanged(snapshot, knownSnapshotRef.current)) {
+      return;
+    }
+
+    knownSnapshotRef.current = snapshot;
+    publishNotificationRealtimeSnapshot(snapshot);
+  }, []);
+
+  useEffect(() => {
+    knownSnapshotRef.current = initialSnapshot;
+    publishNotificationRealtimeSnapshot(initialSnapshot);
+  }, [initialSnapshot]);
+
+  useEffect(() => {
+    setIsPollingFallbackActive(!streamEnabled || !canUseNotificationStream());
+  }, [streamEnabled]);
+
+  useEffect(() => {
+    if (!streamEnabled || !canUseNotificationStream()) {
+      return;
+    }
+
+    let opened = false;
+    const eventSource = new window.EventSource(
+      "/api/account/notifications/stream"
+    );
+
+    function handleOpen() {
+      opened = true;
+      setIsPollingFallbackActive(false);
+    }
+
+    function handleNotificationSnapshot(event: MessageEvent<string>) {
+      try {
+        handleSnapshot(JSON.parse(event.data) as NotificationRealtimeSnapshot);
+      } catch (error) {
+        console.warn("[NotificationLiveUpdates.stream]", error);
+      }
+    }
+
+    function handleError() {
+      if (opened) {
+        return;
+      }
+
+      eventSource.close();
+      setIsPollingFallbackActive(true);
+    }
+
+    eventSource.addEventListener("open", handleOpen);
+    eventSource.addEventListener(
+      "notification-snapshot",
+      handleNotificationSnapshot as EventListener
+    );
+    eventSource.addEventListener("error", handleError);
+
+    return () => {
+      eventSource.removeEventListener("open", handleOpen);
+      eventSource.removeEventListener(
+        "notification-snapshot",
+        handleNotificationSnapshot as EventListener
+      );
+      eventSource.removeEventListener("error", handleError);
+      eventSource.close();
+    };
+  }, [handleSnapshot, streamEnabled]);
+
+  useEffect(() => {
+    if (!isPollingFallbackActive) {
+      return;
+    }
+
+    let cancelled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let controller: AbortController | null = null;
+    let isPolling = false;
+    let pollAgainAfterCurrent = false;
+
+    function clearScheduledPoll() {
+      if (!timeoutId) {
+        return;
+      }
+
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+
+    function schedulePoll(delayMs = resolveNextPollIntervalMs(pollIntervalMs)) {
+      clearScheduledPoll();
+      timeoutId = setTimeout(pollNotifications, delayMs);
+    }
+
+    function requestImmediatePoll() {
+      if (typeof document !== "undefined" && document.hidden) {
+        return;
+      }
+
+      if (isPolling) {
+        pollAgainAfterCurrent = true;
+        return;
+      }
+
+      schedulePoll(0);
+    }
+
+    async function pollNotifications() {
+      timeoutId = null;
+      isPolling = true;
+      controller?.abort();
+      controller = new AbortController();
+
+      try {
+        const response = await fetch("/api/account/notifications/summary", {
+          cache: "no-store",
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          return;
+        }
+
+        handleSnapshot((await response.json()) as NotificationRealtimeSnapshot);
+      } catch (error) {
+        if ((error as { name?: string }).name === "AbortError") {
+          return;
+        }
+
+        console.warn("[NotificationLiveUpdates.poll]", error);
+      } finally {
+        isPolling = false;
+        if (!cancelled) {
+          if (pollAgainAfterCurrent) {
+            pollAgainAfterCurrent = false;
+            schedulePoll(0);
+          } else {
+            schedulePoll();
+          }
+        }
+      }
+    }
+
+    schedulePoll();
+    document.addEventListener("visibilitychange", requestImmediatePoll);
+    window.addEventListener("focus", requestImmediatePoll);
+
+    return () => {
+      cancelled = true;
+      clearScheduledPoll();
+      controller?.abort();
+      document.removeEventListener("visibilitychange", requestImmediatePoll);
+      window.removeEventListener("focus", requestImmediatePoll);
+    };
+  }, [handleSnapshot, isPollingFallbackActive, pollIntervalMs]);
+
+  return null;
+}
+
+export const notificationLiveUpdatesInternals = {
+  canUseNotificationStream,
+  isSnapshotChanged,
+  resolveNextPollIntervalMs,
+};

--- a/components/top-right-controls.tsx
+++ b/components/top-right-controls.tsx
@@ -5,10 +5,10 @@ import { AppMetadataPill } from "@/components/app-metadata-pill";
 import { NotificationLiveUpdates } from "@/components/notification-live-updates";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { getSessionUserIdFromServer } from "@/lib/auth/session-user";
+import { getInitialNotificationRealtimeSnapshotForUser } from "@/lib/notification-realtime-server";
+import type { NotificationRealtimeSnapshot } from "@/lib/notification-realtime-types";
 import { logServerError } from "@/lib/observability/logger";
 import { getAccountIdentitySummary } from "@/lib/services/account-identity-service";
-import { getNotificationRealtimeSnapshotForUser } from "@/lib/services/notification-service";
-import type { NotificationRealtimeSnapshot } from "@/lib/notification-realtime-types";
 
 export async function TopRightControls() {
   noStore();
@@ -22,10 +22,10 @@ export async function TopRightControls() {
   };
 
   if (actorUserId) {
-    const [accountIdentityResult, unreadNotificationCountResult] =
+    const [accountIdentityResult, notificationSnapshotResult] =
       await Promise.allSettled([
         getAccountIdentitySummary(actorUserId),
-        getNotificationRealtimeSnapshotForUser(actorUserId),
+        getInitialNotificationRealtimeSnapshotForUser(actorUserId),
       ]);
 
     if (accountIdentityResult.status === "fulfilled") {
@@ -37,20 +37,12 @@ export async function TopRightControls() {
       );
     }
 
-    if (unreadNotificationCountResult.status === "fulfilled") {
-      const result = unreadNotificationCountResult.value;
-      if (result.ok) {
-        notificationSnapshot = result.data;
-      } else {
-        logServerError(
-          "TopRightControls.getNotificationRealtimeSnapshotForUser",
-          new Error(result.error)
-        );
-      }
+    if (notificationSnapshotResult.status === "fulfilled") {
+      notificationSnapshot = notificationSnapshotResult.value;
     } else {
       logServerError(
-        "TopRightControls.getNotificationRealtimeSnapshotForUser",
-        unreadNotificationCountResult.reason
+        "TopRightControls.getInitialNotificationRealtimeSnapshotForUser",
+        notificationSnapshotResult.reason
       );
     }
   }

--- a/components/top-right-controls.tsx
+++ b/components/top-right-controls.tsx
@@ -2,23 +2,30 @@ import { unstable_noStore as noStore } from "next/cache";
 
 import { AccountMenu } from "@/components/account-menu";
 import { AppMetadataPill } from "@/components/app-metadata-pill";
+import { NotificationLiveUpdates } from "@/components/notification-live-updates";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { getSessionUserIdFromServer } from "@/lib/auth/session-user";
 import { logServerError } from "@/lib/observability/logger";
 import { getAccountIdentitySummary } from "@/lib/services/account-identity-service";
-import { countUnreadNotificationsForUser } from "@/lib/services/notification-service";
+import { getNotificationRealtimeSnapshotForUser } from "@/lib/services/notification-service";
+import type { NotificationRealtimeSnapshot } from "@/lib/notification-realtime-types";
 
 export async function TopRightControls() {
   noStore();
   const actorUserId = await getSessionUserIdFromServer();
   let accountIdentity = null;
-  let unreadNotificationCount = 0;
+  let notificationSnapshot: NotificationRealtimeSnapshot = {
+    version: new Date(0).toISOString(),
+    unreadCount: 0,
+    latestUnreadNotification: null,
+    serverTime: new Date().toISOString(),
+  };
 
   if (actorUserId) {
     const [accountIdentityResult, unreadNotificationCountResult] =
       await Promise.allSettled([
         getAccountIdentitySummary(actorUserId),
-        countUnreadNotificationsForUser(actorUserId),
+        getNotificationRealtimeSnapshotForUser(actorUserId),
       ]);
 
     if (accountIdentityResult.status === "fulfilled") {
@@ -31,10 +38,18 @@ export async function TopRightControls() {
     }
 
     if (unreadNotificationCountResult.status === "fulfilled") {
-      unreadNotificationCount = unreadNotificationCountResult.value;
+      const result = unreadNotificationCountResult.value;
+      if (result.ok) {
+        notificationSnapshot = result.data;
+      } else {
+        logServerError(
+          "TopRightControls.getNotificationRealtimeSnapshotForUser",
+          new Error(result.error)
+        );
+      }
     } else {
       logServerError(
-        "TopRightControls.countUnreadNotificationsForUser",
+        "TopRightControls.getNotificationRealtimeSnapshotForUser",
         unreadNotificationCountResult.reason
       );
     }
@@ -42,13 +57,16 @@ export async function TopRightControls() {
 
   return (
     <div className="fixed right-4 top-4 z-40 flex items-center gap-2">
+      {actorUserId ? (
+        <NotificationLiveUpdates initialSnapshot={notificationSnapshot} />
+      ) : null}
       <AppMetadataPill />
       <AccountMenu
         isAuthenticated={Boolean(actorUserId)}
         displayName={accountIdentity?.displayName ?? null}
         usernameTag={accountIdentity?.usernameTag ?? null}
         avatarSeed={accountIdentity?.avatarSeed ?? null}
-        unreadNotificationCount={unreadNotificationCount}
+        initialUnreadNotificationCount={notificationSnapshot.unreadCount}
       />
       <ThemeToggle />
     </div>

--- a/journal.md
+++ b/journal.md
@@ -32,6 +32,16 @@ Use it for important implementation milestones, blockers, validation runs, and r
   persistent account SSE connection; the projects helper now waits for visible
   UI readiness instead.
 
+# 2026-06-04 - TASK-263 PR opened for maintainer review
+
+- Summary: Opened ready PR #320 from
+  `feature/task-263-live-notification-updates` and intentionally left it
+  unmerged for maintainer review.
+- Evidence: PR checks passed: `check-name`, `Quality Core (lint, test,
+  coverage, build)`, `E2E Smoke (Playwright)`, and `Container Image (build +
+  metadata artifact)`. Copilot review/comment polling found no actionable
+  comments.
+
 # 2026-06-04 - TASK-312 hidden project refresh reconciliation
 
 - Summary: Removed the user-facing project refresh prompt/button while keeping

--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,35 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-06-04 - TASK-263 realtime notification updates started
+
+- Summary: Drafted the implementation brief for live in-app notification
+  updates after inspecting notification services, account menu count rendering,
+  awareness banner rendering, notification center list behavior, and the
+  existing project activity SSE transport.
+- Decision: Reuse the SSE-first realtime pattern for an authenticated
+  account-scoped notification snapshot stream. `Notification` remains the
+  source of truth; the stream publishes compact unread/version/latest-title
+  state and the notification center refetches full rows when that version
+  changes. Email digest batching remains separate.
+
+# 2026-06-04 - TASK-263 account notification realtime implemented
+
+- Summary: Implemented account-scoped live notification snapshots with SSE-first
+  transport and polling fallback. Account menu badges, account notification
+  links, awareness banners, and the notification center now consume live
+  snapshots; the notification center refetches full rows when the snapshot
+  version changes.
+- Evidence: Added `/api/account/notifications/summary` and
+  `/api/account/notifications/stream`, `NotificationLiveUpdates`, shared
+  notification realtime client state, and service snapshot support. Focused
+  notification tests passed 7 files / 41 tests. `npm run lint`, local
+  PostgreSQL env `npm test`, local PostgreSQL env `npm run test:coverage`,
+  local-safe `npm run build`, and local-safe `npm run test:e2e` passed. The
+  first E2E run exposed that `networkidle` waits are incompatible with the new
+  persistent account SSE connection; the projects helper now waits for visible
+  UI readiness instead.
+
 # 2026-06-04 - TASK-312 hidden project refresh reconciliation
 
 - Summary: Removed the user-facing project refresh prompt/button while keeping

--- a/journal.md
+++ b/journal.md
@@ -39,8 +39,19 @@ Use it for important implementation milestones, blockers, validation runs, and r
   unmerged for maintainer review.
 - Evidence: PR checks passed: `check-name`, `Quality Core (lint, test,
   coverage, build)`, `E2E Smoke (Playwright)`, and `Container Image (build +
-  metadata artifact)`. Copilot review/comment polling found no actionable
-  comments.
+  metadata artifact)`.
+
+# 2026-06-04 - TASK-263 Copilot review handled
+
+- Summary: Addressed all four Copilot comments by adding no-store headers to
+  summary-route error responses, introducing a request-scoped cached server
+  helper for initial notification snapshots, reusing that helper across chrome
+  and notification-aware pages/layouts, and restoring `Link` navigation in the
+  awareness banner.
+- Evidence: Focused notification tests passed 7 files / 42 tests. `npm run
+  lint`, local PostgreSQL env `npm test` (118 files passed, 2 skipped; 880 tests
+  passed, 2 skipped), local PostgreSQL env `npm run test:coverage`, and
+  local-safe `npm run test:e2e` passed 8/8 Playwright specs.
 
 # 2026-06-04 - TASK-312 hidden project refresh reconciliation
 

--- a/lib/notification-realtime-client.ts
+++ b/lib/notification-realtime-client.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import type { NotificationRealtimeSnapshot } from "@/lib/notification-realtime-types";
+
+export const NOTIFICATION_REALTIME_EVENT = "nexusdash:notification-realtime";
+
+interface NotificationRealtimeEventDetail {
+  snapshot: NotificationRealtimeSnapshot;
+}
+
+let latestSnapshot: NotificationRealtimeSnapshot | null = null;
+
+export function publishNotificationRealtimeSnapshot(
+  snapshot: NotificationRealtimeSnapshot
+) {
+  latestSnapshot = snapshot;
+
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.dispatchEvent(
+    new CustomEvent<NotificationRealtimeEventDetail>(NOTIFICATION_REALTIME_EVENT, {
+      detail: {
+        snapshot,
+      },
+    })
+  );
+}
+
+export function getLatestNotificationRealtimeSnapshot() {
+  return latestSnapshot;
+}
+
+export function useNotificationRealtimeSnapshot(
+  initialSnapshot: NotificationRealtimeSnapshot
+) {
+  const [snapshot, setSnapshot] = useState<NotificationRealtimeSnapshot>(
+    () => latestSnapshot ?? initialSnapshot
+  );
+
+  useEffect(() => {
+    if (!latestSnapshot) {
+      latestSnapshot = initialSnapshot;
+    }
+
+    function handleSnapshot(event: Event) {
+      const detail = (event as CustomEvent<NotificationRealtimeEventDetail>)
+        .detail;
+      if (!detail?.snapshot) {
+        return;
+      }
+
+      setSnapshot(detail.snapshot);
+    }
+
+    window.addEventListener(NOTIFICATION_REALTIME_EVENT, handleSnapshot);
+
+    return () => {
+      window.removeEventListener(NOTIFICATION_REALTIME_EVENT, handleSnapshot);
+    };
+  }, [initialSnapshot]);
+
+  return snapshot;
+}

--- a/lib/notification-realtime-server.ts
+++ b/lib/notification-realtime-server.ts
@@ -1,0 +1,34 @@
+import { cache } from "react";
+
+import type { NotificationRealtimeSnapshot } from "@/lib/notification-realtime-types";
+import { logServerError } from "@/lib/observability/logger";
+import { getNotificationRealtimeSnapshotForUser } from "@/lib/services/notification-service";
+
+function createEmptyNotificationRealtimeSnapshot(): NotificationRealtimeSnapshot {
+  return {
+    version: new Date(0).toISOString(),
+    unreadCount: 0,
+    latestUnreadNotification: null,
+    serverTime: new Date().toISOString(),
+  };
+}
+
+export const getInitialNotificationRealtimeSnapshotForUser = cache(
+  async (actorUserId: string): Promise<NotificationRealtimeSnapshot> => {
+    try {
+      const result = await getNotificationRealtimeSnapshotForUser(actorUserId);
+      if (result.ok) {
+        return result.data;
+      }
+
+      logServerError(
+        "getInitialNotificationRealtimeSnapshotForUser",
+        new Error(result.error)
+      );
+    } catch (error) {
+      logServerError("getInitialNotificationRealtimeSnapshotForUser", error);
+    }
+
+    return createEmptyNotificationRealtimeSnapshot();
+  }
+);

--- a/lib/notification-realtime-types.ts
+++ b/lib/notification-realtime-types.ts
@@ -1,0 +1,10 @@
+export interface NotificationRealtimeLatestUnread {
+  title: string;
+}
+
+export interface NotificationRealtimeSnapshot {
+  version: string;
+  unreadCount: number;
+  latestUnreadNotification: NotificationRealtimeLatestUnread | null;
+  serverTime: string;
+}

--- a/lib/services/notification-service.ts
+++ b/lib/services/notification-service.ts
@@ -3,6 +3,7 @@ import { Prisma } from "@prisma/client";
 import { logServerError } from "@/lib/observability/logger";
 import { enqueueNotificationEmailForNotification } from "@/lib/services/project-notification-email-service";
 import { type DbClient, withActorRlsContext } from "@/lib/services/rls-context";
+import type { NotificationRealtimeSnapshot } from "@/lib/notification-realtime-types";
 import { formatTaskDeadlineForDisplay } from "@/lib/task-deadline";
 
 const NOTIFICATION_TYPE_PROJECT_INVITATION = "project_invitation";
@@ -153,6 +154,10 @@ export interface NotificationSummary {
 
 export interface LatestUnreadNotificationSummary {
   title: string;
+}
+
+interface NotificationRealtimeSnapshotOptions {
+  syncProjectInvitations?: boolean;
 }
 
 function createError(status: number, error: string): ServiceErrorResult {
@@ -741,6 +746,70 @@ export async function countUnreadNotificationsForUser(
     } catch (error) {
       logServerError("countUnreadNotificationsForUser", error);
       return 0;
+    }
+  });
+}
+
+export async function getNotificationRealtimeSnapshotForUser(
+  actorUserId: string,
+  options: NotificationRealtimeSnapshotOptions = {}
+): Promise<ServiceResult<NotificationRealtimeSnapshot>> {
+  const normalizedActorUserId = normalizeActorUserId(actorUserId);
+  if (!normalizedActorUserId) {
+    return createError(401, "unauthorized");
+  }
+
+  return withActorRlsContext(normalizedActorUserId, async (db) => {
+    try {
+      if (options.syncProjectInvitations !== false) {
+        await syncProjectInvitationNotificationsForUser(
+          db,
+          normalizedActorUserId
+        );
+      }
+
+      const [latestNotification, unreadCount, latestUnreadNotification] =
+        await Promise.all([
+          db.notification.findFirst({
+            where: {
+              recipientUserId: normalizedActorUserId,
+            },
+            orderBy: [{ updatedAt: "desc" }],
+            select: {
+              updatedAt: true,
+            },
+          }),
+          db.notification.count({
+            where: {
+              recipientUserId: normalizedActorUserId,
+              resolvedAt: null,
+              readAt: null,
+            },
+          }),
+          db.notification.findFirst({
+            where: {
+              recipientUserId: normalizedActorUserId,
+              resolvedAt: null,
+              readAt: null,
+            },
+            orderBy: [{ createdAt: "desc" }],
+            select: {
+              title: true,
+            },
+          }),
+        ]);
+
+      return createSuccess(200, {
+        version: (latestNotification?.updatedAt ?? new Date(0)).toISOString(),
+        unreadCount,
+        latestUnreadNotification: latestUnreadNotification
+          ? { title: latestUnreadNotification.title }
+          : null,
+        serverTime: new Date().toISOString(),
+      });
+    } catch (error) {
+      logServerError("getNotificationRealtimeSnapshotForUser", error);
+      return createError(500, "notification-snapshot-failed");
     }
   });
 }

--- a/project.md
+++ b/project.md
@@ -27,6 +27,9 @@ NexusDash is a personal/team execution workspace that keeps project planning, de
   - durable per-user in-app inbox at `/account/notifications`
   - unread/read state and resolved lifecycle
   - project invitation delivery, accept/decline actions, and notification-aware account menu counts
+  - account-scoped live notification snapshots over SSE with polling fallback
+    so unread counts, awareness banners, and notification-center rows update
+    without navigation
   - foundation for future mention and activity producers
   - DB-backed notification email orchestration for project activity digests,
     invitation reminders, and three-day task due-date reminders, with
@@ -115,9 +118,8 @@ Source of truth: [`prisma/schema.prisma`](./prisma/schema.prisma)
 
 From `tasks/current.md` + `tasks/backlog.md`:
 
-1. TASK-312: hidden project refresh reconciliation
+1. TASK-263: real-time notification updates for inbox/count awareness
 2. TASK-224: agent roadmap access for scoped roadmap phase/event APIs
-3. TASK-263: real-time notification updates for inbox/count awareness
 
 ## 8. Source-of-Truth Docs
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -13,7 +13,7 @@ Last reviewed: 2026-05-31
   Dependencies: TASK-127, TASK-130, TASK-059
 - ID: TASK-263
   Title: Real-time notification updates - live in-app inbox, counts, and awareness
-  Status: Implemented and locally validated on `feature/task-263-realtime-notification-updates`; PR workflow pending
+  Status: Implemented and locally validated on `feature/task-263-live-notification-updates`; PR #320 open for maintainer review
   Rationale: Make notification-center rows, unread counts, and the in-app awareness banner update without requiring navigation or manual refresh when assignments, mentions, project invitations, or future notification producers create new atomic `Notification` rows. Invitation recipients should see newly received invites and notification count/banner changes while already on the app, without needing a page reload. Keep email digest batching fully separate: in-app remains one notification per action/artifact, while email remains the grouped/debounced channel. This task should reuse or align with the broader TASK-118 realtime transport decision rather than introduce a parallel realtime stack.
   Dependencies: TASK-118, TASK-123, TASK-260
 ### Deferred (Intentional)

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -13,7 +13,7 @@ Last reviewed: 2026-05-31
   Dependencies: TASK-127, TASK-130, TASK-059
 - ID: TASK-263
   Title: Real-time notification updates - live in-app inbox, counts, and awareness
-  Status: Promoted 2026-05-31
+  Status: Implemented and locally validated on `feature/task-263-realtime-notification-updates`; PR workflow pending
   Rationale: Make notification-center rows, unread counts, and the in-app awareness banner update without requiring navigation or manual refresh when assignments, mentions, project invitations, or future notification producers create new atomic `Notification` rows. Invitation recipients should see newly received invites and notification count/banner changes while already on the app, without needing a page reload. Keep email digest batching fully separate: in-app remains one notification per action/artifact, while email remains the grouped/debounced channel. This task should reuse or align with the broader TASK-118 realtime transport decision rather than introduce a parallel realtime stack.
   Dependencies: TASK-118, TASK-123, TASK-260
 ### Deferred (Intentional)
@@ -119,7 +119,7 @@ Last reviewed: 2026-05-31
 ## Completed
 - ID: TASK-312
   Title: Hidden project refresh reconciliation - remove user-facing refresh prompt
-  Status: Done (2026-06-04, PR pending)
+  Status: Done (2026-06-04, merged via PR #319)
   Rationale: Removed the visible bottom-right project refresh prompt and manual refresh button while preserving hidden pending-version tracking and automatic refresh once active edit locks or hidden-tab constraints clear. This keeps realtime collaboration machinery out of the user's way.
   Dependencies: TASK-311, TASK-308
 - ID: TASK-311

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,65 +1,115 @@
-# Current Task: TASK-312 Hidden Project Refresh Reconciliation
+# Current Task: TASK-263 Real-Time Notification Updates
 
 ## Task ID
-TASK-312
+TASK-263
 
 ## Status
-Implemented on `feature/task-312-hide-project-refresh-affordance`; PR workflow
-in progress.
+Implemented and locally validated on
+`feature/task-263-realtime-notification-updates`; PR workflow pending.
 
 ## Source
-- User feedback after TASK-311: the bottom-right "Project updates are ready /
-  Refresh" button exposes internal synchronization machinery and adds
-  unnecessary product noise.
+- Execution queue task promoted on 2026-05-31.
+- User feedback after multi-account testing: invitation recipients still needed
+  a page reload to see new invitations/notifications.
+- Existing realtime foundation: TASK-309 project activity SSE transport and
+  TASK-311 typed project event reconciliation.
 
 ## Objective
-Keep the live project reconciliation safety fallback, but make it invisible to
-users. Remote updates may still be deferred while a user is actively editing or
-the tab is hidden, then auto-apply as soon as the dashboard is safe to refresh.
+Make in-app notifications feel live across authenticated sessions. Newly
+created or updated `Notification` rows should update the account menu unread
+indicator, notification awareness banner, and notification center list without
+requiring navigation or manual refresh.
 
 ## Why This Matters
-NexusDash should feel collaborative and automatic. A visible manual refresh
-control suggests the user must understand or operate the realtime system, even
-though the app already has enough state to apply pending updates safely once
-editing locks clear.
+Invitations, assignments, mentions, and future notification producers are
+collaboration signals. If recipients must reload to discover them, the product
+does not meet the standard set by modern collaborative tools.
+
+## Current Behavior
+- `TopRightControls` server-renders the unread count once by calling
+  `countUnreadNotificationsForUser`.
+- `NotificationAwarenessBanner` server-renders the latest unread title once.
+- `/account/notifications` server-renders the inbox by calling
+  `listNotificationsForUser`.
+- Notification read actions refresh through server actions or API writes, but
+  other open tabs/sessions do not update until navigation or reload.
+- Project invitation notification rows are reconciled lazily during notification
+  service reads, so live checks must keep that reconciliation path.
+
+## Architecture Direction
+- Reuse the existing SSE-first realtime pattern from project activity rather
+  than introducing WebSockets or a second realtime provider.
+- Scope the stream to the authenticated account, not to a project.
+- Keep `Notification` as the source of truth. The realtime stream publishes a
+  compact recipient snapshot: version, unread count, and latest unread title.
+- Mount a single authenticated client stream in the app chrome, then let account
+  menu, awareness banner, and notification-center clients subscribe to that
+  browser event/state.
+- Let the notification center refetch its full list via
+  `/api/account/notifications` when the snapshot version changes.
+- Preserve email digest batching exactly as-is; realtime only changes in-app
+  freshness.
 
 ## Scope
-- Remove the rendered project-refresh prompt and manual refresh button from
-  `ProjectLiveRefresh`.
-- Preserve hidden pending-version tracking and automatic refresh once locks,
-  hidden-tab state, or in-flight refresh state clear.
-- Update component tests so they assert silent deferral and automatic follow-up
-  refresh behavior.
-- Mark TASK-311 complete in backlog tracking now that PR #318 is merged.
+- Add notification snapshot service support with durable version semantics.
+- Add authenticated account notification snapshot and SSE stream API routes.
+- Add a client live-notification source that prefers `EventSource` and falls
+  back to adaptive polling.
+- Update the account menu unread indicator from live snapshots.
+- Replace the server-only awareness banner with a live client banner that can
+  appear/disappear as unread state changes.
+- Update the notification center list so it can refresh rows in place when the
+  live snapshot changes.
+- Cover service, route, and component behavior with tests.
 
 ## Out Of Scope
-- Changing the typed realtime event contract from TASK-311.
-- Replacing the SSE/fallback transport.
-- Notification-center realtime behavior; TASK-263 remains the dedicated task.
+- Managed realtime provider provisioning.
+- Email digest timing/grouping changes.
+- Push/browser notifications, presence, or mobile OS notification delivery.
+- Changing notification producers beyond preserving their current row writes.
 
 ## Acceptance Criteria
-1. Users never see the bottom-right project refresh prompt or refresh button.
-2. Remote updates that cannot be applied immediately remain pending internally.
-3. Pending updates still auto-refresh when the dashboard becomes safe.
-4. Existing typed-event patching and fallback-refresh behavior remain covered by
-   tests.
+1. A user with an open authenticated app session sees unread notification count
+   changes without navigation when a notification row is created, read, unread,
+   or resolved.
+2. The in-app awareness banner appears for the latest unread notification and
+   disappears when no unread unresolved notification remains.
+3. `/account/notifications` updates its list in place when notification state
+   changes in another tab/session.
+4. Project invitation recipients can see newly received invitations through the
+   live notification path without reloading.
+5. The implementation reuses the app's SSE-first realtime pattern and keeps a
+   polling fallback.
+6. Email notification digest batching remains separate and unchanged.
 
 ## Definition Of Done
-- [x] `ProjectLiveRefresh` no longer renders user-facing pending-refresh UI.
-- [x] Focused tests cover invisible deferral and automatic pending refresh.
-- [x] `tasks/backlog.md`, `tasks/current.md`, and `journal.md` are updated.
-- [ ] PR is opened, checks pass, Copilot feedback is handled, and the PR is
-      merged.
+- [x] Notification snapshot service, API route, and SSE stream are implemented.
+- [x] Account menu, awareness banner, and notification center consume live
+      notification snapshots.
+- [x] Tests cover service snapshots, stream formatting/auth failure, polling
+      fallback, count/banner/list updates, and notification-center refetch.
+- [x] `npm run lint`, `npm test`, `npm run test:coverage`, `npm run build`, and
+      `npm run test:e2e` pass.
+- [x] `tasks/backlog.md`, `tasks/current.md`, `journal.md`, `project.md`, and
+      ADR docs are updated.
+- [ ] A ready PR is opened and Copilot feedback is handled.
+- [ ] The PR is left unmerged for maintainer review.
 
 ## Validation Evidence
-- `npm test -- --run tests/components/project-live-refresh.test.tsx` passed 1
-  file / 10 tests.
+- Focused `npm test -- --run tests/lib/notification-service.test.ts
+  tests/api/account-notifications.route.test.ts
+  tests/components/notification-live-updates.test.tsx
+  tests/components/notification-center-list.test.ts
+  tests/components/notification-awareness-banner.test.tsx
+  tests/components/account-menu.test.ts
+  tests/components/account-notifications-link.test.tsx` passed 7 files / 41
+  tests.
 - `npm run lint` passed.
-- Local PostgreSQL env `npm test` passed: 116 files passed, 2 skipped; 866
+- Local PostgreSQL env `npm test` passed: 118 files passed, 2 skipped; 879
   tests passed, 2 skipped.
 - Local PostgreSQL env `npm run test:coverage` passed with 91.37% statements,
   81.33% branches, 92.2% functions, and 91.88% lines.
 - Local-safe production env `npm run build` passed.
 - Local-safe production env `npm run test:e2e` passed 8/8 Playwright specs
-  after providing the expected `NEXTAUTH_URL`/`NEXTAUTH_SECRET` and trusted
-  local origins for the password-reset flow.
+  after replacing the projects helper `networkidle` wait with UI-ready
+  assertions because account-level SSE keeps a persistent connection open.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,8 +4,9 @@
 TASK-263
 
 ## Status
-Implemented and locally validated on
-`feature/task-263-realtime-notification-updates`; PR workflow pending.
+Implemented and locally validated on `feature/task-263-live-notification-updates`.
+Ready PR #320 is open, checks are green, and the PR is intentionally left
+unmerged for maintainer review.
 
 ## Source
 - Execution queue task promoted on 2026-05-31.
@@ -92,8 +93,8 @@ does not meet the standard set by modern collaborative tools.
       `npm run test:e2e` pass.
 - [x] `tasks/backlog.md`, `tasks/current.md`, `journal.md`, `project.md`, and
       ADR docs are updated.
-- [ ] A ready PR is opened and Copilot feedback is handled.
-- [ ] The PR is left unmerged for maintainer review.
+- [x] A ready PR is opened and Copilot feedback is handled.
+- [x] The PR is left unmerged for maintainer review.
 
 ## Validation Evidence
 - Focused `npm test -- --run tests/lib/notification-service.test.ts
@@ -113,3 +114,7 @@ does not meet the standard set by modern collaborative tools.
 - Local-safe production env `npm run test:e2e` passed 8/8 Playwright specs
   after replacing the projects helper `networkidle` wait with UI-ready
   assertions because account-level SSE keeps a persistent connection open.
+- PR #320 checks passed: `check-name`, `Quality Core (lint, test, coverage,
+  build)`, `E2E Smoke (Playwright)`, and `Container Image (build + metadata
+  artifact)`.
+- Copilot review/comment polling found no actionable comments.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -103,10 +103,10 @@ does not meet the standard set by modern collaborative tools.
   tests/components/notification-center-list.test.ts
   tests/components/notification-awareness-banner.test.tsx
   tests/components/account-menu.test.ts
-  tests/components/account-notifications-link.test.tsx` passed 7 files / 41
+  tests/components/account-notifications-link.test.tsx` passed 7 files / 42
   tests.
 - `npm run lint` passed.
-- Local PostgreSQL env `npm test` passed: 118 files passed, 2 skipped; 879
+- Local PostgreSQL env `npm test` passed: 118 files passed, 2 skipped; 880
   tests passed, 2 skipped.
 - Local PostgreSQL env `npm run test:coverage` passed with 91.37% statements,
   81.33% branches, 92.2% functions, and 91.88% lines.
@@ -117,4 +117,6 @@ does not meet the standard set by modern collaborative tools.
 - PR #320 checks passed: `check-name`, `Quality Core (lint, test, coverage,
   build)`, `E2E Smoke (Playwright)`, and `Container Image (build + metadata
   artifact)`.
-- Copilot review/comment polling found no actionable comments.
+- Copilot review comments were addressed by adding no-store error headers to
+  the summary route, request-scoped cached server snapshot reads, and `Link`
+  navigation in the awareness banner.

--- a/tests/api/account-notifications.route.test.ts
+++ b/tests/api/account-notifications.route.test.ts
@@ -6,6 +6,7 @@ const apiGuardMock = vi.hoisted(() => ({
 }));
 
 const notificationServiceMock = vi.hoisted(() => ({
+  getNotificationRealtimeSnapshotForUser: vi.fn(),
   listNotificationsForUser: vi.fn(),
   markAllNotificationsReadForUser: vi.fn(),
   setNotificationReadState: vi.fn(),
@@ -27,6 +28,8 @@ vi.mock("@/lib/observability/logger", () => ({
 }));
 
 vi.mock("@/lib/services/notification-service", () => ({
+  getNotificationRealtimeSnapshotForUser:
+    notificationServiceMock.getNotificationRealtimeSnapshotForUser,
   listNotificationsForUser: notificationServiceMock.listNotificationsForUser,
   markAllNotificationsReadForUser:
     notificationServiceMock.markAllNotificationsReadForUser,
@@ -44,6 +47,11 @@ import {
   PATCH as updateNotification,
 } from "@/app/api/account/notifications/route";
 import { POST as markAllRead } from "@/app/api/account/notifications/mark-all-read/route";
+import { GET as getNotificationSummary } from "@/app/api/account/notifications/summary/route";
+import {
+  GET as streamNotifications,
+  notificationStreamRouteInternals,
+} from "@/app/api/account/notifications/stream/route";
 import { GET as listInvitations } from "@/app/api/account/invitations/route";
 import { POST as respondToInvitation } from "@/app/api/account/invitations/[invitationId]/respond/route";
 
@@ -53,6 +61,17 @@ async function readJson(response: Response): Promise<Record<string, unknown>> {
 
 function invitationParams(invitationId: string) {
   return { params: Promise.resolve({ invitationId }) };
+}
+
+async function readFirstChunk(response: Response): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    throw new Error("missing-response-body");
+  }
+
+  const { value } = await reader.read();
+  await reader.cancel();
+  return new TextDecoder().decode(value);
 }
 
 describe("account notification and invitation routes", () => {
@@ -198,6 +217,82 @@ describe("account notification and invitation routes", () => {
     expect(
       notificationServiceMock.markAllNotificationsReadForUser
     ).toHaveBeenCalledWith("user-1");
+  });
+
+  test("GET notification summary returns realtime snapshot data", async () => {
+    notificationServiceMock.getNotificationRealtimeSnapshotForUser.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: {
+        version: "2026-06-04T10:00:00.000Z",
+        unreadCount: 2,
+        latestUnreadNotification: { title: "Assigned: Ship realtime" },
+        serverTime: "2026-06-04T10:00:00.000Z",
+      },
+    });
+
+    const response = await getNotificationSummary(
+      new NextRequest("http://localhost/api/account/notifications/summary")
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    await expect(readJson(response)).resolves.toEqual({
+      version: "2026-06-04T10:00:00.000Z",
+      unreadCount: 2,
+      latestUnreadNotification: { title: "Assigned: Ship realtime" },
+      serverTime: "2026-06-04T10:00:00.000Z",
+    });
+    expect(
+      notificationServiceMock.getNotificationRealtimeSnapshotForUser
+    ).toHaveBeenCalledWith("user-1");
+  });
+
+  test("notification stream emits the authorized realtime snapshot", async () => {
+    notificationServiceMock.getNotificationRealtimeSnapshotForUser.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      data: {
+        version: "2026-06-04T10:00:00.000Z",
+        unreadCount: 1,
+        latestUnreadNotification: { title: "Project invitation: Alpha" },
+        serverTime: "2026-06-04T10:00:00.000Z",
+      },
+    });
+
+    const response = await streamNotifications(
+      new NextRequest("http://localhost/api/account/notifications/stream")
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    expect(response.headers.get("cache-control")).toBe("no-store, no-transform");
+
+    const chunk = await readFirstChunk(response);
+    expect(chunk).toContain("retry: 2000");
+    expect(chunk).toContain("id: 2026-06-04T10:00:00.000Z");
+    expect(chunk).toContain("event: notification-snapshot");
+    expect(chunk).toContain('"unreadCount":1');
+    expect(chunk).toContain('"Project invitation: Alpha"');
+  });
+
+  test("notification stream reports changed snapshots", () => {
+    expect(
+      notificationStreamRouteInternals.isSnapshotChanged(
+        {
+          version: "2026-06-04T10:01:00.000Z",
+          unreadCount: 1,
+          latestUnreadNotification: { title: "A" },
+          serverTime: "2026-06-04T10:01:00.000Z",
+        },
+        {
+          version: "2026-06-04T10:00:00.000Z",
+          unreadCount: 1,
+          latestUnreadNotification: { title: "A" },
+          serverTime: "2026-06-04T10:00:00.000Z",
+        }
+      )
+    ).toBe(true);
   });
 
   test("GET invitations returns pending invitations", async () => {

--- a/tests/api/account-notifications.route.test.ts
+++ b/tests/api/account-notifications.route.test.ts
@@ -248,6 +248,24 @@ describe("account notification and invitation routes", () => {
     ).toHaveBeenCalledWith("user-1");
   });
 
+  test("GET notification summary does not cache service errors", async () => {
+    notificationServiceMock.getNotificationRealtimeSnapshotForUser.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      error: "notification-snapshot-failed",
+    });
+
+    const response = await getNotificationSummary(
+      new NextRequest("http://localhost/api/account/notifications/summary")
+    );
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    await expect(readJson(response)).resolves.toEqual({
+      error: "notification-snapshot-failed",
+    });
+  });
+
   test("notification stream emits the authorized realtime snapshot", async () => {
     notificationServiceMock.getNotificationRealtimeSnapshotForUser.mockResolvedValueOnce({
       ok: true,

--- a/tests/components/account-menu.test.ts
+++ b/tests/components/account-menu.test.ts
@@ -1,6 +1,11 @@
+// @vitest-environment jsdom
+
 import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { publishNotificationRealtimeSnapshot } from "@/lib/notification-realtime-client";
 
 vi.mock("@/lib/hooks/use-dismissible-menu", () => ({
   useDismissibleMenu: vi.fn(() => ({ current: null })),
@@ -22,7 +27,7 @@ describe("account-menu", () => {
         displayName: null,
         usernameTag: null,
         avatarSeed: null,
-        unreadNotificationCount: 0,
+        initialUnreadNotificationCount: 0,
       })
     );
 
@@ -36,7 +41,7 @@ describe("account-menu", () => {
         displayName: "test.user",
         usernameTag: "test.user#1234",
         avatarSeed: "seed-123",
-        unreadNotificationCount: 0,
+        initialUnreadNotificationCount: 0,
       })
     );
 
@@ -53,10 +58,46 @@ describe("account-menu", () => {
         displayName: "test.user",
         usernameTag: "test.user#1234",
         avatarSeed: "seed-123",
-        unreadNotificationCount: 3,
+        initialUnreadNotificationCount: 3,
       })
     );
 
     expect(result).toContain("bg-red-500");
+  });
+
+  test("updates the notification indicator from live snapshots", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        React.createElement(AccountMenu, {
+          isAuthenticated: true,
+          displayName: "test.user",
+          usernameTag: "test.user#1234",
+          avatarSeed: "seed-123",
+          initialUnreadNotificationCount: 0,
+        })
+      );
+    });
+
+    expect(container.textContent).not.toContain("Notifications");
+    expect(container.querySelector(".bg-red-500")).toBeNull();
+
+    await act(async () => {
+      publishNotificationRealtimeSnapshot({
+        version: "2026-06-04T10:00:00.000Z",
+        unreadCount: 2,
+        latestUnreadNotification: { title: "Assigned: Ship realtime" },
+        serverTime: "2026-06-04T10:00:00.000Z",
+      });
+    });
+
+    expect(container.querySelector(".bg-red-500")).not.toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
   });
 });

--- a/tests/components/account-notifications-link.test.tsx
+++ b/tests/components/account-notifications-link.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { AccountNotificationsLink } from "@/components/account-notifications-link";
+import { publishNotificationRealtimeSnapshot } from "@/lib/notification-realtime-client";
+
+(globalThis as { React?: typeof React }).React = React;
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const initialSnapshot = {
+  version: "2026-06-04T10:00:00.000Z",
+  unreadCount: 0,
+  latestUnreadNotification: null,
+  serverTime: "2026-06-04T10:00:00.000Z",
+};
+
+describe("AccountNotificationsLink", () => {
+  test("renders the notifications link without a badge when all read", () => {
+    const result = renderToStaticMarkup(
+      React.createElement(AccountNotificationsLink, {
+        initialSnapshot,
+      })
+    );
+
+    expect(result).toContain("Notifications");
+    expect(result).not.toContain("bg-red-500");
+  });
+
+  test("updates the badge from live snapshots", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        React.createElement(AccountNotificationsLink, {
+          initialSnapshot,
+        })
+      );
+    });
+
+    expect(container.querySelector(".bg-red-500")).toBeNull();
+
+    await act(async () => {
+      publishNotificationRealtimeSnapshot({
+        version: "2026-06-04T10:01:00.000Z",
+        unreadCount: 12,
+        latestUnreadNotification: { title: "Mentioned in: Task C" },
+        serverTime: "2026-06-04T10:01:00.000Z",
+      });
+    });
+
+    expect(container.textContent).toContain("9+");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/tests/components/notification-awareness-banner.test.tsx
+++ b/tests/components/notification-awareness-banner.test.tsx
@@ -1,25 +1,13 @@
+// @vitest-environment jsdom
+
 import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-const notificationServiceMock = vi.hoisted(() => ({
-  getLatestUnreadNotificationForUser: vi.fn(),
-}));
-
-vi.mock("next/cache", () => ({
-  unstable_noStore: vi.fn(),
-}));
-
-vi.mock("@/lib/observability/logger", () => ({
-  logServerError: vi.fn(),
-}));
-
-vi.mock("@/lib/services/notification-service", () => ({
-  getLatestUnreadNotificationForUser:
-    notificationServiceMock.getLatestUnreadNotificationForUser,
-}));
-
 import { NotificationAwarenessBanner } from "@/components/notification-awareness-banner";
+import { publishNotificationRealtimeSnapshot } from "@/lib/notification-realtime-client";
 
 (globalThis as { React?: typeof React }).React = React;
 
@@ -29,44 +17,73 @@ describe("notification-awareness-banner", () => {
   });
 
   test("renders only the latest atomic notification instead of grouped unread text", async () => {
-    notificationServiceMock.getLatestUnreadNotificationForUser.mockResolvedValueOnce(
-      {
-        ok: true,
-        status: 200,
-        data: {
-          notification: {
+    const result = renderToStaticMarkup(
+      React.createElement(NotificationAwarenessBanner, {
+        initialSnapshot: {
+          version: "2026-06-04T10:00:00.000Z",
+          unreadCount: 1,
+          latestUnreadNotification: {
             title: "Mentioned in: Task C",
           },
+          serverTime: "2026-06-04T10:00:00.000Z",
         },
-      }
-    );
-
-    const result = renderToStaticMarkup(
-      await NotificationAwarenessBanner({ actorUserId: "user-1" })
+      })
     );
 
     expect(result).toContain("Mentioned in: Task C");
     expect(result).not.toContain("Mentioned in: Task B");
     expect(result).not.toContain("more unread notification");
     expect(result).toContain("Review notifications");
-    expect(
-      notificationServiceMock.getLatestUnreadNotificationForUser
-    ).toHaveBeenCalledWith("user-1");
   });
 
   test("renders nothing when all notifications are already read", async () => {
-    notificationServiceMock.getLatestUnreadNotificationForUser.mockResolvedValueOnce(
-      {
-        ok: true,
-        status: 200,
-        data: {
-          notification: null,
+    const result = renderToStaticMarkup(
+      React.createElement(NotificationAwarenessBanner, {
+        initialSnapshot: {
+          version: "2026-06-04T10:00:00.000Z",
+          unreadCount: 0,
+          latestUnreadNotification: null,
+          serverTime: "2026-06-04T10:00:00.000Z",
         },
-      }
+      })
     );
 
-    const result = await NotificationAwarenessBanner({ actorUserId: "user-1" });
+    expect(result).toBe("");
+  });
 
-    expect(result).toBeNull();
+  test("appears when a live snapshot reports unread notifications", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        React.createElement(NotificationAwarenessBanner, {
+          initialSnapshot: {
+            version: "2026-06-04T10:00:00.000Z",
+            unreadCount: 0,
+            latestUnreadNotification: null,
+            serverTime: "2026-06-04T10:00:00.000Z",
+          },
+        })
+      );
+    });
+
+    expect(container.textContent).toBe("");
+
+    await act(async () => {
+      publishNotificationRealtimeSnapshot({
+        version: "2026-06-04T10:01:00.000Z",
+        unreadCount: 1,
+        latestUnreadNotification: { title: "Project invitation: Alpha" },
+        serverTime: "2026-06-04T10:01:00.000Z",
+      });
+    });
+
+    expect(container.textContent).toContain("Project invitation: Alpha");
+
+    await act(async () => {
+      root.unmount();
+    });
   });
 });

--- a/tests/components/notification-center-list.test.ts
+++ b/tests/components/notification-center-list.test.ts
@@ -1,18 +1,41 @@
+// @vitest-environment jsdom
+
 import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { NotificationCenterList } from "@/components/account/notification-center-list";
+import { publishNotificationRealtimeSnapshot } from "@/lib/notification-realtime-client";
 
 (globalThis as { React?: typeof React }).React = React;
 
 const noopAction = () => {};
+const fetchMock = vi.hoisted(() => vi.fn());
+const initialSnapshot = {
+  version: "2026-06-04T10:00:00.000Z",
+  unreadCount: 0,
+  latestUnreadNotification: null,
+  serverTime: "2026-06-04T10:00:00.000Z",
+};
 
 describe("notification-center-list", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.body.innerHTML = "";
+  });
+
   test("renders an empty notification inbox", () => {
     const result = renderToStaticMarkup(
       React.createElement(NotificationCenterList, {
         notifications: [],
+        initialSnapshot,
         onMarkRead: noopAction,
         onMarkUnread: noopAction,
         onMarkAllRead: noopAction,
@@ -54,6 +77,13 @@ describe("notification-center-list", () => {
             updatedAt: "2026-04-29T08:01:00.000Z",
           },
         ],
+        initialSnapshot: {
+          ...initialSnapshot,
+          unreadCount: 1,
+          latestUnreadNotification: {
+            title: "Project invitation: Shared Project",
+          },
+        },
         onMarkRead: noopAction,
         onMarkUnread: noopAction,
         onMarkAllRead: noopAction,
@@ -68,5 +98,72 @@ describe("notification-center-list", () => {
     expect(result).toContain("Accept");
     expect(result).toContain("Decline");
     expect(result).toContain("Mark read");
+  });
+
+  test("refreshes visible rows when a live snapshot changes", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        notifications: [
+          {
+            id: "notification-2",
+            type: "task_assignment",
+            title: "Assigned: Ship realtime",
+            body: "Dorian assigned you to Ship realtime.",
+            targetPath: "/projects/project-1?taskId=task-2",
+            sourceType: "task_assignment",
+            sourceId: "task-2",
+            metadata: null,
+            readAt: null,
+            resolvedAt: null,
+            createdAt: "2026-06-04T10:01:00.000Z",
+            updatedAt: "2026-06-04T10:01:00.000Z",
+          },
+        ],
+      }),
+    });
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        React.createElement(NotificationCenterList, {
+          notifications: [],
+          initialSnapshot,
+          onMarkRead: noopAction,
+          onMarkUnread: noopAction,
+          onMarkAllRead: noopAction,
+          onAcceptInvitation: noopAction,
+          onDeclineInvitation: noopAction,
+        })
+      );
+    });
+
+    expect(container.textContent).toContain("No active notifications.");
+
+    await act(async () => {
+      publishNotificationRealtimeSnapshot({
+        version: "2026-06-04T10:01:00.000Z",
+        unreadCount: 1,
+        latestUnreadNotification: { title: "Assigned: Ship realtime" },
+        serverTime: "2026-06-04T10:01:00.000Z",
+      });
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/account/notifications", {
+      cache: "no-store",
+      signal: expect.any(AbortSignal),
+    });
+    expect(container.textContent).toContain("Assigned: Ship realtime");
+
+    await act(async () => {
+      root.unmount();
+    });
   });
 });

--- a/tests/components/notification-live-updates.test.tsx
+++ b/tests/components/notification-live-updates.test.tsx
@@ -1,0 +1,211 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { NotificationLiveUpdates } from "@/components/notification-live-updates";
+import {
+  NOTIFICATION_REALTIME_EVENT,
+} from "@/lib/notification-realtime-client";
+
+const fetchMock = vi.hoisted(() => vi.fn());
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  readonly url: string;
+  closed = false;
+  private listeners = new Map<string, Set<EventListener>>();
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? new Set<EventListener>();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: EventListener) {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  close() {
+    this.closed = true;
+  }
+
+  emit(type: string, event: Event) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+
+  open() {
+    this.emit("open", new Event("open"));
+  }
+
+  error() {
+    this.emit("error", new Event("error"));
+  }
+
+  notificationSnapshot(payload: unknown) {
+    this.emit(
+      "notification-snapshot",
+      new MessageEvent("notification-snapshot", {
+        data: JSON.stringify(payload),
+      }) as unknown as Event
+    );
+  }
+}
+
+function createTestRenderer() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  return {
+    container,
+    root,
+  };
+}
+
+async function renderWithRoot(root: Root, ui: React.ReactElement) {
+  await act(async () => {
+    root.render(ui);
+  });
+}
+
+const initialSnapshot = {
+  version: "2026-06-04T10:00:00.000Z",
+  unreadCount: 0,
+  latestUnreadNotification: null,
+  serverTime: "2026-06-04T10:00:00.000Z",
+};
+
+describe("NotificationLiveUpdates", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    MockEventSource.instances = [];
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    document.body.innerHTML = "";
+  });
+
+  test("uses the notification stream when EventSource is available", async () => {
+    vi.stubGlobal("EventSource", MockEventSource);
+    const { root } = createTestRenderer();
+
+    await renderWithRoot(
+      root,
+      React.createElement(NotificationLiveUpdates, {
+        initialSnapshot,
+        pollIntervalMs: 50,
+      })
+    );
+
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0]?.url).toBe(
+      "/api/account/notifications/stream"
+    );
+
+    await act(async () => {
+      MockEventSource.instances[0]?.open();
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      root.unmount();
+    });
+
+    expect(MockEventSource.instances[0]?.closed).toBe(true);
+  });
+
+  test("publishes stream snapshots to browser subscribers", async () => {
+    vi.stubGlobal("EventSource", MockEventSource);
+    const { root } = createTestRenderer();
+    const listener = vi.fn();
+    window.addEventListener(NOTIFICATION_REALTIME_EVENT, listener);
+
+    await renderWithRoot(
+      root,
+      React.createElement(NotificationLiveUpdates, {
+        initialSnapshot,
+        pollIntervalMs: 50,
+      })
+    );
+
+    await act(async () => {
+      MockEventSource.instances[0]?.open();
+      MockEventSource.instances[0]?.notificationSnapshot({
+        version: "2026-06-04T10:01:00.000Z",
+        unreadCount: 1,
+        latestUnreadNotification: { title: "Assigned: Ship realtime" },
+        serverTime: "2026-06-04T10:01:00.000Z",
+      });
+    });
+
+    expect(listener).toHaveBeenCalled();
+
+    window.removeEventListener(NOTIFICATION_REALTIME_EVENT, listener);
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  test("falls back to polling when the stream fails before opening", async () => {
+    vi.stubGlobal("EventSource", MockEventSource);
+    const { root } = createTestRenderer();
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        version: "2026-06-04T10:02:00.000Z",
+        unreadCount: 2,
+        latestUnreadNotification: { title: "Project invitation: Alpha" },
+        serverTime: "2026-06-04T10:02:00.000Z",
+      }),
+    });
+
+    await renderWithRoot(
+      root,
+      React.createElement(NotificationLiveUpdates, {
+        initialSnapshot,
+        pollIntervalMs: 50,
+      })
+    );
+
+    await act(async () => {
+      MockEventSource.instances[0]?.error();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    expect(MockEventSource.instances[0]?.closed).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/account/notifications/summary",
+      {
+        cache: "no-store",
+        signal: expect.any(AbortSignal),
+      }
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/tests/e2e/helpers/project-helpers.ts
+++ b/tests/e2e/helpers/project-helpers.ts
@@ -14,15 +14,15 @@ export async function createProjectFromProjectsPage(
   description = "Smoke test project"
 ): Promise<void> {
   await page.goto("/projects");
-  await page.waitForLoadState("networkidle");
 
   const createProjectButton = page.getByRole("button", { name: "Create project" }).first();
   const createNameField = page.locator("#create-name");
 
+  await expect(createProjectButton).toBeVisible();
   await createProjectButton.click();
 
   if (!(await createNameField.isVisible().catch(() => false))) {
-    await page.waitForLoadState("networkidle");
+    await expect(createProjectButton).toBeVisible();
     await createProjectButton.click();
   }
 

--- a/tests/lib/notification-service.test.ts
+++ b/tests/lib/notification-service.test.ts
@@ -30,6 +30,7 @@ import {
   countUnreadNotificationsForUser,
   createTaskDueDateReminderNotification,
   getLatestUnreadNotificationForUser,
+  getNotificationRealtimeSnapshotForUser,
   listNotificationsForUser,
   markAllNotificationsReadForUser,
   resolveProjectInvitationNotifications,
@@ -227,6 +228,62 @@ describe("notification-service", () => {
         title: true,
       },
     });
+  });
+
+  test("builds a realtime notification snapshot after syncing invitations", async () => {
+    prismaMock.notification.findFirst
+      .mockResolvedValueOnce({
+        updatedAt: new Date("2026-06-04T10:00:00.000Z"),
+      })
+      .mockResolvedValueOnce({
+        title: "Project invitation: Alpha",
+      });
+    prismaMock.notification.count.mockResolvedValueOnce(3);
+
+    const result = await getNotificationRealtimeSnapshotForUser("user-1");
+
+    expect(result.ok).toBe(true);
+    expect(result.ok ? result.data : null).toMatchObject({
+      version: "2026-06-04T10:00:00.000Z",
+      unreadCount: 3,
+      latestUnreadNotification: {
+        title: "Project invitation: Alpha",
+      },
+    });
+    expect(prismaMock.notification.findFirst).toHaveBeenCalledWith({
+      where: {
+        recipientUserId: "user-1",
+      },
+      orderBy: [{ updatedAt: "desc" }],
+      select: {
+        updatedAt: true,
+      },
+    });
+    expect(prismaMock.notification.count).toHaveBeenCalledWith({
+      where: {
+        recipientUserId: "user-1",
+        resolvedAt: null,
+        readAt: null,
+      },
+    });
+  });
+
+  test("can build realtime notification snapshots without invitation sync", async () => {
+    prismaMock.notification.findFirst
+      .mockResolvedValueOnce({
+        updatedAt: new Date("2026-06-04T10:00:00.000Z"),
+      })
+      .mockResolvedValueOnce(null);
+    prismaMock.notification.count.mockResolvedValueOnce(0);
+
+    const result = await getNotificationRealtimeSnapshotForUser("user-1", {
+      syncProjectInvitations: false,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(prismaMock.$queryRaw).not.toHaveBeenCalled();
+    expect(prismaMock.notification.updateMany).not.toHaveBeenCalled();
+    expect(result.ok ? result.data.unreadCount : null).toBe(0);
   });
 
   test("does not refresh existing active invitation notifications during count sync", async () => {


### PR DESCRIPTION
## Summary
- Adds account-scoped realtime notification snapshots with authenticated summary and SSE stream routes.
- Mounts a single chrome live-update source that prefers EventSource and falls back to adaptive polling.
- Updates account menu counts, the account notifications link, awareness banners, and notification-center rows to consume live snapshots.
- Keeps email digest batching unchanged and records the TASK-263 architecture decision in ADR/docs.
- Updates E2E helpers to wait for visible UI readiness because authenticated pages now keep a persistent SSE connection open.

## Validation
- `npm test -- --run tests/lib/notification-service.test.ts tests/api/account-notifications.route.test.ts tests/components/notification-live-updates.test.tsx tests/components/notification-center-list.test.ts tests/components/notification-awareness-banner.test.tsx tests/components/account-menu.test.ts tests/components/account-notifications-link.test.tsx` passed 7 files / 41 tests.
- `npm run lint` passed.
- Local PostgreSQL env `npm test` passed: 118 files passed, 2 skipped; 879 tests passed, 2 skipped.
- Local PostgreSQL env `npm run test:coverage` passed: 91.37% statements, 81.33% branches, 92.2% functions, 91.88% lines.
- Local-safe production env `npm run build` passed.
- Local-safe production env `npm run test:e2e` passed 8/8 Playwright specs.

## Notes
- The stream reconciles project invitations on the initial snapshot, then uses read-only snapshot polling for steady-state updates to avoid repeated write-path work.
- This PR is intentionally left unmerged for maintainer review per instruction.
