### PR TITLE
TASK-313 Correct historical app version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ SHA, deployment URL, and workflow run belong in release evidence.
 
 - Define each release entry before the product-impacting PR is merged.
 
+## v0.18.0 - 2026-06-08
+
+- Corrected the app product version after auditing the merge history from
+  TASK-132/#270 (`v0.2.0`) through TASK-313/#329.
+- Backfilled the branch-based SemVer policy across shipped non-doc feature
+  work so the current app version reflects the product capabilities already
+  delivered instead of only the version-governance PR.
+- Recorded the reconciliation basis in
+  `docs/releases/version-reconciliation-2026-06-08.md`.
+
 ## v0.3.0 - 2026-06-06
 
 - Added product version governance so feature branches bump minor versions,

--- a/README.md
+++ b/README.md
@@ -405,10 +405,10 @@ minor and reset patch, for example `0.2.0` to `0.3.0`; release-impacting
 detailed checklist lives in
 [`docs/runbooks/release-versioning.md`](docs/runbooks/release-versioning.md).
 
-The running app displays only the clean product version, for example `v0.3.0`.
+The running app displays only the clean product version, for example `v0.18.0`.
 Build revision and runtime environment are kept as diagnostic metadata so
 operators can identify the deployed commit without turning the user-facing
-version into `v0.3.0+<sha>`.
+version into `v0.18.0+<sha>`.
 
 The Vercel deploy workflow resolves metadata from the checked-out ref and
 injects:

--- a/docs/releases/version-reconciliation-2026-06-08.md
+++ b/docs/releases/version-reconciliation-2026-06-08.md
@@ -1,0 +1,57 @@
+# Version Reconciliation - 2026-06-08
+
+## Summary
+
+NexusDash was at `v0.2.0` after TASK-132/#270 made `package.json` the
+canonical product-version source. TASK-313/#329 implemented branch-based SemVer
+governance and bumped the app to `v0.3.0`, but that only counted the governance
+PR itself. The shipped history between `v0.2.0` and TASK-313 already contained
+multiple non-doc feature releases.
+
+Applying the TASK-313 policy retroactively, the current app version should be
+`v0.18.0`.
+
+## Applied Rule
+
+- `feature/*` PRs that shipped non-doc product, runtime, or operational
+  capability incremented the minor version and reset patch to `0`.
+- Release-impacting `fix/*` PRs incremented patch until the next minor release.
+- Documentation-only, task-tracking-only, dependency, and investigation report
+  PRs did not move the product version.
+- Commit count was ignored because it is build/repository metadata, not product
+  release intent.
+
+## Release Path
+
+| PR | Branch | Classification | Result |
+| --- | --- | --- | --- |
+| #270 | `feature/task-132-version-update-system` | Baseline product metadata release | `v0.2.0` |
+| #271 | `feature/task-268-github-actions-notification-email-scheduler` | Minor: notification email dispatch scheduler | `v0.3.0` |
+| #274 | `fix/notification-email-dispatch-production-origin` | Patch: production dispatch target fix | `v0.3.1` |
+| #275 | `fix/task-271-notification-email-no-repeat` | Patch: notification digest deduplication | `v0.3.2` |
+| #278 | `feature/task-226-task-due-date-email-reminders` | Minor: task due-date email reminders | `v0.4.0` |
+| #277 | `feature/task-265-notification-actor-attribution` | Minor: notification actor attribution | `v0.5.0` |
+| #279 | `fix/task-226-due-reminder-rls` | Patch: due reminder RLS reconciliation | `v0.5.1` |
+| #288 | `feature/task-273-cost-aware-scheduler` | Minor: scheduler cadence implementation | `v0.6.0` |
+| #289 | `fix/task-273-notification-workflow-yaml` | Patch: scheduler workflow YAML repair | `v0.6.1` |
+| #290 | `fix/task-273-rollback` | Patch: scheduler rollback | `v0.6.2` |
+| #291 | `feature/task-273-cost-aware-scheduler-review` | Minor: scheduler cadence reimplementation | `v0.7.0` |
+| #293 | `feature/task-266-pg-query-deprecation-cleanup` | Minor: runtime transaction serialization | `v0.8.0` |
+| #305 | `feature/task-118-realtime-collaboration` | Minor: live project refresh | `v0.9.0` |
+| #307 | `fix/task-306-mention-cursor-spacing` | Patch: mention cursor spacing fix | `v0.9.1` |
+| #309 | `feature/task-307-agent-comment-identity` | Minor: agent comment identity | `v0.10.0` |
+| #314 | `feature/task-276-performance-remediation` | Minor: dashboard mutation responsiveness | `v0.11.0` |
+| #315 | `feature/task-308-smart-live-refresh` | Minor: smart live project refresh | `v0.12.0` |
+| #316 | `feature/task-309-realtime-event-stream` | Minor: realtime SSE foundation | `v0.13.0` |
+| #318 | `feature/task-311-product-latency-remediation` | Minor: typed realtime reconciliation | `v0.14.0` |
+| #319 | `feature/task-312-hide-project-refresh-affordance` | Minor: hidden refresh reconciliation | `v0.15.0` |
+| #320 | `feature/task-263-live-notification-updates` | Minor: realtime notification updates | `v0.16.0` |
+| #326 | `feature/task-224-agent-roadmap-access` | Minor: agent roadmap API access | `v0.17.0` |
+| #329 | `feature/task-313-version-governance` | Minor: version governance implementation | `v0.18.0` |
+
+## Explicit Non-Movers
+
+The audit intentionally did not count docs-only/task-tracking PRs, performance
+investigation reports, Dependabot updates, and routine workflow/dependency
+maintenance PRs. Examples include #272, #273, #276, #280, #287, #292, #294,
+#296, #310, #311, #317, #327, and #328.

--- a/docs/runbooks/release-versioning.md
+++ b/docs/runbooks/release-versioning.md
@@ -53,6 +53,14 @@ The CI `release:check` guard validates these rules for PRs:
 - A production-bound PR without a version bump must carry an explicit
   `no-release-impact` or `release:none` label.
 
+Historical reconciliation is the one version-only exception: when maintainers
+discover that the current product version is already behind shipped history, use
+a `chore/*` PR with an explicit target version, matching package-lock metadata,
+a changelog entry, and a reconciliation note under `docs/releases/`. Because
+that PR changes release metadata rather than shipping new product runtime files,
+`release:check` validates that the target is greater than the base version and
+that release notes exist, without forcing the normal patch/minor branch mapping.
+
 ## 1.0.0 Readiness
 
 Move to `1.0.0` when the team is ready to preserve the core product contract:

--- a/docs/runbooks/vercel-env-contract-and-secrets.md
+++ b/docs/runbooks/vercel-env-contract-and-secrets.md
@@ -26,7 +26,7 @@ Optional but bounded:
 
 ## App Metadata
 
-The app displays a clean product version such as `v0.3.0`. The commit SHA is
+The app displays a clean product version such as `v0.18.0`. The commit SHA is
 not appended to that visible version; it is kept as diagnostic metadata for
 operators.
 

--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,17 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-06-08 - Version history reconciliation
+
+- Summary: Audited merged PR history from TASK-132/#270 (`v0.2.0`) through
+  TASK-313/#329 and corrected the current app version to `v0.18.0`.
+- Decision: Count non-doc `feature/*` PRs as minor releases, count
+  release-impacting `fix/*` PRs as patch releases until the next minor, and
+  ignore docs-only/task-tracking/dependency/investigation-report PRs. Commit
+  count remains diagnostic metadata and does not influence SemVer.
+- Evidence: Added `docs/releases/version-reconciliation-2026-06-08.md` with
+  the PR-by-PR release path.
+
 # 2026-06-06 - TASK-313 app version governance implemented
 
 - Summary: Implemented branch-based product version governance. `feature/*`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexusdash",
-  "version": "0.3.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexusdash",
-      "version": "0.3.0",
+      "version": "0.18.0",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1056.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexusdash",
-  "version": "0.3.0",
+  "version": "0.18.0",
   "private": true,
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0",

--- a/tests/lib/app-metadata.test.ts
+++ b/tests/lib/app-metadata.test.ts
@@ -60,10 +60,10 @@ describe("app-metadata", () => {
 
     const summary = getAppMetadataSummary();
 
-    expect(summary.versionTag).toBe("v0.3.0");
+    expect(summary.versionTag).toBe("v0.18.0");
     expect(summary.revision).toBeNull();
     expect(summary.revisionLabel).toBeNull();
-    expect(summary.versionLabel).toBe("v0.3.0");
+    expect(summary.versionLabel).toBe("v0.18.0");
   });
 
   test("strips build metadata from the visible version", () => {
@@ -84,8 +84,8 @@ describe("app-metadata", () => {
 
     const summary = getAppMetadataSummary();
 
-    expect(summary.versionTag).toBe("v0.3.0");
-    expect(summary.versionLabel).toBe("v0.3.0");
+    expect(summary.versionTag).toBe("v0.18.0");
+    expect(summary.versionLabel).toBe("v0.18.0");
   });
 
   test("uses optional repository override when present", () => {


### PR DESCRIPTION
## Summary
- Correct the current app version from `0.3.0` to `0.18.0` after auditing merged history from TASK-132/#270 through TASK-313/#329
- Add a release reconciliation note with the PR-by-PR version path
- Update package metadata, changelog, metadata docs, and app metadata fallback tests

## Version Audit Result
Starting from `v0.2.0` at TASK-132/#270, the shipped non-doc feature history reaches `v0.18.0` under the TASK-313 policy:
- feature/non-doc capability PRs bump minor and reset patch
- release-impacting fixes bump patch until the next minor
- docs-only, task tracking, investigation reports, and dependency maintenance do not move product version
- commit count remains diagnostic metadata, not SemVer input

## Validation
- `npm run release:check -- --base origin/main --branch chore/task-313-version-history-correction`
- `npx vitest run tests/lib/app-metadata.test.ts`
- `git diff --check`