### PR TITLE
TASK-320 Fix project membership live refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ SHA, deployment URL, and workflow run belong in release evidence.
 
 - Define each release entry before the product-impacting PR is merged.
 
+## v0.22.1 - 2026-06-26
+
+- Fixed project dashboards so already-open pages refresh after an invited
+  member accepts a project invitation.
+- Added a membership-specific project activity marker touch that validates the
+  accepted invite and resulting membership without relaxing editor-only content
+  activity rules.
+- Added regression coverage for viewer invitation acceptance advancing the
+  project refresh marker.
+
 ## v0.22.0 - 2026-06-25
 
 - Added durable in-app reminders for meeting-note todos that remain open seven

--- a/journal.md
+++ b/journal.md
@@ -28,6 +28,12 @@ Use it for important implementation milestones, blockers, validation runs, and r
   `git diff --check` passed. An initial bare `npm test` failed before
   assertions in DB-backed suites because `DATABASE_URL` was not set in the
   shell.
+- Review: Copilot flagged that the membership activity function could overwrite
+  `Project.updatedAt` with a non-monotonic app-supplied timestamp. Updated the
+  function to lock/read the current project version, cap the requested version
+  at database time, and advance by one millisecond when the current version is
+  already newer. Focused tests, lint, and local `prisma db execute` of the
+  patched function passed.
 
 # 2026-06-25 - TASK-314 meeting todo overdue reminders started
 

--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,32 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-06-26 - TASK-320 project membership live refresh started
+
+- Summary: Created GitHub issue #352 and worktree
+  `../nexus_dash_task320` on
+  `fix/task-320-project-membership-live-refresh`.
+- Root cause: `respondToProjectInvitation(...)` created the membership and
+  accepted the invitation but never advanced `Project.updatedAt` or recorded a
+  typed project activity event. Existing project dashboards subscribe to that
+  activity version through SSE/polling, so open pages had no signal that a new
+  member joined.
+- Decision: Added a membership-specific activity touch instead of relaxing the
+  editor-only typed activity writer. The database function validates the
+  authenticated invitee, accepted invitation, and resulting membership before
+  updating the project activity marker, so viewer invitations can refresh open
+  dashboards without changing content mutation authorization.
+- Validation: Focused membership activity tests passed (2 files / 19 tests),
+  app metadata tests passed after deriving package fallback expectations from
+  `package.json`, `npm run lint`, `npm run rls:check`, release-policy
+  validation for `v0.22.1`, local PostgreSQL `npm test` (124 files passed, 2
+  skipped; 924 tests passed, 2 skipped), `npm run db:migrate`,
+  `npm run test:coverage` (91.37% statements, 81.33% branches, 92.2%
+  functions, 91.88% lines), local-safe `npm run build`, and
+  `git diff --check` passed. An initial bare `npm test` failed before
+  assertions in DB-backed suites because `DATABASE_URL` was not set in the
+  shell.
+
 # 2026-06-25 - TASK-314 meeting todo overdue reminders started
 
 - Summary: Removed clean local task worktrees for TASK-316, TASK-318, and

--- a/lib/services/project-activity-service.ts
+++ b/lib/services/project-activity-service.ts
@@ -29,6 +29,11 @@ interface TouchProjectActivityInput {
   occurredAt?: Date;
 }
 
+interface TouchProjectMembershipActivityInput extends TouchProjectActivityInput {
+  actorUserId: string;
+  invitationId: string;
+}
+
 interface ProjectActivitySnapshot {
   projectId: string;
   version: Date;
@@ -84,6 +89,14 @@ function normalizeId(value: string | null | undefined): string {
 }
 
 function canCallRawProjectActivityTouch(db: DbClient): db is DbClient & {
+  $queryRaw<T = unknown>(query: Prisma.Sql): Promise<T>;
+} {
+  return typeof (db as { $queryRaw?: unknown }).$queryRaw === "function";
+}
+
+function canCallRawProjectMembershipActivityTouch(
+  db: DbClient
+): db is DbClient & {
   $queryRaw<T = unknown>(query: Prisma.Sql): Promise<T>;
 } {
   return typeof (db as { $queryRaw?: unknown }).$queryRaw === "function";
@@ -215,6 +228,41 @@ export async function touchProjectActivity(
   if (process.env.NODE_ENV !== "test" && canCallRawProjectActivityTouch(input.db)) {
     const rows = await input.db.$queryRaw<Array<{ updated_at: Date }>>(
       Prisma.sql`SELECT app.touch_project_activity(${projectId}, ${occurredAt}) AS updated_at`
+    );
+    return rows[0]?.updated_at ?? occurredAt;
+  }
+
+  const projectDelegate = (input.db as { project?: { update?: unknown } }).project;
+  if (typeof projectDelegate?.update !== "function") {
+    return occurredAt;
+  }
+
+  await input.db.project.update({
+    where: { id: projectId },
+    data: { updatedAt: occurredAt },
+    select: { id: true },
+  });
+
+  return occurredAt;
+}
+
+export async function touchProjectMembershipActivity(
+  input: TouchProjectMembershipActivityInput
+): Promise<Date> {
+  const projectId = normalizeId(input.projectId);
+  const actorUserId = normalizeId(input.actorUserId);
+  const invitationId = normalizeId(input.invitationId);
+  const occurredAt = input.occurredAt ?? new Date();
+  if (!projectId || !actorUserId || !invitationId) {
+    return occurredAt;
+  }
+
+  if (
+    process.env.NODE_ENV !== "test" &&
+    canCallRawProjectMembershipActivityTouch(input.db)
+  ) {
+    const rows = await input.db.$queryRaw<Array<{ updated_at: Date }>>(
+      Prisma.sql`SELECT app.touch_project_membership_activity(${projectId}, ${actorUserId}, ${invitationId}, ${occurredAt}) AS updated_at`
     );
     return rows[0]?.updated_at ?? occurredAt;
   }

--- a/lib/services/project-collaboration-service.ts
+++ b/lib/services/project-collaboration-service.ts
@@ -14,6 +14,7 @@ import {
   hasRequiredRole,
   requireProjectRole,
 } from "@/lib/services/project-access-service";
+import { touchProjectMembershipActivity } from "@/lib/services/project-activity-service";
 import {
   createProjectInvitationNotification,
   resolveProjectInvitationNotifications,
@@ -1547,6 +1548,28 @@ export async function respondToProjectInvitation(input: {
         invitationIds: [invitation.id],
       });
     };
+    const touchAcceptedMembershipActivity = async (acceptedAt: Date) => {
+      try {
+        await touchProjectMembershipActivity({
+          db,
+          actorUserId,
+          projectId: invitation.projectId,
+          invitationId: invitation.id,
+          occurredAt: acceptedAt,
+        });
+      } catch (error) {
+        logServerWarning(
+          "respondToProjectInvitation.activityTouchFailed",
+          "Could not advance project activity after invitation acceptance",
+          {
+            actorUserId,
+            projectId: invitation.projectId,
+            invitationId: invitation.id,
+            error,
+          }
+        );
+      }
+    };
 
     if (invitation.acceptedAt) {
       await resolveCurrentInvitationNotification();
@@ -1732,6 +1755,7 @@ export async function respondToProjectInvitation(input: {
     }
 
     await resolveCurrentInvitationNotification();
+    await touchAcceptedMembershipActivity(acceptedAt);
     return createSuccess(200, { projectId: invitation.projectId });
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexusdash",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexusdash",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1064.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexusdash",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "private": true,
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0",

--- a/prisma/migrations/20260626090000_task320_project_membership_activity_touch/migration.sql
+++ b/prisma/migrations/20260626090000_task320_project_membership_activity_touch/migration.sql
@@ -1,0 +1,61 @@
+CREATE OR REPLACE FUNCTION app.touch_project_membership_activity(
+  project_id TEXT,
+  member_user_id TEXT,
+  invitation_id TEXT,
+  activity_at TIMESTAMPTZ DEFAULT now()
+)
+RETURNS TIMESTAMPTZ
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  actor_user_id TEXT;
+  touched_at TIMESTAMPTZ;
+BEGIN
+  actor_user_id := app.current_user_id();
+
+  IF actor_user_id IS NULL THEN
+    RAISE EXCEPTION 'project membership activity touch requires an authenticated actor'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF member_user_id IS DISTINCT FROM actor_user_id THEN
+    RAISE EXCEPTION 'project membership activity touch actor mismatch'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM "ProjectInvitation" pi
+    JOIN "User" u
+      ON u.id = member_user_id
+      AND u.email = pi."invitedEmail"
+    JOIN "ProjectMembership" pm
+      ON pm."projectId" = pi."projectId"
+      AND pm."userId" = member_user_id
+    WHERE pi.id = invitation_id
+      AND pi."projectId" = project_id
+      AND pi."acceptedAt" IS NOT NULL
+      AND pi."revokedAt" IS NULL
+      AND pi."replacedAt" IS NULL
+  ) THEN
+    RAISE EXCEPTION 'project membership activity touch forbidden'
+      USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE "Project"
+  SET "updatedAt" = activity_at
+  WHERE id = project_id
+  RETURNING "updatedAt" INTO touched_at;
+
+  RETURN touched_at;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION app.touch_project_membership_activity(
+  TEXT,
+  TEXT,
+  TEXT,
+  TIMESTAMPTZ
+) TO PUBLIC;

--- a/prisma/migrations/20260626090000_task320_project_membership_activity_touch/migration.sql
+++ b/prisma/migrations/20260626090000_task320_project_membership_activity_touch/migration.sql
@@ -11,6 +11,9 @@ SET search_path = pg_catalog, public
 AS $$
 DECLARE
   actor_user_id TEXT;
+  current_project_updated_at TIMESTAMP(3);
+  requested_version TIMESTAMP(3);
+  activity_version TIMESTAMP(3);
   touched_at TIMESTAMPTZ;
 BEGIN
   actor_user_id := app.current_user_id();
@@ -44,8 +47,30 @@ BEGIN
       USING ERRCODE = '42501';
   END IF;
 
+  SELECT p."updatedAt"
+  INTO current_project_updated_at
+  FROM "Project" p
+  WHERE p.id = project_id
+  FOR UPDATE;
+
+  IF current_project_updated_at IS NULL THEN
+    RAISE EXCEPTION 'project membership activity touch project not found'
+      USING ERRCODE = '42501';
+  END IF;
+
+  requested_version := LEAST(
+    activity_at::TIMESTAMP(3),
+    clock_timestamp()::TIMESTAMP(3)
+  );
+
+  IF current_project_updated_at >= requested_version THEN
+    activity_version := current_project_updated_at + INTERVAL '1 millisecond';
+  ELSE
+    activity_version := requested_version;
+  END IF;
+
   UPDATE "Project"
-  SET "updatedAt" = activity_at
+  SET "updatedAt" = activity_version
   WHERE id = project_id
   RETURNING "updatedAt" INTO touched_at;
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -6,6 +6,12 @@ Last reviewed: 2026-06-21
 
 ## Pending
 ### Execution Queue (Now / Next)
+- ID: TASK-320
+  Title: Project membership live refresh - update project pages when invited members join
+  Status: In progress - GitHub issue #352
+  Rationale: Already-open project dashboards do not refresh when an invited user accepts a project invitation because invitation acceptance does not advance the project activity marker watched by the SSE/polling refresh path.
+  Dependencies: TASK-058, TASK-309, TASK-311, TASK-119
+  Brief: `tasks/task-320-project-membership-live-refresh.md`
 - ID: TASK-314
   Title: Meeting todo overdue reminders - notification email and in-app reminder dispatch
   Status: Next 1 - meeting workflow completion

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,7 +4,7 @@
 TASK-320
 
 ## Status
-In progress.
+PR open. Copilot review feedback addressed.
 
 ## Branch
 `fix/task-320-project-membership-live-refresh`
@@ -68,8 +68,8 @@ refresh.
 - [x] Invitation acceptance calls the activity touch after successful accept.
 - [x] Focused service tests cover the regression.
 - [x] Local validation passes for the required baseline.
-- [ ] Branch is pushed and a ready-for-review PR is opened.
-- [ ] Copilot review/check feedback is monitored and handled.
+- [x] Branch is pushed and a ready-for-review PR is opened.
+- [x] Copilot review/check feedback is monitored and handled.
 
 ## Validation Plan
 - Focused during development:
@@ -115,3 +115,7 @@ refresh.
   Focused service/app-metadata tests, `npm run lint`, and
   `npx prisma db execute --file prisma/migrations/20260626090000_task320_project_membership_activity_touch/migration.sql`
   passed after the change.
+- PR #353 is open and ready for review. Copilot's monotonic timestamp comment
+  was addressed in commit `92e1048`, replied to, and resolved. Refreshed GitHub
+  checks passed for branch name, Quality Core, E2E Smoke, Tenant Isolation, and
+  Container Image.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,137 +1,110 @@
-# Current Task: TASK-314 Meeting Todo Overdue Reminders
+# Current Task: TASK-320 Project Membership Live Refresh
 
 ## Task ID
-TASK-314
+TASK-320
 
 ## Status
-Implemented in PR #346. Awaiting final review and merge.
+In progress.
 
 ## Branch
-`feature/task-314-meeting-todo-overdue-reminders`
+`fix/task-320-project-membership-live-refresh`
 
 ## Source
-- User feedback on TASK-098 on 2026-06-10.
-- `tasks/task-314-meeting-todo-overdue-reminders.md`
+- GitHub issue #352: Project page does not update when a member joins.
+- User report on 2026-06-26.
 
 ## Objective
-Add durable in-app and email reminders for open meeting-note todos that remain
-incomplete seven or more days after the meeting date, using the existing
-notification email dispatcher and queue semantics.
+Ensure already-open project pages update automatically after an invited user
+joins the project, so collaborator/member surfaces do not require a manual page
+refresh.
 
 ## Context
-- TASK-098 added `ProjectMeetingNote` and `ProjectMeetingNoteAction`, including
-  meeting dates, action completion state, labels, lifecycle state, and UI-level
-  overdue highlighting.
-- TASK-316 added a project-wide floating panel for open meeting todos and a
-  focused action-completion API path.
-- The notification email dispatcher already reconciles task due-date reminders
-  during `GET /api/cron/notification-emails`, creates durable `Notification`
-  rows, queues `ProjectNotificationEmail` groups, honors outbound email skip
-  modes, and records delivery outcomes.
-- Current scheduler bridge: `.github/workflows/notification-email-dispatch.yml`
-  calls the protected dispatcher every 30 minutes.
+- Project dashboards use `ProjectLiveRefresh` with an SSE-first activity stream
+  and polling fallback.
+- That refresh path observes `Project.updatedAt` as the project activity
+  version, and typed `ProjectActivityEvent` rows are used for targeted
+  reconciliation where available.
+- Invitation acceptance creates a `ProjectMembership` and marks the
+  `ProjectInvitation` accepted, but it did not advance the project activity
+  marker, so open dashboards had no freshness signal for membership changes.
+- The normal typed activity writer intentionally requires editor-or-owner
+  access. Invitees may accept viewer invitations, so membership acceptance needs
+  a narrower refresh-marker path rather than relaxing content mutation rules.
 
 ## Scope
-- Identify incomplete `ProjectMeetingNoteAction` rows whose parent note has a
-  scheduled meeting date at least seven local calendar days in the past.
-- Send the reminder to the meeting-note owner/creator while they still have
-  access to the project.
-- Create one durable in-app notification per eligible meeting todo and reminder
-  window.
-- Queue the notification through the existing project notification email digest
-  path so delivery, skipped mode, grouping, and logging remain consistent.
-- Extend dispatcher summaries, runbooks, and tests so operators can distinguish
-  task due-date reminder reconciliation from meeting-todo overdue reconciliation.
-- Preserve existing meeting-note UI behavior; this task is about durable
-  reminders and delivery, not a redesign of the floating panel or note editor.
+- Add a membership-specific project activity touch that is valid only after the
+  authenticated invitee has accepted the invitation and has a project
+  membership.
+- Call that touch after successful invitation acceptance so project SSE/polling
+  clients observe a newer project version and refresh.
+- Keep owner-only sharing management and editor-only content activity events
+  unchanged.
+- Add regression coverage for viewer invitation acceptance advancing the
+  project refresh marker.
+- Update task tracking and release metadata for the fix.
 
-## Implementation Notes
-- Start with:
-  - `lib/services/project-notification-email-service.ts`
-  - `lib/services/notification-service.ts`
-  - `lib/services/project-meeting-note-service.ts`
-  - `prisma/schema.prisma`
-  - `docs/runbooks/notification-email-dispatch.md`
-  - `tests/lib/project-notification-email-service.test.ts`
-  - `tests/lib/notification-service.test.ts`
-  - `tests/api/notification-email-dispatch.route.test.ts`
-- Prefer a durable per-action reminder state if notification/email history alone
-  cannot express "same todo, same seven-day window" clearly enough for
-  idempotency and future re-reminder decisions.
-- If adding persistence, include Prisma migration, RLS inventory/policy updates,
-  and indexes that support dispatcher scans without broad project reads.
-- Keep persistence access inside `lib/services/**`; the cron route should remain
-  a thin auth and response adapter.
-- Reuse the task due-date reminder source-id pattern, but use a distinct
-  notification `type` and `sourceType`, such as
-  `meeting_todo_overdue_reminder`.
-- The email digest item should be concise and actionable, with metadata that can
-  build a target URL back to the project/meeting context.
-- Preview validation must use disabled or safe outbound email behavior unless an
-  explicit test recipient is intentionally configured.
+## Out Of Scope
+- New UI for project membership or online presence.
+- Invitation creation, revocation, role mutation, or removal semantics.
+- Targeted client-side patching for membership rows; a full dashboard refresh is
+  acceptable for this membership-change event.
 
 ## Acceptance Criteria
-1. A service can find meeting-note todos that are incomplete seven or more days
-   after the parent note's scheduled meeting date.
-2. Reminder dispatch is idempotent per todo and reminder window.
-3. The owning meeting-note user receives a durable in-app notification/reminder
-   record while they still have project access.
-4. The reminder is queued and sent/skipped through the existing notification
-   email dispatcher, outbound email mode controls, and delivery logging.
-5. Dispatcher responses and runbooks document how meeting-todo overdue
-   reminders are triggered manually and by the scheduler bridge.
-6. Tests cover overdue selection, idempotency, email payload shape, skipped
-   delivery behavior, and permission/tenancy boundaries.
+1. Successful project invitation acceptance advances the project activity
+   version observed by the existing project live-refresh stream.
+2. Viewer invitees can trigger the membership-refresh marker only through the
+   accepted-invitation path; editor-only content activity behavior remains
+   unchanged.
+3. Owner-only collaboration management APIs and project authorization
+   boundaries remain unchanged.
+4. Tests cover the acceptance path and the membership activity touch behavior.
+5. The GitHub issue is linked from the PR and repository task tracking is
+   updated.
 
 ## Definition Of Done
-- [x] Existing notification-email services, scheduler workflow, and runbook are
-      reviewed.
-- [x] Reminder eligibility is implemented in the service layer with project and
-      recipient access checks.
-- [x] Persistence changes, if needed, are added through Prisma migrations and
-      RLS inventory/policy updates. No new persistence table was needed; the
-      existing `Notification` unique key and email item coverage provide the
-      durable per-window idempotency record.
-- [x] In-app notification metadata and email digest rendering support
-      meeting-todo overdue reminders.
-- [x] API/cron dispatcher output includes meeting-todo reminder reconciliation
-      evidence.
-- [x] Tests cover service, API/scheduler, email grouping/rendering, skipped
-      delivery, and tenancy behavior.
-- [x] Documentation explains local, preview, and production reminder behavior.
-- [x] Preview validation proves the reminder path can run safely without sending
-      unintended external email.
+- [x] Root cause is identified in the invitation acceptance and project activity
+      flow.
+- [x] A membership-specific activity touch is implemented.
+- [x] Invitation acceptance calls the activity touch after successful accept.
+- [x] Focused service tests cover the regression.
+- [x] Local validation passes for the required baseline.
+- [ ] Branch is pushed and a ready-for-review PR is opened.
+- [ ] Copilot review/check feedback is monitored and handled.
 
 ## Validation Plan
-- [x] `npm run lint`
-- [x] `npm run rls:check`
-- [x] `npm test`
-- [x] `npm run test:coverage`
-- [x] `npm run build`
-- Run focused notification dispatcher and meeting-note tests during development.
-- If Prisma/RLS changes are introduced, also run:
-  - `npm run test:rls:setup`
-  - `npm run test:rls`
-- For preview validation, dispatch the notification email workflow with
-  `git_ref=feature/task-314-meeting-todo-overdue-reminders`, confirm logs check
-  out that ref, and capture the dispatcher summary plus safe outbound email
-  outcome.
+- Focused during development:
+  - `npm test -- tests/lib/project-activity-service.test.ts tests/lib/project-collaboration-service.test.ts`
+- Before handoff:
+  - `npm run lint`
+  - `npm run rls:check`
+  - `npm test`
+  - `npm run test:coverage`
+  - `npm run build`
 
 ## Evidence
-- Local validation passed with `npm run lint`, `npm run rls:check`, focused
-  notification/API tests, local PostgreSQL `npm test` (124 files passed, 2
-  skipped; 922 tests passed, 2 skipped), `npm run test:coverage` (91.37%
-  statements, 81.33% branches, 92.2% functions, 91.88% lines), preview-env
-  `npm run build`, and `git diff --check`.
-- PR #346 checks passed on commit
-  `39f80f2da44419fa37c3cb7ec9114f673879204b` for branch name, Quality Core,
-  E2E Smoke, Tenant Isolation, and Container Image.
-- Preview workflow run `28135528412` used
-  `git_ref=feature/task-314-meeting-todo-overdue-reminders`, checked out commit
-  `39f80f2da44419fa37c3cb7ec9114f673879204b`, deployed app version `0.22.0` to
-  `https://nexus-dash-hyp9z5w0q-dorian-agaesses-projects.vercel.app`, and
-  passed the secret-injection check for `NOTIFICATION_EMAIL_DISPATCH_SECRET`.
-- Notification dispatch workflow run `28135630372` against that preview returned
-  `ok: true` with `meetingTodoOverdueRemindersReconciled: 0`, all delivery
-  counts at `0`, and `errors: 0`, proving the guarded reminder path can run
-  safely without sending unintended external email.
+- Root cause: invitation acceptance did not advance `Project.updatedAt` or
+  create a typed activity event, so existing SSE/polling clients had no newer
+  project activity version to observe after a member joined.
+- Added `app.touch_project_membership_activity(...)`, which validates the
+  authenticated invitee, accepted invitation, actor email, and resulting
+  membership before updating the project activity marker.
+- `respondToProjectInvitation(...)` now touches the membership activity marker
+  after successful acceptance, causing existing project activity SSE/polling
+  clients to observe a newer project version and refresh.
+- Validation passed:
+  - `npm test -- tests/lib/project-activity-service.test.ts tests/lib/project-collaboration-service.test.ts`
+  - `npm test -- tests/lib/app-metadata.test.ts`
+  - `npm run lint`
+  - `npm run rls:check`
+  - `npm run release:check -- --base origin/main --branch fix/task-320-project-membership-live-refresh`
+  - local PostgreSQL `npm test` (124 files passed, 2 skipped; 924 tests passed,
+    2 skipped)
+  - `npm run db:migrate`
+  - `npm run test:coverage` (91.37% statements, 81.33% branches, 92.2%
+    functions, 91.88% lines)
+  - `npm run build` with local-safe placeholder production secrets
+  - `git diff --check`
+- Initial bare `npm test` failed because `DATABASE_URL` was not set in the
+  shell and stale app metadata assertions still expected `v0.22.0`; rerunning
+  with local database env after deriving those assertions from `package.json`
+  passed.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -108,3 +108,10 @@ refresh.
   shell and stale app metadata assertions still expected `v0.22.0`; rerunning
   with local database env after deriving those assertions from `package.json`
   passed.
+- Copilot review follow-up: changed
+  `app.touch_project_membership_activity(...)` to lock the current project row
+  and compute a monotonic activity version from database time, preventing
+  `updatedAt` from moving backward under clock skew or concurrent writes.
+  Focused service/app-metadata tests, `npm run lint`, and
+  `npx prisma db execute --file prisma/migrations/20260626090000_task320_project_membership_activity_touch/migration.sql`
+  passed after the change.

--- a/tasks/task-320-project-membership-live-refresh.md
+++ b/tasks/task-320-project-membership-live-refresh.md
@@ -1,0 +1,39 @@
+# TASK-320 Project Membership Live Refresh
+
+## Status
+In progress.
+
+## Source
+- GitHub issue #352: Project page does not update when a member joins.
+- User report on 2026-06-26.
+
+## Objective
+Refresh already-open project pages automatically when an invited user accepts a
+project invitation and becomes a member.
+
+## Root Cause
+`respondToProjectInvitation(...)` created the `ProjectMembership` and marked the
+`ProjectInvitation` accepted, but did not advance the project activity marker
+used by `ProjectLiveRefresh`. Because `Project.updatedAt` stayed unchanged and
+no typed project activity event was recorded, the SSE stream and polling
+fallback had no newer version to emit to existing project dashboards.
+
+## Acceptance Criteria
+1. Successful project invitation acceptance advances the project activity
+   version observed by the existing project live-refresh stream.
+2. Viewer invitees can trigger the membership-refresh marker only through the
+   accepted-invitation path; editor-only content activity behavior remains
+   unchanged.
+3. Owner-only collaboration management APIs and project authorization
+   boundaries remain unchanged.
+4. Tests cover the acceptance path and the membership activity touch behavior.
+5. The GitHub issue is linked from the PR and repository task tracking is
+   updated.
+
+## Validation Plan
+- `npm test -- tests/lib/project-activity-service.test.ts tests/lib/project-collaboration-service.test.ts`
+- `npm run lint`
+- `npm run rls:check`
+- `npm test`
+- `npm run test:coverage`
+- `npm run build`

--- a/tests/lib/app-metadata.test.ts
+++ b/tests/lib/app-metadata.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, test } from "vitest";
 
 import { getAppMetadataSummary } from "@/lib/app-metadata";
+import packageJson from "@/package.json";
 
 describe("app-metadata", () => {
+  const packageVersionTag = `v${packageJson.version}`;
   const originalAppVersion = process.env.APP_VERSION;
   const originalPublicAppVersion = process.env.NEXT_PUBLIC_APP_VERSION;
   const originalVercelSha = process.env.VERCEL_GIT_COMMIT_SHA;
@@ -60,10 +62,10 @@ describe("app-metadata", () => {
 
     const summary = getAppMetadataSummary();
 
-    expect(summary.versionTag).toBe("v0.22.0");
+    expect(summary.versionTag).toBe(packageVersionTag);
     expect(summary.revision).toBeNull();
     expect(summary.revisionLabel).toBeNull();
-    expect(summary.versionLabel).toBe("v0.22.0");
+    expect(summary.versionLabel).toBe(packageVersionTag);
   });
 
   test("strips build metadata from the visible version", () => {
@@ -84,8 +86,8 @@ describe("app-metadata", () => {
 
     const summary = getAppMetadataSummary();
 
-    expect(summary.versionTag).toBe("v0.22.0");
-    expect(summary.versionLabel).toBe("v0.22.0");
+    expect(summary.versionTag).toBe(packageVersionTag);
+    expect(summary.versionLabel).toBe(packageVersionTag);
   });
 
   test("uses optional repository override when present", () => {

--- a/tests/lib/project-activity-service.test.ts
+++ b/tests/lib/project-activity-service.test.ts
@@ -8,6 +8,7 @@ import {
   recordProjectActivityEvent,
   projectActivityServiceInternals,
   touchProjectActivity,
+  touchProjectMembershipActivity,
 } from "@/lib/services/project-activity-service";
 
 describe("project-activity-service", () => {
@@ -49,6 +50,30 @@ describe("project-activity-service", () => {
 
     expect(result).toBe(occurredAt);
     expect(projectUpdate).not.toHaveBeenCalled();
+  });
+
+  test("touchProjectMembershipActivity advances the project marker for accepted membership changes", async () => {
+    const occurredAt = new Date("2026-06-26T08:00:00.000Z");
+    const projectUpdate = vi.fn().mockResolvedValue({ id: "project-1" });
+
+    const result = await touchProjectMembershipActivity({
+      db: {
+        project: {
+          update: projectUpdate,
+        },
+      } as never,
+      projectId: " project-1 ",
+      actorUserId: " user-1 ",
+      invitationId: " invite-1 ",
+      occurredAt,
+    });
+
+    expect(result).toBe(occurredAt);
+    expect(projectUpdate).toHaveBeenCalledWith({
+      where: { id: "project-1" },
+      data: { updatedAt: occurredAt },
+      select: { id: true },
+    });
   });
 
   test("recordProjectActivityEvent creates a typed event and advances project activity", async () => {

--- a/tests/lib/project-collaboration-service.test.ts
+++ b/tests/lib/project-collaboration-service.test.ts
@@ -21,6 +21,7 @@ const prismaMock = vi.hoisted(() => ({
   project: {
     findFirst: vi.fn(),
     findUnique: vi.fn(),
+    update: vi.fn(),
   },
 }));
 
@@ -564,6 +565,58 @@ describe("project-collaboration-service", () => {
     expect(prismaMock.projectMembership.create).toHaveBeenCalledTimes(1);
     expect(prismaMock.projectInvitation.updateMany).toHaveBeenCalledTimes(1);
     expect(prismaMock.projectMembership.deleteMany).not.toHaveBeenCalled();
+  });
+
+  test("advances project activity when a viewer accepts an invitation", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-20T02:30:00.000Z"));
+
+    prismaMock.user.findUnique.mockResolvedValueOnce({
+      email: "invitee@example.com",
+      emailVerified: new Date("2026-03-20T00:00:00.000Z"),
+    });
+    prismaMock.projectInvitation.findUnique.mockResolvedValueOnce({
+      id: "invite-1",
+      projectId: "project-1",
+      invitedEmail: "invitee@example.com",
+      role: "viewer",
+      acceptedAt: null,
+      revokedAt: null,
+      replacedAt: null,
+      expiresAt: new Date("2099-03-21T00:00:00.000Z"),
+    });
+    prismaMock.projectMembership.findUnique.mockResolvedValueOnce(null);
+    prismaMock.projectMembership.create.mockResolvedValueOnce({
+      id: "membership-1",
+    });
+    prismaMock.projectInvitation.updateMany.mockResolvedValueOnce({ count: 1 });
+    prismaMock.project.update.mockResolvedValueOnce({ id: "project-1" });
+
+    const result = await respondToProjectInvitation({
+      actorUserId: "user-1",
+      invitationId: "invite-1",
+      decision: "accept",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      status: 200,
+      data: {
+        projectId: "project-1",
+      },
+    });
+    expect(prismaMock.projectMembership.create).toHaveBeenCalledWith({
+      data: {
+        projectId: "project-1",
+        userId: "user-1",
+        role: "viewer",
+      },
+    });
+    expect(prismaMock.project.update).toHaveBeenCalledWith({
+      where: { id: "project-1" },
+      data: { updatedAt: new Date("2026-03-20T02:30:00.000Z") },
+      select: { id: true },
+    });
   });
 
   test("removes a just-created membership when invitation acceptance loses to revocation", async () => {


### PR DESCRIPTION
## Summary
- Fixes invitation acceptance so already-open project dashboards refresh after a new member joins.
- Adds `app.touch_project_membership_activity(...)`, a narrow membership-specific activity marker function that validates the authenticated invitee, accepted invitation, actor email, and resulting membership before updating `Project.updatedAt`.
- Keeps editor-only typed content activity events unchanged, bumps the fix release to `v0.22.1`, and records TASK-320 tracking context.

## Root cause
`respondToProjectInvitation(...)` created the `ProjectMembership` and marked the `ProjectInvitation` accepted, but it did not advance `Project.updatedAt` or create a typed project activity event. `ProjectLiveRefresh` watches that project activity version via SSE/polling, so open dashboards had no newer version to observe when a member joined.

## Validation
- `npm test -- tests/lib/project-activity-service.test.ts tests/lib/project-collaboration-service.test.ts`
- `npm test -- tests/lib/app-metadata.test.ts`
- `npm run lint`
- `npm run rls:check`
- `npm run release:check -- --base origin/main --branch fix/task-320-project-membership-live-refresh`
- local PostgreSQL `npm test` (124 files passed, 2 skipped; 924 tests passed, 2 skipped)
- `npm run db:migrate`
- `npm run test:coverage` (91.37% statements, 81.33% branches, 92.2% functions, 91.88% lines)
- `npm run build` with local-safe placeholder production secrets
- `git diff --check`

Closes #352