### PR TITLE
TASK-224 Add agent roadmap API access

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Open `http://localhost:3000`.
 - Logout endpoint: `POST /api/auth/logout`.
 - Agent access is project-scoped and owner-managed from the project settings surface.
 - Agent raw API keys exchange at `POST /api/auth/agent/token` into short-lived bearer tokens.
-- Agent v1 is limited to project/task/context APIs and does not include calendar or binary attachment parity.
+- Agent v1 is limited to project/roadmap/task/context APIs and does not include calendar access.
 
 ## Database and Migrations
 

--- a/adr/decisions.md
+++ b/adr/decisions.md
@@ -217,7 +217,7 @@ Keep UI-only or task-only notes in `journal.md`.
 ## 2026-03-31 - Ship agent access v1 as project-scoped API credentials exchanged into short-lived bearer tokens
 - Status: Accepted
 - Context: TASK-059 needs safe non-human access without reusing browser sessions, while preserving the current human session model, RLS visibility boundary, and project-scoped authorization guarantees.
-- Decision: Store owner-managed API credentials per project with explicit scope grants, show the raw key only once, hash secrets at rest, exchange raw keys at a dedicated auth endpoint for short-lived signed bearer tokens, and enforce agent scope/project checks explicitly in project/task/context services and routes while resolving DB visibility through the credential owner's RLS subject.
+- Decision: Store owner-managed API credentials per project with explicit scope grants, show the raw key only once, hash secrets at rest, exchange raw keys at a dedicated auth endpoint for short-lived signed bearer tokens, and enforce agent scope/project checks explicitly in project/roadmap/task/context services and routes while resolving DB visibility through the credential owner's RLS subject.
 - Consequences: Agent automation now has a safe first-class path with rotation, revocation, and auditability, but v1 intentionally excludes calendar delegation and binary attachment parity until ownership semantics for those assets are designed explicitly.
 - Links: `tasks/task-059-agent-access-implementation.md`, `lib/auth/api-guard.ts`, `lib/auth/agent-token-service.ts`, `lib/services/project-agent-access-service.ts`, `prisma/migrations/20260331153000_task059_agent_access_v1/migration.sql`
 

--- a/app/api/projects/[projectId]/roadmap/events/[eventId]/route.ts
+++ b/app/api/projects/[projectId]/roadmap/events/[eventId]/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { requireAuthenticatedApiUser } from "@/lib/auth/api-guard";
+import {
+  getAgentProjectAccessContext,
+  requireApiPrincipal,
+} from "@/lib/auth/api-guard";
 import { logServerWarning } from "@/lib/observability/logger";
+import { requireAgentProjectScopes } from "@/lib/services/project-access-service";
 import {
   deleteProjectRoadmapEvent,
   updateProjectRoadmapEvent,
@@ -23,9 +27,22 @@ export async function PATCH(
   props: { params: Promise<{ projectId: string; eventId: string }> }
 ) {
   const params = await props.params;
-  const authenticatedUser = await requireAuthenticatedApiUser(request);
-  if (!authenticatedUser.ok) {
-    return authenticatedUser.response;
+  const principalResult = await requireApiPrincipal(request);
+  if (!principalResult.ok) {
+    return principalResult.response;
+  }
+
+  const agentAccess = getAgentProjectAccessContext(principalResult.principal);
+  const agentScopeAccess = requireAgentProjectScopes({
+    agentAccess,
+    projectId: params.projectId,
+    requiredScopes: ["roadmap:write"],
+  });
+  if (!agentScopeAccess.ok) {
+    return NextResponse.json(
+      { error: agentScopeAccess.error },
+      { status: agentScopeAccess.status }
+    );
   }
 
   let payload: RoadmapEventRequestBody;
@@ -66,9 +83,10 @@ export async function PATCH(
   }
 
   const result = await updateProjectRoadmapEvent({
-    actorUserId: authenticatedUser.userId,
+    actorUserId: principalResult.principal.actorUserId,
     projectId: params.projectId,
     eventId: params.eventId,
+    agentAccess,
     ...(hasOwn(payload, "title") ? { title: payload.title as string } : {}),
     ...(hasOwn(payload, "description")
       ? { description: (payload.description ?? null) as string | null }
@@ -96,15 +114,29 @@ export async function DELETE(
   props: { params: Promise<{ projectId: string; eventId: string }> }
 ) {
   const params = await props.params;
-  const authenticatedUser = await requireAuthenticatedApiUser(request);
-  if (!authenticatedUser.ok) {
-    return authenticatedUser.response;
+  const principalResult = await requireApiPrincipal(request);
+  if (!principalResult.ok) {
+    return principalResult.response;
+  }
+
+  const agentAccess = getAgentProjectAccessContext(principalResult.principal);
+  const agentScopeAccess = requireAgentProjectScopes({
+    agentAccess,
+    projectId: params.projectId,
+    requiredScopes: ["roadmap:delete"],
+  });
+  if (!agentScopeAccess.ok) {
+    return NextResponse.json(
+      { error: agentScopeAccess.error },
+      { status: agentScopeAccess.status }
+    );
   }
 
   const result = await deleteProjectRoadmapEvent({
-    actorUserId: authenticatedUser.userId,
+    actorUserId: principalResult.principal.actorUserId,
     projectId: params.projectId,
     eventId: params.eventId,
+    agentAccess,
   });
 
   if (!result.ok) {

--- a/app/api/projects/[projectId]/roadmap/events/move/route.ts
+++ b/app/api/projects/[projectId]/roadmap/events/move/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { requireAuthenticatedApiUser } from "@/lib/auth/api-guard";
+import {
+  getAgentProjectAccessContext,
+  requireApiPrincipal,
+} from "@/lib/auth/api-guard";
 import { logServerWarning } from "@/lib/observability/logger";
+import { requireAgentProjectScopes } from "@/lib/services/project-access-service";
 import {
   isValidRoadmapEventMovePayload,
   moveProjectRoadmapEvent,
@@ -12,9 +16,22 @@ export async function POST(
   props: { params: Promise<{ projectId: string }> }
 ) {
   const params = await props.params;
-  const authenticatedUser = await requireAuthenticatedApiUser(request);
-  if (!authenticatedUser.ok) {
-    return authenticatedUser.response;
+  const principalResult = await requireApiPrincipal(request);
+  if (!principalResult.ok) {
+    return principalResult.response;
+  }
+
+  const agentAccess = getAgentProjectAccessContext(principalResult.principal);
+  const agentScopeAccess = requireAgentProjectScopes({
+    agentAccess,
+    projectId: params.projectId,
+    requiredScopes: ["roadmap:write"],
+  });
+  if (!agentScopeAccess.ok) {
+    return NextResponse.json(
+      { error: agentScopeAccess.error },
+      { status: agentScopeAccess.status }
+    );
   }
 
   let payload: unknown;
@@ -34,8 +51,9 @@ export async function POST(
   }
 
   const result = await moveProjectRoadmapEvent({
-    actorUserId: authenticatedUser.userId,
+    actorUserId: principalResult.principal.actorUserId,
     projectId: params.projectId,
+    agentAccess,
     eventId: payload.eventId,
     targetPhaseId: payload.targetPhaseId,
     targetIndex: payload.targetIndex,

--- a/app/api/projects/[projectId]/roadmap/events/reorder/route.ts
+++ b/app/api/projects/[projectId]/roadmap/events/reorder/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { requireAuthenticatedApiUser } from "@/lib/auth/api-guard";
+import {
+  getAgentProjectAccessContext,
+  requireApiPrincipal,
+} from "@/lib/auth/api-guard";
 import { logServerWarning } from "@/lib/observability/logger";
+import { requireAgentProjectScopes } from "@/lib/services/project-access-service";
 import {
   isValidRoadmapEventReorderPayload,
   reorderProjectRoadmapEvents,
@@ -12,9 +16,22 @@ export async function POST(
   props: { params: Promise<{ projectId: string }> }
 ) {
   const params = await props.params;
-  const authenticatedUser = await requireAuthenticatedApiUser(request);
-  if (!authenticatedUser.ok) {
-    return authenticatedUser.response;
+  const principalResult = await requireApiPrincipal(request);
+  if (!principalResult.ok) {
+    return principalResult.response;
+  }
+
+  const agentAccess = getAgentProjectAccessContext(principalResult.principal);
+  const agentScopeAccess = requireAgentProjectScopes({
+    agentAccess,
+    projectId: params.projectId,
+    requiredScopes: ["roadmap:write"],
+  });
+  if (!agentScopeAccess.ok) {
+    return NextResponse.json(
+      { error: agentScopeAccess.error },
+      { status: agentScopeAccess.status }
+    );
   }
 
   let payload: unknown;
@@ -34,8 +51,9 @@ export async function POST(
   }
 
   const result = await reorderProjectRoadmapEvents({
-    actorUserId: authenticatedUser.userId,
+    actorUserId: principalResult.principal.actorUserId,
     projectId: params.projectId,
+    agentAccess,
     phaseId: payload.phaseId,
     eventIds: payload.eventIds,
   });

--- a/app/api/projects/[projectId]/roadmap/phases/[phaseId]/events/route.ts
+++ b/app/api/projects/[projectId]/roadmap/phases/[phaseId]/events/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { requireAuthenticatedApiUser } from "@/lib/auth/api-guard";
+import {
+  getAgentProjectAccessContext,
+  requireApiPrincipal,
+} from "@/lib/auth/api-guard";
 import { logServerWarning } from "@/lib/observability/logger";
+import { requireAgentProjectScopes } from "@/lib/services/project-access-service";
 import { createProjectRoadmapEvent } from "@/lib/services/project-roadmap-service";
 
 interface RoadmapEventRequestBody {
@@ -16,9 +20,22 @@ export async function POST(
   props: { params: Promise<{ projectId: string; phaseId: string }> }
 ) {
   const params = await props.params;
-  const authenticatedUser = await requireAuthenticatedApiUser(request);
-  if (!authenticatedUser.ok) {
-    return authenticatedUser.response;
+  const principalResult = await requireApiPrincipal(request);
+  if (!principalResult.ok) {
+    return principalResult.response;
+  }
+
+  const agentAccess = getAgentProjectAccessContext(principalResult.principal);
+  const agentScopeAccess = requireAgentProjectScopes({
+    agentAccess,
+    projectId: params.projectId,
+    requiredScopes: ["roadmap:write"],
+  });
+  if (!agentScopeAccess.ok) {
+    return NextResponse.json(
+      { error: agentScopeAccess.error },
+      { status: agentScopeAccess.status }
+    );
   }
 
   let payload: RoadmapEventRequestBody;
@@ -34,9 +51,10 @@ export async function POST(
   }
 
   const result = await createProjectRoadmapEvent({
-    actorUserId: authenticatedUser.userId,
+    actorUserId: principalResult.principal.actorUserId,
     projectId: params.projectId,
     phaseId: params.phaseId,
+    agentAccess,
     title: typeof payload.title === "string" ? payload.title : "",
     description: typeof payload.description === "string" ? payload.description : null,
     targetDate: typeof payload.targetDate === "string" ? payload.targetDate : null,

--- a/app/api/projects/[projectId]/roadmap/phases/[phaseId]/route.ts
+++ b/app/api/projects/[projectId]/roadmap/phases/[phaseId]/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { requireAuthenticatedApiUser } from "@/lib/auth/api-guard";
+import {
+  getAgentProjectAccessContext,
+  requireApiPrincipal,
+} from "@/lib/auth/api-guard";
 import { logServerWarning } from "@/lib/observability/logger";
+import { requireAgentProjectScopes } from "@/lib/services/project-access-service";
 import {
   deleteProjectRoadmapPhase,
   updateProjectRoadmapPhase,
@@ -23,9 +27,22 @@ export async function PATCH(
   props: { params: Promise<{ projectId: string; phaseId: string }> }
 ) {
   const params = await props.params;
-  const authenticatedUser = await requireAuthenticatedApiUser(request);
-  if (!authenticatedUser.ok) {
-    return authenticatedUser.response;
+  const principalResult = await requireApiPrincipal(request);
+  if (!principalResult.ok) {
+    return principalResult.response;
+  }
+
+  const agentAccess = getAgentProjectAccessContext(principalResult.principal);
+  const agentScopeAccess = requireAgentProjectScopes({
+    agentAccess,
+    projectId: params.projectId,
+    requiredScopes: ["roadmap:write"],
+  });
+  if (!agentScopeAccess.ok) {
+    return NextResponse.json(
+      { error: agentScopeAccess.error },
+      { status: agentScopeAccess.status }
+    );
   }
 
   let payload: RoadmapPhaseRequestBody;
@@ -66,9 +83,10 @@ export async function PATCH(
   }
 
   const result = await updateProjectRoadmapPhase({
-    actorUserId: authenticatedUser.userId,
+    actorUserId: principalResult.principal.actorUserId,
     projectId: params.projectId,
     phaseId: params.phaseId,
+    agentAccess,
     ...(hasOwn(payload, "title") ? { title: payload.title as string } : {}),
     ...(hasOwn(payload, "description")
       ? { description: (payload.description ?? null) as string | null }
@@ -95,15 +113,29 @@ export async function DELETE(
   props: { params: Promise<{ projectId: string; phaseId: string }> }
 ) {
   const params = await props.params;
-  const authenticatedUser = await requireAuthenticatedApiUser(request);
-  if (!authenticatedUser.ok) {
-    return authenticatedUser.response;
+  const principalResult = await requireApiPrincipal(request);
+  if (!principalResult.ok) {
+    return principalResult.response;
+  }
+
+  const agentAccess = getAgentProjectAccessContext(principalResult.principal);
+  const agentScopeAccess = requireAgentProjectScopes({
+    agentAccess,
+    projectId: params.projectId,
+    requiredScopes: ["roadmap:delete"],
+  });
+  if (!agentScopeAccess.ok) {
+    return NextResponse.json(
+      { error: agentScopeAccess.error },
+      { status: agentScopeAccess.status }
+    );
   }
 
   const result = await deleteProjectRoadmapPhase({
-    actorUserId: authenticatedUser.userId,
+    actorUserId: principalResult.principal.actorUserId,
     projectId: params.projectId,
     phaseId: params.phaseId,
+    agentAccess,
   });
 
   if (!result.ok) {

--- a/app/api/projects/[projectId]/roadmap/phases/reorder/route.ts
+++ b/app/api/projects/[projectId]/roadmap/phases/reorder/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { requireAuthenticatedApiUser } from "@/lib/auth/api-guard";
+import {
+  getAgentProjectAccessContext,
+  requireApiPrincipal,
+} from "@/lib/auth/api-guard";
 import { logServerWarning } from "@/lib/observability/logger";
+import { requireAgentProjectScopes } from "@/lib/services/project-access-service";
 import {
   isValidRoadmapPhaseReorderPayload,
   reorderProjectRoadmapPhases,
@@ -12,9 +16,22 @@ export async function POST(
   props: { params: Promise<{ projectId: string }> }
 ) {
   const params = await props.params;
-  const authenticatedUser = await requireAuthenticatedApiUser(request);
-  if (!authenticatedUser.ok) {
-    return authenticatedUser.response;
+  const principalResult = await requireApiPrincipal(request);
+  if (!principalResult.ok) {
+    return principalResult.response;
+  }
+
+  const agentAccess = getAgentProjectAccessContext(principalResult.principal);
+  const agentScopeAccess = requireAgentProjectScopes({
+    agentAccess,
+    projectId: params.projectId,
+    requiredScopes: ["roadmap:write"],
+  });
+  if (!agentScopeAccess.ok) {
+    return NextResponse.json(
+      { error: agentScopeAccess.error },
+      { status: agentScopeAccess.status }
+    );
   }
 
   let payload: unknown;
@@ -34,8 +51,9 @@ export async function POST(
   }
 
   const result = await reorderProjectRoadmapPhases({
-    actorUserId: authenticatedUser.userId,
+    actorUserId: principalResult.principal.actorUserId,
     projectId: params.projectId,
+    agentAccess,
     phaseIds: payload.phaseIds,
   });
 

--- a/app/api/projects/[projectId]/roadmap/route.ts
+++ b/app/api/projects/[projectId]/roadmap/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { requireAuthenticatedApiUser } from "@/lib/auth/api-guard";
+import {
+  getAgentProjectAccessContext,
+  requireApiPrincipal,
+} from "@/lib/auth/api-guard";
 import { logServerWarning } from "@/lib/observability/logger";
+import { requireAgentProjectScopes } from "@/lib/services/project-access-service";
 import {
   createProjectRoadmapPhase,
   listProjectRoadmapPhases,
@@ -19,12 +23,29 @@ export async function GET(
   props: { params: Promise<{ projectId: string }> }
 ) {
   const params = await props.params;
-  const authenticatedUser = await requireAuthenticatedApiUser(request);
-  if (!authenticatedUser.ok) {
-    return authenticatedUser.response;
+  const principalResult = await requireApiPrincipal(request);
+  if (!principalResult.ok) {
+    return principalResult.response;
   }
 
-  const phases = await listProjectRoadmapPhases(params.projectId, authenticatedUser.userId);
+  const agentAccess = getAgentProjectAccessContext(principalResult.principal);
+  const agentScopeAccess = requireAgentProjectScopes({
+    agentAccess,
+    projectId: params.projectId,
+    requiredScopes: ["roadmap:read"],
+  });
+  if (!agentScopeAccess.ok) {
+    return NextResponse.json(
+      { error: agentScopeAccess.error },
+      { status: agentScopeAccess.status }
+    );
+  }
+
+  const phases = await listProjectRoadmapPhases(
+    params.projectId,
+    principalResult.principal.actorUserId,
+    agentAccess
+  );
 
   return NextResponse.json({
     phases,
@@ -36,9 +57,22 @@ export async function POST(
   props: { params: Promise<{ projectId: string }> }
 ) {
   const params = await props.params;
-  const authenticatedUser = await requireAuthenticatedApiUser(request);
-  if (!authenticatedUser.ok) {
-    return authenticatedUser.response;
+  const principalResult = await requireApiPrincipal(request);
+  if (!principalResult.ok) {
+    return principalResult.response;
+  }
+
+  const agentAccess = getAgentProjectAccessContext(principalResult.principal);
+  const agentScopeAccess = requireAgentProjectScopes({
+    agentAccess,
+    projectId: params.projectId,
+    requiredScopes: ["roadmap:write"],
+  });
+  if (!agentScopeAccess.ok) {
+    return NextResponse.json(
+      { error: agentScopeAccess.error },
+      { status: agentScopeAccess.status }
+    );
   }
 
   let payload: RoadmapPhaseRequestBody;
@@ -52,8 +86,9 @@ export async function POST(
   }
 
   const result = await createProjectRoadmapPhase({
-    actorUserId: authenticatedUser.userId,
+    actorUserId: principalResult.principal.actorUserId,
     projectId: params.projectId,
+    agentAccess,
     title: typeof payload.title === "string" ? payload.title : "",
     description: typeof payload.description === "string" ? payload.description : null,
     targetDate: typeof payload.targetDate === "string" ? payload.targetDate : null,

--- a/components/agent-onboarding/agent-onboarding-guide.tsx
+++ b/components/agent-onboarding/agent-onboarding-guide.tsx
@@ -22,6 +22,7 @@ import {
   buildAgentContextUpdateExample,
   buildAgentTokenExchangeExample,
   buildAgentProjectReadExample,
+  buildAgentRoadmapCreateExample,
   buildAgentSmokeTestExample,
   buildAgentTaskArchiveExample,
   buildAgentTaskCommentExample,
@@ -116,9 +117,9 @@ export function AgentOnboardingGuide({
               <CardTitle className="text-base">Call only the stable surface</CardTitle>
             </div>
             <CardDescription>
-              This v1 guide covers the supported agent routes only: project read, task routes,
-              context-card routes, and the documented attachment upload flow already validated in
-              preview-like environments.
+              This v1 guide covers the supported agent routes only: project read, epics,
+              roadmap phases and events, task routes, context-card routes, and the documented
+              attachment upload flow already validated in preview-like environments.
             </CardDescription>
           </CardHeader>
         </Card>
@@ -165,7 +166,7 @@ export function AgentOnboardingGuide({
             </div>
             <CardDescription>
               Exchange once per runtime session, then send the bearer token on each project,
-              task, or context-card request.
+              roadmap, task, or context-card request.
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
@@ -294,6 +295,7 @@ export function AgentOnboardingGuide({
           </CardHeader>
           <CardContent className="space-y-4">
             <CodeBlock value={buildAgentTaskCreateExample()} />
+            <CodeBlock value={buildAgentRoadmapCreateExample()} />
             <CodeBlock value={buildAgentContextCreateExample()} />
           </CardContent>
         </Card>

--- a/components/project-dashboard/project-dashboard-owner-agent-access-panel.tsx
+++ b/components/project-dashboard/project-dashboard-owner-agent-access-panel.tsx
@@ -395,7 +395,7 @@ export function ProjectDashboardOwnerAgentAccessPanel({
               <p>
                 Send <code>Authorization: ApiKey &lt;key&gt;</code> to{" "}
                 <code>/api/auth/agent/token</code>, then use the returned bearer token on project,
-                task, and context endpoints allowed by this credential&apos;s scopes.
+                roadmap, task, and context endpoints allowed by this credential&apos;s scopes.
               </p>
             </div>
           </section>
@@ -538,8 +538,8 @@ export function ProjectDashboardOwnerAgentAccessPanel({
               then send the returned bearer token to the scoped project routes.
             </p>
             <p>
-              This project ships agent-ready support for project read, task routes,
-              context-card routes, and documented attachment upload/download flows.
+              This project ships agent-ready support for project read, roadmap routes, task
+              routes, context-card routes, and documented attachment upload/download flows.
             </p>
           </div>
         </section>

--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,29 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-06-06 - TASK-224 agent roadmap access started
+
+- Summary: Started TASK-224 on
+  `feature/task-224-agent-roadmap-access`, moved TASK-263 to completed after PR
+  #320 merged, and drafted the active task brief.
+- Decision: Add dedicated `roadmap:read`, `roadmap:write`, and
+  `roadmap:delete` scopes instead of folding roadmap access into task scopes.
+  Roadmap routes will use the same `requireApiPrincipal` and
+  `AgentProjectAccessContext` pattern as task/context agent APIs, while
+  roadmap services remain the authorization boundary.
+
+# 2026-06-06 - TASK-224 agent roadmap access implemented
+
+- Summary: Added dedicated roadmap credential scopes, Prisma enum migration,
+  runtime scope mappings, agent-aware roadmap route handlers, service-level
+  scope enforcement, hosted onboarding copy, and OpenAPI schemas/paths for
+  roadmap phases, events, reorder, move, and delete operations.
+- Evidence: Focused Vitest passed 8 files / 40 tests. `npm run lint`, local
+  validation env `npm test`, local validation env `npm run test:coverage`, and
+  local validation env `npm run build` passed. `npm run db:migrate` applied all
+  migrations, including `20260606090000_task224_agent_roadmap_scopes`, against
+  a fresh local PostgreSQL on host port 5433.
+
 # 2026-06-04 - TASK-263 realtime notification updates started
 
 - Summary: Drafted the implementation brief for live in-app notification

--- a/lib/agent-access.ts
+++ b/lib/agent-access.ts
@@ -6,6 +6,9 @@ export const AGENT_SCOPE_VALUES = [
   "context:read",
   "context:write",
   "context:delete",
+  "roadmap:read",
+  "roadmap:write",
+  "roadmap:delete",
 ] as const;
 
 export type AgentScope = (typeof AGENT_SCOPE_VALUES)[number];
@@ -63,6 +66,21 @@ export const AGENT_SCOPE_DEFINITIONS: ReadonlyArray<AgentScopeDefinition> = [
     scope: "context:delete",
     label: "Context Delete",
     description: "Delete project context cards.",
+  },
+  {
+    scope: "roadmap:read",
+    label: "Roadmap Read",
+    description: "List and inspect project roadmap phases and events.",
+  },
+  {
+    scope: "roadmap:write",
+    label: "Roadmap Write",
+    description: "Create, update, reorder, and move roadmap phases and events.",
+  },
+  {
+    scope: "roadmap:delete",
+    label: "Roadmap Delete",
+    description: "Delete roadmap phases and events.",
   },
 ];
 

--- a/lib/agent-onboarding.ts
+++ b/lib/agent-onboarding.ts
@@ -1,6 +1,7 @@
 import { AGENT_SCOPE_DEFINITIONS, type AgentScope } from "@/lib/agent-access";
 import { CONTEXT_CARD_COLORS } from "@/lib/context-card-colors";
 import { EPIC_STATUSES } from "@/lib/epic";
+import { ROADMAP_STATUSES } from "@/lib/roadmap-milestone";
 import { TASK_STATUSES, type TaskStatus } from "@/lib/task-status";
 
 export const AGENT_API_VERSION = "v1";
@@ -12,7 +13,7 @@ export const AGENT_API_KEY_PLACEHOLDER = "nda_public.secret";
 export const AGENT_BEARER_TOKEN_ENV_NAME = "NEXUSDASH_AGENT_BEARER_TOKEN";
 export const AGENT_ATTACHMENT_MAX_FILE_SIZE_LABEL = "25MB";
 
-type AgentApiTag = "Auth" | "Projects" | "Epics" | "Tasks" | "Context";
+type AgentApiTag = "Auth" | "Projects" | "Epics" | "Roadmap" | "Tasks" | "Context";
 type AgentHttpMethod = "GET" | "POST" | "PATCH" | "DELETE";
 type AgentRequestContentType = "application/json" | "multipart/form-data";
 
@@ -107,6 +108,99 @@ export const AGENT_API_ENDPOINTS: ReadonlyArray<AgentApiEndpointDefinition> = [
     description: "Delete an epic and clear the epic link from its tasks.",
     requiredScopes: ["task:write"],
     notes: ["Deleting an epic does not delete its tasks."],
+  },
+  {
+    tag: "Roadmap",
+    method: "GET",
+    path: "/api/projects/{projectId}/roadmap",
+    title: "List roadmap phases",
+    description: "List project roadmap phases with nested roadmap events.",
+    requiredScopes: ["roadmap:read"],
+  },
+  {
+    tag: "Roadmap",
+    method: "POST",
+    path: "/api/projects/{projectId}/roadmap",
+    title: "Create roadmap phase",
+    description: "Create a new roadmap phase.",
+    requiredScopes: ["roadmap:write"],
+    requestContentType: "application/json",
+    notes: [`status must be one of: ${ROADMAP_STATUSES.join(", ")}.`],
+  },
+  {
+    tag: "Roadmap",
+    method: "PATCH",
+    path: "/api/projects/{projectId}/roadmap/phases/{phaseId}",
+    title: "Update roadmap phase",
+    description: "Update an existing roadmap phase.",
+    requiredScopes: ["roadmap:write"],
+    requestContentType: "application/json",
+    notes: ["Set targetDate to null or an empty string to clear it."],
+  },
+  {
+    tag: "Roadmap",
+    method: "DELETE",
+    path: "/api/projects/{projectId}/roadmap/phases/{phaseId}",
+    title: "Delete roadmap phase",
+    description: "Delete a roadmap phase and its nested events.",
+    requiredScopes: ["roadmap:delete"],
+    notes: ["Delete scope does not imply read or write."],
+  },
+  {
+    tag: "Roadmap",
+    method: "POST",
+    path: "/api/projects/{projectId}/roadmap/phases/{phaseId}/events",
+    title: "Create roadmap event",
+    description: "Create a roadmap event inside a phase.",
+    requiredScopes: ["roadmap:write"],
+    requestContentType: "application/json",
+    notes: [`status defaults to the phase status and must be one of: ${ROADMAP_STATUSES.join(", ")}.`],
+  },
+  {
+    tag: "Roadmap",
+    method: "PATCH",
+    path: "/api/projects/{projectId}/roadmap/events/{eventId}",
+    title: "Update roadmap event",
+    description: "Update an existing roadmap event.",
+    requiredScopes: ["roadmap:write"],
+    requestContentType: "application/json",
+    notes: ["Set targetDate to null or an empty string to clear it."],
+  },
+  {
+    tag: "Roadmap",
+    method: "DELETE",
+    path: "/api/projects/{projectId}/roadmap/events/{eventId}",
+    title: "Delete roadmap event",
+    description: "Delete a roadmap event from the project.",
+    requiredScopes: ["roadmap:delete"],
+    notes: ["Delete scope does not imply read or write."],
+  },
+  {
+    tag: "Roadmap",
+    method: "POST",
+    path: "/api/projects/{projectId}/roadmap/phases/reorder",
+    title: "Reorder roadmap phases",
+    description: "Persist roadmap phase ordering.",
+    requiredScopes: ["roadmap:write"],
+    requestContentType: "application/json",
+  },
+  {
+    tag: "Roadmap",
+    method: "POST",
+    path: "/api/projects/{projectId}/roadmap/events/reorder",
+    title: "Reorder roadmap events",
+    description: "Persist roadmap event ordering inside one phase.",
+    requiredScopes: ["roadmap:write"],
+    requestContentType: "application/json",
+  },
+  {
+    tag: "Roadmap",
+    method: "POST",
+    path: "/api/projects/{projectId}/roadmap/events/move",
+    title: "Move roadmap event",
+    description: "Move a roadmap event to another phase and index.",
+    requiredScopes: ["roadmap:write"],
+    requestContentType: "application/json",
   },
   {
     tag: "Tasks",
@@ -357,6 +451,7 @@ export const AGENT_LIMITATIONS: readonly string[] = [
   "Binary files and images use the direct-upload attachment routes; non-file writes should not rely on multipart/form-data.",
   "attachmentLinks must be arrays of { name, url } objects. Plain string URL arrays are not the canonical v1 format.",
   "Epic status and progress are automatic. Agents should not try to set them directly.",
+  "Roadmap delete scope is separate from roadmap read/write. Grant it only when the agent should remove phases or events.",
   "Task status changes happen through POST /api/projects/{projectId}/tasks/reorder, not PATCH /api/projects/{projectId}/tasks/{taskId}.",
   "Rich HTML is sanitized. Inline <img> content should not be treated as a supported image-delivery path; use attachments instead.",
   "Preview deployments may still be protected by Vercel. If a preview returns Vercel's auth wall, make the preview reachable or use an approved bypass before testing the agent flow.",
@@ -449,6 +544,22 @@ export function buildAgentTaskCreateExample(): string {
     `  -H "Authorization: Bearer $${AGENT_BEARER_TOKEN_ENV_NAME}" \\`,
     '  -H "Content-Type: application/json" \\',
     "  -d '{\"title\":\"Draft release notes\",\"description\":\"<p>Summarize this week''s changes.</p>\",\"deadlineDate\":\"2026-04-24\",\"epicId\":\"epic_456\",\"assigneeUserId\":\"user_456\",\"labels\":[\"release\",\"docs\"],\"attachmentLinks\":[{\"name\":\"Spec\",\"url\":\"https://example.com/spec\"}]}'",
+  ].join("\n");
+}
+
+export function buildAgentRoadmapCreateExample(): string {
+  return [
+    '# Create a roadmap phase with roadmap:write',
+    'curl -X POST "$NEXUSDASH_BASE_URL/api/projects/$NEXUSDASH_PROJECT_ID/roadmap" \\',
+    `  -H "Authorization: Bearer $${AGENT_BEARER_TOKEN_ENV_NAME}" \\`,
+    '  -H "Content-Type: application/json" \\',
+    '  -d \'{"title":"Public beta","description":"Coordinate beta readiness.","targetDate":"2026-05-15","status":"planned"}\'',
+    "",
+    '# Create an event inside that phase with roadmap:write',
+    'curl -X POST "$NEXUSDASH_BASE_URL/api/projects/$NEXUSDASH_PROJECT_ID/roadmap/phases/$PHASE_ID/events" \\',
+    `  -H "Authorization: Bearer $${AGENT_BEARER_TOKEN_ENV_NAME}" \\`,
+    '  -H "Content-Type: application/json" \\',
+    '  -d \'{"title":"Invite first cohort","description":"Ship invite flow and monitor feedback.","status":"active"}\'',
   ].join("\n");
 }
 
@@ -789,6 +900,11 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
           "Create, read, update, and delete project epics with automatic status and progress.",
       },
       {
+        name: "Roadmap",
+        description:
+          "Create, read, update, reorder, move, and delete project roadmap phases and events.",
+      },
+      {
         name: "Tasks",
         description:
           "Create, read, update, reorder, archive, delete, and attach files to project tasks.",
@@ -1069,6 +1185,203 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
           properties: {
             epic: {
               $ref: "#/components/schemas/ProjectEpicRecord",
+            },
+          },
+        },
+        RoadmapEventRecord: {
+          type: "object",
+          required: [
+            "id",
+            "phaseId",
+            "title",
+            "description",
+            "targetDate",
+            "status",
+            "position",
+            "createdAt",
+            "updatedAt",
+          ],
+          properties: {
+            id: { type: "string" },
+            phaseId: { type: "string" },
+            title: { type: "string" },
+            description: { type: ["string", "null"] },
+            targetDate: { type: ["string", "null"], format: "date" },
+            status: {
+              type: "string",
+              enum: ROADMAP_STATUSES,
+            },
+            position: { type: "integer" },
+            createdAt: { type: "string", format: "date-time" },
+            updatedAt: { type: "string", format: "date-time" },
+          },
+        },
+        RoadmapPhaseRecord: {
+          type: "object",
+          required: [
+            "id",
+            "title",
+            "description",
+            "targetDate",
+            "status",
+            "position",
+            "createdAt",
+            "updatedAt",
+            "events",
+          ],
+          properties: {
+            id: { type: "string" },
+            title: { type: "string" },
+            description: { type: ["string", "null"] },
+            targetDate: { type: ["string", "null"], format: "date" },
+            status: {
+              type: "string",
+              enum: ROADMAP_STATUSES,
+            },
+            position: { type: "integer" },
+            createdAt: { type: "string", format: "date-time" },
+            updatedAt: { type: "string", format: "date-time" },
+            events: {
+              type: "array",
+              items: {
+                $ref: "#/components/schemas/RoadmapEventRecord",
+              },
+            },
+          },
+        },
+        RoadmapPhaseListResponse: {
+          type: "object",
+          required: ["phases"],
+          properties: {
+            phases: {
+              type: "array",
+              items: {
+                $ref: "#/components/schemas/RoadmapPhaseRecord",
+              },
+            },
+          },
+        },
+        RoadmapPhaseCreateRequest: {
+          type: "object",
+          required: ["title"],
+          properties: {
+            title: { type: "string" },
+            description: { type: ["string", "null"] },
+            targetDate: { type: ["string", "null"], format: "date" },
+            status: {
+              type: ["string", "null"],
+              enum: [...ROADMAP_STATUSES, null],
+            },
+          },
+        },
+        RoadmapPhaseCreateResponse: {
+          type: "object",
+          required: ["phase"],
+          properties: {
+            phase: {
+              $ref: "#/components/schemas/RoadmapPhaseRecord",
+            },
+          },
+        },
+        RoadmapPhaseUpdateRequest: {
+          type: "object",
+          properties: {
+            title: { type: "string" },
+            description: { type: ["string", "null"] },
+            targetDate: { type: ["string", "null"], format: "date" },
+            status: {
+              type: ["string", "null"],
+              enum: [...ROADMAP_STATUSES, null],
+            },
+          },
+        },
+        RoadmapPhaseUpdateResponse: {
+          type: "object",
+          required: ["phase"],
+          properties: {
+            phase: {
+              $ref: "#/components/schemas/RoadmapPhaseRecord",
+            },
+          },
+        },
+        RoadmapEventCreateRequest: {
+          type: "object",
+          required: ["title"],
+          properties: {
+            title: { type: "string" },
+            description: { type: ["string", "null"] },
+            targetDate: { type: ["string", "null"], format: "date" },
+            status: {
+              type: ["string", "null"],
+              enum: [...ROADMAP_STATUSES, null],
+            },
+          },
+        },
+        RoadmapEventMutationResponse: {
+          type: "object",
+          required: ["event", "phase"],
+          properties: {
+            event: {
+              $ref: "#/components/schemas/RoadmapEventRecord",
+            },
+            phase: {
+              $ref: "#/components/schemas/RoadmapPhaseRecord",
+            },
+          },
+        },
+        RoadmapEventUpdateRequest: {
+          type: "object",
+          properties: {
+            title: { type: "string" },
+            description: { type: ["string", "null"] },
+            targetDate: { type: ["string", "null"], format: "date" },
+            status: {
+              type: ["string", "null"],
+              enum: [...ROADMAP_STATUSES, null],
+            },
+          },
+        },
+        RoadmapEventDeleteResponse: {
+          type: "object",
+          required: ["ok", "phaseId"],
+          properties: {
+            ok: {
+              type: "boolean",
+              enum: [true],
+            },
+            phaseId: { type: "string" },
+          },
+        },
+        RoadmapPhaseReorderRequest: {
+          type: "object",
+          required: ["phaseIds"],
+          properties: {
+            phaseIds: {
+              type: "array",
+              items: { type: "string" },
+            },
+          },
+        },
+        RoadmapEventReorderRequest: {
+          type: "object",
+          required: ["phaseId", "eventIds"],
+          properties: {
+            phaseId: { type: "string" },
+            eventIds: {
+              type: "array",
+              items: { type: "string" },
+            },
+          },
+        },
+        RoadmapEventMoveRequest: {
+          type: "object",
+          required: ["eventId", "targetPhaseId", "targetIndex"],
+          properties: {
+            eventId: { type: "string" },
+            targetPhaseId: { type: "string" },
+            targetIndex: {
+              type: "integer",
+              minimum: 0,
             },
           },
         },
@@ -1618,6 +1931,22 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
             type: "string",
           },
         },
+        PhaseId: {
+          name: "phaseId",
+          in: "path",
+          required: true,
+          schema: {
+            type: "string",
+          },
+        },
+        EventId: {
+          name: "eventId",
+          in: "path",
+          required: true,
+          schema: {
+            type: "string",
+          },
+        },
         TaskId: {
           name: "taskId",
           in: "path",
@@ -1856,6 +2185,306 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
           responses: {
             200: {
               description: "Epic deleted",
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "#/components/schemas/OkResponse",
+                  },
+                },
+              },
+            },
+            ...commonErrorResponses,
+          },
+        },
+      },
+      "/api/projects/{projectId}/roadmap": {
+        get: {
+          ...buildOperationMetadata("GET", "/api/projects/{projectId}/roadmap"),
+          security: [{ BearerAuth: [] }],
+          parameters: [{ $ref: "#/components/parameters/ProjectId" }],
+          responses: {
+            200: {
+              description: "Roadmap phases returned",
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "#/components/schemas/RoadmapPhaseListResponse",
+                  },
+                },
+              },
+            },
+            ...commonErrorResponses,
+          },
+        },
+        post: {
+          ...buildOperationMetadata("POST", "/api/projects/{projectId}/roadmap"),
+          security: [{ BearerAuth: [] }],
+          parameters: [{ $ref: "#/components/parameters/ProjectId" }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/RoadmapPhaseCreateRequest",
+                },
+              },
+            },
+          },
+          responses: {
+            201: {
+              description: "Roadmap phase created",
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "#/components/schemas/RoadmapPhaseCreateResponse",
+                  },
+                },
+              },
+            },
+            ...commonErrorResponses,
+          },
+        },
+      },
+      "/api/projects/{projectId}/roadmap/phases/{phaseId}": {
+        patch: {
+          ...buildOperationMetadata(
+            "PATCH",
+            "/api/projects/{projectId}/roadmap/phases/{phaseId}"
+          ),
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            { $ref: "#/components/parameters/ProjectId" },
+            { $ref: "#/components/parameters/PhaseId" },
+          ],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/RoadmapPhaseUpdateRequest",
+                },
+              },
+            },
+          },
+          responses: {
+            200: {
+              description: "Roadmap phase updated",
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "#/components/schemas/RoadmapPhaseUpdateResponse",
+                  },
+                },
+              },
+            },
+            ...commonErrorResponses,
+          },
+        },
+        delete: {
+          ...buildOperationMetadata(
+            "DELETE",
+            "/api/projects/{projectId}/roadmap/phases/{phaseId}"
+          ),
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            { $ref: "#/components/parameters/ProjectId" },
+            { $ref: "#/components/parameters/PhaseId" },
+          ],
+          responses: {
+            200: {
+              description: "Roadmap phase deleted",
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "#/components/schemas/OkResponse",
+                  },
+                },
+              },
+            },
+            ...commonErrorResponses,
+          },
+        },
+      },
+      "/api/projects/{projectId}/roadmap/phases/{phaseId}/events": {
+        post: {
+          ...buildOperationMetadata(
+            "POST",
+            "/api/projects/{projectId}/roadmap/phases/{phaseId}/events"
+          ),
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            { $ref: "#/components/parameters/ProjectId" },
+            { $ref: "#/components/parameters/PhaseId" },
+          ],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/RoadmapEventCreateRequest",
+                },
+              },
+            },
+          },
+          responses: {
+            201: {
+              description: "Roadmap event created",
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "#/components/schemas/RoadmapEventMutationResponse",
+                  },
+                },
+              },
+            },
+            ...commonErrorResponses,
+          },
+        },
+      },
+      "/api/projects/{projectId}/roadmap/events/{eventId}": {
+        patch: {
+          ...buildOperationMetadata(
+            "PATCH",
+            "/api/projects/{projectId}/roadmap/events/{eventId}"
+          ),
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            { $ref: "#/components/parameters/ProjectId" },
+            { $ref: "#/components/parameters/EventId" },
+          ],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/RoadmapEventUpdateRequest",
+                },
+              },
+            },
+          },
+          responses: {
+            200: {
+              description: "Roadmap event updated",
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "#/components/schemas/RoadmapEventMutationResponse",
+                  },
+                },
+              },
+            },
+            ...commonErrorResponses,
+          },
+        },
+        delete: {
+          ...buildOperationMetadata(
+            "DELETE",
+            "/api/projects/{projectId}/roadmap/events/{eventId}"
+          ),
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            { $ref: "#/components/parameters/ProjectId" },
+            { $ref: "#/components/parameters/EventId" },
+          ],
+          responses: {
+            200: {
+              description: "Roadmap event deleted",
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "#/components/schemas/RoadmapEventDeleteResponse",
+                  },
+                },
+              },
+            },
+            ...commonErrorResponses,
+          },
+        },
+      },
+      "/api/projects/{projectId}/roadmap/phases/reorder": {
+        post: {
+          ...buildOperationMetadata(
+            "POST",
+            "/api/projects/{projectId}/roadmap/phases/reorder"
+          ),
+          security: [{ BearerAuth: [] }],
+          parameters: [{ $ref: "#/components/parameters/ProjectId" }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/RoadmapPhaseReorderRequest",
+                },
+              },
+            },
+          },
+          responses: {
+            200: {
+              description: "Roadmap phase ordering persisted",
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "#/components/schemas/OkResponse",
+                  },
+                },
+              },
+            },
+            ...commonErrorResponses,
+          },
+        },
+      },
+      "/api/projects/{projectId}/roadmap/events/reorder": {
+        post: {
+          ...buildOperationMetadata(
+            "POST",
+            "/api/projects/{projectId}/roadmap/events/reorder"
+          ),
+          security: [{ BearerAuth: [] }],
+          parameters: [{ $ref: "#/components/parameters/ProjectId" }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/RoadmapEventReorderRequest",
+                },
+              },
+            },
+          },
+          responses: {
+            200: {
+              description: "Roadmap event ordering persisted",
+              content: {
+                "application/json": {
+                  schema: {
+                    $ref: "#/components/schemas/OkResponse",
+                  },
+                },
+              },
+            },
+            ...commonErrorResponses,
+          },
+        },
+      },
+      "/api/projects/{projectId}/roadmap/events/move": {
+        post: {
+          ...buildOperationMetadata("POST", "/api/projects/{projectId}/roadmap/events/move"),
+          security: [{ BearerAuth: [] }],
+          parameters: [{ $ref: "#/components/parameters/ProjectId" }],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/RoadmapEventMoveRequest",
+                },
+              },
+            },
+          },
+          responses: {
+            200: {
+              description: "Roadmap event moved",
               content: {
                 "application/json": {
                   schema: {

--- a/lib/services/project-agent-access-service.ts
+++ b/lib/services/project-agent-access-service.ts
@@ -101,6 +101,9 @@ const AGENT_SCOPE_TO_DB_SCOPE: Record<AgentScope, ApiCredentialScope> = {
   "context:read": ApiCredentialScope.context_read,
   "context:write": ApiCredentialScope.context_write,
   "context:delete": ApiCredentialScope.context_delete,
+  "roadmap:read": ApiCredentialScope.roadmap_read,
+  "roadmap:write": ApiCredentialScope.roadmap_write,
+  "roadmap:delete": ApiCredentialScope.roadmap_delete,
 };
 
 const DB_SCOPE_TO_AGENT_SCOPE: Record<ApiCredentialScope, AgentScope> = {
@@ -111,6 +114,9 @@ const DB_SCOPE_TO_AGENT_SCOPE: Record<ApiCredentialScope, AgentScope> = {
   [ApiCredentialScope.context_read]: "context:read",
   [ApiCredentialScope.context_write]: "context:write",
   [ApiCredentialScope.context_delete]: "context:delete",
+  [ApiCredentialScope.roadmap_read]: "roadmap:read",
+  [ApiCredentialScope.roadmap_write]: "roadmap:write",
+  [ApiCredentialScope.roadmap_delete]: "roadmap:delete",
 };
 
 function createError(status: number, error: string): ServiceError {

--- a/lib/services/project-roadmap-service.ts
+++ b/lib/services/project-roadmap-service.ts
@@ -7,7 +7,11 @@ import {
   type RoadmapStatus,
 } from "@/lib/roadmap-milestone";
 import { touchProjectActivity } from "@/lib/services/project-activity-service";
-import { requireProjectRole } from "@/lib/services/project-access-service";
+import {
+  type AgentProjectAccessContext,
+  requireAgentProjectScopes,
+  requireProjectRole,
+} from "@/lib/services/project-access-service";
 import { type DbClient, withActorRlsContext } from "@/lib/services/rls-context";
 import { parseTaskDeadlineDate } from "@/lib/task-deadline";
 
@@ -31,6 +35,7 @@ type ServiceResult<T> = ServiceSuccessResult<T> | ServiceErrorResult;
 interface CreateRoadmapPhaseInput {
   actorUserId: string;
   projectId: string;
+  agentAccess?: AgentProjectAccessContext;
   title: string;
   description?: string | null;
   targetDate?: string | null;
@@ -40,6 +45,7 @@ interface CreateRoadmapPhaseInput {
 interface UpdateRoadmapPhaseInput {
   actorUserId: string;
   projectId: string;
+  agentAccess?: AgentProjectAccessContext;
   phaseId: string;
   title?: string;
   description?: string | null;
@@ -50,6 +56,7 @@ interface UpdateRoadmapPhaseInput {
 interface CreateRoadmapEventInput {
   actorUserId: string;
   projectId: string;
+  agentAccess?: AgentProjectAccessContext;
   phaseId: string;
   title: string;
   description?: string | null;
@@ -60,6 +67,7 @@ interface CreateRoadmapEventInput {
 interface UpdateRoadmapEventInput {
   actorUserId: string;
   projectId: string;
+  agentAccess?: AgentProjectAccessContext;
   eventId: string;
   title?: string;
   description?: string | null;
@@ -70,12 +78,14 @@ interface UpdateRoadmapEventInput {
 interface ReorderRoadmapPhasesInput {
   actorUserId: string;
   projectId: string;
+  agentAccess?: AgentProjectAccessContext;
   phaseIds: string[];
 }
 
 interface ReorderRoadmapEventsInput {
   actorUserId: string;
   projectId: string;
+  agentAccess?: AgentProjectAccessContext;
   phaseId: string;
   eventIds: string[];
 }
@@ -83,6 +93,7 @@ interface ReorderRoadmapEventsInput {
 interface MoveRoadmapEventInput {
   actorUserId: string;
   projectId: string;
+  agentAccess?: AgentProjectAccessContext;
   eventId: string;
   targetPhaseId: string;
   targetIndex: number;
@@ -334,15 +345,34 @@ async function readRoadmapEventById(input: {
   return event ? mapRoadmapEvent(event) : null;
 }
 
-async function requireRoadmapEditor(input: {
+async function requireRoadmapAccess(input: {
   actorUserId: string;
   projectId: string;
   db: DbClient;
+  agentAccess?: AgentProjectAccessContext;
+  minimumRole: "viewer" | "editor";
+  requiredAgentScopes: ["roadmap:read"] | ["roadmap:write"] | ["roadmap:delete"];
 }): Promise<ServiceResult<{ ok: true }>> {
+  const agentScopeAccess = requireAgentProjectScopes({
+    agentAccess: input.agentAccess,
+    projectId: input.projectId,
+    requiredScopes: input.requiredAgentScopes,
+  });
+  if (!agentScopeAccess.ok) {
+    return createError(agentScopeAccess.status, agentScopeAccess.error);
+  }
+
+  if (input.agentAccess) {
+    return {
+      ok: true,
+      data: { ok: true },
+    };
+  }
+
   const access = await requireProjectRole({
     actorUserId: input.actorUserId,
     projectId: input.projectId,
-    minimumRole: "editor",
+    minimumRole: input.minimumRole,
     db: input.db,
   });
 
@@ -489,7 +519,8 @@ export function isValidRoadmapEventMovePayload(
 
 export async function listProjectRoadmapPhases(
   projectId: string,
-  actorUserId: string
+  actorUserId: string,
+  agentAccess?: AgentProjectAccessContext
 ): Promise<ProjectRoadmapPhase[]> {
   const normalizedActorUserId = normalizeText(actorUserId);
   if (!normalizedActorUserId) {
@@ -497,11 +528,13 @@ export async function listProjectRoadmapPhases(
   }
 
   return withActorRlsContext(normalizedActorUserId, async (db) => {
-    const access = await requireProjectRole({
+    const access = await requireRoadmapAccess({
       actorUserId: normalizedActorUserId,
       projectId,
-      minimumRole: "viewer",
       db,
+      agentAccess,
+      minimumRole: "viewer",
+      requiredAgentScopes: ["roadmap:read"],
     });
     if (!access.ok) {
       return [];
@@ -546,10 +579,13 @@ export async function createProjectRoadmapPhase(
   }
 
   return withActorRlsContext(actorUserId, async (db) => {
-    const editorCheck = await requireRoadmapEditor({
+    const editorCheck = await requireRoadmapAccess({
       actorUserId,
       projectId: input.projectId,
       db,
+      agentAccess: input.agentAccess,
+      minimumRole: "editor",
+      requiredAgentScopes: ["roadmap:write"],
     });
     if (!editorCheck.ok) {
       return editorCheck;
@@ -643,10 +679,13 @@ export async function updateProjectRoadmapPhase(
   }
 
   return withActorRlsContext(actorUserId, async (db) => {
-    const editorCheck = await requireRoadmapEditor({
+    const editorCheck = await requireRoadmapAccess({
       actorUserId,
       projectId: input.projectId,
       db,
+      agentAccess: input.agentAccess,
+      minimumRole: "editor",
+      requiredAgentScopes: ["roadmap:write"],
     });
     if (!editorCheck.ok) {
       return editorCheck;
@@ -719,6 +758,7 @@ export async function updateProjectRoadmapPhase(
 export async function deleteProjectRoadmapPhase(input: {
   actorUserId: string;
   projectId: string;
+  agentAccess?: AgentProjectAccessContext;
   phaseId: string;
 }): Promise<ServiceResult<{ ok: true }>> {
   const actorUserId = normalizeText(input.actorUserId);
@@ -731,10 +771,13 @@ export async function deleteProjectRoadmapPhase(input: {
   }
 
   return withActorRlsContext(actorUserId, async (db) => {
-    const editorCheck = await requireRoadmapEditor({
+    const editorCheck = await requireRoadmapAccess({
       actorUserId,
       projectId: input.projectId,
       db,
+      agentAccess: input.agentAccess,
+      minimumRole: "editor",
+      requiredAgentScopes: ["roadmap:delete"],
     });
     if (!editorCheck.ok) {
       return editorCheck;
@@ -810,10 +853,13 @@ export async function createProjectRoadmapEvent(
   }
 
   return withActorRlsContext(actorUserId, async (db) => {
-    const editorCheck = await requireRoadmapEditor({
+    const editorCheck = await requireRoadmapAccess({
       actorUserId,
       projectId: input.projectId,
       db,
+      agentAccess: input.agentAccess,
+      minimumRole: "editor",
+      requiredAgentScopes: ["roadmap:write"],
     });
     if (!editorCheck.ok) {
       return editorCheck;
@@ -936,10 +982,13 @@ export async function updateProjectRoadmapEvent(
   }
 
   return withActorRlsContext(actorUserId, async (db) => {
-    const editorCheck = await requireRoadmapEditor({
+    const editorCheck = await requireRoadmapAccess({
       actorUserId,
       projectId: input.projectId,
       db,
+      agentAccess: input.agentAccess,
+      minimumRole: "editor",
+      requiredAgentScopes: ["roadmap:write"],
     });
     if (!editorCheck.ok) {
       return editorCheck;
@@ -1019,6 +1068,7 @@ export async function updateProjectRoadmapEvent(
 export async function deleteProjectRoadmapEvent(input: {
   actorUserId: string;
   projectId: string;
+  agentAccess?: AgentProjectAccessContext;
   eventId: string;
 }): Promise<ServiceResult<{ ok: true; phaseId: string }>> {
   const actorUserId = normalizeText(input.actorUserId);
@@ -1031,10 +1081,13 @@ export async function deleteProjectRoadmapEvent(input: {
   }
 
   return withActorRlsContext(actorUserId, async (db) => {
-    const editorCheck = await requireRoadmapEditor({
+    const editorCheck = await requireRoadmapAccess({
       actorUserId,
       projectId: input.projectId,
       db,
+      agentAccess: input.agentAccess,
+      minimumRole: "editor",
+      requiredAgentScopes: ["roadmap:delete"],
     });
     if (!editorCheck.ok) {
       return editorCheck;
@@ -1097,10 +1150,13 @@ export async function reorderProjectRoadmapPhases(
   }
 
   return withActorRlsContext(actorUserId, async (db) => {
-    const editorCheck = await requireRoadmapEditor({
+    const editorCheck = await requireRoadmapAccess({
       actorUserId,
       projectId: input.projectId,
       db,
+      agentAccess: input.agentAccess,
+      minimumRole: "editor",
+      requiredAgentScopes: ["roadmap:write"],
     });
     if (!editorCheck.ok) {
       return editorCheck;
@@ -1164,10 +1220,13 @@ export async function reorderProjectRoadmapEvents(
   }
 
   return withActorRlsContext(actorUserId, async (db) => {
-    const editorCheck = await requireRoadmapEditor({
+    const editorCheck = await requireRoadmapAccess({
       actorUserId,
       projectId: input.projectId,
       db,
+      agentAccess: input.agentAccess,
+      minimumRole: "editor",
+      requiredAgentScopes: ["roadmap:write"],
     });
     if (!editorCheck.ok) {
       return editorCheck;
@@ -1254,10 +1313,13 @@ export async function moveProjectRoadmapEvent(
   }
 
   return withActorRlsContext(actorUserId, async (db) => {
-    const editorCheck = await requireRoadmapEditor({
+    const editorCheck = await requireRoadmapAccess({
       actorUserId,
       projectId: input.projectId,
       db,
+      agentAccess: input.agentAccess,
+      minimumRole: "editor",
+      requiredAgentScopes: ["roadmap:write"],
     });
     if (!editorCheck.ok) {
       return editorCheck;

--- a/prisma/migrations/20260606090000_task224_agent_roadmap_scopes/migration.sql
+++ b/prisma/migrations/20260606090000_task224_agent_roadmap_scopes/migration.sql
@@ -1,0 +1,3 @@
+ALTER TYPE "ApiCredentialScope" ADD VALUE IF NOT EXISTS 'roadmap_read';
+ALTER TYPE "ApiCredentialScope" ADD VALUE IF NOT EXISTS 'roadmap_write';
+ALTER TYPE "ApiCredentialScope" ADD VALUE IF NOT EXISTS 'roadmap_delete';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -580,6 +580,9 @@ enum ApiCredentialScope {
   context_read
   context_write
   context_delete
+  roadmap_read
+  roadmap_write
+  roadmap_delete
 }
 
 enum AuthAuditActorKind {

--- a/project.md
+++ b/project.md
@@ -1,6 +1,6 @@
 # NexusDash Project Blueprint (Current State)
 
-Last verified: 2026-06-04
+Last verified: 2026-06-06
 
 ## 1. Vision
 
@@ -43,7 +43,7 @@ NexusDash is a personal/team execution workspace that keeps project planning, de
 - Project-scoped agent access:
   - owner-managed API credentials in project settings
   - one-time raw API key reveal with rotate/revoke lifecycle
-  - short-lived bearer token exchange for supported project/task/context APIs
+  - short-lived bearer token exchange for supported project/roadmap/task/context APIs
   - audit trail for credential lifecycle and request use
   - hosted agent onboarding at `/docs/agent/v1` with account-level developer entry and OpenAPI JSON contract
 - Attachment system for tasks and context cards:
@@ -110,7 +110,7 @@ Source of truth: [`prisma/schema.prisma`](./prisma/schema.prisma)
 
 ## 6. Known Gaps (Intentionally Pending)
 
-- Agent v1 intentionally excludes calendar access, binary attachment upload/download parity, and MCP-based tool transport.
+- Agent v1 intentionally excludes calendar access and MCP-based tool transport.
 - App-managed invite email delivery is not implemented yet.
 - Broader security hardening and verification phases remain pending.
 
@@ -118,8 +118,7 @@ Source of truth: [`prisma/schema.prisma`](./prisma/schema.prisma)
 
 From `tasks/current.md` + `tasks/backlog.md`:
 
-1. TASK-263: real-time notification updates for inbox/count awareness
-2. TASK-224: agent roadmap access for scoped roadmap phase/event APIs
+1. TASK-224: agent roadmap access for scoped roadmap phase/event APIs
 
 ## 8. Source-of-Truth Docs
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -8,14 +8,9 @@ Last reviewed: 2026-05-31
 ### Execution Queue (Now / Next)
 - ID: TASK-224
   Title: Agent roadmap access - scoped API contract for roadmap phases and events
-  Status: Promoted 2026-05-31
+  Status: In progress on `feature/task-224-agent-roadmap-access`
   Rationale: Make the project roadmap manageable by project-scoped agent tokens so agents can inspect, create, update, move, reorder, and delete roadmap phases/events when they are responsible for project planning. This should be a deliberate agent API contract expansion with dedicated roadmap scopes, OpenAPI/onboarding documentation, credential UI updates, route guard coverage, and smoke tests rather than implicitly folding roadmap permissions into existing project or task scopes.
   Dependencies: TASK-127, TASK-130, TASK-059
-- ID: TASK-263
-  Title: Real-time notification updates - live in-app inbox, counts, and awareness
-  Status: Implemented and locally validated on `feature/task-263-live-notification-updates`; PR #320 open for maintainer review
-  Rationale: Make notification-center rows, unread counts, and the in-app awareness banner update without requiring navigation or manual refresh when assignments, mentions, project invitations, or future notification producers create new atomic `Notification` rows. Invitation recipients should see newly received invites and notification count/banner changes while already on the app, without needing a page reload. Keep email digest batching fully separate: in-app remains one notification per action/artifact, while email remains the grouped/debounced channel. This task should reuse or align with the broader TASK-118 realtime transport decision rather than introduce a parallel realtime stack.
-  Dependencies: TASK-118, TASK-123, TASK-260
 ### Deferred (Intentional)
 - ID: TASK-133
   Title: Task UI bug fixing - mini scrollbar and edit modal polish
@@ -117,6 +112,11 @@ Last reviewed: 2026-05-31
   Dependencies: TASK-051
 
 ## Completed
+- ID: TASK-263
+  Title: Real-time notification updates - live in-app inbox, counts, and awareness
+  Status: Done (2026-06-06, merged via PR #320)
+  Rationale: Added account-scoped live notification snapshots with SSE-first transport and polling fallback so notification-center rows, unread counts, and awareness banners update without navigation. The implementation keeps in-app notifications atomic, preserves grouped/debounced email delivery, and updates route/component/service/docs coverage.
+  Dependencies: TASK-118, TASK-123, TASK-260
 - ID: TASK-312
   Title: Hidden project refresh reconciliation - remove user-facing refresh prompt
   Status: Done (2026-06-04, merged via PR #319)

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,122 +1,106 @@
-# Current Task: TASK-263 Real-Time Notification Updates
+# Current Task: TASK-224 Agent Roadmap Access
 
 ## Task ID
-TASK-263
+TASK-224
 
 ## Status
-Implemented and locally validated on `feature/task-263-live-notification-updates`.
-Ready PR #320 is open, checks are green, and the PR is intentionally left
-unmerged for maintainer review.
+Implemented locally on `feature/task-224-agent-roadmap-access`; PR workflow pending.
 
 ## Source
 - Execution queue task promoted on 2026-05-31.
-- User feedback after multi-account testing: invitation recipients still needed
-  a page reload to see new invitations/notifications.
-- Existing realtime foundation: TASK-309 project activity SSE transport and
-  TASK-311 typed project event reconciliation.
+- Agent access v1 currently supports project/task/context APIs, while roadmap
+  APIs remain human-session-only.
+- Roadmap v2 is now a core dashboard planning surface, so project planning
+  agents need explicit scoped access instead of borrowing task scopes.
 
 ## Objective
-Make in-app notifications feel live across authenticated sessions. Newly
-created or updated `Notification` rows should update the account menu unread
-indicator, notification awareness banner, and notification center list without
-requiring navigation or manual refresh.
+Expand the project-scoped agent API contract so trusted agents can inspect and
+manage project roadmap phases and events through dedicated roadmap scopes.
 
 ## Why This Matters
-Invitations, assignments, mentions, and future notification producers are
-collaboration signals. If recipients must reload to discover them, the product
-does not meet the standard set by modern collaborative tools.
+NexusDash agents are meant to participate in planning work, not only task
+execution. Roadmap access must be explicit, least-privilege, auditable, and
+documented so owners can grant planning capability without accidentally granting
+task or context privileges.
 
 ## Current Behavior
-- `TopRightControls` server-renders the unread count once by calling
-  `countUnreadNotificationsForUser`.
-- `NotificationAwarenessBanner` server-renders the latest unread title once.
-- `/account/notifications` server-renders the inbox by calling
-  `listNotificationsForUser`.
-- Notification read actions refresh through server actions or API writes, but
-  other open tabs/sessions do not update until navigation or reload.
-- Project invitation notification rows are reconciled lazily during notification
-  service reads, so live checks must keep that reconciliation path.
+- `ApiCredentialScope` supports project, task, and context scopes only.
+- Agent token exchange validates and serializes only the current scope set.
+- Roadmap API routes call `requireAuthenticatedApiUser`, which rejects bearer
+  tokens and only accepts human sessions.
+- `project-roadmap-service` enforces human project roles through
+  `requireProjectRole`, with no `agentAccess` path.
+- Hosted agent docs and OpenAPI omit roadmap endpoints.
 
 ## Architecture Direction
-- Reuse the existing SSE-first realtime pattern from project activity rather
-  than introducing WebSockets or a second realtime provider.
-- Scope the stream to the authenticated account, not to a project.
-- Keep `Notification` as the source of truth. The realtime stream publishes a
-  compact recipient snapshot: version, unread count, and latest unread title.
-- Mount a single authenticated client stream in the app chrome, then let account
-  menu, awareness banner, and notification-center clients subscribe to that
-  browser event/state.
-- Let the notification center refetch its full list via
-  `/api/account/notifications` when the snapshot version changes.
-- Preserve email digest batching exactly as-is; realtime only changes in-app
-  freshness.
+- Add dedicated roadmap scopes:
+  - `roadmap:read` for roadmap phase/event listing.
+  - `roadmap:write` for phase/event create, update, reorder, and move.
+  - `roadmap:delete` for phase/event deletion.
+- Keep project-scoped bearer tokens as the authentication mechanism; no new
+  token type or unscoped agent surface.
+- Reuse the existing route pattern from task/context APIs:
+  `requireApiPrincipal`, `getAgentProjectAccessContext`, and
+  `requireAgentProjectScopes`.
+- Thread optional `agentAccess` into roadmap services so services continue to
+  enforce authorization, not only route adapters.
+- Keep roadmap mutations integrated with project activity version headers so
+  dashboards continue to reconcile changes.
+- Update credential UI, token exchange, onboarding copy, and OpenAPI in the
+  same PR so the contract is discoverable and testable.
 
 ## Scope
-- Add notification snapshot service support with durable version semantics.
-- Add authenticated account notification snapshot and SSE stream API routes.
-- Add a client live-notification source that prefers `EventSource` and falls
-  back to adaptive polling.
-- Update the account menu unread indicator from live snapshots.
-- Replace the server-only awareness banner with a live client banner that can
-  appear/disappear as unread state changes.
-- Update the notification center list so it can refresh rows in place when the
-  live snapshot changes.
-- Cover service, route, and component behavior with tests.
+- Add roadmap scope values to schema, runtime scope definitions, DB mapping,
+  token validation, and credential UI.
+- Add a Prisma migration for the `ApiCredentialScope` enum expansion.
+- Convert roadmap API routes to accept human or agent principals.
+- Enforce roadmap scopes in routes and roadmap services.
+- Update hosted agent docs/OpenAPI with roadmap endpoints and schemas.
+- Add route, service, token, and docs tests for roadmap scopes and bearer-token
+  access.
+- Mark TASK-263 complete now that PR #320 is merged.
 
 ## Out Of Scope
-- Managed realtime provider provisioning.
-- Email digest timing/grouping changes.
-- Push/browser notifications, presence, or mobile OS notification delivery.
-- Changing notification producers beyond preserving their current row writes.
+- Calendar agent access.
+- Attachment binary parity beyond already-supported task/context routes.
+- A separate managed realtime or MCP transport for agents.
+- Changing human roadmap UI behavior beyond preserving existing responses and
+  activity-version headers.
 
 ## Acceptance Criteria
-1. A user with an open authenticated app session sees unread notification count
-   changes without navigation when a notification row is created, read, unread,
-   or resolved.
-2. The in-app awareness banner appears for the latest unread notification and
-   disappears when no unread unresolved notification remains.
-3. `/account/notifications` updates its list in place when notification state
-   changes in another tab/session.
-4. Project invitation recipients can see newly received invitations through the
-   live notification path without reloading.
-5. The implementation reuses the app's SSE-first realtime pattern and keeps a
-   polling fallback.
-6. Email notification digest batching remains separate and unchanged.
+1. Owners can create project agent credentials with `roadmap:read`,
+   `roadmap:write`, and `roadmap:delete` scopes.
+2. Agent bearer tokens preserve and validate the new roadmap scopes.
+3. Agents with `roadmap:read` can list roadmap phases/events for their project.
+4. Agents with `roadmap:write` can create/update phases and events, reorder
+   phases/events, and move events.
+5. Agents with `roadmap:delete` can delete phases/events; delete is not implied
+   by read or write.
+6. Agents without the required roadmap scope receive `403`, and agents scoped to
+   another project receive `404`.
+7. Human session behavior and existing roadmap UI/API responses remain
+   compatible.
+8. Hosted docs/OpenAPI advertise the roadmap contract and required scopes.
 
 ## Definition Of Done
-- [x] Notification snapshot service, API route, and SSE stream are implemented.
-- [x] Account menu, awareness banner, and notification center consume live
-      notification snapshots.
-- [x] Tests cover service snapshots, stream formatting/auth failure, polling
-      fallback, count/banner/list updates, and notification-center refetch.
-- [x] `npm run lint`, `npm test`, `npm run test:coverage`, `npm run build`, and
-      `npm run test:e2e` pass.
-- [x] `tasks/backlog.md`, `tasks/current.md`, `journal.md`, `project.md`, and
-      ADR docs are updated.
-- [x] A ready PR is opened and Copilot feedback is handled.
-- [x] The PR is left unmerged for maintainer review.
+- [x] Schema and migration include roadmap credential scopes.
+- [x] Runtime scope definitions, credential UI, token exchange, and audit
+      summaries handle the new scopes.
+- [x] Roadmap routes and services enforce agent project/scope access.
+- [x] Agent onboarding docs/OpenAPI include roadmap endpoints and examples.
+- [x] Focused tests cover roadmap bearer access and scope denial.
+- [x] `npm run lint`, `npm test`, `npm run test:coverage`, and `npm run build`
+      pass.
+- [ ] A ready PR is opened and Copilot feedback is handled.
 
 ## Validation Evidence
-- Focused `npm test -- --run tests/lib/notification-service.test.ts
-  tests/api/account-notifications.route.test.ts
-  tests/components/notification-live-updates.test.tsx
-  tests/components/notification-center-list.test.ts
-  tests/components/notification-awareness-banner.test.tsx
-  tests/components/account-menu.test.ts
-  tests/components/account-notifications-link.test.tsx` passed 7 files / 42
-  tests.
+- `npx prisma generate` passed through `npm ci` postinstall.
+- Focused Vitest passed: 8 files / 40 tests.
 - `npm run lint` passed.
-- Local PostgreSQL env `npm test` passed: 118 files passed, 2 skipped; 880
-  tests passed, 2 skipped.
-- Local PostgreSQL env `npm run test:coverage` passed with 91.37% statements,
-  81.33% branches, 92.2% functions, and 91.88% lines.
-- Local-safe production env `npm run build` passed.
-- Local-safe production env `npm run test:e2e` passed 8/8 Playwright specs
-  after replacing the projects helper `networkidle` wait with UI-ready
-  assertions because account-level SSE keeps a persistent connection open.
-- PR #320 checks passed: `check-name`, `Quality Core (lint, test, coverage,
-  build)`, `E2E Smoke (Playwright)`, and `Container Image (build + metadata
-  artifact)`.
-- Copilot review comments were addressed by adding no-store error headers to
-  the summary route, request-scoped cached server snapshot reads, and `Link`
-  navigation in the awareness banner.
+- `npm test` passed with local validation env: 119 files passed, 2 skipped;
+  889 tests passed, 2 skipped.
+- `npm run test:coverage` passed with local validation env: 91.37%
+  statements, 81.33% branches.
+- `npm run build` passed with local validation env.
+- `npm run db:migrate` passed against fresh local PostgreSQL on host port
+  5433, applying the new enum migration successfully.

--- a/tests/api/project-roadmap.route.test.ts
+++ b/tests/api/project-roadmap.route.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const apiGuardMock = vi.hoisted(() => ({
-  requireAuthenticatedApiUser: vi.fn(),
+  getAgentProjectAccessContext: vi.fn(),
+  requireApiPrincipal: vi.fn(),
 }));
 
 const roadmapServiceMock = vi.hoisted(() => ({
@@ -20,8 +21,40 @@ const roadmapServiceMock = vi.hoisted(() => ({
   isValidRoadmapEventMovePayload: vi.fn(),
 }));
 
+const projectAccessServiceMock = vi.hoisted(() => ({
+  requireAgentProjectScopes: vi.fn(
+    (input: {
+      agentAccess?: { projectId: string; scopes: string[] };
+      projectId: string;
+      requiredScopes: string[];
+    }) => {
+      if (!input.agentAccess) {
+        return { ok: true };
+      }
+
+      if (input.agentAccess.projectId !== input.projectId) {
+        return { ok: false, status: 404, error: "project-not-found" };
+      }
+
+      const hasRequiredScopes = input.requiredScopes.every((scope) =>
+        input.agentAccess?.scopes.includes(scope)
+      );
+      if (!hasRequiredScopes) {
+        return { ok: false, status: 403, error: "agent-scope-forbidden" };
+      }
+
+      return { ok: true };
+    }
+  ),
+}));
+
 vi.mock("@/lib/auth/api-guard", () => ({
-  requireAuthenticatedApiUser: apiGuardMock.requireAuthenticatedApiUser,
+  getAgentProjectAccessContext: apiGuardMock.getAgentProjectAccessContext,
+  requireApiPrincipal: apiGuardMock.requireApiPrincipal,
+}));
+
+vi.mock("@/lib/services/project-access-service", () => ({
+  requireAgentProjectScopes: projectAccessServiceMock.requireAgentProjectScopes,
 }));
 
 vi.mock("@/lib/services/project-roadmap-service", () => ({
@@ -76,13 +109,41 @@ function eventParams(projectId: string, eventId: string) {
 describe("project roadmap routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    apiGuardMock.requireAuthenticatedApiUser.mockResolvedValue({
+    apiGuardMock.requireApiPrincipal.mockResolvedValue({
       ok: true,
-      userId: "user-1",
+      principal: {
+        kind: "human",
+        actorUserId: "user-1",
+        requestId: "request-1",
+      },
     });
+    apiGuardMock.getAgentProjectAccessContext.mockReturnValue(undefined);
     roadmapServiceMock.isValidRoadmapPhaseReorderPayload.mockReturnValue(true);
+    roadmapServiceMock.isValidRoadmapEventReorderPayload.mockReturnValue(true);
     roadmapServiceMock.isValidRoadmapEventMovePayload.mockReturnValue(true);
   });
+
+  function mockAgentAccess(scopes: string[] = ["roadmap:read", "roadmap:write", "roadmap:delete"]) {
+    const agentAccess = {
+      projectId: "p1",
+      credentialId: "credential-1",
+      credentialLabel: "Build bot",
+      ownerUserId: "owner-1",
+      scopes,
+    };
+
+    apiGuardMock.requireApiPrincipal.mockResolvedValueOnce({
+      ok: true,
+      principal: {
+        kind: "agent",
+        actorUserId: "owner-1",
+        requestId: "request-agent-1",
+      },
+    });
+    apiGuardMock.getAgentProjectAccessContext.mockReturnValueOnce(agentAccess);
+
+    return agentAccess;
+  }
 
   test("GET /api/projects/:projectId/roadmap returns serialized phases", async () => {
     roadmapServiceMock.listProjectRoadmapPhases.mockResolvedValueOnce([
@@ -120,7 +181,59 @@ describe("project roadmap routes", () => {
         },
       ],
     });
-    expect(roadmapServiceMock.listProjectRoadmapPhases).toHaveBeenCalledWith("p1", "user-1");
+    expect(roadmapServiceMock.listProjectRoadmapPhases).toHaveBeenCalledWith(
+      "p1",
+      "user-1",
+      undefined
+    );
+  });
+
+  test("GET /api/projects/:projectId/roadmap passes scoped agent access", async () => {
+    const agentAccess = mockAgentAccess(["roadmap:read"]);
+    roadmapServiceMock.listProjectRoadmapPhases.mockResolvedValueOnce([]);
+
+    const response = await getRoadmap(
+      new Request("http://localhost/api/projects/p1/roadmap") as never,
+      projectParams("p1")
+    );
+
+    expect(response.status).toBe(200);
+    expect(roadmapServiceMock.listProjectRoadmapPhases).toHaveBeenCalledWith(
+      "p1",
+      "owner-1",
+      agentAccess
+    );
+  });
+
+  test("GET /api/projects/:projectId/roadmap rejects agents without roadmap read", async () => {
+    mockAgentAccess(["roadmap:write"]);
+
+    const response = await getRoadmap(
+      new Request("http://localhost/api/projects/p1/roadmap") as never,
+      projectParams("p1")
+    );
+
+    expect(response.status).toBe(403);
+    await expect(readJson(response)).resolves.toEqual({
+      error: "agent-scope-forbidden",
+    });
+    expect(roadmapServiceMock.listProjectRoadmapPhases).not.toHaveBeenCalled();
+  });
+
+  test("GET /api/projects/:projectId/roadmap rejects cross-project agent access", async () => {
+    const agentAccess = mockAgentAccess(["roadmap:read"]);
+    agentAccess.projectId = "other-project";
+
+    const response = await getRoadmap(
+      new Request("http://localhost/api/projects/p1/roadmap") as never,
+      projectParams("p1")
+    );
+
+    expect(response.status).toBe(404);
+    await expect(readJson(response)).resolves.toEqual({
+      error: "project-not-found",
+    });
+    expect(roadmapServiceMock.listProjectRoadmapPhases).not.toHaveBeenCalled();
   });
 
   test("POST /api/projects/:projectId/roadmap returns 400 for invalid json", async () => {
@@ -190,6 +303,47 @@ describe("project roadmap routes", () => {
     });
   });
 
+  test("POST /api/projects/:projectId/roadmap passes roadmap write agent access", async () => {
+    const agentAccess = mockAgentAccess(["roadmap:write"]);
+    roadmapServiceMock.createProjectRoadmapPhase.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        phase: {
+          id: "phase-agent",
+          title: "Agent phase",
+          description: null,
+          targetDate: null,
+          status: "planned",
+          position: 0,
+          createdAt: "2026-04-23T08:00:00.000Z",
+          updatedAt: "2026-04-23T08:00:00.000Z",
+          events: [],
+        },
+      },
+    });
+
+    const response = await createRoadmapPhase(
+      new Request("http://localhost/api/projects/p1/roadmap", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ title: "Agent phase" }),
+      }) as never,
+      projectParams("p1")
+    );
+
+    expect(response.status).toBe(201);
+    expect(roadmapServiceMock.createProjectRoadmapPhase).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorUserId: "owner-1",
+        projectId: "p1",
+        agentAccess,
+        title: "Agent phase",
+      })
+    );
+  });
+
   test("PATCH /api/projects/:projectId/roadmap/phases/:phaseId rejects invalid field types", async () => {
     const response = await updateRoadmapPhase(
       new Request("http://localhost/api/projects/p1/roadmap/phases/phase-1", {
@@ -228,6 +382,29 @@ describe("project roadmap routes", () => {
 
     expect(response.status).toBe(200);
     await expect(readJson(response)).resolves.toEqual({ ok: true });
+    expect(roadmapServiceMock.deleteProjectRoadmapPhase).toHaveBeenCalledWith({
+      actorUserId: "user-1",
+      projectId: "p1",
+      phaseId: "phase-1",
+      agentAccess: undefined,
+    });
+  });
+
+  test("DELETE /api/projects/:projectId/roadmap/phases/:phaseId requires roadmap delete for agents", async () => {
+    mockAgentAccess(["roadmap:write"]);
+
+    const response = await deleteRoadmapPhase(
+      new Request("http://localhost/api/projects/p1/roadmap/phases/phase-1", {
+        method: "DELETE",
+      }) as never,
+      phaseParams("p1", "phase-1")
+    );
+
+    expect(response.status).toBe(403);
+    await expect(readJson(response)).resolves.toEqual({
+      error: "agent-scope-forbidden",
+    });
+    expect(roadmapServiceMock.deleteProjectRoadmapPhase).not.toHaveBeenCalled();
   });
 
   test("POST /api/projects/:projectId/roadmap/phases/:phaseId/events creates an event", async () => {
@@ -392,6 +569,7 @@ describe("project roadmap routes", () => {
     expect(roadmapServiceMock.reorderProjectRoadmapPhases).toHaveBeenCalledWith({
       actorUserId: "user-1",
       projectId: "p1",
+      agentAccess: undefined,
       phaseIds: ["phase-2", "phase-1"],
     });
   });
@@ -424,6 +602,7 @@ describe("project roadmap routes", () => {
     expect(roadmapServiceMock.reorderProjectRoadmapEvents).toHaveBeenCalledWith({
       actorUserId: "user-1",
       projectId: "p1",
+      agentAccess: undefined,
       phaseId: "phase-1",
       eventIds: ["event-2", "event-1"],
     });
@@ -457,6 +636,7 @@ describe("project roadmap routes", () => {
     expect(roadmapServiceMock.moveProjectRoadmapEvent).toHaveBeenCalledWith({
       actorUserId: "user-1",
       projectId: "p1",
+      agentAccess: undefined,
       eventId: "event-1",
       targetPhaseId: "phase-2",
       targetIndex: 1,

--- a/tests/api/project-roadmap.route.test.ts
+++ b/tests/api/project-roadmap.route.test.ts
@@ -40,7 +40,7 @@ const projectAccessServiceMock = vi.hoisted(() => ({
         input.agentAccess?.scopes.includes(scope)
       );
       if (!hasRequiredScopes) {
-        return { ok: false, status: 403, error: "agent-scope-forbidden" };
+        return { ok: false, status: 403, error: "forbidden" };
       }
 
       return { ok: true };
@@ -215,7 +215,7 @@ describe("project roadmap routes", () => {
 
     expect(response.status).toBe(403);
     await expect(readJson(response)).resolves.toEqual({
-      error: "agent-scope-forbidden",
+      error: "forbidden",
     });
     expect(roadmapServiceMock.listProjectRoadmapPhases).not.toHaveBeenCalled();
   });
@@ -402,7 +402,7 @@ describe("project roadmap routes", () => {
 
     expect(response.status).toBe(403);
     await expect(readJson(response)).resolves.toEqual({
-      error: "agent-scope-forbidden",
+      error: "forbidden",
     });
     expect(roadmapServiceMock.deleteProjectRoadmapPhase).not.toHaveBeenCalled();
   });

--- a/tests/components/agent-onboarding-guide.test.ts
+++ b/tests/components/agent-onboarding-guide.test.ts
@@ -20,6 +20,9 @@ describe("agent-onboarding-guide", () => {
     expect(result).toContain("Authentication flow");
     expect(result).toContain("Supported endpoints");
     expect(result).toContain("/api/projects/{projectId}/epics");
+    expect(result).toContain("/api/projects/{projectId}/roadmap");
+    expect(result).toContain("/api/projects/{projectId}/roadmap/events/move");
+    expect(result).toContain("roadmap:delete");
     expect(result).toContain("/api/projects/{projectId}/tasks");
     expect(result).toContain("/api/projects/{projectId}/tasks/{taskId}/comments");
     expect(result).toContain("application/json");

--- a/tests/lib/agent-onboarding.test.ts
+++ b/tests/lib/agent-onboarding.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  AGENT_API_ENDPOINTS,
+  buildAgentOpenApiDocument,
+} from "@/lib/agent-onboarding";
+
+describe("agent-onboarding contract", () => {
+  test("documents the scoped roadmap API surface", () => {
+    const document = buildAgentOpenApiDocument("https://preview.nexusdash.test");
+
+    expect(
+      AGENT_API_ENDPOINTS.filter((endpoint) => endpoint.tag === "Roadmap").map(
+        (endpoint) => `${endpoint.method} ${endpoint.path}`
+      )
+    ).toEqual([
+      "GET /api/projects/{projectId}/roadmap",
+      "POST /api/projects/{projectId}/roadmap",
+      "PATCH /api/projects/{projectId}/roadmap/phases/{phaseId}",
+      "DELETE /api/projects/{projectId}/roadmap/phases/{phaseId}",
+      "POST /api/projects/{projectId}/roadmap/phases/{phaseId}/events",
+      "PATCH /api/projects/{projectId}/roadmap/events/{eventId}",
+      "DELETE /api/projects/{projectId}/roadmap/events/{eventId}",
+      "POST /api/projects/{projectId}/roadmap/phases/reorder",
+      "POST /api/projects/{projectId}/roadmap/events/reorder",
+      "POST /api/projects/{projectId}/roadmap/events/move",
+    ]);
+
+    expect(document.components.schemas.TokenExchangeResponse.properties.scopes.items.enum)
+      .toEqual(
+        expect.arrayContaining(["roadmap:read", "roadmap:write", "roadmap:delete"])
+      );
+    expect(document.paths["/api/projects/{projectId}/roadmap"].get).toBeDefined();
+    expect(
+      document.paths["/api/projects/{projectId}/roadmap/events/{eventId}"].delete
+        .responses[200].content["application/json"].schema.$ref
+    ).toBe("#/components/schemas/RoadmapEventDeleteResponse");
+  });
+});

--- a/tests/lib/agent-token-service.test.ts
+++ b/tests/lib/agent-token-service.test.ts
@@ -34,7 +34,7 @@ describe("agent-token-service", () => {
       credentialId: "credential-1",
       projectId: "project-1",
       ownerUserId: "owner-1",
-      scopes: ["task:read", "task:write"],
+      scopes: ["roadmap:read", "roadmap:write", "task:read", "task:write"],
     });
 
     const verifiedToken = verifyAgentAccessToken(issuedToken.accessToken);
@@ -47,7 +47,12 @@ describe("agent-token-service", () => {
     expect(verifiedToken.data.credentialId).toBe("credential-1");
     expect(verifiedToken.data.projectId).toBe("project-1");
     expect(verifiedToken.data.ownerUserId).toBe("owner-1");
-    expect(verifiedToken.data.scopes).toEqual(["task:read", "task:write"]);
+    expect(verifiedToken.data.scopes).toEqual([
+      "task:read",
+      "task:write",
+      "roadmap:read",
+      "roadmap:write",
+    ]);
     expect(verifiedToken.data.tokenId).toBe(issuedToken.tokenId);
     expect(Math.floor(verifiedToken.data.expiresAt.getTime() / 1000)).toBe(
       Math.floor(issuedToken.expiresAt.getTime() / 1000)

--- a/tests/lib/project-agent-access-exchange.test.ts
+++ b/tests/lib/project-agent-access-exchange.test.ts
@@ -101,7 +101,10 @@ describe("exchangeAgentApiKeyForAccessToken", () => {
       createdByUserId: "owner-1",
       expiresAt: null,
       revokedAt: null,
-      scopeGrants: [{ scope: ApiCredentialScope.task_read }],
+      scopeGrants: [
+        { scope: ApiCredentialScope.roadmap_write },
+        { scope: ApiCredentialScope.task_read },
+      ],
     });
 
     const result = await exchangeAgentApiKeyForAccessToken({
@@ -120,7 +123,7 @@ describe("exchangeAgentApiKeyForAccessToken", () => {
         expiresAt: "2026-03-31T10:10:00.000Z",
         expiresInSeconds: 600,
         projectId: "project-1",
-        scopes: ["task:read"],
+        scopes: ["roadmap:write", "task:read"],
       },
     });
     expect(passwordServiceMock.verifySecret).toHaveBeenCalledWith(
@@ -131,7 +134,7 @@ describe("exchangeAgentApiKeyForAccessToken", () => {
       credentialId: "credential-1",
       projectId: "project-1",
       ownerUserId: "owner-1",
-      scopes: ["task:read"],
+      scopes: ["roadmap:write", "task:read"],
     });
     expect(prismaMock.apiCredential.findUnique).toHaveBeenCalledWith({
       where: {

--- a/tests/lib/project-roadmap-service.test.ts
+++ b/tests/lib/project-roadmap-service.test.ts
@@ -19,7 +19,7 @@ const projectAccessServiceMock = vi.hoisted(() => ({
         input.agentAccess?.scopes.includes(scope)
       );
       if (!hasRequiredScopes) {
-        return { ok: false, status: 403, error: "agent-scope-forbidden" };
+        return { ok: false, status: 403, error: "forbidden" };
       }
 
       return { ok: true };
@@ -201,7 +201,7 @@ describe("project-roadmap-service", () => {
     expect(result).toEqual({
       ok: false,
       status: 403,
-      error: "agent-scope-forbidden",
+      error: "forbidden",
     });
     expect(dbMock.roadmapPhase.create).not.toHaveBeenCalled();
     expect(projectAccessServiceMock.requireProjectRole).not.toHaveBeenCalled();

--- a/tests/lib/project-roadmap-service.test.ts
+++ b/tests/lib/project-roadmap-service.test.ts
@@ -1,6 +1,30 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const projectAccessServiceMock = vi.hoisted(() => ({
+  requireAgentProjectScopes: vi.fn(
+    (input: {
+      agentAccess?: { projectId: string; scopes: string[] };
+      projectId: string;
+      requiredScopes: string[];
+    }) => {
+      if (!input.agentAccess) {
+        return { ok: true };
+      }
+
+      if (input.agentAccess.projectId !== input.projectId) {
+        return { ok: false, status: 404, error: "project-not-found" };
+      }
+
+      const hasRequiredScopes = input.requiredScopes.every((scope) =>
+        input.agentAccess?.scopes.includes(scope)
+      );
+      if (!hasRequiredScopes) {
+        return { ok: false, status: 403, error: "agent-scope-forbidden" };
+      }
+
+      return { ok: true };
+    }
+  ),
   requireProjectRole: vi.fn(),
 }));
 
@@ -33,6 +57,7 @@ const dbMock = vi.hoisted(() => ({
 }));
 
 vi.mock("@/lib/services/project-access-service", () => ({
+  requireAgentProjectScopes: projectAccessServiceMock.requireAgentProjectScopes,
   requireProjectRole: projectAccessServiceMock.requireProjectRole,
 }));
 
@@ -134,6 +159,75 @@ describe("project-roadmap-service", () => {
       minimumRole: "viewer",
       db: dbMock,
     });
+  });
+
+  test("lists roadmap phases for agents with roadmap read without human role lookup", async () => {
+    dbMock.roadmapPhase.findMany.mockResolvedValueOnce([]);
+
+    const result = await listProjectRoadmapPhases("project-1", "owner-1", {
+      projectId: "project-1",
+      credentialId: "credential-1",
+      credentialLabel: "Build bot",
+      ownerUserId: "owner-1",
+      scopes: ["roadmap:read"],
+    });
+
+    expect(result).toEqual([]);
+    expect(projectAccessServiceMock.requireProjectRole).not.toHaveBeenCalled();
+    expect(projectAccessServiceMock.requireAgentProjectScopes).toHaveBeenCalledWith({
+      agentAccess: expect.objectContaining({
+        credentialId: "credential-1",
+        scopes: ["roadmap:read"],
+      }),
+      projectId: "project-1",
+      requiredScopes: ["roadmap:read"],
+    });
+  });
+
+  test("blocks agents that lack roadmap write before creating phases", async () => {
+    const result = await createProjectRoadmapPhase({
+      actorUserId: "owner-1",
+      projectId: "project-1",
+      agentAccess: {
+        projectId: "project-1",
+        credentialId: "credential-1",
+        credentialLabel: "Build bot",
+        ownerUserId: "owner-1",
+        scopes: ["roadmap:read"],
+      },
+      title: "Public launch",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 403,
+      error: "agent-scope-forbidden",
+    });
+    expect(dbMock.roadmapPhase.create).not.toHaveBeenCalled();
+    expect(projectAccessServiceMock.requireProjectRole).not.toHaveBeenCalled();
+  });
+
+  test("returns project not found for cross-project roadmap agents", async () => {
+    const result = await createProjectRoadmapPhase({
+      actorUserId: "owner-1",
+      projectId: "project-1",
+      agentAccess: {
+        projectId: "project-2",
+        credentialId: "credential-1",
+        credentialLabel: "Build bot",
+        ownerUserId: "owner-1",
+        scopes: ["roadmap:write"],
+      },
+      title: "Public launch",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 404,
+      error: "project-not-found",
+    });
+    expect(dbMock.roadmapPhase.create).not.toHaveBeenCalled();
+    expect(projectAccessServiceMock.requireProjectRole).not.toHaveBeenCalled();
   });
 
   test("creates roadmap phase with sequential position", async () => {


### PR DESCRIPTION
## Summary
- Add dedicated `roadmap:read`, `roadmap:write`, and `roadmap:delete` agent credential scopes plus a Prisma enum migration.
- Convert roadmap phase/event API routes and roadmap services to support project-scoped agent principals with explicit scope checks.
- Extend hosted agent onboarding and OpenAPI v1 with roadmap endpoints, schemas, examples, and scope documentation.
- Mark TASK-263 complete and update TASK-224 tracking docs with validation evidence.

## Validation
- `npm run lint`
- `npm test` with local validation env
- `npm run test:coverage` with local validation env
- `npm run build` with local validation env
- `npm run db:migrate` against fresh local PostgreSQL on host port 5433

Commit: `2aee52b`