### PR TITLE
Finalize completed-task tracking after TASK-270

### DIFF
--- a/journal.md
+++ b/journal.md
@@ -58,6 +58,16 @@ Use it for important implementation milestones, blockers, validation runs, and r
   `docs/reports/task-270-ui-ux-assets/`.
 - Delivery: Commit `1dfe373` was pushed and PR #356 opened ready for review.
 
+# 2026-07-02 - Execution backlog reconciled
+
+- Summary: Audited the active execution queue against merged Git history and
+  GitHub PR state. TASK-314 (PR #346), TASK-119 (PR #347), and TASK-320
+  (PR #354) were all complete, merged, and green, so they were moved from the
+  execution queue to the completed ledger.
+- Tracking: Cleared the stale current-task brief, marked the TASK-314 and
+  TASK-320 briefs complete, and refreshed the project priority snapshot. No new
+  execution task was selected during this documentation-only reconciliation.
+
 # 2026-06-26 - TASK-320 project membership live refresh started
 
 - Summary: Created GitHub issue #352 and worktree

--- a/project.md
+++ b/project.md
@@ -1,6 +1,6 @@
 # NexusDash Project Blueprint (Current State)
 
-Last verified: 2026-06-06
+Last verified: 2026-07-05
 
 ## 1. Vision
 
@@ -126,7 +126,8 @@ Source of truth: [`prisma/schema.prisma`](./prisma/schema.prisma)
 
 From `tasks/current.md` + `tasks/backlog.md`:
 
-1. No active implementation task selected after TASK-313 closes.
+1. The prioritized UI/UX remediation sequence is TASK-321, TASK-322, TASK-100,
+   TASK-133, TASK-129, TASK-108, then the TASK-323 verification gate.
 
 ## 8. Source-of-Truth Docs
 

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,52 +1,9 @@
-# Current Task: TASK-270 App UI/UX Design Assessment
-
-## Task ID
-TASK-270
+# Current Task
 
 ## Status
-Done (2026-07-03); PR #356 open and ready for review
+No active implementation task selected.
 
-## Branch
-`feature/task-270-app-ui-ux-design-assessment`
-
-## Objective
-Produce a product-wide, evidence-backed UI/UX assessment and route each finding
-to a clear existing or new implementation task without mixing redesign code
-into the assessment.
-
-## Acceptance Criteria
-1. A concise assessment document contains ranked findings, evidence, impact,
-   type, and owning task.
-2. Existing UI tasks are cross-referenced and refined instead of duplicated.
-3. Newly discovered standalone work is captured as focused backlog tasks.
-4. Product design, defects, accessibility, and responsive-layout findings are
-   distinguished.
-5. Desktop/mobile and light/dark screenshots support the high-priority findings.
-
-## Definition Of Done
-- [x] Core unauthenticated and authenticated flows were reviewed.
-- [x] Playwright screenshot evidence was captured at desktop and mobile widths.
-- [x] The assessment report and screenshot inventory were added.
-- [x] Existing UI owners were clarified in the backlog.
-- [x] TASK-321, TASK-322, and TASK-323 were created as focused follow-ups.
-- [x] The remediation queue was prioritized by dependency and UX risk.
-- [x] `tasks/backlog.md`, the TASK-270 brief, and `journal.md` were updated.
-- [x] Documentation validation, commit, push, and ready-for-review PR complete.
-- [x] Initial automated review completed and its tracking consistency comment
-      was addressed.
-
-## Evidence
-- Report: `docs/reports/task-270-ui-ux-assessment.md`
-- Screenshots: `docs/reports/task-270-ui-ux-assets/`
-- Playwright capture: 2 tests passed against a local production build and
-  migrated PostgreSQL database.
-- Focused navigation addendum: 2 Playwright tests passed, reproducing the
-  in-product project-context loss and confirming native browser Back preserves
-  the exact source project URL.
-- Build used for capture: `npm run build` passed with local-safe runtime values.
-- Pull request: `https://github.com/dorianagaesse/nexus_dash/pull/356`
-
-## Validation Plan
-- `git diff --check`
-- Verify all report links and task IDs.
-- Confirm the worktree contains documentation/evidence only.
+## Next Step
+Start with TASK-321, the first item in the prioritized execution queue in
+`tasks/backlog.md`. Replace this placeholder with its active task brief before
+implementation begins.

--- a/tasks/task-314-meeting-todo-overdue-reminders.md
+++ b/tasks/task-314-meeting-todo-overdue-reminders.md
@@ -40,14 +40,14 @@ the existing NexusDash notification-email architecture:
    delivery behavior, and permission/tenancy boundaries.
 
 ## Definition Of Done
-- [ ] Existing notification-email services and scheduler runbooks are reviewed.
-- [ ] Persistence changes, if needed, are added through Prisma migrations.
-- [ ] Reminder dispatch code is service-owned and route/scheduler adapters stay
+- [x] Existing notification-email services and scheduler runbooks are reviewed.
+- [x] Persistence changes, if needed, are added through Prisma migrations.
+- [x] Reminder dispatch code is service-owned and route/scheduler adapters stay
       thin.
-- [ ] Tests cover service, API/scheduler, and email behavior.
-- [ ] Documentation and runbooks explain local, preview, and production
+- [x] Tests cover service, API/scheduler, and email behavior.
+- [x] Documentation and runbooks explain local, preview, and production
       reminder behavior.
-- [ ] Preview validation proves the reminder path can run safely without
+- [x] Preview validation proves the reminder path can run safely without
       sending unintended external email.
 
 ## Initial Implementation Notes


### PR DESCRIPTION
## What changed

- rebased the tracking cleanup onto current `main`
- removed backlog edits already delivered by PR #356
- replaced the stale completed TASK-270 current-task page with a neutral pointer
  to TASK-321, the first prioritized UI/UX implementation task
- updated the project priority snapshot to the TASK-321 through TASK-323 sequence
- completed TASK-314's Definition of Done checklist and retained the historical
  reconciliation journal entry

## Why

The original PR had become conflicting and partly obsolete. PR #356 already
moved TASK-314, TASK-119, and TASK-320 into the completed ledger and established
the new UI/UX execution queue. Merging the old patch unchanged would have erased
that queue. This refresh keeps only the remaining accurate tracking cleanup.

## Impact

Documentation and task tracking only. Runtime behavior is unchanged.

## Validation

- `git diff --check origin/main...HEAD`
- backlog IDs verified unique during conflict resolution
- `npm run release:check -- --base origin/main --branch docs/backlog-execution-queue-cleanup`
