### PR TITLE
TASK-224 Close out tracking docs

### DIFF
--- a/journal.md
+++ b/journal.md
@@ -26,6 +26,16 @@ Use it for important implementation milestones, blockers, validation runs, and r
   migrations, including `20260606090000_task224_agent_roadmap_scopes`, against
   a fresh local PostgreSQL on host port 5433.
 
+# 2026-06-06 - TASK-224 PR merged
+
+- Summary: Merged TASK-224 through PR #326 after handling Copilot's five
+  test-contract comments about the `forbidden` agent-scope error.
+- Evidence: PR #326 merged as
+  `3d497c77a790a14e32c9cb20a85349d2e448239e`; follow-up review fix
+  `f1f800c41498966acadd55940906acb1b99a2677`; GitHub checks passed:
+  `check-name`, `Quality Core (lint, test, coverage, build)`, `E2E Smoke
+  (Playwright)`, and `Container Image (build + metadata artifact)`.
+
 # 2026-06-04 - TASK-263 realtime notification updates started
 
 - Summary: Drafted the implementation brief for live in-app notification

--- a/project.md
+++ b/project.md
@@ -118,7 +118,7 @@ Source of truth: [`prisma/schema.prisma`](./prisma/schema.prisma)
 
 From `tasks/current.md` + `tasks/backlog.md`:
 
-1. TASK-224: agent roadmap access for scoped roadmap phase/event APIs
+1. No active task selected after TASK-224 completion.
 
 ## 8. Source-of-Truth Docs
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -6,11 +6,6 @@ Last reviewed: 2026-05-31
 
 ## Pending
 ### Execution Queue (Now / Next)
-- ID: TASK-224
-  Title: Agent roadmap access - scoped API contract for roadmap phases and events
-  Status: In progress on `feature/task-224-agent-roadmap-access`
-  Rationale: Make the project roadmap manageable by project-scoped agent tokens so agents can inspect, create, update, move, reorder, and delete roadmap phases/events when they are responsible for project planning. This should be a deliberate agent API contract expansion with dedicated roadmap scopes, OpenAPI/onboarding documentation, credential UI updates, route guard coverage, and smoke tests rather than implicitly folding roadmap permissions into existing project or task scopes.
-  Dependencies: TASK-127, TASK-130, TASK-059
 ### Deferred (Intentional)
 - ID: TASK-133
   Title: Task UI bug fixing - mini scrollbar and edit modal polish
@@ -112,6 +107,11 @@ Last reviewed: 2026-05-31
   Dependencies: TASK-051
 
 ## Completed
+- ID: TASK-224
+  Title: Agent roadmap access - scoped API contract for roadmap phases and events
+  Status: Done (2026-06-06, merged via PR #326)
+  Rationale: Added dedicated roadmap agent scopes, token/credential mappings, route and service authorization, hosted onboarding/OpenAPI coverage, and focused tests so project-scoped agents can inspect, create, update, move, reorder, and delete roadmap phases/events without borrowing task permissions.
+  Dependencies: TASK-127, TASK-130, TASK-059
 - ID: TASK-263
   Title: Real-time notification updates - live in-app inbox, counts, and awareness
   Status: Done (2026-06-06, merged via PR #320)

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,7 +4,7 @@
 TASK-224
 
 ## Status
-Implemented locally on `feature/task-224-agent-roadmap-access`; PR workflow pending.
+Completed on 2026-06-06 via PR #326.
 
 ## Source
 - Execution queue task promoted on 2026-05-31.
@@ -91,7 +91,7 @@ task or context privileges.
 - [x] Focused tests cover roadmap bearer access and scope denial.
 - [x] `npm run lint`, `npm test`, `npm run test:coverage`, and `npm run build`
       pass.
-- [ ] A ready PR is opened and Copilot feedback is handled.
+- [x] A ready PR is opened and Copilot feedback is handled.
 
 ## Validation Evidence
 - `npx prisma generate` passed through `npm ci` postinstall.
@@ -104,3 +104,9 @@ task or context privileges.
 - `npm run build` passed with local validation env.
 - `npm run db:migrate` passed against fresh local PostgreSQL on host port
   5433, applying the new enum migration successfully.
+- PR #326 merged as `3d497c77a790a14e32c9cb20a85349d2e448239e`.
+- Copilot review produced five test-contract comments; addressed in
+  `f1f800c41498966acadd55940906acb1b99a2677` and resolved.
+- GitHub checks passed after the review fix: `check-name`, `Quality Core
+  (lint, test, coverage, build)`, `E2E Smoke (Playwright)`, and `Container
+  Image (build + metadata artifact)`.


### PR DESCRIPTION
## Summary
- Move TASK-224 from the execution queue to Completed after PR #326 merged.
- Mark the TASK-224 current brief as completed and record Copilot/check evidence.
- Clear the active priority entry until the next task is assigned.

## Validation
- `git diff --check`

Commit: `8814ac2`