### PR TITLE
Refresh backlog and execution queue after TASK-088

### DIFF
--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,19 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-06-19 - Post-TASK-088 repository and backlog reset
+
+- Merged PR #341 and closed TASK-088 as complete.
+- Removed 30 obsolete secondary Git worktrees after matching their branches to
+  merged or superseded pull requests. The sole dirty worktree contained only an
+  obsolete staged TASK-088 planning brief superseded by PR #341.
+- Returned the primary checkout to an up-to-date `main`.
+- Reconciled stale backlog states for TASK-317 and TASK-098 after PRs #332 and
+  #331 merged.
+- Set the next execution queue to TASK-319, TASK-318, TASK-316, TASK-314, and
+  TASK-119, balancing bounded security/architecture work with immediate
+  user-facing collaboration features.
+
 # 2026-06-19 - TASK-088 architecture audit correction
 
 - Summary: Replaced the draft TASK-088 audit with an evidence-backed review of

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -8,23 +8,33 @@ Last reviewed: 2026-06-19
 ### Execution Queue (Now / Next)
 - ID: TASK-319
   Title: Prisma tooling dependency advisory remediation - restore green security audit
-  Status: Pending (security maintenance; address near-term without freezing feature delivery)
+  Status: Next 1 - current task
   Rationale: TASK-088 validation found that `npm run security:audit` currently fails on high-severity Hono advisories in Prisma's `@prisma/dev` tooling chain. The affected packages are marked dev-optional and are not imported by the deployed NexusDash request runtime, but the repository's production-audit command is red and the prior TASK-274 baseline has regressed. Triage the dependency path, update Prisma or apply a safe patched override, and restore a green audit without a breaking downgrade.
   Dependencies: TASK-061, TASK-274, TASK-088
   Brief: `tasks/task-319-prisma-tooling-dependency-advisory-remediation.md`
 - ID: TASK-318
   Title: RLS coverage inventory and tenant-isolation CI guardrail
-  Status: Pending (high-priority architecture guardrail; does not block normal feature delivery)
+  Status: Next 2 - high-priority architecture guardrail
   Rationale: Close the verification gap identified by TASK-088 by classifying every Prisma model as RLS-protected or intentionally exempt, reviewing project-derived tables that currently rely on service authorization, and adding real PostgreSQL isolation tests that run as the least-privilege non-BYPASSRLS runtime role instead of the CI superuser. This creates a durable guardrail against tenant-boundary drift as new project-scoped models are added.
   Dependencies: TASK-085, TASK-088
   Brief: `tasks/task-318-rls-coverage-tenant-isolation-guardrail.md`
-- ID: TASK-317
-  Title: Agent access settings loading and overflow containment
-  Status: Complete once PR #332 merges
-  Rationale: Resolve GitHub issue #312 by prefetching project agent credentials
-    when settings opens, showing an immediate loading state, and containing long
-    credential/quickstart/audit values inside the modal.
-  Dependencies: TASK-059, TASK-115
+- ID: TASK-316
+  Title: Meeting todo side panel - project-wide open follow-up list
+  Status: Next 3 - next user-facing feature
+  Rationale: Externalize open todos from all meeting notes into a project-side panel so users can review and close meeting follow-ups without opening each historical note, while preserving links back to the source meeting and future compatibility with TASK-314 overdue reminders.
+  Dependencies: TASK-098
+  Brief: `tasks/task-316-meeting-todo-side-panel.md`
+- ID: TASK-314
+  Title: Meeting todo overdue reminders - notification email and in-app reminder dispatch
+  Status: Next 4 - meeting workflow completion
+  Rationale: Send the meeting-note owner a notification email and in-app reminder when a personal meeting todo remains open seven days after the meeting date, using the existing notification email delivery conventions and scheduler/dispatcher architecture instead of mixing background delivery concerns into the TASK-098 UI rollout.
+  Dependencies: TASK-098, TASK-227, TASK-268, TASK-316
+  Brief: `tasks/task-314-meeting-todo-overdue-reminders.md`
+- ID: TASK-119
+  Title: Project collaboration presence UX - member avatars on project pages
+  Status: Next 5 - bounded collaboration UX improvement
+  Rationale: Improve shared-project awareness by showing collaborator avatars and identity affordances directly on project pages so users can quickly understand who has access and who is participating, with sensible fallback behavior for accounts without uploaded photos.
+  Dependencies: TASK-058, TASK-082, TASK-089
 ### Deferred (Intentional)
 - ID: TASK-133
   Title: Task UI bug fixing - mini scrollbar and edit modal polish
@@ -42,23 +52,6 @@ Last reviewed: 2026-06-19
   Status: Deferred 2026-05-31
   Rationale: Redesign the login and home page so they feel like a polished product surface rather than a technical auth form: improve visual hierarchy, copy, branding presence, and call-to-action clarity so new visitors understand the product value at a glance and returning users get a frictionless sign-in experience.
   Dependencies: TASK-045, TASK-059, TASK-083
-- ID: TASK-098
-  Title: Meeting notes manager - structured project meeting log with participants, labels, outputs, and todos
-  Status: In Review (PR #331, feature/task-98-meeting-notes-manager)
-  Rationale: Add a dedicated project-scoped meeting-notes surface so discussions are not buried in generic context cards; each entry should separate meeting preparation from after-meeting notes, capture meeting date/time, participants, task-style labels, preparation inputs, outputs, personal todos, and lifecycle state, and keep done notes in an archived list while preserving search/filtering and future room for task linkage.
-  Dependencies: TASK-076, TASK-079
-- ID: TASK-314
-  Title: Meeting todo overdue reminders - notification email and in-app reminder dispatch
-  Status: Pending
-  Rationale: Send the meeting-note owner a notification email and in-app reminder when a personal meeting todo remains open seven days after the meeting date, using the existing notification email delivery conventions and scheduler/dispatcher architecture instead of mixing background delivery concerns into the TASK-098 UI rollout.
-  Dependencies: TASK-098, TASK-227, TASK-268
-  Brief: `tasks/task-314-meeting-todo-overdue-reminders.md`
-- ID: TASK-316
-  Title: Meeting todo side panel - project-wide open follow-up list
-  Status: Pending
-  Rationale: Externalize open todos from all meeting notes into a project-side panel so users can review and close meeting follow-ups without opening each historical note, while preserving links back to the source meeting and future compatibility with TASK-314 overdue reminders.
-  Dependencies: TASK-098
-  Brief: `tasks/task-316-meeting-todo-side-panel.md`
 - ID: TASK-102
   Title: Collaboration service modularization - split invite, membership, and recipient flows into smaller service units
   Status: Pending
@@ -69,11 +62,6 @@ Last reviewed: 2026-06-19
   Status: Pending
   Rationale: Add a lighter-weight todo list surface for quick checklist-style capture that does not require the full structure of Kanban tasks, giving teams a place for small actionable items, personal punch lists, or short operational checklists that may later connect to richer task flows.
   Dependencies: TASK-076, TASK-079
-- ID: TASK-119
-  Title: Project collaboration presence UX - member avatars on project pages
-  Status: Pending
-  Rationale: Improve shared-project awareness by showing collaborator avatars and identity affordances directly on project pages so users can quickly understand who has access and who is participating, with sensible fallback behavior for accounts without uploaded photos.
-  Dependencies: TASK-058, TASK-082, TASK-089
 - ID: TASK-090
   Title: Internationalization baseline - FR/EN translation capabilities
   Status: Pending
@@ -133,9 +121,19 @@ Last reviewed: 2026-06-19
   Dependencies: TASK-051
 
 ## Completed
+- ID: TASK-317
+  Title: Agent access settings loading and overflow containment
+  Status: Done (2026-06-18, merged via PR #332)
+  Rationale: Resolved GitHub issue #312 by prefetching project agent credentials when settings opens, showing an immediate loading state, and containing long credential, quickstart, and audit values inside the settings modal.
+  Dependencies: TASK-059, TASK-115
+- ID: TASK-098
+  Title: Meeting notes manager - structured project meeting log with participants, labels, outputs, and todos
+  Status: Done (2026-06-18, merged via PR #331)
+  Rationale: Added project-scoped meeting preparation and notes with participants, labels, outputs, personal todos, lifecycle state, archive/search behavior, API/service coverage, and project dashboard integration.
+  Dependencies: TASK-076, TASK-079
 - ID: TASK-088
   Title: Milestone architecture and security audit - post-auth/account hardening review
-  Status: Complete once PR #341 merges
+  Status: Done (2026-06-19, merged via PR #341)
   Rationale: Audited service and transport boundaries, authentication and agent-token controls, tenancy enforcement, environment and deployment safeguards, storage abstraction, scheduler trade-offs, caching, dependency posture, CI, and observability. The architecture remains sound enough for normal feature delivery; TASK-318 captures the RLS verification gap and TASK-319 owns the newly regressed Prisma/Hono tooling audit.
   Dependencies: TASK-084, TASK-085, TASK-086
   Report: `tasks/task-088-architecture-audit.md`

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,48 +1,44 @@
-# Current Task: TASK-088 Architecture And Security Audit
+# Current Task: TASK-319 Prisma Tooling Dependency Advisory Remediation
 
 ## Task ID
-TASK-088
+TASK-319
 
 ## Status
-Complete once PR #341 merges.
+Ready to start.
 
 ## Source
-- Existing milestone audit item in `tasks/backlog.md`.
-- Replacement for the incomplete and overconfident audit in draft PR #334.
+- TASK-088 architecture and security audit.
+- `npm run security:audit` currently reports high-severity Hono advisories
+  through Prisma's development-tooling dependency chain.
 
 ## Objective
-Determine whether NexusDash should pause feature delivery for architectural
-remediation or continue shipping, based on repository evidence rather than
-architecture claims alone.
+Restore a green dependency-security audit using a supported, non-breaking
+Prisma or transitive dependency resolution, while documenting why the current
+advisory is or is not reachable in the deployed application.
 
 ## Scope
-- Review transport/service/database boundaries.
-- Review sessions, social authentication, agent credentials, authorization,
-  abuse controls, and secrets.
-- Review PostgreSQL RLS scope and how tenant isolation is exercised in CI.
-- Review storage, deployment, scheduler, caching, observability, and quality
-  gates.
-- Identify existing backlog coverage and create only non-duplicate follow-up
-  work.
+- Trace the exact `prisma -> @prisma/dev -> @hono/node-server` and `hono`
+  dependency relationship.
+- Prefer a supported Prisma patch/minor update or compatible patched override.
+- Avoid `npm audit fix --force` and major downgrades.
+- Remove stale dependency overrides where safe.
+- Revalidate Prisma generation, migrations, tests, build, E2E, and the
+  production security audit.
+- Record deployed-runtime reachability and any bounded exception if upstream
+  remediation is unavailable.
 
 ## Acceptance Criteria
-1. The report cites concrete repository evidence for each major conclusion.
-2. Verified controls, assumptions, and residual risks are clearly separated.
-3. The report gives an explicit pause-or-continue recommendation.
-4. Existing scheduler and rate-limiting tasks are referenced instead of
-   duplicated.
-5. Any new task has bounded scope, priority, and acceptance criteria.
-6. Task tracking contains one canonical TASK-088 entry.
+1. `npm run security:audit` exits successfully, or a time-bounded documented
+   exception has an explicit upstream/removal condition.
+2. No breaking Prisma downgrade is used as an audit workaround.
+3. Clean install and Prisma generation succeed.
+4. Database migration commands remain operational.
+5. Lint, tests, coverage, build, and E2E pass.
+6. Remaining overrides are justified and documented.
 
 ## Definition Of Done
-- [x] Evidence-backed architecture audit is written.
-- [x] Project-wide pause decision is documented.
-- [x] TASK-318 captures the RLS verification follow-up.
-- [x] TASK-319 captures the Prisma/Hono tooling advisory follow-up.
-- [x] TASK-063 and TASK-064 are retained as the existing scheduler/rate-limit
-      follow-ups.
-- [x] Backlog and journal tracking are updated without duplicate TASK-088
-      entries.
-- [x] Documentation, lint, test, build, and release-policy checks pass.
-- [x] Security-audit failure is traced and captured in TASK-319.
-- [x] Replacement draft PR #341 supersedes PR #334.
+- [ ] Advisory path and runtime reachability are documented.
+- [ ] Supported dependency remediation is applied.
+- [ ] Production security audit is green or a bounded exception is recorded.
+- [ ] Full repository validation passes.
+- [ ] A ready-for-review PR is open and review feedback is resolved.


### PR DESCRIPTION
## Summary

- records the merge of TASK-088 PR #341 and the cleanup of 30 obsolete local worktrees
- moves TASK-317 and TASK-098 from stale pending/in-review states to completed
- marks TASK-088 done after merge
- sets TASK-319 as the current task
- defines the next five-task execution queue as TASK-319, TASK-318, TASK-316, TASK-314, and TASK-119

## Queue rationale

1. TASK-319 restores the dependency-security audit baseline with bounded maintenance work.
2. TASK-318 adds durable RLS model classification and least-privilege tenant-isolation CI proof.
3. TASK-316 completes the daily-use meeting-todo workflow with a project-wide follow-up panel.
4. TASK-314 adds reminder delivery after the todo lifecycle and shared surface are settled.
5. TASK-119 returns to a bounded, visible collaboration improvement using mature membership/avatar foundations.

This sequence addresses the two concrete audit findings without imposing an architecture freeze, then resumes user-facing feature delivery.

## Validation

- `git diff --check`
- backlog task-ID uniqueness check: 163 unique IDs
- execution queue check: exactly five tasks
- `npm ci`
- `npm run lint`
- `npm run release:check -- --base origin/main --branch docs/backlog-post-task-088-cleanup`

No runtime code is changed.