### PR TITLE
TASK-318 Add RLS coverage and tenant-isolation guardrail

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Generate Prisma client
         run: npx prisma generate
 
+      - name: Check RLS model inventory
+        run: npm run rls:check
+
       - name: Lint
         run: npm run lint
 
@@ -129,12 +132,62 @@ jobs:
             test-results
           if-no-files-found: ignore
 
+  tenant-isolation:
+    name: Tenant Isolation (PostgreSQL RLS)
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: nexusdash
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d nexusdash"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/nexusdash?schema=public
+      DIRECT_URL: postgresql://postgres:postgres@127.0.0.1:5432/nexusdash?schema=public
+      RLS_TEST_ADMIN_DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/nexusdash
+      RLS_TEST_RUNTIME_DATABASE_URL: postgresql://nexusdash_rls_test:nexusdash_rls_test@127.0.0.1:5432/nexusdash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Apply Prisma migrations with admin connection
+        run: npm run db:migrate
+
+      - name: Provision least-privilege runtime role
+        run: npm run test:rls:setup
+
+      - name: Run tenant-isolation matrix as runtime role
+        run: npm run test:rls
+
   container-image:
     name: Container Image (build + metadata artifact)
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     needs:
       - quality-core
       - e2e-smoke
+      - tenant-isolation
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ SHA, deployment URL, and workflow run belong in release evidence.
 
 - Define each release entry before the product-impacting PR is merged.
 
+## v0.20.0 - 2026-06-19
+
+- Added a machine-checked RLS inventory that classifies every Prisma model and
+  blocks unclassified schema additions.
+- Extended forced PostgreSQL RLS to task comment reactions and project agent
+  credential, scope-grant, and audit records, with a narrow pre-authentication
+  credential lookup for raw-key exchange.
+- Added a CI tenant-isolation matrix that provisions a non-superuser
+  `NOBYPASSRLS` role and verifies cross-project CRUD denial, role differences,
+  revoked membership, child rows, and agent credential visibility.
+
 ## v0.19.1 - 2026-06-18
 
 - Prefetched project agent credentials when the settings modal opens so the

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Runbooks:
 
 - `docs/runbooks/vercel-env-contract-and-secrets.md`
 - `docs/runbooks/database-connection-hardening.md`
+- `docs/runbooks/rls-tenant-isolation.md`
 - `docs/runbooks/notification-email-dispatch.md`
 - `docs/runbooks/release-versioning.md`
 - `docs/runbooks/protected-preview-agent-access.md`
@@ -256,8 +257,11 @@ npm run dev
 npm run build
 npm run start
 npm run lint
+npm run rls:check
 npm test
 npm run test:coverage
+npm run test:rls:setup
+npm run test:rls
 npm run test:e2e
 npm run test:e2e:headed
 npm run db:migrate
@@ -287,6 +291,20 @@ Manual sequence and troubleshooting details are in
 npm test
 npm run test:coverage
 ```
+
+### PostgreSQL tenant isolation
+
+`npm run rls:check` verifies that every Prisma model has an explicit committed
+RLS or exemption decision. The real PostgreSQL matrix runs with separate admin
+and non-superuser `NOBYPASSRLS` runtime URLs:
+
+```bash
+npm run test:rls:setup
+npm run test:rls
+```
+
+See [`docs/runbooks/rls-tenant-isolation.md`](docs/runbooks/rls-tenant-isolation.md)
+for environment variables, policy conventions, and troubleshooting.
 
 ### E2E (Playwright)
 
@@ -386,6 +404,7 @@ audit decision are documented in
 ### CI workflows
 
 - `Quality Core (lint, test, coverage, build)`
+- `Tenant Isolation (PostgreSQL RLS)`
 - `E2E Smoke (Playwright)`
 - `Container Image (build + metadata artifact)`
 - `Check Branch Name` (PR branch naming contract)

--- a/agent.md
+++ b/agent.md
@@ -115,9 +115,19 @@ Run before handoff (unless task is docs-only):
 
 ```bash
 npm run lint
+npm run rls:check
 npm test
 npm run test:coverage
 npm run build
+```
+
+When Prisma models, RLS migrations, tenant ownership, or runtime database roles
+change, also run the real PostgreSQL matrix from
+`docs/runbooks/rls-tenant-isolation.md`:
+
+```bash
+npm run test:rls:setup
+npm run test:rls
 ```
 
 Use `npm run test:e2e` when UI flows, auth flows, calendar flows, or upload flows are touched.

--- a/docs/runbooks/github-actions-workflows.md
+++ b/docs/runbooks/github-actions-workflows.md
@@ -9,7 +9,7 @@ because each owns a distinct operational lane.
 | Workflow | File | Purpose | Triggers | Permissions | Secrets / env | Artifacts / outputs |
 | --- | --- | --- | --- | --- | --- | --- |
 | Check Branch Name | `.github/workflows/check-branch-names.yml` | Enforce branch naming for human and Dependabot PRs. | `pull_request`, `workflow_dispatch` | none | none | check result only |
-| Quality Gates | `.github/workflows/quality-gates.yml` | Run lint, unit/API tests, coverage, build, Playwright smoke, and container-image build. | `pull_request`, `push` to `main`, `workflow_dispatch` | `contents: read` | local CI placeholders for DB/email/agent signing | Playwright report on failure; container image metadata |
+| Quality Gates | `.github/workflows/quality-gates.yml` | Run RLS inventory validation, lint, unit/API tests, coverage, build, a least-privilege PostgreSQL tenant-isolation matrix, Playwright smoke, and container-image build. | `pull_request`, `push` to `main`, `workflow_dispatch` | `contents: read` | local CI placeholders for DB/email/agent signing; separate admin/runtime PostgreSQL URLs in the isolation job | Playwright report on failure; container image metadata |
 | Deploy Vercel (CD + Rollback) | `.github/workflows/deploy-vercel.yml` | Create staged production deployments after green `main`, and run manual preview deploy, staged deploy, promote, or rollback. | successful `Quality Gates` workflow on `main`, `workflow_dispatch` | `contents: read` | Vercel project/token secrets, database/migration URLs, production runtime secrets, OAuth/R2/email/agent secrets as needed | preview/staged deployment URL artifacts and job summaries |
 | Notification Email Dispatch Scheduler | `.github/workflows/notification-email-dispatch.yml` | Call the protected notification email dispatcher on the active no-new-cost production cadence. | schedule every 30 minutes, `workflow_dispatch` | none | `NOTIFICATION_EMAIL_DISPATCH_SECRET` or legacy `CRON_SECRET` | dispatcher response and parsed summary in job summary |
 | Dependency Security | `.github/workflows/dependency-security.yml` | Run the scheduled/manual npm audit baseline and persist audit JSON. | weekly schedule, `workflow_dispatch` | `contents: read` | none | production/full npm audit JSON |
@@ -48,7 +48,8 @@ quoted heredocs so future failures represent the audit result itself.
 
 1. Open a non-draft PR from an allowed branch prefix.
 2. Confirm `Check Branch Name` passes.
-3. Confirm `Quality Core`, `E2E Smoke`, and `Container Image` pass.
+3. Confirm `Quality Core`, `Tenant Isolation`, `E2E Smoke`, and
+   `Container Image` pass.
 4. Review any uploaded Playwright report if E2E fails.
 
 ### Preview Deploy

--- a/docs/runbooks/local-validation.md
+++ b/docs/runbooks/local-validation.md
@@ -85,6 +85,7 @@ npm run db:local:up
 npm ci
 npx prisma generate
 npm run db:migrate
+npm run rls:check
 npm run lint
 npm test
 npm run test:coverage
@@ -94,6 +95,18 @@ $env:NODE_ENV = "test"
 npm run test:e2e
 Remove-Item Env:\NODE_ENV
 ```
+
+Run the real PostgreSQL tenant-isolation matrix after migrations:
+
+```pwsh
+$env:RLS_TEST_ADMIN_DATABASE_URL = "postgresql://postgres:postgres@127.0.0.1:5432/nexusdash"
+$env:RLS_TEST_RUNTIME_DATABASE_URL = "postgresql://nexusdash_rls_test:nexusdash_rls_test@127.0.0.1:5432/nexusdash"
+npm run test:rls:setup
+npm run test:rls
+```
+
+The migration/admin URL and runtime URL must remain separate. See
+[`rls-tenant-isolation.md`](./rls-tenant-isolation.md).
 
 ## App + Database Through Docker Compose
 

--- a/docs/runbooks/rls-tenant-isolation.md
+++ b/docs/runbooks/rls-tenant-isolation.md
@@ -1,0 +1,116 @@
+# RLS Inventory and Tenant-Isolation Validation
+
+This runbook owns the repository contract for classifying Prisma models,
+extending PostgreSQL row-level security, and reproducing the least-privilege
+tenant-isolation test matrix.
+
+## Sources of Truth
+
+- `prisma/schema.prisma`: database model definitions.
+- `prisma/rls-inventory.json`: classification and enforcement decision for
+  every Prisma model.
+- `prisma/migrations/**/migration.sql`: committed RLS policies.
+- `scripts/check-rls-inventory.mjs`: schema/inventory/policy guardrail.
+- `scripts/test-rls-isolation.mjs`: real PostgreSQL isolation scenarios.
+
+Every inventory entry declares:
+
+- one of the supported classifications;
+- whether enforcement is `rls`, `service`, or `operational`;
+- the service or operational owner;
+- the reason for the decision.
+
+Authentication/session tables remain service-enforced because they must be
+queried before an actor is authenticated. Project notification email queue
+tables remain operationally enforced because the protected scheduler claims
+and reconciles work across recipients. These exemptions are intentional and
+must not be copied to ordinary project content.
+
+## Adding a Prisma Model
+
+When `prisma/schema.prisma` gains a model:
+
+1. Add exactly one matching entry to `prisma/rls-inventory.json`.
+2. If it carries `projectId` or derives from project-owned data, prefer forced
+   RLS unless a pre-authentication or cross-tenant operational workflow makes
+   database policy enforcement unsuitable.
+3. For an exemption, name the enforcement owner and explain why a normal actor
+   transaction cannot be used.
+4. For RLS enforcement, add both `ENABLE ROW LEVEL SECURITY` and
+   `FORCE ROW LEVEL SECURITY`, plus explicit command policies.
+5. Extend the real-database matrix when the new model adds a materially new
+   ownership path or role rule.
+6. Run `npm run rls:check`.
+
+CI fails when a Prisma model is absent from the inventory or an RLS-enforced
+model has no committed enable/force migration.
+
+## Policy Conventions
+
+- Actor identity is transaction-local:
+
+  ```sql
+  SELECT set_config('app.user_id', '<user-id>', true);
+  ```
+
+- Application code uses `withActorRlsContext` so context and queries share one
+  transaction/client.
+- `owner` has full project-content access.
+- `editor` may read/create/update content but cannot perform owner-only deletes
+  or project/credential administration.
+- `viewer` is read-only.
+- Child-table policies derive tenant ownership through their parent relation.
+- Pre-authentication database functions must be narrowly scoped,
+  `SECURITY DEFINER`, use a fixed safe `search_path`, and expose only the fields
+  required for that operation.
+
+## Local Reproduction
+
+Start a disposable PostgreSQL 16 database and apply migrations with the admin
+connection:
+
+```pwsh
+$env:DATABASE_URL = "postgresql://postgres:postgres@127.0.0.1:5432/nexusdash?schema=public"
+$env:DIRECT_URL = $env:DATABASE_URL
+npm run db:local:up
+npm run db:migrate
+```
+
+Configure separate admin and runtime URLs, then provision and test the runtime
+role:
+
+```pwsh
+$env:RLS_TEST_ADMIN_DATABASE_URL = "postgresql://postgres:postgres@127.0.0.1:5432/nexusdash"
+$env:RLS_TEST_RUNTIME_DATABASE_URL = "postgresql://nexusdash_rls_test:nexusdash_rls_test@127.0.0.1:5432/nexusdash"
+npm run test:rls:setup
+npm run test:rls
+```
+
+The setup script creates or repairs a login role that is non-superuser,
+`NOBYPASSRLS`, cannot create databases or roles, and cannot mutate Prisma's
+migration history. Migrations continue to use the privileged admin connection;
+the isolation matrix uses only the runtime URL.
+
+The matrix covers:
+
+- absent and unknown actor context;
+- cross-project SELECT/INSERT/UPDATE/DELETE;
+- owner/editor/viewer differences;
+- revoked membership;
+- child rows reached through foreign IDs;
+- agent credential, scope-grant, and audit visibility;
+- the exact-public-ID agent exchange function.
+
+## Troubleshooting
+
+- `42501` on an allowed operation: inspect the command policy and confirm the
+  actor context was set in the same transaction.
+- Rows unexpectedly invisible: verify membership, role, parent foreign keys,
+  and `app.current_user_id()`.
+- Test unexpectedly succeeds: confirm the runtime role has `rolsuper = false`
+  and `rolbypassrls = false`; do not run the matrix as `postgres`.
+- Migration succeeds but runtime gets table permission errors: rerun the local
+  role setup after migrations and review production grants for the new table.
+- Security-definer lookup fails: verify the function owner can read the target
+  table, its `search_path` is fixed, and execute permission is granted only to
+  the intended runtime role/public contract.

--- a/journal.md
+++ b/journal.md
@@ -2314,3 +2314,8 @@ Low-value entries to avoid going forward:
 - Type: Validation
 - Summary: TASK-318 local real-PostgreSQL validation was deferred to the new branch CI lane because the workstation Docker Desktop Linux engine was unavailable.
 - Evidence: Docker Desktop returned HTTP 500 for engine API requests, `127.0.0.1:5432` refused connections, and no local PostgreSQL service was installed. The repository now provisions a non-superuser `NOBYPASSRLS` role in the `Tenant Isolation (PostgreSQL RLS)` GitHub Actions job, keeps migration and runtime URLs separate, and runs the cross-project CRUD/role/child-row/credential matrix there.
+
+### 2026-06-19
+- Type: Review
+- Summary: TASK-318 opened ready-for-review PR #344 and completed CI plus Copilot review without findings.
+- Evidence: Commit `4f4b58696fb36f892990595b87054231a3a43712` was pushed to `feature/task-318-rls-coverage-tenant-isolation`. Quality Gates run `27850744706` passed Quality Core, the new PostgreSQL Tenant Isolation job, E2E Smoke, and Container Image. Copilot reviewed 22 of 23 changed files and generated no comments or unresolved review threads.

--- a/journal.md
+++ b/journal.md
@@ -2305,3 +2305,12 @@ Low-value entries to avoid going forward:
 - Type: Review
 - Summary: TASK-098 addressed the refreshed Copilot review's legacy data-preservation finding.
 - Evidence: Copilot found that meeting preparation and note-taking updates sent `decisions: ""`, erasing values created before the Decisions UI was removed. Updated the shared payload and preparation save path to retain the stored `decisions` value, and extended the meeting-notes Playwright flow to seed legacy data and verify it survives both update paths. `npm run lint`, the Playwright-triggered `npm run build`, and focused meeting-note API/service tests (2 files / 10 tests) passed. Local PostgreSQL-backed validation was blocked because Docker Desktop's Linux engine returned HTTP 500. Commit `13f2d63ccfee484e3c57bcec18e708fb56edf75d` was deployed by branch-ref preview workflow run `27726221721` with `git_ref=feature/task-98-meeting-notes-manager` to `https://nexus-dash-39lkz815n-dorian-agaesses-projects.vercel.app`; preview Playwright passed all 6 project smoke specs, including preservation of a seeded legacy decision after preparation and note-taking saves.
+### 2026-06-19
+- Type: Implementation
+- Summary: TASK-318 added a complete Prisma RLS inventory, forced policy coverage for previously unclassified project-derived tables, and a least-privilege PostgreSQL tenant-isolation CI lane.
+- Evidence: `prisma/rls-inventory.json` classifies all 33 Prisma models with an enforcement owner and rationale. Migration `20260619120000_task318_rls_coverage` enables and forces RLS for `TaskCommentReaction`, `ApiCredential`, `ApiCredentialScopeGrant`, and `AuthAuditEvent`, and replaces pre-authentication credential table reads with an exact-public-ID security-definer function. `npm run rls:check`, focused agent-access/inventory tests, the full 911-test unit suite, lint, version policy, Prisma validation, and the production build passed locally.
+
+### 2026-06-19
+- Type: Validation
+- Summary: TASK-318 local real-PostgreSQL validation was deferred to the new branch CI lane because the workstation Docker Desktop Linux engine was unavailable.
+- Evidence: Docker Desktop returned HTTP 500 for engine API requests, `127.0.0.1:5432` refused connections, and no local PostgreSQL service was installed. The repository now provisions a non-superuser `NOBYPASSRLS` role in the `Tenant Isolation (PostgreSQL RLS)` GitHub Actions job, keeps migration and runtime URLs separate, and runs the cross-project CRUD/role/child-row/credential matrix there.

--- a/lib/services/project-agent-access-service.ts
+++ b/lib/services/project-agent-access-service.ts
@@ -119,12 +119,67 @@ const DB_SCOPE_TO_AGENT_SCOPE: Record<ApiCredentialScope, AgentScope> = {
   [ApiCredentialScope.roadmap_delete]: "roadmap:delete",
 };
 
+interface AgentCredentialExchangeRow {
+  id: string;
+  label: string;
+  secret_hash: string;
+  public_id: string;
+  project_id: string;
+  created_by_user_id: string;
+  expires_at: Date | null;
+  revoked_at: Date | null;
+  scopes: string[];
+}
+
+interface AgentCredentialExchangeRecord {
+  id: string;
+  label: string;
+  secretHash: string;
+  publicId: string;
+  projectId: string;
+  createdByUserId: string;
+  expiresAt: Date | null;
+  revokedAt: Date | null;
+  scopeGrants: Array<{ scope: ApiCredentialScope }>;
+}
+
 function createError(status: number, error: string): ServiceError {
   return { ok: false, status, error };
 }
 
 function createSuccess<T>(status: number, data: T): ServiceSuccess<T> {
   return { ok: true, status, data };
+}
+
+function isApiCredentialScope(value: string): value is ApiCredentialScope {
+  return Object.prototype.hasOwnProperty.call(DB_SCOPE_TO_AGENT_SCOPE, value);
+}
+
+async function findAgentCredentialForExchange(
+  publicId: string
+): Promise<AgentCredentialExchangeRecord | null> {
+  const rows = await prisma.$queryRaw<AgentCredentialExchangeRow[]>`
+    SELECT *
+    FROM app.get_agent_credential_for_exchange(${publicId})
+  `;
+  const row = rows[0];
+  if (!row) {
+    return null;
+  }
+
+  return {
+    id: row.id,
+    label: row.label,
+    secretHash: row.secret_hash,
+    publicId: row.public_id,
+    projectId: row.project_id,
+    createdByUserId: row.created_by_user_id,
+    expiresAt: row.expires_at,
+    revokedAt: row.revoked_at,
+    scopeGrants: row.scopes
+      .filter(isApiCredentialScope)
+      .map((scope) => ({ scope })),
+  };
 }
 
 function normalizeActorUserId(value: string | null | undefined): string {
@@ -412,28 +467,31 @@ async function recordFailedAgentTokenExchange(input: {
   if (!input.credential) {
     return;
   }
+  const credential = input.credential;
 
   try {
-    await prisma.authAuditEvent.create({
-      data: {
-        projectId: input.credential.projectId,
-        credentialId: input.credential.id,
-        actorUserId: input.credential.createdByUserId,
-        actorKind: "agent",
-        action: "token_exchange_failed",
-        requestId: normalizeTrimmedString(input.requestId ?? null),
-        ipAddress: normalizeBoundedString(input.ipAddress ?? null, MAX_IP_ADDRESS_LENGTH),
-        userAgent: normalizeBoundedString(input.userAgent ?? null, MAX_USER_AGENT_LENGTH),
-        metadata: buildAuditMetadata({
-          scopes: input.credential.scopeGrants.map((grant) =>
-            mapDbScopeToAgentScope(grant.scope)
-          ),
-          publicId: input.credential.publicId,
-          expiresAt: input.credential.expiresAt,
-          failureReason: input.reason,
-        }),
-      },
-    });
+    await withActorRlsContext(credential.createdByUserId, (db) =>
+      db.authAuditEvent.create({
+        data: {
+          projectId: credential.projectId,
+          credentialId: credential.id,
+          actorUserId: credential.createdByUserId,
+          actorKind: "agent",
+          action: "token_exchange_failed",
+          requestId: normalizeTrimmedString(input.requestId ?? null),
+          ipAddress: normalizeBoundedString(input.ipAddress ?? null, MAX_IP_ADDRESS_LENGTH),
+          userAgent: normalizeBoundedString(input.userAgent ?? null, MAX_USER_AGENT_LENGTH),
+          metadata: buildAuditMetadata({
+            scopes: credential.scopeGrants.map((grant) =>
+              mapDbScopeToAgentScope(grant.scope)
+            ),
+            publicId: credential.publicId,
+            expiresAt: credential.expiresAt,
+            failureReason: input.reason,
+          }),
+        },
+      })
+    );
   } catch (error) {
     logServerWarning(
       "projectAgentAccess.tokenExchangeFailedAudit",
@@ -976,24 +1034,7 @@ export async function exchangeAgentApiKeyForAccessToken(input: {
   });
   if (!abuseCheck.ok) {
     const throttledCredential = parsedApiKey
-      ? await prisma.apiCredential.findUnique({
-          where: {
-            publicId: parsedApiKey.publicId,
-          },
-          select: {
-            id: true,
-            projectId: true,
-            createdByUserId: true,
-            publicId: true,
-            expiresAt: true,
-            scopeGrants: {
-              orderBy: [{ scope: "asc" }],
-              select: {
-                scope: true,
-              },
-            },
-          },
-        })
+      ? await findAgentCredentialForExchange(parsedApiKey.publicId)
       : null;
 
     await recordFailedAgentTokenExchange({
@@ -1021,27 +1062,7 @@ export async function exchangeAgentApiKeyForAccessToken(input: {
     return createError(failureResult.ok ? 401 : 429, failureResult.ok ? "invalid-api-key" : "too-many-attempts");
   }
 
-  const credential = await prisma.apiCredential.findUnique({
-    where: {
-      publicId: parsedApiKey.publicId,
-    },
-    select: {
-      id: true,
-      label: true,
-      secretHash: true,
-      publicId: true,
-      projectId: true,
-      createdByUserId: true,
-      expiresAt: true,
-      revokedAt: true,
-      scopeGrants: {
-        orderBy: [{ scope: "asc" }],
-        select: {
-          scope: true,
-        },
-      },
-    },
-  });
+  const credential = await findAgentCredentialForExchange(parsedApiKey.publicId);
 
   if (!credential) {
     const failureResult = await registerAuthAbuseFailure({
@@ -1122,14 +1143,14 @@ export async function exchangeAgentApiKeyForAccessToken(input: {
     scopes,
   });
 
-  await prisma.$transaction([
-    prisma.apiCredential.update({
+  await withActorRlsContext(credential.createdByUserId, async (db) => {
+    await db.apiCredential.update({
       where: { id: credential.id },
       data: {
         lastExchangedAt: issuedToken.issuedAt,
       },
-    }),
-    prisma.authAuditEvent.create({
+    });
+    await db.authAuditEvent.create({
       data: {
         projectId: credential.projectId,
         credentialId: credential.id,
@@ -1146,8 +1167,8 @@ export async function exchangeAgentApiKeyForAccessToken(input: {
           tokenId: issuedToken.tokenId,
         }),
       },
-    }),
-  ]);
+    });
+  });
 
   return createSuccess(200, {
     accessToken: issuedToken.accessToken,
@@ -1179,8 +1200,8 @@ export async function recordAgentRequestUsage(input: {
 
   const requestTimestamp = new Date();
   try {
-    const authorizedUpdate = await prisma.$transaction(async (tx) => {
-      const updateResult = await tx.apiCredential.updateMany({
+    const authorizedUpdate = await withActorRlsContext(ownerUserId, async (db) => {
+      const updateResult = await db.apiCredential.updateMany({
         where: {
           id: credentialId,
           projectId: input.projectId,
@@ -1207,7 +1228,7 @@ export async function recordAgentRequestUsage(input: {
         return false;
       }
 
-      await tx.authAuditEvent.create({
+      await db.authAuditEvent.create({
         data: {
           projectId: input.projectId,
           credentialId,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexusdash",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexusdash",
-      "version": "0.19.1",
+      "version": "0.20.0",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1064.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexusdash",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "private": true,
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0",
@@ -12,6 +12,9 @@
     "postinstall": "prisma generate",
     "start": "npm run db:migrate && next start",
     "lint": "eslint .",
+    "rls:check": "node scripts/check-rls-inventory.mjs",
+    "test:rls:setup": "node scripts/setup-rls-test-role.mjs",
+    "test:rls": "node scripts/test-rls-isolation.mjs",
     "security:audit": "npm audit --omit=dev --audit-level=high",
     "security:audit:full": "npm audit --json",
     "test": "vitest run",

--- a/prisma/migrations/20260619120000_task318_rls_coverage/migration.sql
+++ b/prisma/migrations/20260619120000_task318_rls_coverage/migration.sql
@@ -1,0 +1,210 @@
+-- TASK-318 extends forced RLS to project-derived tables that previously relied
+-- only on service-layer authorization.
+
+ALTER TABLE "TaskCommentReaction" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "TaskCommentReaction" FORCE ROW LEVEL SECURITY;
+ALTER TABLE "ApiCredential" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "ApiCredential" FORCE ROW LEVEL SECURITY;
+ALTER TABLE "ApiCredentialScopeGrant" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "ApiCredentialScopeGrant" FORCE ROW LEVEL SECURITY;
+ALTER TABLE "AuthAuditEvent" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "AuthAuditEvent" FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY task_comment_reaction_select_policy ON "TaskCommentReaction"
+FOR SELECT
+USING (
+  EXISTS (
+    SELECT 1
+    FROM "TaskComment" comment
+    JOIN "Task" task ON task.id = comment."taskId"
+    JOIN "Project" project ON project.id = task."projectId"
+    WHERE comment.id = "TaskCommentReaction"."commentId"
+      AND (
+        project."ownerId" = app.current_user_id()
+        OR EXISTS (
+          SELECT 1
+          FROM "ProjectMembership" membership
+          WHERE membership."projectId" = project.id
+            AND membership."userId" = app.current_user_id()
+        )
+      )
+  )
+);
+
+CREATE POLICY task_comment_reaction_insert_policy ON "TaskCommentReaction"
+FOR INSERT
+WITH CHECK (
+  "userId" = app.current_user_id()
+  AND EXISTS (
+    SELECT 1
+    FROM "TaskComment" comment
+    JOIN "Task" task ON task.id = comment."taskId"
+    JOIN "Project" project ON project.id = task."projectId"
+    WHERE comment.id = "TaskCommentReaction"."commentId"
+      AND (
+        project."ownerId" = app.current_user_id()
+        OR EXISTS (
+          SELECT 1
+          FROM "ProjectMembership" membership
+          WHERE membership."projectId" = project.id
+            AND membership."userId" = app.current_user_id()
+            AND membership.role IN ('owner', 'editor')
+        )
+      )
+  )
+);
+
+CREATE POLICY task_comment_reaction_delete_policy ON "TaskCommentReaction"
+FOR DELETE
+USING (
+  "userId" = app.current_user_id()
+  AND EXISTS (
+    SELECT 1
+    FROM "TaskComment" comment
+    JOIN "Task" task ON task.id = comment."taskId"
+    JOIN "Project" project ON project.id = task."projectId"
+    WHERE comment.id = "TaskCommentReaction"."commentId"
+      AND (
+        project."ownerId" = app.current_user_id()
+        OR EXISTS (
+          SELECT 1
+          FROM "ProjectMembership" membership
+          WHERE membership."projectId" = project.id
+            AND membership."userId" = app.current_user_id()
+            AND membership.role IN ('owner', 'editor')
+        )
+      )
+  )
+);
+
+CREATE POLICY api_credential_select_policy ON "ApiCredential"
+FOR SELECT
+USING (app.is_project_owner("projectId"));
+
+CREATE POLICY api_credential_insert_policy ON "ApiCredential"
+FOR INSERT
+WITH CHECK (
+  app.is_project_owner("projectId")
+  AND "createdByUserId" = app.current_user_id()
+);
+
+CREATE POLICY api_credential_update_policy ON "ApiCredential"
+FOR UPDATE
+USING (app.is_project_owner("projectId"))
+WITH CHECK (
+  app.is_project_owner("projectId")
+  AND "createdByUserId" = app.current_user_id()
+  AND (
+    "revokedByUserId" IS NULL
+    OR "revokedByUserId" = app.current_user_id()
+  )
+);
+
+CREATE POLICY api_credential_delete_policy ON "ApiCredential"
+FOR DELETE
+USING (app.is_project_owner("projectId"));
+
+CREATE POLICY api_credential_scope_grant_select_policy ON "ApiCredentialScopeGrant"
+FOR SELECT
+USING (
+  EXISTS (
+    SELECT 1
+    FROM "ApiCredential" credential
+    WHERE credential.id = "ApiCredentialScopeGrant"."credentialId"
+      AND app.is_project_owner(credential."projectId")
+  )
+);
+
+CREATE POLICY api_credential_scope_grant_insert_policy ON "ApiCredentialScopeGrant"
+FOR INSERT
+WITH CHECK (
+  EXISTS (
+    SELECT 1
+    FROM "ApiCredential" credential
+    WHERE credential.id = "ApiCredentialScopeGrant"."credentialId"
+      AND app.is_project_owner(credential."projectId")
+  )
+);
+
+CREATE POLICY api_credential_scope_grant_delete_policy ON "ApiCredentialScopeGrant"
+FOR DELETE
+USING (
+  EXISTS (
+    SELECT 1
+    FROM "ApiCredential" credential
+    WHERE credential.id = "ApiCredentialScopeGrant"."credentialId"
+      AND app.is_project_owner(credential."projectId")
+  )
+);
+
+CREATE POLICY auth_audit_event_select_policy ON "AuthAuditEvent"
+FOR SELECT
+USING (app.is_project_owner("projectId"));
+
+CREATE POLICY auth_audit_event_insert_policy ON "AuthAuditEvent"
+FOR INSERT
+WITH CHECK (
+  "actorUserId" = app.current_user_id()
+  AND app.is_project_owner("projectId")
+  AND (
+    "credentialId" IS NULL
+    OR EXISTS (
+      SELECT 1
+      FROM "ApiCredential" credential
+      WHERE credential.id = "AuthAuditEvent"."credentialId"
+        AND credential."projectId" = "AuthAuditEvent"."projectId"
+    )
+  )
+);
+
+-- Raw API keys must be resolved before an actor context exists. Keep that
+-- pre-authentication capability narrow: one exact public ID and only the fields
+-- required to verify the secret and issue a token.
+CREATE OR REPLACE FUNCTION app.get_agent_credential_for_exchange(_public_id TEXT)
+RETURNS TABLE (
+  id TEXT,
+  label TEXT,
+  secret_hash TEXT,
+  public_id TEXT,
+  project_id TEXT,
+  created_by_user_id TEXT,
+  expires_at TIMESTAMP(3),
+  revoked_at TIMESTAMP(3),
+  scopes TEXT[]
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT
+    credential.id,
+    credential.label,
+    credential."secretHash",
+    credential."publicId",
+    credential."projectId",
+    credential."createdByUserId",
+    credential."expiresAt",
+    credential."revokedAt",
+    COALESCE(
+      array_agg(scope_grant.scope::TEXT ORDER BY scope_grant.scope)
+        FILTER (WHERE scope_grant.scope IS NOT NULL),
+      ARRAY[]::TEXT[]
+    )
+  FROM public."ApiCredential" credential
+  LEFT JOIN public."ApiCredentialScopeGrant" scope_grant
+    ON scope_grant."credentialId" = credential.id
+  WHERE credential."publicId" = _public_id
+  GROUP BY credential.id;
+$$;
+
+REVOKE ALL ON FUNCTION app.get_agent_credential_for_exchange(TEXT) FROM PUBLIC;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_runtime') THEN
+    EXECUTE
+      'GRANT EXECUTE ON FUNCTION app.get_agent_credential_for_exchange(TEXT) TO app_runtime';
+  END IF;
+END
+$$;

--- a/prisma/rls-inventory.json
+++ b/prisma/rls-inventory.json
@@ -1,0 +1,236 @@
+{
+  "version": 1,
+  "models": [
+    {
+      "model": "User",
+      "classification": "system-operational-exempt",
+      "enforcement": "service",
+      "owner": "authentication and account services",
+      "rationale": "Authentication must resolve users by email before an actor context exists; account services enforce subject ownership."
+    },
+    {
+      "model": "EmailVerificationToken",
+      "classification": "system-operational-exempt",
+      "enforcement": "service",
+      "owner": "email verification service",
+      "rationale": "Opaque token validation occurs before a trusted actor context exists."
+    },
+    {
+      "model": "PasswordResetToken",
+      "classification": "system-operational-exempt",
+      "enforcement": "service",
+      "owner": "password reset service",
+      "rationale": "Opaque token validation occurs before a trusted actor context exists."
+    },
+    {
+      "model": "OutboundEmailDelivery",
+      "classification": "system-operational-exempt",
+      "enforcement": "service",
+      "owner": "outbound email service",
+      "rationale": "Provider delivery records are system-owned operational data processed across recipients."
+    },
+    {
+      "model": "Account",
+      "classification": "system-operational-exempt",
+      "enforcement": "service",
+      "owner": "authentication services",
+      "rationale": "OAuth account resolution is part of pre-session authentication."
+    },
+    {
+      "model": "Session",
+      "classification": "system-operational-exempt",
+      "enforcement": "service",
+      "owner": "session service",
+      "rationale": "Session lookup authenticates the request before an actor context can be established."
+    },
+    {
+      "model": "VerificationToken",
+      "classification": "system-operational-exempt",
+      "enforcement": "service",
+      "owner": "authentication services",
+      "rationale": "Compatibility verification tokens are resolved before authentication."
+    },
+    {
+      "model": "SystemGuard",
+      "classification": "system-operational-exempt",
+      "enforcement": "operational",
+      "owner": "database operations",
+      "rationale": "Singleton deployment-safety configuration is not tenant data and is administered through privileged operations."
+    },
+    {
+      "model": "Project",
+      "classification": "project-scoped-direct-rls",
+      "enforcement": "rls",
+      "owner": "project service",
+      "rationale": "The project owner and memberships define the tenant boundary."
+    },
+    {
+      "model": "ProjectMeetingNote",
+      "classification": "project-scoped-direct-rls",
+      "enforcement": "rls",
+      "owner": "project meeting note service",
+      "rationale": "Rows carry projectId and follow project membership read/write rules."
+    },
+    {
+      "model": "ProjectMeetingNoteAction",
+      "classification": "indirect-project-derived",
+      "enforcement": "rls",
+      "owner": "project meeting note service",
+      "rationale": "Tenant ownership is inherited through ProjectMeetingNote."
+    },
+    {
+      "model": "ProjectActivityEvent",
+      "classification": "project-scoped-direct-rls",
+      "enforcement": "rls",
+      "owner": "project activity service",
+      "rationale": "Rows carry projectId and are visible only to project members."
+    },
+    {
+      "model": "ProjectMembership",
+      "classification": "project-scoped-direct-rls",
+      "enforcement": "rls",
+      "owner": "project collaboration service",
+      "rationale": "Membership rows are part of the project authorization boundary."
+    },
+    {
+      "model": "ProjectInvitation",
+      "classification": "project-scoped-direct-rls",
+      "enforcement": "rls",
+      "owner": "project collaboration service",
+      "rationale": "Policies cover project owners and the email-bound invited user."
+    },
+    {
+      "model": "Notification",
+      "classification": "user-scoped-direct-rls",
+      "enforcement": "rls",
+      "owner": "notification service",
+      "rationale": "Rows are recipient-owned with narrowly scoped producer policies."
+    },
+    {
+      "model": "ProjectNotificationEmail",
+      "classification": "indirect-project-derived",
+      "enforcement": "operational",
+      "owner": "project notification email service",
+      "rationale": "The authenticated scheduler must claim and reconcile groups across recipients; recipient and project constraints remain service-owned."
+    },
+    {
+      "model": "ProjectNotificationEmailItem",
+      "classification": "indirect-project-derived",
+      "enforcement": "operational",
+      "owner": "project notification email service",
+      "rationale": "Queue items inherit ownership from an operational email group and notification and are processed across recipients."
+    },
+    {
+      "model": "Epic",
+      "classification": "project-scoped-direct-rls",
+      "enforcement": "rls",
+      "owner": "project epic service",
+      "rationale": "Rows carry projectId and follow project membership rules."
+    },
+    {
+      "model": "RoadmapPhase",
+      "classification": "project-scoped-direct-rls",
+      "enforcement": "rls",
+      "owner": "project roadmap service",
+      "rationale": "Rows carry projectId and follow project membership rules."
+    },
+    {
+      "model": "RoadmapEvent",
+      "classification": "project-scoped-direct-rls",
+      "enforcement": "rls",
+      "owner": "project roadmap service",
+      "rationale": "Rows carry projectId and follow project membership rules."
+    },
+    {
+      "model": "Task",
+      "classification": "project-scoped-direct-rls",
+      "enforcement": "rls",
+      "owner": "project task service",
+      "rationale": "Rows carry projectId and enforce project role differences."
+    },
+    {
+      "model": "TaskComment",
+      "classification": "indirect-project-derived",
+      "enforcement": "rls",
+      "owner": "project task comment service",
+      "rationale": "Tenant ownership is inherited through Task."
+    },
+    {
+      "model": "TaskCommentReaction",
+      "classification": "indirect-project-derived",
+      "enforcement": "rls",
+      "owner": "project task comment service",
+      "rationale": "Tenant ownership is inherited through TaskComment and mutations are limited to the reacting user."
+    },
+    {
+      "model": "TaskRelation",
+      "classification": "project-scoped-direct-rls",
+      "enforcement": "rls",
+      "owner": "project task service",
+      "rationale": "Rows carry projectId and both task IDs must remain inside that project."
+    },
+    {
+      "model": "Resource",
+      "classification": "project-scoped-direct-rls",
+      "enforcement": "rls",
+      "owner": "context card service",
+      "rationale": "Rows carry projectId and follow project role differences."
+    },
+    {
+      "model": "TaskAttachment",
+      "classification": "indirect-project-derived",
+      "enforcement": "rls",
+      "owner": "project attachment service",
+      "rationale": "Tenant ownership is inherited through Task."
+    },
+    {
+      "model": "ResourceAttachment",
+      "classification": "indirect-project-derived",
+      "enforcement": "rls",
+      "owner": "project attachment service",
+      "rationale": "Tenant ownership is inherited through Resource."
+    },
+    {
+      "model": "TaskBlockedFollowUp",
+      "classification": "indirect-project-derived",
+      "enforcement": "rls",
+      "owner": "project task service",
+      "rationale": "Tenant ownership is inherited through Task."
+    },
+    {
+      "model": "GoogleCalendarCredential",
+      "classification": "user-scoped-direct-rls",
+      "enforcement": "rls",
+      "owner": "Google Calendar credential service",
+      "rationale": "Each row is accessible only to its userId."
+    },
+    {
+      "model": "ApiCredential",
+      "classification": "project-scoped-direct-rls",
+      "enforcement": "rls",
+      "owner": "project agent access service",
+      "rationale": "Credential management is owner-only; unauthenticated key exchange uses a single exact-public-id security-definer lookup."
+    },
+    {
+      "model": "ApiCredentialScopeGrant",
+      "classification": "indirect-project-derived",
+      "enforcement": "rls",
+      "owner": "project agent access service",
+      "rationale": "Tenant ownership is inherited through ApiCredential."
+    },
+    {
+      "model": "AuthAuditEvent",
+      "classification": "project-scoped-direct-rls",
+      "enforcement": "rls",
+      "owner": "project agent access service",
+      "rationale": "Project owners can read events while owner-attributed human and agent flows can append audit rows."
+    },
+    {
+      "model": "AuthRateLimitBucket",
+      "classification": "system-operational-exempt",
+      "enforcement": "operational",
+      "owner": "authentication abuse-control service",
+      "rationale": "Rate-limit buckets are cross-request security state keyed by hashed signals, not tenant content."
+    }
+  ]
+}

--- a/scripts/check-rls-inventory.mjs
+++ b/scripts/check-rls-inventory.mjs
@@ -1,0 +1,127 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const schemaPath = path.join(repoRoot, "prisma", "schema.prisma");
+const inventoryPath = path.join(repoRoot, "prisma", "rls-inventory.json");
+const migrationsPath = path.join(repoRoot, "prisma", "migrations");
+
+const allowedClassifications = new Set([
+  "project-scoped-direct-rls",
+  "user-scoped-direct-rls",
+  "system-operational-exempt",
+  "indirect-project-derived",
+]);
+const allowedEnforcement = new Set(["rls", "service", "operational"]);
+
+function readModelNames(schema) {
+  return Array.from(schema.matchAll(/^model\s+([A-Za-z][A-Za-z0-9_]*)\s*\{/gm), (match) => match[1]);
+}
+
+function readMigrationSql(directory) {
+  return fs
+    .readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(directory, entry.name, "migration.sql"))
+    .filter((filePath) => fs.existsSync(filePath))
+    .map((filePath) => fs.readFileSync(filePath, "utf8"))
+    .join("\n");
+}
+
+export function validateRlsInventory({
+  schema = fs.readFileSync(schemaPath, "utf8"),
+  inventory = JSON.parse(fs.readFileSync(inventoryPath, "utf8")),
+  migrationSql = readMigrationSql(migrationsPath),
+} = {}) {
+  const errors = [];
+  const schemaModels = readModelNames(schema);
+  const entries = Array.isArray(inventory.models) ? inventory.models : [];
+  const entriesByModel = new Map();
+
+  for (const entry of entries) {
+    if (!entry || typeof entry.model !== "string") {
+      errors.push("Every inventory entry must declare a model.");
+      continue;
+    }
+    if (entriesByModel.has(entry.model)) {
+      errors.push(`Duplicate inventory entry: ${entry.model}.`);
+      continue;
+    }
+    entriesByModel.set(entry.model, entry);
+
+    if (!allowedClassifications.has(entry.classification)) {
+      errors.push(`${entry.model} has invalid classification ${String(entry.classification)}.`);
+    }
+    if (!allowedEnforcement.has(entry.enforcement)) {
+      errors.push(`${entry.model} has invalid enforcement ${String(entry.enforcement)}.`);
+    }
+    if (typeof entry.owner !== "string" || !entry.owner.trim()) {
+      errors.push(`${entry.model} must declare an enforcement owner.`);
+    }
+    if (typeof entry.rationale !== "string" || !entry.rationale.trim()) {
+      errors.push(`${entry.model} must declare a rationale.`);
+    }
+    if (
+      entry.classification === "system-operational-exempt" &&
+      entry.enforcement === "rls"
+    ) {
+      errors.push(`${entry.model} cannot be both operationally exempt and RLS-enforced.`);
+    }
+    if (
+      (entry.classification === "project-scoped-direct-rls" ||
+        entry.classification === "user-scoped-direct-rls") &&
+      entry.enforcement !== "rls"
+    ) {
+      errors.push(`${entry.model} is classified as direct RLS but enforcement is not rls.`);
+    }
+  }
+
+  for (const model of schemaModels) {
+    if (!entriesByModel.has(model)) {
+      errors.push(`Prisma model ${model} is missing from prisma/rls-inventory.json.`);
+    }
+  }
+  for (const model of entriesByModel.keys()) {
+    if (!schemaModels.includes(model)) {
+      errors.push(`Inventory model ${model} does not exist in prisma/schema.prisma.`);
+    }
+  }
+
+  for (const [model, entry] of entriesByModel) {
+    if (entry.enforcement !== "rls") continue;
+    const enablePattern = new RegExp(
+      `ALTER\\s+TABLE\\s+"${model}"\\s+ENABLE\\s+ROW\\s+LEVEL\\s+SECURITY`,
+      "i"
+    );
+    const forcePattern = new RegExp(
+      `ALTER\\s+TABLE\\s+"${model}"\\s+FORCE\\s+ROW\\s+LEVEL\\s+SECURITY`,
+      "i"
+    );
+    if (!enablePattern.test(migrationSql)) {
+      errors.push(`${model} is marked RLS-enforced but no ENABLE RLS migration was found.`);
+    }
+    if (!forcePattern.test(migrationSql)) {
+      errors.push(`${model} is marked RLS-enforced but no FORCE RLS migration was found.`);
+    }
+  }
+
+  return errors;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+) {
+  const errors = validateRlsInventory();
+  if (errors.length > 0) {
+    console.error("RLS inventory validation failed:");
+    for (const error of errors) console.error(`- ${error}`);
+    process.exit(1);
+  }
+
+  console.log(
+    "RLS inventory covers every Prisma model and matches committed policy migrations."
+  );
+}

--- a/scripts/local-validation.mjs
+++ b/scripts/local-validation.mjs
@@ -11,6 +11,14 @@ const MIN_NODE_RANGES = [
 const DEFAULT_DATABASE_URL =
   process.env.LOCAL_DATABASE_URL ||
   `postgresql://postgres:postgres@127.0.0.1:${process.env.POSTGRES_PORT || "5432"}/nexusdash?schema=public`;
+const DEFAULT_RLS_ADMIN_DATABASE_URL = DEFAULT_DATABASE_URL.replace(
+  /\?schema=public$/,
+  ""
+);
+const DEFAULT_RLS_RUNTIME_DATABASE_URL =
+  `postgresql://nexusdash_rls_test:nexusdash_rls_test@127.0.0.1:${
+    process.env.POSTGRES_PORT || "5432"
+  }/nexusdash`;
 
 const commonEnv = {
   ...process.env,
@@ -21,6 +29,10 @@ const commonEnv = {
     "local-placeholder-agent-token-signing-secret-0123456789",
   RESEND_API_KEY: process.env.RESEND_API_KEY || "local-placeholder-resend-key",
   STORAGE_PROVIDER: process.env.STORAGE_PROVIDER || "local",
+  RLS_TEST_ADMIN_DATABASE_URL:
+    process.env.RLS_TEST_ADMIN_DATABASE_URL || DEFAULT_RLS_ADMIN_DATABASE_URL,
+  RLS_TEST_RUNTIME_DATABASE_URL:
+    process.env.RLS_TEST_RUNTIME_DATABASE_URL || DEFAULT_RLS_RUNTIME_DATABASE_URL,
 };
 
 function commandName(baseName) {
@@ -87,6 +99,9 @@ try {
   run("Install dependencies", commandName("npm"), ["ci"]);
   run("Generate Prisma client", commandName("npx"), ["prisma", "generate"]);
   run("Apply Prisma migrations", commandName("npm"), ["run", "db:migrate"]);
+  run("Check RLS model inventory", commandName("npm"), ["run", "rls:check"]);
+  run("Provision RLS test role", commandName("npm"), ["run", "test:rls:setup"]);
+  run("PostgreSQL tenant isolation", commandName("npm"), ["run", "test:rls"]);
   run("Lint", commandName("npm"), ["run", "lint"]);
   run("Unit/API tests", commandName("npm"), ["test"]);
   run("Coverage", commandName("npm"), ["run", "test:coverage"]);

--- a/scripts/setup-rls-test-role.mjs
+++ b/scripts/setup-rls-test-role.mjs
@@ -1,0 +1,109 @@
+import process from "node:process";
+
+import pg from "pg";
+
+const { Client } = pg;
+
+const adminDatabaseUrl = process.env.RLS_TEST_ADMIN_DATABASE_URL;
+const runtimeDatabaseUrl = process.env.RLS_TEST_RUNTIME_DATABASE_URL;
+
+if (!adminDatabaseUrl || !runtimeDatabaseUrl) {
+  throw new Error(
+    "RLS_TEST_ADMIN_DATABASE_URL and RLS_TEST_RUNTIME_DATABASE_URL are required."
+  );
+}
+
+const adminUrl = new URL(adminDatabaseUrl);
+const runtimeUrl = new URL(runtimeDatabaseUrl);
+const runtimeRole = decodeURIComponent(runtimeUrl.username);
+const runtimePassword = decodeURIComponent(runtimeUrl.password);
+const databaseName = decodeURIComponent(adminUrl.pathname.replace(/^\//, ""));
+
+if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(runtimeRole)) {
+  throw new Error("RLS test runtime role contains unsupported characters.");
+}
+if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(databaseName)) {
+  throw new Error("RLS test database name contains unsupported characters.");
+}
+if (!runtimePassword) {
+  throw new Error("RLS test runtime URL must include a password.");
+}
+if (runtimeRole === decodeURIComponent(adminUrl.username) || runtimeRole === "postgres") {
+  throw new Error("RLS test runtime role must differ from the migration/admin role.");
+}
+
+function quoteLiteral(value) {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+const admin = new Client({ connectionString: adminDatabaseUrl });
+await admin.connect();
+
+try {
+  const roleResult = await admin.query(
+    "SELECT 1 FROM pg_roles WHERE rolname = $1",
+    [runtimeRole]
+  );
+  if (roleResult.rowCount === 0) {
+    await admin.query(`
+      CREATE ROLE "${runtimeRole}"
+      LOGIN
+      PASSWORD ${quoteLiteral(runtimePassword)}
+      NOSUPERUSER
+      NOCREATEDB
+      NOCREATEROLE
+      NOINHERIT
+      NOBYPASSRLS
+    `);
+  } else {
+    await admin.query(`
+      ALTER ROLE "${runtimeRole}"
+      WITH
+      LOGIN
+      PASSWORD ${quoteLiteral(runtimePassword)}
+      NOSUPERUSER
+      NOCREATEDB
+      NOCREATEROLE
+      NOINHERIT
+      NOBYPASSRLS
+    `);
+  }
+
+  await admin.query(`GRANT CONNECT ON DATABASE "${databaseName}" TO "${runtimeRole}"`);
+  await admin.query(`GRANT USAGE ON SCHEMA public, app TO "${runtimeRole}"`);
+  await admin.query(
+    `GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO "${runtimeRole}"`
+  );
+  await admin.query(
+    `REVOKE ALL ON TABLE public."_prisma_migrations" FROM "${runtimeRole}"`
+  );
+  await admin.query(
+    `GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO "${runtimeRole}"`
+  );
+  await admin.query(
+    `GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA app TO "${runtimeRole}"`
+  );
+
+  const attributes = await admin.query(
+    `
+      SELECT rolsuper, rolbypassrls, rolcreatedb, rolcreaterole
+      FROM pg_roles
+      WHERE rolname = $1
+    `,
+    [runtimeRole]
+  );
+  const role = attributes.rows[0];
+  if (
+    !role ||
+    role.rolsuper ||
+    role.rolbypassrls ||
+    role.rolcreatedb ||
+    role.rolcreaterole
+  ) {
+    throw new Error("RLS test role is not least privilege.");
+  }
+} finally {
+  await admin.end();
+}
+
+console.log(`Prepared least-privilege NOBYPASSRLS role ${runtimeRole}.`);

--- a/scripts/test-rls-isolation.mjs
+++ b/scripts/test-rls-isolation.mjs
@@ -1,0 +1,396 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import process from "node:process";
+
+import pg from "pg";
+
+const { Client } = pg;
+
+const adminDatabaseUrl = process.env.RLS_TEST_ADMIN_DATABASE_URL;
+const runtimeDatabaseUrl = process.env.RLS_TEST_RUNTIME_DATABASE_URL;
+
+if (!adminDatabaseUrl || !runtimeDatabaseUrl) {
+  throw new Error(
+    "RLS_TEST_ADMIN_DATABASE_URL and RLS_TEST_RUNTIME_DATABASE_URL are required."
+  );
+}
+
+const suffix = crypto.randomUUID().replaceAll("-", "");
+const ids = {
+  ownerA: `rls_owner_a_${suffix}`,
+  ownerB: `rls_owner_b_${suffix}`,
+  editorB: `rls_editor_b_${suffix}`,
+  viewerB: `rls_viewer_b_${suffix}`,
+  revokedB: `rls_revoked_b_${suffix}`,
+  outsider: `rls_outsider_${suffix}`,
+  projectA: `rls_project_a_${suffix}`,
+  projectB: `rls_project_b_${suffix}`,
+  taskA: `rls_task_a_${suffix}`,
+  taskB: `rls_task_b_${suffix}`,
+  commentA: `rls_comment_a_${suffix}`,
+  commentB: `rls_comment_b_${suffix}`,
+  reactionA: `rls_reaction_a_${suffix}`,
+  reactionB: `rls_reaction_b_${suffix}`,
+  credentialA: `rls_credential_a_${suffix}`,
+  credentialB: `rls_credential_b_${suffix}`,
+  auditA: `rls_audit_a_${suffix}`,
+  auditB: `rls_audit_b_${suffix}`,
+};
+
+const admin = new Client({ connectionString: adminDatabaseUrl });
+const runtime = new Client({ connectionString: runtimeDatabaseUrl });
+
+async function runtimeTransaction(actorUserId, operation) {
+  await runtime.query("BEGIN");
+  try {
+    if (actorUserId !== undefined) {
+      await runtime.query("SELECT set_config('app.user_id', $1, true)", [
+        actorUserId,
+      ]);
+    }
+    const result = await operation();
+    await runtime.query("ROLLBACK");
+    return result;
+  } catch (error) {
+    await runtime.query("ROLLBACK");
+    throw error;
+  }
+}
+
+async function expectRlsViolation(operation, label) {
+  await assert.rejects(operation, (error) => {
+    assert.equal(error?.code, "42501", `${label} should fail with RLS denial`);
+    return true;
+  });
+}
+
+async function seed() {
+  const users = [
+    ids.ownerA,
+    ids.ownerB,
+    ids.editorB,
+    ids.viewerB,
+    ids.revokedB,
+    ids.outsider,
+  ];
+  for (const userId of users) {
+    await admin.query(
+      `INSERT INTO "User" ("id", "email", "createdAt", "updatedAt")
+       VALUES ($1, $2, NOW(), NOW())`,
+      [userId, `${userId}@example.test`]
+    );
+  }
+
+  await admin.query(
+    `INSERT INTO "Project" ("id", "ownerId", "name", "createdAt", "updatedAt")
+     VALUES
+       ($1, $2, 'RLS Project A', NOW(), NOW()),
+       ($3, $4, 'RLS Project B', NOW(), NOW())`,
+    [ids.projectA, ids.ownerA, ids.projectB, ids.ownerB]
+  );
+  await admin.query(
+    `INSERT INTO "ProjectMembership" ("id", "projectId", "userId", "role", "createdAt", "updatedAt")
+     VALUES
+       ($1, $2, $3, 'editor', NOW(), NOW()),
+       ($4, $2, $5, 'viewer', NOW(), NOW()),
+       ($6, $2, $7, 'editor', NOW(), NOW())`,
+    [
+      `rls_membership_editor_${suffix}`,
+      ids.projectB,
+      ids.editorB,
+      `rls_membership_viewer_${suffix}`,
+      ids.viewerB,
+      `rls_membership_revoked_${suffix}`,
+      ids.revokedB,
+    ]
+  );
+  await admin.query(
+    `INSERT INTO "Task"
+      ("id", "title", "status", "position", "projectId", "createdByUserId", "updatedByUserId", "createdAt", "updatedAt")
+     VALUES
+       ($1, 'Task A', 'Backlog', 0, $2, $3, $3, NOW(), NOW()),
+       ($4, 'Task B', 'Backlog', 0, $5, $6, $6, NOW(), NOW())`,
+    [ids.taskA, ids.projectA, ids.ownerA, ids.taskB, ids.projectB, ids.ownerB]
+  );
+  await admin.query(
+    `INSERT INTO "TaskComment" ("id", "taskId", "authorUserId", "content", "createdAt")
+     VALUES
+       ($1, $2, $3, 'Comment A', NOW()),
+       ($4, $5, $6, 'Comment B', NOW())`,
+    [
+      ids.commentA,
+      ids.taskA,
+      ids.ownerA,
+      ids.commentB,
+      ids.taskB,
+      ids.ownerB,
+    ]
+  );
+  await admin.query(
+    `INSERT INTO "TaskCommentReaction" ("id", "commentId", "userId", "emoji", "createdAt")
+     VALUES
+       ($1, $2, $3, 'thumbs-up', NOW()),
+       ($4, $5, $6, 'check', NOW())`,
+    [
+      ids.reactionA,
+      ids.commentA,
+      ids.ownerA,
+      ids.reactionB,
+      ids.commentB,
+      ids.ownerB,
+    ]
+  );
+  await admin.query(
+    `INSERT INTO "ApiCredential"
+      ("id", "projectId", "createdByUserId", "label", "publicId", "secretHash", "createdAt", "updatedAt")
+     VALUES
+       ($1, $2, $3, 'Agent A', $4, 'hash-a', NOW(), NOW()),
+       ($5, $6, $7, 'Agent B', $8, 'hash-b', NOW(), NOW())`,
+    [
+      ids.credentialA,
+      ids.projectA,
+      ids.ownerA,
+      `nda_${ids.credentialA}`,
+      ids.credentialB,
+      ids.projectB,
+      ids.ownerB,
+      `nda_${ids.credentialB}`,
+    ]
+  );
+  await admin.query(
+    `INSERT INTO "ApiCredentialScopeGrant" ("credentialId", "scope", "createdAt")
+     VALUES
+       ($1, 'task_read', NOW()),
+       ($2, 'task_write', NOW())`,
+    [ids.credentialA, ids.credentialB]
+  );
+  await admin.query(
+    `INSERT INTO "AuthAuditEvent"
+      ("id", "projectId", "credentialId", "actorUserId", "actorKind", "action", "createdAt")
+     VALUES
+       ($1, $2, $3, $4, 'human', 'credential_created', NOW()),
+       ($5, $6, $7, $8, 'human', 'credential_created', NOW())`,
+    [
+      ids.auditA,
+      ids.projectA,
+      ids.credentialA,
+      ids.ownerA,
+      ids.auditB,
+      ids.projectB,
+      ids.credentialB,
+      ids.ownerB,
+    ]
+  );
+}
+
+async function cleanup() {
+  await admin.query(`DELETE FROM "User" WHERE "id" = ANY($1::TEXT[])`, [
+    [
+      ids.ownerA,
+      ids.ownerB,
+      ids.editorB,
+      ids.viewerB,
+      ids.revokedB,
+      ids.outsider,
+    ],
+  ]);
+}
+
+await admin.connect();
+await runtime.connect();
+
+try {
+  const role = await admin.query(
+    `
+      SELECT rolsuper, rolbypassrls
+      FROM pg_roles
+      WHERE rolname = $1
+    `,
+    [decodeURIComponent(new URL(runtimeDatabaseUrl).username)]
+  );
+  assert.equal(role.rowCount, 1);
+  assert.equal(role.rows[0].rolsuper, false);
+  assert.equal(role.rows[0].rolbypassrls, false);
+
+  await seed();
+
+  const noActorProjects = await runtimeTransaction(undefined, () =>
+    runtime.query(`SELECT "id" FROM "Project" WHERE "id" IN ($1, $2)`, [
+      ids.projectA,
+      ids.projectB,
+    ])
+  );
+  assert.equal(noActorProjects.rowCount, 0);
+
+  const unknownActorProjects = await runtimeTransaction(ids.outsider, () =>
+    runtime.query(`SELECT "id" FROM "Project" WHERE "id" IN ($1, $2)`, [
+      ids.projectA,
+      ids.projectB,
+    ])
+  );
+  assert.equal(unknownActorProjects.rowCount, 0);
+
+  const ownerAProjects = await runtimeTransaction(ids.ownerA, () =>
+    runtime.query(`SELECT "id" FROM "Project" WHERE "id" IN ($1, $2)`, [
+      ids.projectA,
+      ids.projectB,
+    ])
+  );
+  assert.deepEqual(ownerAProjects.rows.map((row) => row.id), [ids.projectA]);
+
+  await expectRlsViolation(
+    () =>
+      runtimeTransaction(ids.ownerA, () =>
+        runtime.query(
+          `INSERT INTO "Task"
+            ("id", "title", "status", "position", "projectId", "createdByUserId", "updatedByUserId", "createdAt", "updatedAt")
+           VALUES ($1, 'Cross tenant', 'Backlog', 0, $2, $3, $3, NOW(), NOW())`,
+          [`rls_cross_insert_${suffix}`, ids.projectB, ids.ownerA]
+        )
+      ),
+    "cross-project task insert"
+  );
+
+  const crossUpdate = await runtimeTransaction(ids.ownerA, () =>
+    runtime.query(`UPDATE "Task" SET "title" = 'Blocked' WHERE "id" = $1`, [
+      ids.taskB,
+    ])
+  );
+  assert.equal(crossUpdate.rowCount, 0);
+
+  const crossDelete = await runtimeTransaction(ids.ownerA, () =>
+    runtime.query(`DELETE FROM "Task" WHERE "id" = $1`, [ids.taskB])
+  );
+  assert.equal(crossDelete.rowCount, 0);
+
+  const editorRead = await runtimeTransaction(ids.editorB, () =>
+    runtime.query(`SELECT "id" FROM "Task" WHERE "id" = $1`, [ids.taskB])
+  );
+  assert.equal(editorRead.rowCount, 1);
+  const editorUpdate = await runtimeTransaction(ids.editorB, () =>
+    runtime.query(`UPDATE "Task" SET "title" = 'Editor update' WHERE "id" = $1`, [
+      ids.taskB,
+    ])
+  );
+  assert.equal(editorUpdate.rowCount, 1);
+  const editorDelete = await runtimeTransaction(ids.editorB, () =>
+    runtime.query(`DELETE FROM "Task" WHERE "id" = $1`, [ids.taskB])
+  );
+  assert.equal(editorDelete.rowCount, 0);
+
+  await expectRlsViolation(
+    () =>
+      runtimeTransaction(ids.viewerB, () =>
+        runtime.query(
+          `INSERT INTO "Task"
+            ("id", "title", "status", "position", "projectId", "createdByUserId", "updatedByUserId", "createdAt", "updatedAt")
+           VALUES ($1, 'Viewer insert', 'Backlog', 0, $2, $3, $3, NOW(), NOW())`,
+          [`rls_viewer_insert_${suffix}`, ids.projectB, ids.viewerB]
+        )
+      ),
+    "viewer task insert"
+  );
+
+  const viewerUpdate = await runtimeTransaction(ids.viewerB, () =>
+    runtime.query(`UPDATE "Task" SET "title" = 'Viewer update' WHERE "id" = $1`, [
+      ids.taskB,
+    ])
+  );
+  assert.equal(viewerUpdate.rowCount, 0);
+
+  await admin.query(
+    `DELETE FROM "ProjectMembership" WHERE "projectId" = $1 AND "userId" = $2`,
+    [ids.projectB, ids.revokedB]
+  );
+  const revokedRead = await runtimeTransaction(ids.revokedB, () =>
+    runtime.query(`SELECT "id" FROM "Task" WHERE "id" = $1`, [ids.taskB])
+  );
+  assert.equal(revokedRead.rowCount, 0);
+
+  const crossReactionRead = await runtimeTransaction(ids.ownerA, () =>
+    runtime.query(`SELECT "id" FROM "TaskCommentReaction" WHERE "id" = $1`, [
+      ids.reactionB,
+    ])
+  );
+  assert.equal(crossReactionRead.rowCount, 0);
+  await expectRlsViolation(
+    () =>
+      runtimeTransaction(ids.ownerA, () =>
+        runtime.query(
+          `INSERT INTO "TaskCommentReaction"
+            ("id", "commentId", "userId", "emoji", "createdAt")
+           VALUES ($1, $2, $3, 'blocked', NOW())`,
+          [`rls_cross_reaction_${suffix}`, ids.commentB, ids.ownerA]
+        )
+      ),
+    "cross-project reaction insert"
+  );
+  const crossReactionDelete = await runtimeTransaction(ids.ownerA, () =>
+    runtime.query(`DELETE FROM "TaskCommentReaction" WHERE "id" = $1`, [
+      ids.reactionB,
+    ])
+  );
+  assert.equal(crossReactionDelete.rowCount, 0);
+
+  const ownerACredentials = await runtimeTransaction(ids.ownerA, () =>
+    runtime.query(`SELECT "id" FROM "ApiCredential" WHERE "id" IN ($1, $2)`, [
+      ids.credentialA,
+      ids.credentialB,
+    ])
+  );
+  assert.deepEqual(ownerACredentials.rows.map((row) => row.id), [
+    ids.credentialA,
+  ]);
+  const ownerAScopes = await runtimeTransaction(ids.ownerA, () =>
+    runtime.query(
+      `SELECT "credentialId" FROM "ApiCredentialScopeGrant"
+       WHERE "credentialId" IN ($1, $2)`,
+      [ids.credentialA, ids.credentialB]
+    )
+  );
+  assert.deepEqual(ownerAScopes.rows.map((row) => row.credentialId), [
+    ids.credentialA,
+  ]);
+  const ownerAAudit = await runtimeTransaction(ids.ownerA, () =>
+    runtime.query(`SELECT "id" FROM "AuthAuditEvent" WHERE "id" IN ($1, $2)`, [
+      ids.auditA,
+      ids.auditB,
+    ])
+  );
+  assert.deepEqual(ownerAAudit.rows.map((row) => row.id), [ids.auditA]);
+
+  const crossCredentialUpdate = await runtimeTransaction(ids.ownerA, () =>
+    runtime.query(`UPDATE "ApiCredential" SET "label" = 'Cross' WHERE "id" = $1`, [
+      ids.credentialB,
+    ])
+  );
+  assert.equal(crossCredentialUpdate.rowCount, 0);
+
+  const exchangeLookup = await runtimeTransaction(undefined, () =>
+    runtime.query(
+      `SELECT "id", "project_id", "created_by_user_id", "scopes"
+       FROM app.get_agent_credential_for_exchange($1)`,
+      [`nda_${ids.credentialB}`]
+    )
+  );
+  assert.equal(exchangeLookup.rowCount, 1);
+  assert.equal(exchangeLookup.rows[0].id, ids.credentialB);
+  assert.equal(exchangeLookup.rows[0].project_id, ids.projectB);
+  assert.deepEqual(exchangeLookup.rows[0].scopes, ["task_write"]);
+
+  const missingLookup = await runtimeTransaction(undefined, () =>
+    runtime.query(
+      `SELECT "id" FROM app.get_agent_credential_for_exchange($1)`,
+      [`nda_missing_${suffix}`]
+    )
+  );
+  assert.equal(missingLookup.rowCount, 0);
+
+  console.log(
+    "RLS isolation matrix passed for absent actors, cross-project CRUD, role differences, child rows, revoked membership, and agent credentials."
+  );
+} finally {
+  await cleanup().catch(() => undefined);
+  await runtime.end();
+  await admin.end();
+}

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -12,12 +12,6 @@ Last reviewed: 2026-06-19
   Rationale: TASK-088 validation found that `npm run security:audit` currently fails on high-severity Hono advisories in Prisma's `@prisma/dev` tooling chain. The affected packages are marked dev-optional and are not imported by the deployed NexusDash request runtime, but the repository's production-audit command is red and the prior TASK-274 baseline has regressed. Triage the dependency path, update Prisma or apply a safe patched override, and restore a green audit without a breaking downgrade.
   Dependencies: TASK-061, TASK-274, TASK-088
   Brief: `tasks/task-319-prisma-tooling-dependency-advisory-remediation.md`
-- ID: TASK-318
-  Title: RLS coverage inventory and tenant-isolation CI guardrail
-  Status: In progress
-  Rationale: Close the verification gap identified by TASK-088 by classifying every Prisma model as RLS-protected or intentionally exempt, reviewing project-derived tables that currently rely on service authorization, and adding real PostgreSQL isolation tests that run as the least-privilege non-BYPASSRLS runtime role instead of the CI superuser. This creates a durable guardrail against tenant-boundary drift as new project-scoped models are added.
-  Dependencies: TASK-085, TASK-088
-  Brief: `tasks/task-318-rls-coverage-tenant-isolation-guardrail.md`
 - ID: TASK-316
   Title: Meeting todo side panel - project-wide open follow-up list
   Status: Next 3 - next user-facing feature
@@ -121,6 +115,12 @@ Last reviewed: 2026-06-19
   Dependencies: TASK-051
 
 ## Completed
+- ID: TASK-318
+  Title: RLS coverage inventory and tenant-isolation CI guardrail
+  Status: Done (2026-06-19, PR #344 open)
+  Rationale: Classified all 33 Prisma models, extended forced RLS to previously unclassified project-derived tables, replaced broad pre-authentication credential reads with a narrow security-definer lookup, and added a non-superuser `NOBYPASSRLS` PostgreSQL isolation matrix to CI.
+  Dependencies: TASK-085, TASK-088
+  Brief: `tasks/task-318-rls-coverage-tenant-isolation-guardrail.md`
 - ID: TASK-317
   Title: Agent access settings loading and overflow containment
   Status: Done (2026-06-18, merged via PR #332)

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -14,7 +14,7 @@ Last reviewed: 2026-06-19
   Brief: `tasks/task-319-prisma-tooling-dependency-advisory-remediation.md`
 - ID: TASK-318
   Title: RLS coverage inventory and tenant-isolation CI guardrail
-  Status: Next 2 - high-priority architecture guardrail
+  Status: In progress
   Rationale: Close the verification gap identified by TASK-088 by classifying every Prisma model as RLS-protected or intentionally exempt, reviewing project-derived tables that currently rely on service authorization, and adding real PostgreSQL isolation tests that run as the least-privilege non-BYPASSRLS runtime role instead of the CI superuser. This creates a durable guardrail against tenant-boundary drift as new project-scoped models are added.
   Dependencies: TASK-085, TASK-088
   Brief: `tasks/task-318-rls-coverage-tenant-isolation-guardrail.md`

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,7 +4,7 @@
 TASK-318
 
 ## Status
-In progress.
+Done. PR #344 is open and ready for review.
 
 ## Source
 - TASK-088 architecture and security audit.
@@ -37,10 +37,21 @@ the Prisma schema or RLS migrations change.
 8. Runbooks explain local reproduction and policy troubleshooting.
 
 ## Definition Of Done
-- [ ] Model inventory is complete and machine checked.
-- [ ] Required policy migrations are implemented.
-- [ ] Least-privilege runtime role exists in local and CI setup.
-- [ ] Real-database tenant-isolation tests cover the acceptance matrix.
-- [ ] Schema-change guardrail and developer documentation are active.
-- [ ] Lint, tests, coverage, build, and E2E validation pass.
-- [ ] A ready-for-review PR is open and Copilot feedback is handled.
+- [x] Model inventory is complete and machine checked.
+- [x] Required policy migrations are implemented.
+- [x] Least-privilege runtime role exists in local and CI setup.
+- [x] Real-database tenant-isolation tests cover the acceptance matrix.
+- [x] Schema-change guardrail and developer documentation are active.
+- [x] Lint, tests, coverage, build, and E2E validation pass.
+- [x] A ready-for-review PR is open and Copilot feedback is handled.
+
+## Delivery Evidence
+
+- Implementation commit: `4f4b58696fb36f892990595b87054231a3a43712`
+- Pull request: #344
+- Quality Gates run: `27850744706`
+  - Quality Core: passed
+  - Tenant Isolation (PostgreSQL RLS): passed
+  - E2E Smoke: passed
+  - Container Image: passed
+- Copilot completed its initial review with no comments or review threads.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,44 +1,46 @@
-# Current Task: TASK-319 Prisma Tooling Dependency Advisory Remediation
+# Current Task: TASK-318 RLS Coverage and Tenant-Isolation CI Guardrail
 
 ## Task ID
-TASK-319
+TASK-318
 
 ## Status
-Ready to start.
+In progress.
 
 ## Source
 - TASK-088 architecture and security audit.
-- `npm run security:audit` currently reports high-severity Hono advisories
-  through Prisma's development-tooling dependency chain.
+- `tasks/task-318-rls-coverage-tenant-isolation-guardrail.md`
 
 ## Objective
-Restore a green dependency-security audit using a supported, non-breaking
-Prisma or transitive dependency resolution, while documenting why the current
-advisory is or is not reachable in the deployed application.
+Make tenant isolation explicit, reviewable, and continuously verified whenever
+the Prisma schema or RLS migrations change.
 
 ## Scope
-- Trace the exact `prisma -> @prisma/dev -> @hono/node-server` and `hono`
-  dependency relationship.
-- Prefer a supported Prisma patch/minor update or compatible patched override.
-- Avoid `npm audit fix --force` and major downgrades.
-- Remove stale dependency overrides where safe.
-- Revalidate Prisma generation, migrations, tests, build, E2E, and the
-  production security audit.
-- Record deployed-runtime reachability and any bounded exception if upstream
-  remediation is unavailable.
+- Classify every Prisma model as directly RLS-protected, intentionally exempt,
+  or indirectly project-derived with a documented enforcement decision.
+- Add or adjust policies where database-level isolation is appropriate.
+- Provision a non-superuser, `NOBYPASSRLS` runtime role for local and CI tests.
+- Run real PostgreSQL isolation scenarios without the unit-test RLS shortcut.
+- Add a schema-change guardrail requiring every new model to declare its RLS
+  classification.
+- Document local reproduction, policy extension, and troubleshooting.
 
 ## Acceptance Criteria
-1. `npm run security:audit` exits successfully, or a time-bounded documented
-   exception has an explicit upstream/removal condition.
-2. No breaking Prisma downgrade is used as an audit workaround.
-3. Clean install and Prisma generation succeed.
-4. Database migration commands remain operational.
-5. Lint, tests, coverage, build, and E2E pass.
-6. Remaining overrides are justified and documented.
+1. Every Prisma model appears in a committed RLS/exemption inventory.
+2. Every project-derived model has an explicit database-enforcement decision.
+3. CI creates and tests with a least-privilege `NOBYPASSRLS` runtime role.
+4. Cross-project SELECT/INSERT/UPDATE/DELETE tests pass against real PostgreSQL
+   policies.
+5. Tests fail demonstrably if actor context is absent or references a user
+   without membership.
+6. Privileged migrations remain separated from runtime queries.
+7. New schema models cannot be added without an explicit RLS classification.
+8. Runbooks explain local reproduction and policy troubleshooting.
 
 ## Definition Of Done
-- [ ] Advisory path and runtime reachability are documented.
-- [ ] Supported dependency remediation is applied.
-- [ ] Production security audit is green or a bounded exception is recorded.
-- [ ] Full repository validation passes.
-- [ ] A ready-for-review PR is open and review feedback is resolved.
+- [ ] Model inventory is complete and machine checked.
+- [ ] Required policy migrations are implemented.
+- [ ] Least-privilege runtime role exists in local and CI setup.
+- [ ] Real-database tenant-isolation tests cover the acceptance matrix.
+- [ ] Schema-change guardrail and developer documentation are active.
+- [ ] Lint, tests, coverage, build, and E2E validation pass.
+- [ ] A ready-for-review PR is open and Copilot feedback is handled.

--- a/tests/lib/app-metadata.test.ts
+++ b/tests/lib/app-metadata.test.ts
@@ -60,10 +60,10 @@ describe("app-metadata", () => {
 
     const summary = getAppMetadataSummary();
 
-    expect(summary.versionTag).toBe("v0.19.1");
+    expect(summary.versionTag).toBe("v0.20.0");
     expect(summary.revision).toBeNull();
     expect(summary.revisionLabel).toBeNull();
-    expect(summary.versionLabel).toBe("v0.19.1");
+    expect(summary.versionLabel).toBe("v0.20.0");
   });
 
   test("strips build metadata from the visible version", () => {
@@ -84,8 +84,8 @@ describe("app-metadata", () => {
 
     const summary = getAppMetadataSummary();
 
-    expect(summary.versionTag).toBe("v0.19.1");
-    expect(summary.versionLabel).toBe("v0.19.1");
+    expect(summary.versionTag).toBe("v0.20.0");
+    expect(summary.versionLabel).toBe("v0.20.0");
   });
 
   test("uses optional repository override when present", () => {

--- a/tests/lib/project-agent-access-exchange.test.ts
+++ b/tests/lib/project-agent-access-exchange.test.ts
@@ -2,9 +2,8 @@ import { ApiCredentialScope } from "@prisma/client";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const prismaMock = vi.hoisted(() => ({
-  $transaction: vi.fn(),
+  $queryRaw: vi.fn(),
   apiCredential: {
-    findUnique: vi.fn(),
     update: vi.fn(),
   },
   authAuditEvent: {
@@ -77,7 +76,8 @@ describe("exchangeAgentApiKeyForAccessToken", () => {
     prismaMock.authAuditEvent.create.mockReturnValue({
       __mock: "authAuditEvent.create",
     });
-    prismaMock.$transaction.mockResolvedValue([]);
+    prismaMock.apiCredential.update.mockResolvedValue({});
+    prismaMock.authAuditEvent.create.mockResolvedValue({});
     abuseControlServiceMock.checkAuthAbuseControls.mockResolvedValue({ ok: true });
     abuseControlServiceMock.registerAuthAbuseFailure.mockResolvedValue({ ok: true });
     abuseControlServiceMock.clearAuthAbuseControls.mockResolvedValue(undefined);
@@ -92,20 +92,20 @@ describe("exchangeAgentApiKeyForAccessToken", () => {
   });
 
   test("uses createdByUserId as the owner identity when issuing tokens", async () => {
-    prismaMock.apiCredential.findUnique.mockResolvedValueOnce({
+    prismaMock.$queryRaw.mockResolvedValueOnce([{
       id: "credential-1",
       label: "Preview validation bot",
-      secretHash: "hashed-secret",
-      publicId: "nda_public",
-      projectId: "project-1",
-      createdByUserId: "owner-1",
-      expiresAt: null,
-      revokedAt: null,
-      scopeGrants: [
-        { scope: ApiCredentialScope.roadmap_write },
-        { scope: ApiCredentialScope.task_read },
+      secret_hash: "hashed-secret",
+      public_id: "nda_public",
+      project_id: "project-1",
+      created_by_user_id: "owner-1",
+      expires_at: null,
+      revoked_at: null,
+      scopes: [
+        ApiCredentialScope.roadmap_write,
+        ApiCredentialScope.task_read,
       ],
-    });
+    }]);
 
     const result = await exchangeAgentApiKeyForAccessToken({
       apiKey: "nda_public.secret-value",
@@ -136,27 +136,7 @@ describe("exchangeAgentApiKeyForAccessToken", () => {
       ownerUserId: "owner-1",
       scopes: ["roadmap:write", "task:read"],
     });
-    expect(prismaMock.apiCredential.findUnique).toHaveBeenCalledWith({
-      where: {
-        publicId: "nda_public",
-      },
-      select: {
-        id: true,
-        label: true,
-        secretHash: true,
-        publicId: true,
-        projectId: true,
-        createdByUserId: true,
-        expiresAt: true,
-        revokedAt: true,
-        scopeGrants: {
-          orderBy: [{ scope: "asc" }],
-          select: {
-            scope: true,
-          },
-        },
-      },
-    });
+    expect(prismaMock.$queryRaw).toHaveBeenCalledTimes(1);
   });
 
   test("returns too-many-attempts when abuse controls are already active", async () => {
@@ -164,6 +144,7 @@ describe("exchangeAgentApiKeyForAccessToken", () => {
       ok: false,
       retryAfterSeconds: 600,
     });
+    prismaMock.$queryRaw.mockResolvedValueOnce([]);
 
     const result = await exchangeAgentApiKeyForAccessToken({
       apiKey: "nda_public.secret-value",
@@ -180,17 +161,17 @@ describe("exchangeAgentApiKeyForAccessToken", () => {
   });
 
   test("still issues a token when abuse-control cleanup fails after a valid exchange", async () => {
-    prismaMock.apiCredential.findUnique.mockResolvedValueOnce({
+    prismaMock.$queryRaw.mockResolvedValueOnce([{
       id: "credential-1",
       label: "Preview validation bot",
-      secretHash: "hashed-secret",
-      publicId: "nda_public",
-      projectId: "project-1",
-      createdByUserId: "owner-1",
-      expiresAt: null,
-      revokedAt: null,
-      scopeGrants: [{ scope: ApiCredentialScope.task_read }],
-    });
+      secret_hash: "hashed-secret",
+      public_id: "nda_public",
+      project_id: "project-1",
+      created_by_user_id: "owner-1",
+      expires_at: null,
+      revoked_at: null,
+      scopes: [ApiCredentialScope.task_read],
+    }]);
     abuseControlServiceMock.clearAuthAbuseControls.mockRejectedValueOnce(
       new Error("cleanup-down")
     );

--- a/tests/lib/project-agent-access-service.test.ts
+++ b/tests/lib/project-agent-access-service.test.ts
@@ -69,7 +69,7 @@ describe("project-agent-access-service", () => {
   });
 
   test("returns a stable 500 when usage persistence fails unexpectedly", async () => {
-    prismaMock.$transaction.mockRejectedValueOnce(new Error("db-down"));
+    prismaMock.apiCredential.updateMany.mockRejectedValueOnce(new Error("db-down"));
 
     const result = await recordAgentRequestUsage({
       credentialId: "credential-1",

--- a/tests/scripts/rls-inventory.test.ts
+++ b/tests/scripts/rls-inventory.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "vitest";
+
+import { validateRlsInventory } from "../../scripts/check-rls-inventory.mjs";
+
+describe("RLS model inventory guardrail", () => {
+  test("accepts the committed schema, inventory, and migrations", () => {
+    expect(validateRlsInventory()).toEqual([]);
+  });
+
+  test("fails when a new Prisma model has no classification", () => {
+    const errors = validateRlsInventory({
+      schema: `model Existing {
+  id String @id
+}
+
+model NewlyAdded {
+  id String @id
+}
+`,
+      inventory: {
+        models: [
+          {
+            model: "Existing",
+            classification: "system-operational-exempt",
+            enforcement: "service",
+            owner: "test owner",
+            rationale: "test rationale",
+          },
+        ],
+      },
+      migrationSql: "",
+    });
+
+    expect(errors).toContain(
+      "Prisma model NewlyAdded is missing from prisma/rls-inventory.json."
+    );
+  });
+
+  test("requires forced policy migrations for RLS-enforced models", () => {
+    const errors = validateRlsInventory({
+      schema: `model Protected {
+  id String @id
+}
+`,
+      inventory: {
+        models: [
+          {
+            model: "Protected",
+            classification: "project-scoped-direct-rls",
+            enforcement: "rls",
+            owner: "test owner",
+            rationale: "test rationale",
+          },
+        ],
+      },
+      migrationSql: `ALTER TABLE "Protected" ENABLE ROW LEVEL SECURITY;`,
+    });
+
+    expect(errors).toContain(
+      "Protected is marked RLS-enforced but no FORCE RLS migration was found."
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- added a machine-checked RLS/exemption inventory for all 33 Prisma models
- added forced RLS policies for task comment reactions, API credentials, credential scope grants, and auth audit events
- replaced pre-authentication credential table reads with a narrow exact-public-ID security-definer lookup
- added a non-superuser `NOBYPASSRLS` PostgreSQL role setup and real cross-tenant isolation matrix
- added the dedicated CI tenant-isolation job and integrated it into the container gate
- documented model classification, policy extension, local reproduction, and troubleshooting
- bumped the product version to `0.20.0`
- merged current `main` after TASK-319, preserving its Hono `4.12.26` remediation and `v0.19.2` release entry
- cleaned task tracking so TASK-319 and TASK-318 are completed exactly once and TASK-316 is the current queue item

## Why

TASK-088 found that service authorization was strong, but not every project-derived Prisma model had an explicit database-enforcement decision and CI used the PostgreSQL superuser. This PR makes the boundary reviewable and proves it continuously with the same least-privilege properties expected from production runtime access.

## Validation

Local after resolving the TASK-319 merge conflict:

- `npm ci` — zero vulnerabilities
- `npm run security:audit`
- `npm run rls:check`
- feature release version policy against `origin/main` (`0.19.2` → `0.20.0`)
- `npm run lint`
- `npm test` — 123 files passed, 2 skipped; 909 tests passed, 2 skipped
- `npm run build`

Final PR Quality Gates run `27889542028` passed:

- Quality Core
- Tenant Isolation (PostgreSQL RLS)
- E2E Smoke
- Container Image

## Review

Copilot completed its initial review and generated no comments or review threads. The conflict-resolution commit only reconciles merged TASK-319 dependency/release/tracking changes and advances the task queue.