### PR TITLE
TASK-313 Implement app version governance

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -45,7 +45,7 @@ jobs:
           VERSION_POLICY_BASE_REF: origin/${{ github.base_ref }}
           VERSION_POLICY_BRANCH_NAME: ${{ github.head_ref }}
         run: |
-          git fetch --no-tags --prune origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+          git fetch --no-tags --prune origin "+refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
           npm run release:check
 
       - name: Install dependencies

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -30,12 +30,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
+
+      - name: Check product version policy
+        if: github.event_name == 'pull_request'
+        env:
+          VERSION_POLICY_BASE_REF: origin/${{ github.base_ref }}
+          VERSION_POLICY_BRANCH_NAME: ${{ github.head_ref }}
+        run: |
+          git fetch --no-tags --prune origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+          npm run release:check
 
       - name: Install dependencies
         run: npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,18 @@ SHA, deployment URL, and workflow run belong in release evidence.
 
 ## Unreleased
 
-- Define each release entry before the release PR is merged.
+- Define each release entry before the product-impacting PR is merged.
+
+## v0.3.0 - 2026-06-06
+
+- Added product version governance so feature branches bump minor versions,
+  release-impacting fix/refactor/chore branches bump patch versions, and
+  commit/build details remain diagnostic metadata instead of visible product
+  version components.
+- Added a CI guard that validates package version consistency, branch-based
+  SemVer bumps, and matching changelog entries for production-bound PRs.
+- Improved the release helper with branch-type aliases such as `feature`,
+  `fix`, `refactor`, and `chore`.
 
 ## v0.2.0 - 2026-05-20
 

--- a/README.md
+++ b/README.md
@@ -392,22 +392,23 @@ Branch-name note:
 
 ### Release version metadata
 
-`package.json` is the canonical product-version source. Release PRs that
-intentionally change the product version must update both `package.json` and
+`package.json` is the canonical product-version source. Product-impacting PRs
+that change the product version must update both `package.json` and
 `package-lock.json`; Dependabot maintenance PRs must not bump the product
 version by themselves.
 
-Product versions move through intentional release PRs, not every production
-deployment. While NexusDash is pre-1.0, use patch bumps such as `0.2.1` for
-bugfix and operational releases, minor bumps such as `0.3.0` for meaningful
-product capability milestones, and reserve `1.0.0` for the first stable product
-baseline. The detailed checklist lives in
+Product versions move through branch-based release decisions, not commit counts
+or every production deployment. While NexusDash is pre-1.0, `feature/*` PRs bump
+minor and reset patch, for example `0.2.0` to `0.3.0`; release-impacting
+`fix/*`, `refactor/*`, and `chore/*` PRs bump patch, for example `0.3.0` to
+`0.3.1`; `1.0.0` remains reserved for the first stable product baseline. The
+detailed checklist lives in
 [`docs/runbooks/release-versioning.md`](docs/runbooks/release-versioning.md).
 
-The running app displays only the clean product version, for example `v0.2.0`.
+The running app displays only the clean product version, for example `v0.3.0`.
 Build revision and runtime environment are kept as diagnostic metadata so
 operators can identify the deployed commit without turning the user-facing
-version into `v0.2.0+<sha>`.
+version into `v0.3.0+<sha>`.
 
 The Vercel deploy workflow resolves metadata from the checked-out ref and
 injects:

--- a/docs/runbooks/release-versioning.md
+++ b/docs/runbooks/release-versioning.md
@@ -6,24 +6,52 @@ is captured, and when the app should graduate from `0.x.y` to `1.0.0`.
 ## Principles
 
 - `package.json` is the canonical product-version source.
-- `package-lock.json` must match `package.json` for every release PR.
+- `package-lock.json` must match `package.json` for every product version bump.
 - The app displays the clean product version, for example `v0.2.1`.
 - Commit SHA, deployment URL, workflow run, and environment are build/revision
   evidence. Do not append them to the user-facing version label.
-- Routine task, dependency, workflow, or documentation PRs do not automatically
-  bump the product version. Version bumps happen in intentional release PRs.
+- Commit count is not part of the product version. A large PR and a small PR
+  may both be one product release; commit SHA remains the exact build identity.
+- Product-impacting PRs carry their version decision in the same PR so the
+  production app cannot silently ship meaningful work forever under the same
+  version.
 
 ## Pre-1.0 Bump Rules
 
 Use `0.x.y` while NexusDash is still before its first stable product baseline.
 
-- Patch: bump `0.2.0` to `0.2.1` for bug fixes, operational corrections,
-  small copy/UI polish, and low-risk improvements.
-- Minor: bump `0.2.1` to `0.3.0` for meaningful user-facing capabilities,
-  workflow changes, or a planned batch of feature work.
+- Minor: bump `0.2.0` to `0.3.0` for `feature/*` PRs that ship meaningful
+  user-facing capabilities, workflow changes, or milestone-level product work.
+- Patch: bump `0.3.0` to `0.3.1` for `fix/*`, `refactor/*`, and
+  production-impacting `chore/*` PRs that ship bug fixes, operational
+  corrections, performance work, small copy/UI polish, or low-risk
+  improvements.
 - Hold steady: do not bump for Dependabot PRs, routine CI cleanup, runbook-only
   clarifications, or task-tracking updates unless they are part of a release.
+  If a production-bound branch is intentionally no-release-impact, label the PR
+  `no-release-impact` or `release:none`.
 - Major: reserve `1.0.0` for the first stable product baseline.
+
+## PR Version Decision Rules
+
+Every product-impacting PR must make exactly one version decision:
+
+- `feature/*`: bump minor and reset patch, for example `0.2.0` to `0.3.0`.
+- `fix/*`: bump patch, for example `0.3.0` to `0.3.1`.
+- `refactor/*`: bump patch when the refactor ships production behavior or
+  runtime risk.
+- `chore/*`: bump patch only when product/runtime files change.
+- `docs/*`: normally hold steady.
+- `dependabot/*`: hold steady unless a human explicitly converts the update
+  into a product release.
+
+The CI `release:check` guard validates these rules for PRs:
+
+- `package.json` and `package-lock.json` must agree.
+- The expected SemVer bump must match the branch type.
+- Version bumps must include a matching `CHANGELOG.md` entry.
+- A production-bound PR without a version bump must carry an explicit
+  `no-release-impact` or `release:none` label.
 
 ## 1.0.0 Readiness
 
@@ -38,38 +66,40 @@ Move to `1.0.0` when the team is ready to preserve the core product contract:
 - Known breaking workflow or schema changes are either resolved or explicitly
   accepted as post-1.0 migration work.
 
-## Release PR Checklist
+## Version Checklist
 
 1. Decide the next product version using the bump rules above.
 2. Run the helper in dry-run mode:
 
    ```bash
-   npm run release:version -- patch --dry-run
+   npm run release:version -- feature --dry-run
    ```
 
 3. Apply the selected bump:
 
    ```bash
-   npm run release:version -- patch
+   npm run release:version -- feature
    ```
 
-   Use `minor`, `major`, or an explicit version such as `0.3.0` when needed.
+   Use `fix`, `refactor`, `chore`, `patch`, `minor`, `major`, or an explicit
+   version such as `0.3.0` when needed.
 
 4. Add or update the matching entry in `CHANGELOG.md`.
-5. Keep the release PR focused on release metadata, release notes, and any
-   small release-only documentation updates.
+5. Keep the version/changelog change in the same product-impacting PR unless
+   the PR is explicitly no-release-impact.
 6. Validate:
 
    ```bash
    git diff --check
+   npm run release:check -- --base origin/main --branch <branch-name>
    npm run lint
    ```
 
 7. After the PR merges, create the matching git tag, for example:
 
    ```bash
-   git tag v0.2.1
-   git push origin v0.2.1
+   git tag v0.3.0
+   git push origin v0.3.0
    ```
 
 8. Confirm the staged-production deployment summary reports the intended
@@ -82,12 +112,13 @@ Move to `1.0.0` when the team is ready to preserve the core product contract:
 Each production release should be traceable to:
 
 - product version, for example `v0.2.1`
-- release PR
+- product-impacting PR
 - git tag
 - merge commit SHA
 - staged-production deployment URL or ID
 - workflow run that produced the deployment
 - promotion or rollback decision
 
-This evidence can live in the release PR, `CHANGELOG.md`, or a dated file under
-`docs/releases/` if a release needs more detail than the changelog entry.
+This evidence can live in the product-impacting PR, `CHANGELOG.md`, or a dated
+file under `docs/releases/` if a release needs more detail than the changelog
+entry.

--- a/docs/runbooks/vercel-env-contract-and-secrets.md
+++ b/docs/runbooks/vercel-env-contract-and-secrets.md
@@ -26,7 +26,7 @@ Optional but bounded:
 
 ## App Metadata
 
-The app displays a clean product version such as `v0.2.0`. The commit SHA is
+The app displays a clean product version such as `v0.3.0`. The commit SHA is
 not appended to that visible version; it is kept as diagnostic metadata for
 operators.
 

--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,25 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-06-06 - TASK-313 app version governance implemented
+
+- Summary: Implemented branch-based product version governance. `feature/*`
+  PRs now require a minor bump/reset patch, release-impacting `fix/*`,
+  `refactor/*`, and `chore/*` PRs require patch bumps, and docs/dependabot/
+  task-tracking work can hold steady unless explicitly released. Commit count
+  remains diagnostic/build metadata, not part of the visible SemVer product
+  version.
+- Evidence: Added `npm run release:check`, CI guard wiring in Quality Core,
+  release helper branch-type aliases, guard tests, changelog enforcement, and
+  bumped the product version from `0.2.0` to `0.3.0` for this feature PR.
+- Validation: `npm run release:check -- --base origin/main --branch
+  feature/task-313-version-governance`, focused Vitest for metadata/version
+  guard tests, `npm run release:version -- feature --dry-run`, `npm run lint`,
+  CI-shaped `npm test`, CI-shaped `npm run test:coverage`, and full-env
+  `npm run build` passed. Local full test initially exposed a stale generated
+  Prisma Client missing roadmap enum values; `npx prisma generate` restored the
+  expected local generated client before the green run.
+
 # 2026-06-06 - TASK-313 app version governance created
 
 - Summary: Created TASK-313 after reviewing the existing versioning history:

--- a/journal.md
+++ b/journal.md
@@ -21,6 +21,10 @@ Use it for important implementation milestones, blockers, validation runs, and r
   `npm run build` passed. Local full test initially exposed a stale generated
   Prisma Client missing roadmap enum values; `npx prisma generate` restored the
   expected local generated client before the green run.
+- PR: Opened PR #329, fixed Copilot's changelog-enforcement gap for
+  non-production-bound version bumps, resolved the review thread, and verified
+  GitHub checks passed: branch name, Quality Core, E2E Smoke, and Container
+  Image.
 
 # 2026-06-06 - TASK-313 app version governance created
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexusdash",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexusdash",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1056.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexusdash",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0",
@@ -25,6 +25,7 @@
     "db:local:down": "docker compose stop postgres",
     "db:local:reset": "node scripts/local-db-reset.mjs",
     "release:version": "node scripts/release-version.mjs",
+    "release:check": "node scripts/check-version-policy.mjs",
     "validate:local": "node scripts/local-validation.mjs"
   },
   "dependencies": {

--- a/project.md
+++ b/project.md
@@ -118,7 +118,7 @@ Source of truth: [`prisma/schema.prisma`](./prisma/schema.prisma)
 
 From `tasks/current.md` + `tasks/backlog.md`:
 
-1. TASK-313: app version governance for semantic release increments and build metadata clarity
+1. No active implementation task selected after TASK-313 closes.
 
 ## 8. Source-of-Truth Docs
 

--- a/scripts/check-version-policy.mjs
+++ b/scripts/check-version-policy.mjs
@@ -212,6 +212,21 @@ function hasNoReleaseImpactDecision(labels) {
   return [...labels].some((label) => NO_RELEASE_IMPACT_LABELS.has(label));
 }
 
+function assertChangelogEntry({ changedFiles, headRef, version }) {
+  if (!changedFiles.includes("CHANGELOG.md")) {
+    fail("Version bumps must update CHANGELOG.md with release notes.");
+  }
+
+  const changelog =
+    headRef === "HEAD"
+      ? readFileSync("CHANGELOG.md", "utf8")
+      : runGit(["show", `${headRef}:CHANGELOG.md`]);
+  const heading = `## v${formatVersion(version)}`;
+  if (!changelog.includes(heading)) {
+    fail(`CHANGELOG.md must include a ${heading} entry.`);
+  }
+}
+
 function parseArgs(argv) {
   const options = {
     baseRef: process.env.VERSION_POLICY_BASE_REF ?? "origin/main",
@@ -306,6 +321,14 @@ try {
       fail("Version metadata changed, but the target version is not greater than base.");
     }
 
+    if (versionChanged) {
+      assertChangelogEntry({
+        changedFiles,
+        headRef: options.headRef,
+        version: headVersion,
+      });
+    }
+
     info("No production-bound version bump required for this branch.");
     process.exit(0);
   }
@@ -329,18 +352,11 @@ try {
     );
   }
 
-  if (!changedFiles.includes("CHANGELOG.md")) {
-    fail("Version bumps must update CHANGELOG.md with release notes.");
-  }
-
-  const changelog =
-    options.headRef === "HEAD"
-      ? readFileSync("CHANGELOG.md", "utf8")
-      : runGit(["show", `${options.headRef}:CHANGELOG.md`]);
-  const heading = `## v${formatVersion(headVersion)}`;
-  if (!changelog.includes(heading)) {
-    fail(`CHANGELOG.md must include a ${heading} entry.`);
-  }
+  assertChangelogEntry({
+    changedFiles,
+    headRef: options.headRef,
+    version: headVersion,
+  });
 
   info("Product version policy check passed.");
 } catch (error) {

--- a/scripts/check-version-policy.mjs
+++ b/scripts/check-version-policy.mjs
@@ -1,0 +1,348 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import process from "node:process";
+
+const VERSION_PATTERN = /^v?(\d+)\.(\d+)\.(\d+)$/;
+const VERSION_METADATA_FILES = new Set([
+  "package.json",
+  "package-lock.json",
+  "CHANGELOG.md",
+]);
+const PRODUCT_FILE_PATTERNS = [
+  /^app\//,
+  /^components\//,
+  /^lib\//,
+  /^prisma\//,
+  /^public\//,
+  /^styles\//,
+  /^middleware\.(js|ts)$/,
+  /^next\.config\./,
+  /^postcss\.config\./,
+  /^tailwind\.config\./,
+  /^tsconfig\.json$/,
+  /^Dockerfile$/,
+];
+const NO_RELEASE_IMPACT_LABELS = new Set([
+  "no-release-impact",
+  "release:none",
+]);
+
+function usage() {
+  console.log(`Usage:
+  npm run release:check -- [--base <ref>] [--head <ref>] [--branch <name>]
+
+Examples:
+  npm run release:check -- --base origin/main --branch feature/task-313-version-governance
+  npm run release:check`);
+}
+
+function fail(message) {
+  console.error(`[version-policy] ${message}`);
+  process.exit(1);
+}
+
+function info(message) {
+  console.log(`[version-policy] ${message}`);
+}
+
+function runGit(args, options = {}) {
+  const result = spawnSync("git", args, {
+    encoding: "utf8",
+    ...options,
+  });
+
+  if (result.error) {
+    throw new Error(`git ${args.join(" ")} failed to start: ${result.error.message}`);
+  }
+
+  if (result.status !== 0) {
+    const stderr = result.stderr?.trim();
+    throw new Error(
+      `git ${args.join(" ")} failed${stderr ? `: ${stderr}` : "."}`
+    );
+  }
+
+  return result.stdout;
+}
+
+function readJsonFromWorkingTree(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function readJsonFromGit(ref, path) {
+  return JSON.parse(runGit(["show", `${ref}:${path}`]));
+}
+
+function parseVersion(rawVersion) {
+  const match = String(rawVersion ?? "").match(VERSION_PATTERN);
+  if (!match) {
+    throw new Error(`Invalid product version: ${rawVersion}`);
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+function formatVersion(version) {
+  return `${version.major}.${version.minor}.${version.patch}`;
+}
+
+function compareVersions(left, right) {
+  for (const key of ["major", "minor", "patch"]) {
+    if (left[key] !== right[key]) {
+      return left[key] - right[key];
+    }
+  }
+
+  return 0;
+}
+
+function assertPackageVersionsMatch(packageJson, packageLock, label) {
+  const packageVersion = parseVersion(packageJson.version);
+  const lockVersion = parseVersion(packageLock.version);
+  const rootLockVersion = parseVersion(packageLock.packages?.[""]?.version);
+
+  if (
+    compareVersions(packageVersion, lockVersion) !== 0 ||
+    compareVersions(packageVersion, rootLockVersion) !== 0
+  ) {
+    throw new Error(
+      `${label} package.json and package-lock.json versions must match.`
+    );
+  }
+
+  return packageVersion;
+}
+
+function expectedVersion(baseVersion, branchType) {
+  if (branchType === "feature") {
+    return {
+      major: baseVersion.major,
+      minor: baseVersion.minor + 1,
+      patch: 0,
+    };
+  }
+
+  return {
+    major: baseVersion.major,
+    minor: baseVersion.minor,
+    patch: baseVersion.patch + 1,
+  };
+}
+
+function uniqueFiles(files) {
+  return [...new Set(files)].sort();
+}
+
+function readChangedFiles(baseRef, headRef) {
+  const committedOutput = runGit(["diff", "--name-only", `${baseRef}...${headRef}`]);
+  const workingTreeOutput =
+    headRef === "HEAD" ? runGit(["diff", "--name-only"]) : "";
+  return uniqueFiles(`${committedOutput}\n${workingTreeOutput}`
+    .split(/\r?\n/)
+    .map((file) => file.trim().replaceAll("\\", "/"))
+    .filter(Boolean));
+}
+
+function inferBranchName() {
+  const envBranch =
+    process.env.VERSION_POLICY_BRANCH_NAME ??
+    process.env.GITHUB_HEAD_REF ??
+    process.env.PULL_REQUEST_BRANCH_NAME;
+  if (envBranch) {
+    return envBranch;
+  }
+
+  return runGit(["branch", "--show-current"]).trim();
+}
+
+function getBranchType(branchName) {
+  if (!branchName.includes("/")) {
+    return branchName;
+  }
+
+  return branchName.split("/", 1)[0];
+}
+
+function isProductFile(file) {
+  if (VERSION_METADATA_FILES.has(file)) {
+    return false;
+  }
+
+  return PRODUCT_FILE_PATTERNS.some((pattern) => pattern.test(file));
+}
+
+function readEventLabels() {
+  const labels = new Set();
+  const rawLabels = process.env.VERSION_POLICY_LABELS;
+  if (rawLabels) {
+    for (const label of rawLabels.split(",")) {
+      const normalized = label.trim().toLowerCase();
+      if (normalized) {
+        labels.add(normalized);
+      }
+    }
+  }
+
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) {
+    return labels;
+  }
+
+  try {
+    const event = JSON.parse(readFileSync(eventPath, "utf8"));
+    for (const label of event.pull_request?.labels ?? []) {
+      const name = String(label.name ?? "").trim().toLowerCase();
+      if (name) {
+        labels.add(name);
+      }
+    }
+  } catch {
+    return labels;
+  }
+
+  return labels;
+}
+
+function hasNoReleaseImpactDecision(labels) {
+  return [...labels].some((label) => NO_RELEASE_IMPACT_LABELS.has(label));
+}
+
+function parseArgs(argv) {
+  const options = {
+    baseRef: process.env.VERSION_POLICY_BASE_REF ?? "origin/main",
+    headRef: process.env.VERSION_POLICY_HEAD_REF ?? "HEAD",
+    branchName: process.env.VERSION_POLICY_BRANCH_NAME ?? null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--help" || arg === "-h") {
+      usage();
+      process.exit(0);
+    }
+
+    if (arg === "--base") {
+      options.baseRef = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--head") {
+      options.headRef = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--branch") {
+      options.branchName = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    fail(`Unknown argument: ${arg}`);
+  }
+
+  if (!options.baseRef || !options.headRef) {
+    fail("Both base and head refs are required.");
+  }
+
+  return options;
+}
+
+try {
+  const options = parseArgs(process.argv.slice(2));
+  const branchName = options.branchName ?? inferBranchName();
+  const branchType = getBranchType(branchName);
+  const labels = readEventLabels();
+
+  if (branchType === "dependabot") {
+    info("Dependabot branch detected; product version policy guard skipped.");
+    process.exit(0);
+  }
+
+  const basePackageJson = readJsonFromGit(options.baseRef, "package.json");
+  const basePackageLock = readJsonFromGit(options.baseRef, "package-lock.json");
+  const headPackageJson =
+    options.headRef === "HEAD"
+      ? readJsonFromWorkingTree("package.json")
+      : readJsonFromGit(options.headRef, "package.json");
+  const headPackageLock =
+    options.headRef === "HEAD"
+      ? readJsonFromWorkingTree("package-lock.json")
+      : readJsonFromGit(options.headRef, "package-lock.json");
+
+  const baseVersion = assertPackageVersionsMatch(
+    basePackageJson,
+    basePackageLock,
+    "Base"
+  );
+  const headVersion = assertPackageVersionsMatch(
+    headPackageJson,
+    headPackageLock,
+    "Head"
+  );
+  const versionChanged = compareVersions(baseVersion, headVersion) !== 0;
+  const changedFiles = readChangedFiles(options.baseRef, options.headRef);
+  const productFiles = changedFiles.filter(isProductFile);
+  const noReleaseImpact = hasNoReleaseImpactDecision(labels);
+  const productionBound =
+    branchType === "feature" ||
+    branchType === "fix" ||
+    branchType === "refactor" ||
+    (branchType === "chore" && productFiles.length > 0);
+
+  info(`Branch: ${branchName}`);
+  info(`Base version: ${formatVersion(baseVersion)}`);
+  info(`Head version: ${formatVersion(headVersion)}`);
+
+  if (!productionBound) {
+    if (versionChanged && compareVersions(headVersion, baseVersion) <= 0) {
+      fail("Version metadata changed, but the target version is not greater than base.");
+    }
+
+    info("No production-bound version bump required for this branch.");
+    process.exit(0);
+  }
+
+  if (noReleaseImpact && !versionChanged) {
+    info("No-release-impact decision found; product version bump is not required.");
+    process.exit(0);
+  }
+
+  if (!versionChanged) {
+    fail(
+      `${branchType}/ branches that ship product changes must include a product version bump, or carry a no-release-impact/release:none label.`
+    );
+  }
+
+  const expected = expectedVersion(baseVersion, branchType);
+  if (compareVersions(headVersion, expected) !== 0) {
+    const expectedKind = branchType === "feature" ? "minor" : "patch";
+    fail(
+      `${branchType}/ branches must use a ${expectedKind} bump: expected ${formatVersion(expected)}, received ${formatVersion(headVersion)}.`
+    );
+  }
+
+  if (!changedFiles.includes("CHANGELOG.md")) {
+    fail("Version bumps must update CHANGELOG.md with release notes.");
+  }
+
+  const changelog =
+    options.headRef === "HEAD"
+      ? readFileSync("CHANGELOG.md", "utf8")
+      : runGit(["show", `${options.headRef}:CHANGELOG.md`]);
+  const heading = `## v${formatVersion(headVersion)}`;
+  if (!changelog.includes(heading)) {
+    fail(`CHANGELOG.md must include a ${heading} entry.`);
+  }
+
+  info("Product version policy check passed.");
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error));
+}

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -4,13 +4,22 @@ import { readFileSync } from "node:fs";
 import process from "node:process";
 
 const VERSION_PATTERN = /^v?(\d+)\.(\d+)\.(\d+)$/;
-const BUMP_TYPES = new Set(["patch", "minor", "major"]);
+const BUMP_ALIASES = new Map([
+  ["patch", "patch"],
+  ["fix", "patch"],
+  ["refactor", "patch"],
+  ["chore", "patch"],
+  ["minor", "minor"],
+  ["feature", "minor"],
+  ["major", "major"],
+]);
 
 function usage() {
   console.log(`Usage:
-  npm run release:version -- <patch|minor|major|x.y.z> [--dry-run]
+  npm run release:version -- <feature|fix|refactor|chore|patch|minor|major|x.y.z> [--dry-run]
 
 Examples:
+  npm run release:version -- feature --dry-run
   npm run release:version -- patch --dry-run
   npm run release:version -- minor
   npm run release:version -- 1.0.0`);
@@ -61,12 +70,12 @@ function bumpVersion(current, bumpType) {
 }
 
 function runNpmVersion(targetVersion) {
-  const command = process.platform === "win32" ? "npm.cmd" : "npm";
-  const result = spawnSync(command, [
-    "version",
-    targetVersion,
-    "--no-git-tag-version",
-  ], {
+  const command = process.platform === "win32" ? "cmd.exe" : "npm";
+  const args =
+    process.platform === "win32"
+      ? ["/d", "/s", "/c", `npm version ${targetVersion} --no-git-tag-version`]
+      : ["version", targetVersion, "--no-git-tag-version"];
+  const result = spawnSync(command, args, {
     stdio: "inherit",
   });
 
@@ -97,8 +106,11 @@ if (positional.length !== 1) {
 
 try {
   const requested = positional[0];
-  if (!BUMP_TYPES.has(requested) && !VERSION_PATTERN.test(requested)) {
-    throw new Error(`Expected patch, minor, major, or x.y.z; received ${requested}.`);
+  const resolvedRequest = BUMP_ALIASES.get(requested) ?? requested;
+  if (!BUMP_ALIASES.has(requested) && !VERSION_PATTERN.test(requested)) {
+    throw new Error(
+      `Expected feature, fix, refactor, chore, patch, minor, major, or x.y.z; received ${requested}.`
+    );
   }
 
   const packageJson = readJson("package.json");
@@ -116,7 +128,7 @@ try {
     );
   }
 
-  const target = bumpVersion(current, requested);
+  const target = bumpVersion(current, resolvedRequest);
   if (compareVersions(target, current) <= 0) {
     throw new Error(
       `Target version ${formatVersion(target)} must be greater than current version ${formatVersion(current)}.`

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -6,11 +6,6 @@ Last reviewed: 2026-05-31
 
 ## Pending
 ### Execution Queue (Now / Next)
-- ID: TASK-313
-  Title: App version governance - semantic release increments and build metadata clarity
-  Status: In review
-  Rationale: The app currently displays a stable `v0.2.0` because prior work made `package.json` the canonical product version, but the release process does not yet force intentional increments after meaningful shipped work. Define and implement an industry-standard versioning flow where product versions follow SemVer, production releases increment predictably, build/revision metadata remains distinct from the product version, and CI/release tooling prevents accidental stagnant versions.
-  Dependencies: TASK-087, TASK-132, TASK-272
 ### Deferred (Intentional)
 - ID: TASK-133
   Title: Task UI bug fixing - mini scrollbar and edit modal polish
@@ -112,6 +107,11 @@ Last reviewed: 2026-05-31
   Dependencies: TASK-051
 
 ## Completed
+- ID: TASK-313
+  Title: App version governance - semantic release increments and build metadata clarity
+  Status: Done (2026-06-06, merged via PR #329)
+  Rationale: Implemented branch-based SemVer governance: `feature/*` PRs bump minor/reset patch, release-impacting `fix/*`/`refactor/*`/`chore/*` PRs bump patch, commit/build metadata remains diagnostic, and CI validates package-lock consistency plus changelog entries so product versions cannot stagnate accidentally.
+  Dependencies: TASK-087, TASK-132, TASK-272
 - ID: TASK-224
   Title: Agent roadmap access - scoped API contract for roadmap phases and events
   Status: Done (2026-06-06, merged via PR #326)

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -8,7 +8,7 @@ Last reviewed: 2026-05-31
 ### Execution Queue (Now / Next)
 - ID: TASK-313
   Title: App version governance - semantic release increments and build metadata clarity
-  Status: Pending
+  Status: In review
   Rationale: The app currently displays a stable `v0.2.0` because prior work made `package.json` the canonical product version, but the release process does not yet force intentional increments after meaningful shipped work. Define and implement an industry-standard versioning flow where product versions follow SemVer, production releases increment predictably, build/revision metadata remains distinct from the product version, and CI/release tooling prevents accidental stagnant versions.
   Dependencies: TASK-087, TASK-132, TASK-272
 ### Deferred (Intentional)

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,7 +4,7 @@
 TASK-313
 
 ## Status
-Implemented locally; PR workflow pending.
+Complete once PR #329 merges.
 
 ## Source
 - User feedback on 2026-06-06: the app previously showed `0.1.<commit>` and
@@ -81,4 +81,4 @@ version plus diagnostic revision metadata.
 - [x] Version increment automation or CI guardrails are implemented.
 - [x] App metadata behavior remains tested.
 - [x] Relevant validation passes.
-- [ ] PR workflow is completed according to `agent.md`.
+- [x] PR workflow is completed according to `agent.md`.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,7 +4,7 @@
 TASK-313
 
 ## Status
-Pending investigation and implementation.
+Implemented locally; PR workflow pending.
 
 ## Source
 - User feedback on 2026-06-06: the app previously showed `0.1.<commit>` and
@@ -30,14 +30,30 @@ Going back to `0.1.<commit>` would also be wrong: commit SHA/build revision is
 not the same as product version. The right target is a clear product release
 version plus diagnostic revision metadata.
 
-## Scope
-- Review current versioning implementation, docs, workflows, and release helper.
-- Decide the release policy: per-production-merge patch bumps vs batched release
-  PRs, with explicit tradeoffs.
-- Implement the selected policy with automation and CI/release guardrails.
-- Ensure visible app metadata and diagnostic metadata match the policy.
-- Update docs/runbooks/changelog expectations.
-- Add tests for version metadata and any guard logic.
+## Selected Policy
+- Keep `package.json` as the canonical product version.
+- Keep commit SHA/build metadata separate from the visible product version.
+- Do not use commit count in SemVer; it is repository/build metadata, not
+  release intent.
+- `feature/*` PRs that ship meaningful product work bump minor and reset patch,
+  for example `0.2.0` to `0.3.0`.
+- Release-impacting `fix/*`, `refactor/*`, and `chore/*` PRs bump patch, for
+  example `0.3.0` to `0.3.1`.
+- `docs/*`, Dependabot, routine CI cleanup, and task-tracking-only work hold
+  steady unless explicitly converted into a product release.
+- `1.0.0` remains reserved for the first stable product baseline.
+
+## Implementation Summary
+- Added `scripts/check-version-policy.mjs` and `npm run release:check`.
+- Wired the version policy guard into the PR Quality Core workflow.
+- Extended `scripts/release-version.mjs` with branch-type aliases:
+  `feature`, `fix`, `refactor`, and `chore`.
+- Bumped the app product version from `0.2.0` to `0.3.0` for this
+  `feature/*` implementation PR.
+- Updated release/version docs, README metadata guidance, changelog, and app
+  metadata tests.
+- Added guard tests that exercise feature minor bumps, fix patch requirements,
+  changelog enforcement, and docs-only no-bump behavior.
 
 ## Out Of Scope
 - Changing dependency package versions for their own sake.
@@ -60,9 +76,9 @@ version plus diagnostic revision metadata.
 7. Tests cover the implemented version metadata and guard behavior.
 
 ## Definition Of Done
-- [ ] Existing TASK-272 and TASK-132 decisions are reviewed.
-- [ ] Policy and implementation path are documented.
-- [ ] Version increment automation or CI guardrails are implemented.
-- [ ] App metadata behavior remains tested.
-- [ ] Relevant validation passes.
+- [x] Existing TASK-272 and TASK-132 decisions are reviewed.
+- [x] Policy and implementation path are documented.
+- [x] Version increment automation or CI guardrails are implemented.
+- [x] App metadata behavior remains tested.
+- [x] Relevant validation passes.
 - [ ] PR workflow is completed according to `agent.md`.

--- a/tasks/task-313-app-version-governance.md
+++ b/tasks/task-313-app-version-governance.md
@@ -1,7 +1,7 @@
 # TASK-313 App Version Governance
 
 ## Status
-Pending.
+Implemented locally; PR workflow pending.
 
 ## Source
 - User feedback on 2026-06-06: the app used to show `0.1.<commit>` and now
@@ -32,24 +32,21 @@ Create a durable versioning system where NexusDash:
 - makes the visible app version logical to users;
 - gives maintainers a low-friction release process and CI guardrails.
 
-## Proposed Direction
+## Selected Direction
 - Keep `package.json` as the canonical product version.
-- Preserve clean user-facing product display such as `v0.2.1`.
+- Preserve clean user-facing product display such as `v0.3.0`.
 - Preserve diagnostic metadata separately, for example `revision`, commit SHA,
   deployment environment, and build date where available.
+- Do not use commit count as part of SemVer. Commit count can describe build
+  shape, but not product release intent.
 - Define pre-1.0 semantics explicitly:
   - `major`: reserved for the `1.0.0` milestone or breaking public API/contract
     decisions.
-  - `minor`: meaningful product capability bundles or visible milestone
-    releases.
-  - `patch`: fixes, focused improvements, documentation/contract corrections,
-    and small shipped changes.
-- Add automation so release PRs can bump versions predictably and CI can detect
-  when production-bound feature/fix work did not include an intentional version
-  decision.
-- Decide whether every merged production PR should bump at least patch, or
-  whether several PRs may accumulate under a single release PR. The chosen
-  policy must be explicit and enforced.
+  - `minor`: meaningful `feature/*` product capabilities; reset patch to `0`.
+  - `patch`: release-impacting `fix/*`, `refactor/*`, and `chore/*` work.
+- Add automation so production-bound feature/fix/refactor/chore work cannot
+  merge without an intentional version decision, matching package-lock
+  metadata, and release notes.
 
 ## Acceptance Criteria
 1. A clear versioning policy exists in the repo and explains product version vs
@@ -66,13 +63,13 @@ Create a durable versioning system where NexusDash:
 7. Tests cover version metadata formatting and any new release/version guard.
 
 ## Definition Of Done
-- [ ] Existing TASK-272/TASK-132 decisions are reviewed and either preserved,
+- [x] Existing TASK-272/TASK-132 decisions are reviewed and either preserved,
       amended, or superseded with a documented rationale.
-- [ ] Versioning policy and runbook updates are merged.
-- [ ] Release/version automation or CI guardrails are implemented.
-- [ ] App metadata tests cover product version and build metadata behavior.
-- [ ] `npm run release:version -- patch --dry-run` or equivalent passes.
-- [ ] `npm run lint`, relevant tests, and `npm run build` pass.
+- [x] Versioning policy and runbook updates are ready for review.
+- [x] Release/version automation or CI guardrails are implemented.
+- [x] App metadata tests cover product version and build metadata behavior.
+- [x] `npm run release:version -- feature --dry-run` passes.
+- [x] `npm run lint`, relevant tests, and `npm run build` pass.
 - [ ] A PR is opened, Copilot feedback is handled, and the task is marked
       complete only after merge.
 

--- a/tasks/task-313-app-version-governance.md
+++ b/tasks/task-313-app-version-governance.md
@@ -1,7 +1,7 @@
 # TASK-313 App Version Governance
 
 ## Status
-Implemented locally; PR workflow pending.
+Complete once PR #329 merges.
 
 ## Source
 - User feedback on 2026-06-06: the app used to show `0.1.<commit>` and now
@@ -70,7 +70,7 @@ Create a durable versioning system where NexusDash:
 - [x] App metadata tests cover product version and build metadata behavior.
 - [x] `npm run release:version -- feature --dry-run` passes.
 - [x] `npm run lint`, relevant tests, and `npm run build` pass.
-- [ ] A PR is opened, Copilot feedback is handled, and the task is marked
+- [x] A PR is opened, Copilot feedback is handled, and the task is marked
       complete only after merge.
 
 ## Initial Implementation Notes

--- a/tests/lib/app-metadata.test.ts
+++ b/tests/lib/app-metadata.test.ts
@@ -60,10 +60,10 @@ describe("app-metadata", () => {
 
     const summary = getAppMetadataSummary();
 
-    expect(summary.versionTag).toBe("v0.2.0");
+    expect(summary.versionTag).toBe("v0.3.0");
     expect(summary.revision).toBeNull();
     expect(summary.revisionLabel).toBeNull();
-    expect(summary.versionLabel).toBe("v0.2.0");
+    expect(summary.versionLabel).toBe("v0.3.0");
   });
 
   test("strips build metadata from the visible version", () => {
@@ -84,8 +84,8 @@ describe("app-metadata", () => {
 
     const summary = getAppMetadataSummary();
 
-    expect(summary.versionTag).toBe("v0.2.0");
-    expect(summary.versionLabel).toBe("v0.2.0");
+    expect(summary.versionTag).toBe("v0.3.0");
+    expect(summary.versionLabel).toBe("v0.3.0");
   });
 
   test("uses optional repository override when present", () => {

--- a/tests/scripts/version-policy.test.ts
+++ b/tests/scripts/version-policy.test.ts
@@ -182,4 +182,18 @@ describe("version policy guard", () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("No production-bound version bump required");
   });
+
+  test("rejects docs branch version bumps without release notes", () => {
+    const cwd = createRepo();
+    repos.push(cwd);
+    git(cwd, ["checkout", "-b", "docs/task-313-brief"]);
+    writePackageFiles(cwd, "0.2.1");
+    writeText(cwd, "docs/versioning.md", "Versioning note.\n");
+    commitAll(cwd, "docs");
+
+    const result = runPolicy(cwd, "docs/task-313-brief");
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Version bumps must update CHANGELOG.md");
+  });
 });

--- a/tests/scripts/version-policy.test.ts
+++ b/tests/scripts/version-policy.test.ts
@@ -1,0 +1,185 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { afterEach, describe, expect, test } from "vitest";
+
+const SCRIPT_PATH = join(process.cwd(), "scripts/check-version-policy.mjs");
+
+function runCommand(cwd: string, command: string, args: string[]) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+  });
+
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(" ")} failed:\n${result.stdout}\n${result.stderr}`
+    );
+  }
+
+  return result;
+}
+
+function git(cwd: string, args: string[]) {
+  return runCommand(cwd, "git", args);
+}
+
+function writeJson(path: string, value: unknown) {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writePackageFiles(cwd: string, version: string) {
+  writeJson(join(cwd, "package.json"), {
+    name: "nexusdash",
+    version,
+    private: true,
+  });
+  writeJson(join(cwd, "package-lock.json"), {
+    name: "nexusdash",
+    version,
+    lockfileVersion: 3,
+    packages: {
+      "": {
+        name: "nexusdash",
+        version,
+      },
+    },
+  });
+}
+
+function writeText(cwd: string, path: string, content: string) {
+  const fullPath = join(cwd, path);
+  mkdirSync(join(fullPath, ".."), { recursive: true });
+  writeFileSync(fullPath, content);
+}
+
+function commitAll(cwd: string, message: string) {
+  git(cwd, ["add", "."]);
+  git(cwd, [
+    "-c",
+    "user.name=NexusDash Test",
+    "-c",
+    "user.email=test@nexusdash.local",
+    "commit",
+    "-m",
+    message,
+  ]);
+}
+
+function createRepo() {
+  const cwd = mkdtempSync(join(tmpdir(), "nexusdash-version-policy-"));
+  git(cwd, ["init", "-b", "main"]);
+  writePackageFiles(cwd, "0.2.0");
+  writeText(
+    cwd,
+    "CHANGELOG.md",
+    "# Changelog\n\n## Unreleased\n\n- Define each release entry before the release PR is merged.\n"
+  );
+  commitAll(cwd, "base");
+  return cwd;
+}
+
+function runPolicy(cwd: string, branch: string) {
+  return spawnSync(
+    process.execPath,
+    [SCRIPT_PATH, "--base", "main", "--branch", branch],
+    {
+      cwd,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GITHUB_EVENT_PATH: "",
+      },
+    }
+  );
+}
+
+describe("version policy guard", () => {
+  const repos: string[] = [];
+
+  afterEach(() => {
+    for (const repo of repos.splice(0)) {
+      rmSync(repo, { force: true, recursive: true });
+    }
+  });
+
+  test("allows feature branches with a minor bump and changelog entry", () => {
+    const cwd = createRepo();
+    repos.push(cwd);
+    git(cwd, ["checkout", "-b", "feature/task-313-version-governance"]);
+    writePackageFiles(cwd, "0.3.0");
+    writeText(cwd, "app/page.tsx", "export default function Page() { return null; }\n");
+    writeText(
+      cwd,
+      "CHANGELOG.md",
+      "# Changelog\n\n## Unreleased\n\n- Define each release entry before the release PR is merged.\n\n## v0.3.0 - 2026-06-06\n\n- Added version governance.\n"
+    );
+    commitAll(cwd, "feature");
+
+    const result = runPolicy(cwd, "feature/task-313-version-governance");
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Product version policy check passed.");
+  });
+
+  test("rejects feature branches with a patch bump", () => {
+    const cwd = createRepo();
+    repos.push(cwd);
+    git(cwd, ["checkout", "-b", "feature/task-313-version-governance"]);
+    writePackageFiles(cwd, "0.2.1");
+    writeText(cwd, "app/page.tsx", "export default function Page() { return null; }\n");
+    writeText(
+      cwd,
+      "CHANGELOG.md",
+      "# Changelog\n\n## Unreleased\n\n- Define each release entry before the release PR is merged.\n\n## v0.2.1 - 2026-06-06\n\n- Added version governance.\n"
+    );
+    commitAll(cwd, "feature");
+
+    const result = runPolicy(cwd, "feature/task-313-version-governance");
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("expected 0.3.0, received 0.2.1");
+  });
+
+  test("rejects release-impacting fix branches without a patch bump", () => {
+    const cwd = createRepo();
+    repos.push(cwd);
+    git(cwd, ["checkout", "-b", "fix/task-modal-bug"]);
+    writeText(cwd, "lib/task-modal.ts", "export const fixed = true;\n");
+    commitAll(cwd, "fix");
+
+    const result = runPolicy(cwd, "fix/task-modal-bug");
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("must include a product version bump");
+  });
+
+  test("rejects version bumps without a matching changelog entry", () => {
+    const cwd = createRepo();
+    repos.push(cwd);
+    git(cwd, ["checkout", "-b", "fix/task-modal-bug"]);
+    writePackageFiles(cwd, "0.2.1");
+    writeText(cwd, "lib/task-modal.ts", "export const fixed = true;\n");
+    commitAll(cwd, "fix");
+
+    const result = runPolicy(cwd, "fix/task-modal-bug");
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Version bumps must update CHANGELOG.md");
+  });
+
+  test("allows docs branches without a product version bump", () => {
+    const cwd = createRepo();
+    repos.push(cwd);
+    git(cwd, ["checkout", "-b", "docs/task-313-brief"]);
+    writeText(cwd, "docs/versioning.md", "Versioning note.\n");
+    commitAll(cwd, "docs");
+
+    const result = runPolicy(cwd, "docs/task-313-brief");
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("No production-bound version bump required");
+  });
+});


### PR DESCRIPTION
## Summary
- Implement TASK-313 app version governance with branch-based SemVer release decisions
- Bump product version from `0.2.0` to `0.3.0` for this `feature/*` PR
- Add `npm run release:check` and wire the version policy guard into PR Quality Core
- Extend the release helper with `feature`, `fix`, `refactor`, and `chore` aliases
- Update release docs, README metadata guidance, changelog, and task tracking docs

## Version Policy
- `feature/*`: minor bump and patch reset, e.g. `0.2.0` -> `0.3.0`
- release-impacting `fix/*`, `refactor/*`, `chore/*`: patch bump, e.g. `0.3.0` -> `0.3.1`
- docs/dependabot/task-tracking-only work: hold steady unless explicitly released
- commit/build metadata stays separate from visible product SemVer

## Validation
- `git diff --check`
- `npm run release:check -- --base origin/main --branch feature/task-313-version-governance`
- `npx vitest run tests/lib/app-metadata.test.ts tests/scripts/version-policy.test.ts`
- `npm run release:version -- feature --dry-run`
- `npm run lint`
- CI-shaped `npm test`
- CI-shaped `npm run test:coverage`
- full-env `npm run build`

Notes: the first local full-test attempt exposed a stale generated Prisma Client missing roadmap enum values; `npx prisma generate` restored the expected local client, matching CI's generate step, before the green run.