### PR TITLE
TASK-315 Document protected preview agent diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Runbooks:
 - `docs/runbooks/database-connection-hardening.md`
 - `docs/runbooks/notification-email-dispatch.md`
 - `docs/runbooks/release-versioning.md`
+- `docs/runbooks/protected-preview-agent-access.md`
 
 ## Attachments and Storage
 
@@ -312,6 +313,13 @@ VERCEL_AUTOMATION_BYPASS_SECRET=<32-char-secret>
 
 The Playwright config forwards that secret through the Vercel preview-protection
 headers so smoke runs can target the deployed branch preview directly.
+
+For manual agent API checks, the NexusDash raw key does not bypass Vercel
+deployment protection. Use `vercel curl` (optionally with
+`--protection-bypass`) and exchange the raw key with
+`Authorization: ApiKey <key>`. Reserve `Authorization: Bearer` for the
+short-lived token returned by the exchange. See
+[`docs/runbooks/protected-preview-agent-access.md`](docs/runbooks/protected-preview-agent-access.md).
 
 ### Notification Email Dispatch
 

--- a/docs/runbooks/protected-preview-agent-access.md
+++ b/docs/runbooks/protected-preview-agent-access.md
@@ -1,0 +1,131 @@
+# Protected Preview Agent Access Diagnostics
+
+Use this runbook when an agent credential appears `Active` in Project settings
+but token exchange against a Vercel preview fails.
+
+## Two Independent Authentication Layers
+
+A protected preview has two gates:
+
+1. Vercel deployment protection decides whether the request may reach the
+   deployment.
+2. NexusDash validates the project agent API key at
+   `POST /api/auth/agent/token`.
+
+The copied NexusDash env block configures the second layer only. It does not
+bypass Vercel deployment protection.
+
+## Correct NexusDash Authentication Schemes
+
+Exchange the one-time raw API key with the canonical header:
+
+```text
+Authorization: ApiKey <raw-agent-api-key>
+```
+
+`x-agent-api-key: <raw-agent-api-key>` and a JSON `apiKey` body remain
+compatibility alternatives.
+
+Do not send the raw API key as `Authorization: Bearer`. `Bearer` is reserved for
+the short-lived access token returned by a successful exchange.
+
+## Preferred Protected-Preview Check
+
+Vercel CLI can target a deployment and handle its protection layer. Keep the
+raw key in an environment variable so it is not copied into shell history,
+logs, issue comments, or PR descriptions.
+
+```bash
+npx vercel curl /api/auth/agent/token \
+  --deployment https://your-preview.vercel.app \
+  -- \
+  --request POST \
+  --header "Authorization: ApiKey ${NEXUSDASH_API_KEY}"
+```
+
+PowerShell:
+
+```pwsh
+npx vercel curl /api/auth/agent/token `
+  --deployment https://your-preview.vercel.app `
+  -- `
+  --request POST `
+  --header "Authorization: ApiKey $env:NEXUSDASH_API_KEY"
+```
+
+For non-interactive automation, pass the configured Vercel protection bypass
+secret separately from the NexusDash API key:
+
+```bash
+npx vercel curl /api/auth/agent/token \
+  --deployment https://your-preview.vercel.app \
+  --protection-bypass "${VERCEL_AUTOMATION_BYPASS_SECRET}" \
+  -- \
+  --request POST \
+  --header "Authorization: ApiKey ${NEXUSDASH_API_KEY}"
+```
+
+Never commit either secret or print command tracing that expands them.
+
+## Distinguish Platform Interception From App Rejection
+
+| Signal | Vercel protection intercepted | NexusDash rejected the key |
+| --- | --- | --- |
+| Status | Usually `401` | `401` |
+| Content type | HTML | JSON |
+| Body | Vercel `Authentication Required` page | `{"error":"invalid-api-key"}` |
+| NexusDash request/audit evidence | No route or exchange event | App request reached token exchange; failed-attempt controls apply |
+| Fix | Authenticate to/bypass preview protection | Use the current raw key, or rotate/recreate the credential |
+
+Do not classify a response as `invalid-api-key` from the status code alone.
+Inspect the response content type and body first.
+
+## Diagnostic Sequence
+
+1. Confirm the exact preview URL matches `NEXUSDASH_BASE_URL`.
+2. Confirm Project settings shows the intended credential as `Active`.
+3. Use `vercel curl` against `/api/health/live` to verify preview access.
+4. Exchange the raw key with `Authorization: ApiKey`, not `Bearer`.
+5. Confirm a successful JSON response includes `accessToken`, `projectId`,
+   `expiresAt`, and `scopes`.
+6. Call a scoped project route with
+   `Authorization: Bearer <returned-access-token>`.
+7. Check the owner-visible audit trail for `Token exchanged` and subsequent
+   request use.
+
+If Vercel returns HTML, fix preview access first. Rotating the NexusDash
+credential cannot change a request that never reached the app.
+
+If NexusDash returns JSON `invalid-api-key`, verify that the raw key belongs to
+the displayed public ID and environment. Raw keys are shown once; an env file
+can remain stale after rotation or revocation even though the UI correctly
+shows the replacement credential as active.
+
+## Rotation And Revocation Assertions
+
+After rotating a credential:
+
+- the old raw key must return NexusDash JSON `invalid-api-key`;
+- the newly displayed raw key must exchange successfully;
+- the credential public ID and audit trail should identify the current
+  credential without exposing either secret.
+
+After revocation:
+
+- Project settings must show `Revoked`, not `Active`;
+- the revoked raw key must return NexusDash JSON `invalid-api-key`;
+- no new bearer token may be issued.
+
+## Secret-Safe Evidence
+
+Safe validation evidence includes:
+
+- deployment URL;
+- HTTP status and content type;
+- app error code;
+- credential label and public ID;
+- NexusDash request ID or Vercel trace ID;
+- audit action and timestamp.
+
+Never record the raw API key, returned bearer token, protection bypass secret,
+or full authorization headers.

--- a/docs/runbooks/task-059-agent-access-preview-validation.md
+++ b/docs/runbooks/task-059-agent-access-preview-validation.md
@@ -13,6 +13,10 @@ are recorded, and rotation/revocation take effect immediately for new exchanges.
 
 - Target preview deployment is live for `feature/task-059-agent-access`.
 - If preview protection is enabled, use `vercel curl` for scripted checks.
+- Read
+  [`protected-preview-agent-access.md`](protected-preview-agent-access.md)
+  before interpreting a preview `401`; Vercel HTML interception and NexusDash
+  JSON `invalid-api-key` are different failures.
 - Use a disposable project owned by a disposable verified user, or a dedicated
   non-production owner account.
 - Keep validation data isolated and delete it after the run.
@@ -31,8 +35,11 @@ are recorded, and rotation/revocation take effect immediately for new exchanges.
    - Owner summary lists the new credential as `active`.
 
 3. Token exchange
-   - `POST /api/auth/agent/token` with the raw API key returns `200`.
+   - `POST /api/auth/agent/token` with
+     `Authorization: ApiKey <raw-agent-api-key>` returns `200`.
    - Response includes bearer token, `projectId`, `expiresAt`, and scopes.
+   - The returned token, not the raw API key, is sent as
+     `Authorization: Bearer <access-token>` on scoped routes.
 
 4. Project read scope
    - `GET /api/projects/:projectId` with the bearer token returns `200`.
@@ -95,6 +102,12 @@ are recorded, and rotation/revocation take effect immediately for new exchanges.
 npx vercel curl /api/health/live --deployment <preview-url>
 ```
 
+- A direct `401` with an HTML `Authentication Required` body is Vercel
+  deployment protection, not an agent-key verdict. An app-owned invalid key
+  response is JSON: `{"error":"invalid-api-key"}`.
+- The project env block does not bypass preview protection. Use Vercel CLI
+  authentication or the `--protection-bypass` option with
+  `VERCEL_AUTOMATION_BYPASS_SECRET` in non-interactive automation.
 - For JSON routes, send request bodies with `curl --data-binary @file.json` to
   avoid shell escaping mistakes.
 

--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,23 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-06-18 - TASK-315 protected preview agent diagnostics
+
+- Summary: Reconciled GitHub issue #313 with the confirmed reproduction: the
+  active credential was valid, while Vercel deployment protection returned an
+  HTML `401 Authentication Required` response before NexusDash received the
+  direct request.
+- Decision: Added a dedicated diagnostic runbook that separates Vercel preview
+  access from NexusDash key validation, documents `ApiKey` for raw-key exchange
+  versus `Bearer` for returned access tokens, and defines secret-safe response,
+  audit, rotation, and revocation evidence.
+- Validation: Confirmed the documented command shape against Vercel CLI
+  `54.14.2` help, verified runbook links and authentication wording with `rg`,
+  passed `git diff --check`, and passed
+  `npm run release:check -- --base origin/main --branch
+  docs/task-315-protected-preview-agent-diagnostics` with no product version
+  bump required.
+
 # 2026-06-08 - Version history reconciliation
 
 - Summary: Audited merged PR history from TASK-132/#270 (`v0.2.0`) through

--- a/journal.md
+++ b/journal.md
@@ -19,6 +19,9 @@ Use it for important implementation milestones, blockers, validation runs, and r
   `npm run release:check -- --base origin/main --branch
   docs/task-315-protected-preview-agent-diagnostics` with no product version
   bump required.
+- GitHub evidence: PR #333 passed branch-name, Quality Core, E2E Smoke, and
+  Container Image checks. Copilot reviewed all changed files and produced no
+  comments or unresolved threads.
 
 # 2026-06-08 - Version history reconciliation
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -8,7 +8,7 @@ Last reviewed: 2026-05-31
 ### Execution Queue (Now / Next)
 - ID: TASK-315
   Title: Protected preview agent-access diagnostics
-  Status: In Progress
+  Status: Complete once PR #333 merges
   Rationale: Resolve GitHub issue #313 by documenting how Vercel deployment
     protection can intercept token exchange before NexusDash, how to use the
     correct raw-key and bearer-token schemes, and how to distinguish platform

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -6,6 +6,14 @@ Last reviewed: 2026-05-31
 
 ## Pending
 ### Execution Queue (Now / Next)
+- ID: TASK-315
+  Title: Protected preview agent-access diagnostics
+  Status: In Progress
+  Rationale: Resolve GitHub issue #313 by documenting how Vercel deployment
+    protection can intercept token exchange before NexusDash, how to use the
+    correct raw-key and bearer-token schemes, and how to distinguish platform
+    HTML failures from app-owned JSON key rejection.
+  Dependencies: TASK-059, TASK-115
 ### Deferred (Intentional)
 - ID: TASK-133
   Title: Task UI bug fixing - mini scrollbar and edit modal polish

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,84 +1,45 @@
-# Current Task: TASK-313 App Version Governance
+# Current Task: TASK-315 Protected Preview Agent Diagnostics
 
 ## Task ID
-TASK-313
+TASK-315
 
 ## Status
-Complete once PR #329 merges.
+In Progress
 
 ## Source
-- User feedback on 2026-06-06: the app previously showed `0.1.<commit>` and
-  now constantly shows `0.2.0`; the version number has no visible logic and
-  should increment according to an industry-standard approach.
-- Existing completed tasks:
-  - TASK-087 exposed product metadata in the app.
-  - TASK-272 defined a release-version cadence and helper.
-  - TASK-132 made `package.json` the canonical product version and separated
-    user-facing version from commit SHA.
+- GitHub issue #313: Investigate active agent credential returning
+  `invalid-api-key` on preview token exchange.
+- Follow-up reproduction confirmed the credential was valid and Vercel
+  deployment protection intercepted direct requests before the app route.
 
 ## Objective
-Review and fix NexusDash app version governance so the product version follows
-SemVer-compatible release logic, increments predictably for production releases,
-and keeps build/revision metadata separate and useful for diagnostics.
+Document a deterministic, secret-safe way to distinguish Vercel preview
+protection from NexusDash agent-key rejection and validate agent access against
+protected previews with the correct authentication schemes.
 
-## Initial Position
-`v0.2.0` being stable is understandable technically because `package.json` is
-the canonical product version. The missing piece is process enforcement: no
-release/version decision is currently required after meaningful shipped work.
-
-Going back to `0.1.<commit>` would also be wrong: commit SHA/build revision is
-not the same as product version. The right target is a clear product release
-version plus diagnostic revision metadata.
-
-## Selected Policy
-- Keep `package.json` as the canonical product version.
-- Keep commit SHA/build metadata separate from the visible product version.
-- Do not use commit count in SemVer; it is repository/build metadata, not
-  release intent.
-- `feature/*` PRs that ship meaningful product work bump minor and reset patch,
-  for example `0.2.0` to `0.3.0`.
-- Release-impacting `fix/*`, `refactor/*`, and `chore/*` PRs bump patch, for
-  example `0.3.0` to `0.3.1`.
-- `docs/*`, Dependabot, routine CI cleanup, and task-tracking-only work hold
-  steady unless explicitly converted into a product release.
-- `1.0.0` remains reserved for the first stable product baseline.
-
-## Implementation Summary
-- Added `scripts/check-version-policy.mjs` and `npm run release:check`.
-- Wired the version policy guard into the PR Quality Core workflow.
-- Extended `scripts/release-version.mjs` with branch-type aliases:
-  `feature`, `fix`, `refactor`, and `chore`.
-- Bumped the app product version from `0.2.0` to `0.3.0` for this
-  `feature/*` implementation PR.
-- Updated release/version docs, README metadata guidance, changelog, and app
-  metadata tests.
-- Added guard tests that exercise feature minor bumps, fix patch requirements,
-  changelog enforcement, and docs-only no-bump behavior.
-
-## Out Of Scope
-- Changing dependency package versions for their own sake.
-- Reintroducing commit SHA as the primary user-facing product version.
-- A full public release-management platform beyond the lightweight process
-  NexusDash needs today.
+## Root Cause
+- A direct request to a protected preview can receive Vercel's HTML
+  `401 Authentication Required` response before NexusDash handles the request.
+- The raw agent API key must use `Authorization: ApiKey <key>`, the
+  `x-agent-api-key` compatibility header, or the JSON body. `Bearer` is reserved
+  for the short-lived token returned by a successful exchange.
+- The copied agent env block configures NexusDash values; it does not bypass
+  deployment-level Vercel protection.
 
 ## Acceptance Criteria
-1. A clear versioning policy exists and explains product version vs
-   build/revision metadata.
-2. The visible app version follows that policy and no longer stagnates
-   accidentally after meaningful production releases.
-3. Release tooling can increment `package.json` and `package-lock.json`
-   predictably.
-4. CI/release automation catches missing version decisions for production-bound
-   feature/fix work.
-5. Changelog/release-note expectations are tied to version increments.
-6. Preview and production build metadata remain deterministic and useful for
-   debugging.
-7. Tests cover the implemented version metadata and guard behavior.
+1. Preview validation docs explain how to identify a Vercel interception versus
+   an app-owned JSON `invalid-api-key` response.
+2. Protected-preview commands use `vercel curl` or an explicit protection
+   bypass secret without exposing agent keys.
+3. The raw-key exchange and returned bearer-token schemes are unambiguous.
+4. Rotation/revocation validation still expects stale keys to fail with the
+   app-owned JSON error.
+5. The runbook includes audit/log signals and a concise troubleshooting
+   decision tree.
 
 ## Definition Of Done
-- [x] Existing TASK-272 and TASK-132 decisions are reviewed.
-- [x] Policy and implementation path are documented.
-- [x] Version increment automation or CI guardrails are implemented.
-- [x] App metadata behavior remains tested.
-- [x] Relevant validation passes.
-- [x] PR workflow is completed according to `agent.md`.
+- [x] A dedicated protected-preview diagnostic runbook is added.
+- [x] Existing agent preview validation and README references are updated.
+- [x] Task tracking and journal evidence are current.
+- [x] Documentation checks pass.
+- [ ] A ready-for-review PR is open and Copilot feedback is handled.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,7 +4,7 @@
 TASK-315
 
 ## Status
-In Progress
+Complete once PR #333 merges.
 
 ## Source
 - GitHub issue #313: Investigate active agent credential returning
@@ -42,4 +42,4 @@ protected previews with the correct authentication schemes.
 - [x] Existing agent preview validation and README references are updated.
 - [x] Task tracking and journal evidence are current.
 - [x] Documentation checks pass.
-- [ ] A ready-for-review PR is open and Copilot feedback is handled.
+- [x] A ready-for-review PR is open and Copilot feedback is handled.


### PR DESCRIPTION
## Summary
- explain the two independent authentication layers on protected Vercel previews
- document `Authorization: ApiKey` for raw-key exchange and reserve `Bearer` for the returned access token
- add `vercel curl` and protection-bypass examples that keep secrets out of repository evidence
- provide a decision table for Vercel HTML interception versus NexusDash JSON `invalid-api-key`
- update the existing TASK-059 preview runbook, README references, and task tracking

## Root cause
The credential reported in issue #313 was valid. Direct requests were intercepted by Vercel deployment protection and returned an HTML `401 Authentication Required` page before `/api/auth/agent/token` ran. A raw agent key sent as `Bearer` is also not the canonical exchange contract.

## Validation
- confirmed command syntax against Vercel CLI 54.14.2 help
- verified runbook links and authentication wording with repository search
- `git diff --check`
- `npm run release:check -- --base origin/main --branch docs/task-315-protected-preview-agent-diagnostics`

This is documentation-only and intentionally does not change product version or agent authorization semantics.

Closes #313