### PR TITLE
TASK-320 Fix project membership live refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ SHA, deployment URL, and workflow run belong in release evidence.
 
 - Define each release entry before the product-impacting PR is merged.
 
+## v0.23.1 - 2026-06-27
+
+- Fixed project dashboards so already-open pages refresh after an invited
+  member accepts a project invitation.
+- Added a membership-specific project activity marker touch that validates the
+  accepted invite and resulting membership without relaxing editor-only content
+  activity rules.
+- Added regression coverage for viewer invitation acceptance advancing the
+  project refresh marker.
+
 ## v0.23.0 - 2026-06-25
 
 - Added a compact collaborator presence block to project dashboards so members

--- a/journal.md
+++ b/journal.md
@@ -28,6 +28,12 @@ Use it for important implementation milestones, blockers, validation runs, and r
   `git diff --check` passed. An initial bare `npm test` failed before
   assertions in DB-backed suites because `DATABASE_URL` was not set in the
   shell.
+- Review: Copilot flagged that the membership activity function could overwrite
+  `Project.updatedAt` with a non-monotonic app-supplied timestamp. Updated the
+  function to lock/read the current project version, cap the requested version
+  at database time, and advance by one millisecond when the current version is
+  already newer. Focused tests, lint, and local `prisma db execute` of the
+  patched function passed.
 
 # 2026-06-25 - TASK-314 meeting todo overdue reminders started
 

--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,32 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-06-26 - TASK-320 project membership live refresh started
+
+- Summary: Created GitHub issue #352 and worktree
+  `../nexus_dash_task320` on
+  `fix/task-320-project-membership-live-refresh`.
+- Root cause: `respondToProjectInvitation(...)` created the membership and
+  accepted the invitation but never advanced `Project.updatedAt` or recorded a
+  typed project activity event. Existing project dashboards subscribe to that
+  activity version through SSE/polling, so open pages had no signal that a new
+  member joined.
+- Decision: Added a membership-specific activity touch instead of relaxing the
+  editor-only typed activity writer. The database function validates the
+  authenticated invitee, accepted invitation, and resulting membership before
+  updating the project activity marker, so viewer invitations can refresh open
+  dashboards without changing content mutation authorization.
+- Validation: Focused membership activity tests passed (2 files / 19 tests),
+  app metadata tests passed after deriving package fallback expectations from
+  `package.json`, `npm run lint`, `npm run rls:check`, release-policy
+  validation for `v0.22.1`, local PostgreSQL `npm test` (124 files passed, 2
+  skipped; 924 tests passed, 2 skipped), `npm run db:migrate`,
+  `npm run test:coverage` (91.37% statements, 81.33% branches, 92.2%
+  functions, 91.88% lines), local-safe `npm run build`, and
+  `git diff --check` passed. An initial bare `npm test` failed before
+  assertions in DB-backed suites because `DATABASE_URL` was not set in the
+  shell.
+
 # 2026-06-25 - TASK-314 meeting todo overdue reminders started
 
 - Summary: Removed clean local task worktrees for TASK-316, TASK-318, and

--- a/journal.md
+++ b/journal.md
@@ -21,7 +21,7 @@ Use it for important implementation milestones, blockers, validation runs, and r
 - Validation: Focused membership activity tests passed (2 files / 19 tests),
   app metadata tests passed after deriving package fallback expectations from
   `package.json`, `npm run lint`, `npm run rls:check`, release-policy
-  validation for `v0.22.1`, local PostgreSQL `npm test` (124 files passed, 2
+  validation for `v0.23.1`, local PostgreSQL `npm test` (124 files passed, 2
   skipped; 924 tests passed, 2 skipped), `npm run db:migrate`,
   `npm run test:coverage` (91.37% statements, 81.33% branches, 92.2%
   functions, 91.88% lines), local-safe `npm run build`, and

--- a/lib/services/project-activity-service.ts
+++ b/lib/services/project-activity-service.ts
@@ -29,6 +29,11 @@ interface TouchProjectActivityInput {
   occurredAt?: Date;
 }
 
+interface TouchProjectMembershipActivityInput extends TouchProjectActivityInput {
+  actorUserId: string;
+  invitationId: string;
+}
+
 interface ProjectActivitySnapshot {
   projectId: string;
   version: Date;
@@ -84,6 +89,14 @@ function normalizeId(value: string | null | undefined): string {
 }
 
 function canCallRawProjectActivityTouch(db: DbClient): db is DbClient & {
+  $queryRaw<T = unknown>(query: Prisma.Sql): Promise<T>;
+} {
+  return typeof (db as { $queryRaw?: unknown }).$queryRaw === "function";
+}
+
+function canCallRawProjectMembershipActivityTouch(
+  db: DbClient
+): db is DbClient & {
   $queryRaw<T = unknown>(query: Prisma.Sql): Promise<T>;
 } {
   return typeof (db as { $queryRaw?: unknown }).$queryRaw === "function";
@@ -215,6 +228,41 @@ export async function touchProjectActivity(
   if (process.env.NODE_ENV !== "test" && canCallRawProjectActivityTouch(input.db)) {
     const rows = await input.db.$queryRaw<Array<{ updated_at: Date }>>(
       Prisma.sql`SELECT app.touch_project_activity(${projectId}, ${occurredAt}) AS updated_at`
+    );
+    return rows[0]?.updated_at ?? occurredAt;
+  }
+
+  const projectDelegate = (input.db as { project?: { update?: unknown } }).project;
+  if (typeof projectDelegate?.update !== "function") {
+    return occurredAt;
+  }
+
+  await input.db.project.update({
+    where: { id: projectId },
+    data: { updatedAt: occurredAt },
+    select: { id: true },
+  });
+
+  return occurredAt;
+}
+
+export async function touchProjectMembershipActivity(
+  input: TouchProjectMembershipActivityInput
+): Promise<Date> {
+  const projectId = normalizeId(input.projectId);
+  const actorUserId = normalizeId(input.actorUserId);
+  const invitationId = normalizeId(input.invitationId);
+  const occurredAt = input.occurredAt ?? new Date();
+  if (!projectId || !actorUserId || !invitationId) {
+    return occurredAt;
+  }
+
+  if (
+    process.env.NODE_ENV !== "test" &&
+    canCallRawProjectMembershipActivityTouch(input.db)
+  ) {
+    const rows = await input.db.$queryRaw<Array<{ updated_at: Date }>>(
+      Prisma.sql`SELECT app.touch_project_membership_activity(${projectId}, ${actorUserId}, ${invitationId}, ${occurredAt}) AS updated_at`
     );
     return rows[0]?.updated_at ?? occurredAt;
   }

--- a/lib/services/project-collaboration-service.ts
+++ b/lib/services/project-collaboration-service.ts
@@ -1573,6 +1573,7 @@ export async function respondToProjectInvitation(input: {
 
     if (invitation.acceptedAt) {
       await resolveCurrentInvitationNotification();
+      await touchAcceptedMembershipActivity(invitation.acceptedAt);
       return createSuccess(200, { projectId: invitation.projectId });
     }
 
@@ -1714,6 +1715,7 @@ export async function respondToProjectInvitation(input: {
 
       if (latestInvitation?.acceptedAt) {
         await resolveCurrentInvitationNotification();
+        await touchAcceptedMembershipActivity(latestInvitation.acceptedAt);
         return createSuccess(200, { projectId: latestInvitation.projectId });
       }
 

--- a/lib/services/project-collaboration-service.ts
+++ b/lib/services/project-collaboration-service.ts
@@ -14,6 +14,7 @@ import {
   hasRequiredRole,
   requireProjectRole,
 } from "@/lib/services/project-access-service";
+import { touchProjectMembershipActivity } from "@/lib/services/project-activity-service";
 import {
   createProjectInvitationNotification,
   resolveProjectInvitationNotifications,
@@ -1547,6 +1548,28 @@ export async function respondToProjectInvitation(input: {
         invitationIds: [invitation.id],
       });
     };
+    const touchAcceptedMembershipActivity = async (acceptedAt: Date) => {
+      try {
+        await touchProjectMembershipActivity({
+          db,
+          actorUserId,
+          projectId: invitation.projectId,
+          invitationId: invitation.id,
+          occurredAt: acceptedAt,
+        });
+      } catch (error) {
+        logServerWarning(
+          "respondToProjectInvitation.activityTouchFailed",
+          "Could not advance project activity after invitation acceptance",
+          {
+            actorUserId,
+            projectId: invitation.projectId,
+            invitationId: invitation.id,
+            error,
+          }
+        );
+      }
+    };
 
     if (invitation.acceptedAt) {
       await resolveCurrentInvitationNotification();
@@ -1732,6 +1755,7 @@ export async function respondToProjectInvitation(input: {
     }
 
     await resolveCurrentInvitationNotification();
+    await touchAcceptedMembershipActivity(acceptedAt);
     return createSuccess(200, { projectId: invitation.projectId });
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexusdash",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexusdash",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1064.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexusdash",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "private": true,
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0",

--- a/prisma/migrations/20260626090000_task320_project_membership_activity_touch/migration.sql
+++ b/prisma/migrations/20260626090000_task320_project_membership_activity_touch/migration.sql
@@ -1,0 +1,61 @@
+CREATE OR REPLACE FUNCTION app.touch_project_membership_activity(
+  project_id TEXT,
+  member_user_id TEXT,
+  invitation_id TEXT,
+  activity_at TIMESTAMPTZ DEFAULT now()
+)
+RETURNS TIMESTAMPTZ
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  actor_user_id TEXT;
+  touched_at TIMESTAMPTZ;
+BEGIN
+  actor_user_id := app.current_user_id();
+
+  IF actor_user_id IS NULL THEN
+    RAISE EXCEPTION 'project membership activity touch requires an authenticated actor'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF member_user_id IS DISTINCT FROM actor_user_id THEN
+    RAISE EXCEPTION 'project membership activity touch actor mismatch'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM "ProjectInvitation" pi
+    JOIN "User" u
+      ON u.id = member_user_id
+      AND u.email = pi."invitedEmail"
+    JOIN "ProjectMembership" pm
+      ON pm."projectId" = pi."projectId"
+      AND pm."userId" = member_user_id
+    WHERE pi.id = invitation_id
+      AND pi."projectId" = project_id
+      AND pi."acceptedAt" IS NOT NULL
+      AND pi."revokedAt" IS NULL
+      AND pi."replacedAt" IS NULL
+  ) THEN
+    RAISE EXCEPTION 'project membership activity touch forbidden'
+      USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE "Project"
+  SET "updatedAt" = activity_at
+  WHERE id = project_id
+  RETURNING "updatedAt" INTO touched_at;
+
+  RETURN touched_at;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION app.touch_project_membership_activity(
+  TEXT,
+  TEXT,
+  TEXT,
+  TIMESTAMPTZ
+) TO PUBLIC;

--- a/prisma/migrations/20260626090000_task320_project_membership_activity_touch/migration.sql
+++ b/prisma/migrations/20260626090000_task320_project_membership_activity_touch/migration.sql
@@ -11,6 +11,9 @@ SET search_path = pg_catalog, public
 AS $$
 DECLARE
   actor_user_id TEXT;
+  current_project_updated_at TIMESTAMP(3);
+  requested_version TIMESTAMP(3);
+  activity_version TIMESTAMP(3);
   touched_at TIMESTAMPTZ;
 BEGIN
   actor_user_id := app.current_user_id();
@@ -44,8 +47,30 @@ BEGIN
       USING ERRCODE = '42501';
   END IF;
 
+  SELECT p."updatedAt"
+  INTO current_project_updated_at
+  FROM "Project" p
+  WHERE p.id = project_id
+  FOR UPDATE;
+
+  IF current_project_updated_at IS NULL THEN
+    RAISE EXCEPTION 'project membership activity touch project not found'
+      USING ERRCODE = '42501';
+  END IF;
+
+  requested_version := LEAST(
+    activity_at::TIMESTAMP(3),
+    clock_timestamp()::TIMESTAMP(3)
+  );
+
+  IF current_project_updated_at >= requested_version THEN
+    activity_version := current_project_updated_at + INTERVAL '1 millisecond';
+  ELSE
+    activity_version := requested_version;
+  END IF;
+
   UPDATE "Project"
-  SET "updatedAt" = activity_at
+  SET "updatedAt" = activity_version
   WHERE id = project_id
   RETURNING "updatedAt" INTO touched_at;
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -6,6 +6,12 @@ Last reviewed: 2026-06-21
 
 ## Pending
 ### Execution Queue (Now / Next)
+- ID: TASK-320
+  Title: Project membership live refresh - update project pages when invited members join
+  Status: In progress - GitHub issue #352
+  Rationale: Already-open project dashboards do not refresh when an invited user accepts a project invitation because invitation acceptance does not advance the project activity marker watched by the SSE/polling refresh path.
+  Dependencies: TASK-058, TASK-309, TASK-311, TASK-119
+  Brief: `tasks/task-320-project-membership-live-refresh.md`
 - ID: TASK-314
   Title: Meeting todo overdue reminders - notification email and in-app reminder dispatch
   Status: Next 1 - meeting workflow completion

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,179 +1,121 @@
-# Current Task: TASK-119 Project Collaboration Presence UX
+# Current Task: TASK-320 Project Membership Live Refresh
 
 ## Task ID
-TASK-119
+TASK-320
 
 ## Status
 PR open. Copilot review feedback addressed.
 
 ## Branch
-`feature/task-119-project-collaboration-presence-ux`
+`fix/task-320-project-membership-live-refresh`
 
 ## Source
-- `tasks/backlog.md`
-- Dependencies and existing implementation context from TASK-058, TASK-082, and
-  TASK-089.
+- GitHub issue #352: Project page does not update when a member joins.
+- User report on 2026-06-26.
 
 ## Objective
-Add a compact collaborator presence experience to project pages so project
-members can quickly see who has access to the project, with avatar-backed
-identity affordances that reuse the existing generated avatar baseline and
-project membership authorization rules.
+Ensure already-open project pages update automatically after an invited user
+joins the project, so collaborator/member surfaces do not require a manual page
+refresh.
 
 ## Context
-- TASK-058 shipped project sharing, membership roles, owner-managed
-  invitations, and service-layer project authorization.
-- TASK-082 added user-facing account identity fields such as display names,
-  username tags, and account settings identity management.
-- TASK-089 added deterministic generated avatars through `User.avatarSeed`,
-  `resolveAvatarSeed(...)`, and `UserAvatar`.
-- Current project pages already derive the actor role from
-  `getProjectSummaryById(...)`, while the Kanban section loads collaborator
-  identities through `listProjectCollaborators(...)` for assignees and mentions.
-- Owner settings already fetch a full `ProjectSharingSummary`, but that path is
-  owner-only and should not become the general member-visible presence source.
+- Project dashboards use `ProjectLiveRefresh` with an SSE-first activity stream
+  and polling fallback.
+- That refresh path observes `Project.updatedAt` as the project activity
+  version, and typed `ProjectActivityEvent` rows are used for targeted
+  reconciliation where available.
+- Invitation acceptance creates a `ProjectMembership` and marks the
+  `ProjectInvitation` accepted, but it did not advance the project activity
+  marker, so open dashboards had no freshness signal for membership changes.
+- The normal typed activity writer intentionally requires editor-or-owner
+  access. Invitees may accept viewer invitations, so membership acceptance needs
+  a narrower refresh-marker path rather than relaxing content mutation rules.
 
 ## Scope
-- Add a member-visible project presence affordance near the project dashboard
-  header, using a compact avatar stack or similarly dense collaboration surface.
-- Show current project members with generated avatars, display names, roles, and
-  secondary identity where useful, while avoiding repeated or noisy identity
-  copy.
-- Include the signed-in actor in the presence data and clearly distinguish their
-  own role without implying live online/offline status.
-- Support owner, editor, and viewer access through a service-layer read path
-  that requires at least project viewer membership.
-- Preserve owner-only collaboration management in the existing settings panels;
-  this task is about awareness on the project page, not editing invitations or
-  roles.
-- Keep the UI responsive on mobile and desktop without overlapping the project
-  title, action buttons, or dashboard stats.
-- Reuse existing avatar, role-formatting, and collaborator identity helpers
-  where they fit; avoid introducing remote image dependencies or a separate
-  avatar system.
+- Add a membership-specific project activity touch that is valid only after the
+  authenticated invitee has accepted the invitation and has a project
+  membership.
+- Call that touch after successful invitation acceptance so project SSE/polling
+  clients observe a newer project version and refresh.
+- Keep owner-only sharing management and editor-only content activity events
+  unchanged.
+- Add regression coverage for viewer invitation acceptance advancing the
+  project refresh marker.
+- Update task tracking and release metadata for the fix.
 
 ## Out Of Scope
-- Real-time online presence, cursor presence, or active editing indicators.
-- New uploaded profile photo support.
-- Changes to invitation creation, role mutation, or member removal workflows.
-- Calendar/member availability semantics.
-- Agent credential avatars or agent presence on project pages.
-
-## Implementation Notes
-- Start with:
-  - `app/projects/[projectId]/page.tsx`
-  - `lib/services/project-service.ts`
-  - `components/ui/user-avatar.tsx`
-  - `components/project-dashboard/project-dashboard-owner-actions.shared.ts`
-  - `components/project-dashboard/project-dashboard-owner-access-panel.tsx`
-  - `components/kanban-board-types.ts`
-  - `tests/lib/project-service.test.ts`
-  - `tests/components/*project*`
-- Consider either extending `ProjectSummaryWithStatsRecord` with a small
-  `members` payload or adding a focused service such as
-  `listProjectPresenceMembers(projectId, actorUserId)`. Prefer the option that
-  avoids extra broad queries and keeps `getProjectSummaryById(...)` readable.
-- The general presence read path must not call the owner-only
-  `getProjectSharingSummary(...)`; that service should remain tied to project
-  settings management.
-- If the surface needs a hidden overflow list or popover for larger projects,
-  use stable dimensions and accessible labels so the avatar stack does not
-  resize the header unexpectedly.
-- Ensure fallback avatars come from `resolveAvatarSeed(user.avatarSeed, user.id)`
-  and existing `UserAvatar` rendering.
-- If project membership query shape changes, check RLS assumptions and update
-  RLS inventory only if new persistence or policy coverage is introduced.
+- New UI for project membership or online presence.
+- Invitation creation, revocation, role mutation, or removal semantics.
+- Targeted client-side patching for membership rows; a full dashboard refresh is
+  acceptable for this membership-change event.
 
 ## Acceptance Criteria
-1. Project pages show a compact collaborator presence affordance for every actor
-   with at least viewer access to the project.
-2. The affordance renders generated avatars and identity labels for project
-   members, including accounts without uploaded photos.
-3. Roles are visible or discoverable for listed members, and the current actor's
-   own role remains clear.
-4. Owner-only management behavior remains unchanged; non-owners do not gain
-   access to invitation or member-management APIs.
-5. The UI works on narrow and wide viewports without text overlap, layout shift,
-   or clipped action controls.
-6. Tests cover service authorization/tenancy, member identity mapping, avatar
-   fallback behavior, and representative UI rendering.
+1. Successful project invitation acceptance advances the project activity
+   version observed by the existing project live-refresh stream.
+2. Viewer invitees can trigger the membership-refresh marker only through the
+   accepted-invitation path; editor-only content activity behavior remains
+   unchanged.
+3. Owner-only collaboration management APIs and project authorization
+   boundaries remain unchanged.
+4. Tests cover the acceptance path and the membership activity touch behavior.
+5. The GitHub issue is linked from the PR and repository task tracking is
+   updated.
 
 ## Definition Of Done
-- [x] Active project context, membership services, and avatar components are
-      reviewed.
-- [x] A member-visible project presence data path is implemented in
-      `lib/services/**` with viewer-or-higher authorization.
-- [x] Project dashboard header renders the presence affordance with accessible
-      avatar/name/role semantics.
-- [x] Existing owner settings sharing and access panels continue to work
-      unchanged.
-- [x] Unit/component coverage is added or updated for the new service/UI path.
+- [x] Root cause is identified in the invitation acceptance and project activity
+      flow.
+- [x] A membership-specific activity touch is implemented.
+- [x] Invitation acceptance calls the activity touch after successful accept.
+- [x] Focused service tests cover the regression.
 - [x] Local validation passes for the required baseline.
-- [x] `tasks/current.md` and `journal.md` are updated with implementation and
-      validation evidence before handoff.
+- [x] Branch is pushed and a ready-for-review PR is opened.
+- [x] Copilot review/check feedback is monitored and handled.
 
 ## Validation Plan
 - Focused during development:
-  - `npm test -- tests/lib/project-service.test.ts`
-  - relevant component tests for the project dashboard/header or new presence
-    component
+  - `npm test -- tests/lib/project-activity-service.test.ts tests/lib/project-collaboration-service.test.ts`
 - Before handoff:
   - `npm run lint`
   - `npm run rls:check`
   - `npm test`
   - `npm run test:coverage`
   - `npm run build`
-- Run `npm run test:e2e` if the final implementation materially changes the
-  project dashboard layout or navigation behavior beyond the header affordance.
 
 ## Evidence
-- Implemented a server-rendered project collaborator presence block in the
-  dashboard header, powered by the existing `listProjectCollaborators(...)`
-  viewer-or-higher service path.
-- Reused generated `UserAvatar` rendering, added optional avatar `title`
-  support, included role/name rows plus screen-reader-only full member context,
-  and kept sharing/settings management owner-only.
-- Added responsive title wrapping with `overflow-wrap:anywhere` after visual
-  validation exposed long project names overflowing on mobile.
-- Added `tests/components/project-collaboration-presence.test.tsx` for member
-  count, actor role, avatar rendering, overflow, and empty rendering behavior.
-- Local dev server started at `http://127.0.0.1:3000`; standalone Playwright
-  visual checks captured `.tmp/task119-presence-desktop.png` and
-  `.tmp/task119-presence-mobile.png`, confirming the presence block and long
-  project title fit desktop and 390px mobile viewports. The probe also surfaced
-  an existing meeting-notes search input hydration warning unrelated to this
-  component.
+- Root cause: invitation acceptance did not advance `Project.updatedAt` or
+  create a typed activity event, so existing SSE/polling clients had no newer
+  project activity version to observe after a member joined.
+- Added `app.touch_project_membership_activity(...)`, which validates the
+  authenticated invitee, accepted invitation, actor email, and resulting
+  membership before updating the project activity marker.
+- `respondToProjectInvitation(...)` now touches the membership activity marker
+  after successful acceptance, causing existing project activity SSE/polling
+  clients to observe a newer project version and refresh.
 - Validation passed:
+  - `npm test -- tests/lib/project-activity-service.test.ts tests/lib/project-collaboration-service.test.ts`
+  - `npm test -- tests/lib/app-metadata.test.ts`
   - `npm run lint`
   - `npm run rls:check`
-  - `npm test` with local PostgreSQL env (125 files passed, 2 skipped; 925
-    tests passed, 2 skipped)
+  - `npm run release:check -- --base origin/main --branch fix/task-320-project-membership-live-refresh`
+  - local PostgreSQL `npm test` (124 files passed, 2 skipped; 924 tests passed,
+    2 skipped)
+  - `npm run db:migrate`
   - `npm run test:coverage` (91.37% statements, 81.33% branches, 92.2%
     functions, 91.88% lines)
   - `npm run build` with local-safe placeholder production secrets
-  - `PORT=3001 npm run test:e2e` with local PostgreSQL env and outbound email
-    disabled (9 passed)
-- PR #347 CI initially caught stale app-metadata fallback expectations pinned to
-  `v0.22.0`; updated the tests to derive the fallback from `package.json`.
-  Focused `tests/lib/app-metadata.test.ts`, full PostgreSQL-backed `npm test`,
-  and `npm run lint` passed after the fix.
-- Copilot review feedback addressed by marking visual member rows
-  `aria-hidden` while keeping the full screen-reader collaborator summary, and
-  by passing the project-page collaborator payload into `KanbanBoardSection` to
-  avoid a second collaborator query in the same dashboard request.
-- Post-review validation passed:
-  - `npm test -- tests/components/project-collaboration-presence.test.tsx`
-  - `npm run lint`
-  - PostgreSQL-backed `npm test`
-  - `npm run build`
-- Screenshot follow-up addressed:
-  - presence header now renders avatars only, with hover titles showing each
-    member's username tag or display name fallback
-  - dashboard stats use equal responsive columns so Attachments and Calendar no
-    longer collapse into narrow one-column cards
-  - verified at `1462x425` with `.tmp/task119-followup-desktop.png`
-- Owner highlight follow-up addressed:
-  - project owner avatar now receives a thicker primary border while other
-    member avatars remain borderless
-  - focused presence component test, `npm run lint`, and local-safe
-    `npm run build` passed
+  - `git diff --check`
+- Initial bare `npm test` failed because `DATABASE_URL` was not set in the
+  shell and stale app metadata assertions still expected `v0.22.0`; rerunning
+  with local database env after deriving those assertions from `package.json`
+  passed.
+- Copilot review follow-up: changed
+  `app.touch_project_membership_activity(...)` to lock the current project row
+  and compute a monotonic activity version from database time, preventing
+  `updatedAt` from moving backward under clock skew or concurrent writes.
+  Focused service/app-metadata tests, `npm run lint`, and
+  `npx prisma db execute --file prisma/migrations/20260626090000_task320_project_membership_activity_touch/migration.sql`
+  passed after the change.
+- PR #353 is open and ready for review. Copilot's monotonic timestamp comment
+  was addressed in commit `92e1048`, replied to, and resolved. Refreshed GitHub
+  checks passed for branch name, Quality Core, E2E Smoke, Tenant Isolation, and
+  Container Image.

--- a/tasks/task-320-project-membership-live-refresh.md
+++ b/tasks/task-320-project-membership-live-refresh.md
@@ -1,0 +1,39 @@
+# TASK-320 Project Membership Live Refresh
+
+## Status
+In progress.
+
+## Source
+- GitHub issue #352: Project page does not update when a member joins.
+- User report on 2026-06-26.
+
+## Objective
+Refresh already-open project pages automatically when an invited user accepts a
+project invitation and becomes a member.
+
+## Root Cause
+`respondToProjectInvitation(...)` created the `ProjectMembership` and marked the
+`ProjectInvitation` accepted, but did not advance the project activity marker
+used by `ProjectLiveRefresh`. Because `Project.updatedAt` stayed unchanged and
+no typed project activity event was recorded, the SSE stream and polling
+fallback had no newer version to emit to existing project dashboards.
+
+## Acceptance Criteria
+1. Successful project invitation acceptance advances the project activity
+   version observed by the existing project live-refresh stream.
+2. Viewer invitees can trigger the membership-refresh marker only through the
+   accepted-invitation path; editor-only content activity behavior remains
+   unchanged.
+3. Owner-only collaboration management APIs and project authorization
+   boundaries remain unchanged.
+4. Tests cover the acceptance path and the membership activity touch behavior.
+5. The GitHub issue is linked from the PR and repository task tracking is
+   updated.
+
+## Validation Plan
+- `npm test -- tests/lib/project-activity-service.test.ts tests/lib/project-collaboration-service.test.ts`
+- `npm run lint`
+- `npm run rls:check`
+- `npm test`
+- `npm run test:coverage`
+- `npm run build`

--- a/tests/lib/project-activity-service.test.ts
+++ b/tests/lib/project-activity-service.test.ts
@@ -8,6 +8,7 @@ import {
   recordProjectActivityEvent,
   projectActivityServiceInternals,
   touchProjectActivity,
+  touchProjectMembershipActivity,
 } from "@/lib/services/project-activity-service";
 
 describe("project-activity-service", () => {
@@ -49,6 +50,30 @@ describe("project-activity-service", () => {
 
     expect(result).toBe(occurredAt);
     expect(projectUpdate).not.toHaveBeenCalled();
+  });
+
+  test("touchProjectMembershipActivity advances the project marker for accepted membership changes", async () => {
+    const occurredAt = new Date("2026-06-26T08:00:00.000Z");
+    const projectUpdate = vi.fn().mockResolvedValue({ id: "project-1" });
+
+    const result = await touchProjectMembershipActivity({
+      db: {
+        project: {
+          update: projectUpdate,
+        },
+      } as never,
+      projectId: " project-1 ",
+      actorUserId: " user-1 ",
+      invitationId: " invite-1 ",
+      occurredAt,
+    });
+
+    expect(result).toBe(occurredAt);
+    expect(projectUpdate).toHaveBeenCalledWith({
+      where: { id: "project-1" },
+      data: { updatedAt: occurredAt },
+      select: { id: true },
+    });
   });
 
   test("recordProjectActivityEvent creates a typed event and advances project activity", async () => {

--- a/tests/lib/project-collaboration-service.test.ts
+++ b/tests/lib/project-collaboration-service.test.ts
@@ -21,6 +21,7 @@ const prismaMock = vi.hoisted(() => ({
   project: {
     findFirst: vi.fn(),
     findUnique: vi.fn(),
+    update: vi.fn(),
   },
 }));
 
@@ -564,6 +565,58 @@ describe("project-collaboration-service", () => {
     expect(prismaMock.projectMembership.create).toHaveBeenCalledTimes(1);
     expect(prismaMock.projectInvitation.updateMany).toHaveBeenCalledTimes(1);
     expect(prismaMock.projectMembership.deleteMany).not.toHaveBeenCalled();
+  });
+
+  test("advances project activity when a viewer accepts an invitation", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-20T02:30:00.000Z"));
+
+    prismaMock.user.findUnique.mockResolvedValueOnce({
+      email: "invitee@example.com",
+      emailVerified: new Date("2026-03-20T00:00:00.000Z"),
+    });
+    prismaMock.projectInvitation.findUnique.mockResolvedValueOnce({
+      id: "invite-1",
+      projectId: "project-1",
+      invitedEmail: "invitee@example.com",
+      role: "viewer",
+      acceptedAt: null,
+      revokedAt: null,
+      replacedAt: null,
+      expiresAt: new Date("2099-03-21T00:00:00.000Z"),
+    });
+    prismaMock.projectMembership.findUnique.mockResolvedValueOnce(null);
+    prismaMock.projectMembership.create.mockResolvedValueOnce({
+      id: "membership-1",
+    });
+    prismaMock.projectInvitation.updateMany.mockResolvedValueOnce({ count: 1 });
+    prismaMock.project.update.mockResolvedValueOnce({ id: "project-1" });
+
+    const result = await respondToProjectInvitation({
+      actorUserId: "user-1",
+      invitationId: "invite-1",
+      decision: "accept",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      status: 200,
+      data: {
+        projectId: "project-1",
+      },
+    });
+    expect(prismaMock.projectMembership.create).toHaveBeenCalledWith({
+      data: {
+        projectId: "project-1",
+        userId: "user-1",
+        role: "viewer",
+      },
+    });
+    expect(prismaMock.project.update).toHaveBeenCalledWith({
+      where: { id: "project-1" },
+      data: { updatedAt: new Date("2026-03-20T02:30:00.000Z") },
+      select: { id: true },
+    });
   });
 
   test("removes a just-created membership when invitation acceptance loses to revocation", async () => {

--- a/tests/lib/project-collaboration-service.test.ts
+++ b/tests/lib/project-collaboration-service.test.ts
@@ -489,7 +489,8 @@ describe("project-collaboration-service", () => {
     });
   });
 
-  test("treats already accepted invitations as idempotent success", async () => {
+  test("repairs project activity for already accepted invitations", async () => {
+    const acceptedAt = new Date("2026-03-20T01:00:00.000Z");
     prismaMock.user.findUnique.mockResolvedValueOnce({
       email: "invitee@example.com",
       emailVerified: new Date("2026-03-20T00:00:00.000Z"),
@@ -499,11 +500,12 @@ describe("project-collaboration-service", () => {
       projectId: "project-1",
       invitedEmail: "invitee@example.com",
       role: "editor",
-      acceptedAt: new Date("2026-03-20T01:00:00.000Z"),
+      acceptedAt,
       revokedAt: null,
       replacedAt: null,
       expiresAt: new Date("2099-03-21T00:00:00.000Z"),
     });
+    prismaMock.project.update.mockResolvedValueOnce({ id: "project-1" });
 
     const result = await respondToProjectInvitation({
       actorUserId: "user-1",
@@ -520,9 +522,15 @@ describe("project-collaboration-service", () => {
     });
     expect(prismaMock.projectMembership.create).not.toHaveBeenCalled();
     expect(prismaMock.projectInvitation.updateMany).not.toHaveBeenCalled();
+    expect(prismaMock.project.update).toHaveBeenCalledWith({
+      where: { id: "project-1" },
+      data: { updatedAt: acceptedAt },
+      select: { id: true },
+    });
   });
 
-  test("accepts invitation idempotently when membership creation loses a race", async () => {
+  test("repairs project activity when membership creation loses a race", async () => {
+    const acceptedAt = new Date("2026-03-20T02:00:00.000Z");
     prismaMock.user.findUnique.mockResolvedValueOnce({
       email: "invitee@example.com",
       emailVerified: new Date("2026-03-20T00:00:00.000Z"),
@@ -540,7 +548,7 @@ describe("project-collaboration-service", () => {
       })
       .mockResolvedValueOnce({
         projectId: "project-1",
-        acceptedAt: new Date("2026-03-20T02:00:00.000Z"),
+        acceptedAt,
         revokedAt: null,
         replacedAt: null,
         expiresAt: new Date("2099-03-21T00:00:00.000Z"),
@@ -548,6 +556,7 @@ describe("project-collaboration-service", () => {
     prismaMock.projectMembership.findUnique.mockResolvedValueOnce(null);
     prismaMock.projectMembership.create.mockRejectedValueOnce({ code: "P2002" });
     prismaMock.projectInvitation.updateMany.mockResolvedValueOnce({ count: 0 });
+    prismaMock.project.update.mockResolvedValueOnce({ id: "project-1" });
 
     const result = await respondToProjectInvitation({
       actorUserId: "user-1",
@@ -565,6 +574,11 @@ describe("project-collaboration-service", () => {
     expect(prismaMock.projectMembership.create).toHaveBeenCalledTimes(1);
     expect(prismaMock.projectInvitation.updateMany).toHaveBeenCalledTimes(1);
     expect(prismaMock.projectMembership.deleteMany).not.toHaveBeenCalled();
+    expect(prismaMock.project.update).toHaveBeenCalledWith({
+      where: { id: "project-1" },
+      data: { updatedAt: acceptedAt },
+      select: { id: true },
+    });
   });
 
   test("advances project activity when a viewer accepts an invitation", async () => {


### PR DESCRIPTION
## Summary
- Fixes invitation acceptance so already-open project dashboards refresh after a new member joins.
- Adds `app.touch_project_membership_activity(...)`, a narrow membership-specific activity marker that validates the authenticated invitee, accepted invitation, actor email, and resulting membership before updating `Project.updatedAt`.
- Keeps editor-only typed content activity events unchanged, rebases the work onto the latest `main`, and bumps the fix release to `v0.23.1`.

## Root cause
`respondToProjectInvitation(...)` created the `ProjectMembership` and marked the `ProjectInvitation` accepted, but it did not advance `Project.updatedAt` or create a typed project activity event. `ProjectLiveRefresh` watches that project activity version via SSE/polling, so open dashboards had no newer version to observe when a member joined.

## Validation
- `npm run release:check -- --base origin/main --branch fix/task-320-project-membership-live-refresh`
- `npm test -- tests/lib/project-activity-service.test.ts tests/lib/project-collaboration-service.test.ts tests/lib/app-metadata.test.ts`
- `npm run lint`
- Earlier branch validation: local PostgreSQL test suite, database migration, coverage, production build, RLS checks, and `git diff --check`

Supersedes #353 because repository rules prohibit force-pushing its rebased head branch.

Closes #352