### PR TITLE
TASK-321 Accessible modal and sheet foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ SHA, deployment URL, and workflow run belong in release evidence.
 
 - Define each release entry before the product-impacting PR is merged.
 
+## v0.24.0 - 2026-07-05
+
+- Added a shared accessible dialog and responsive-sheet foundation with named
+  modal semantics, focus containment/restoration, background isolation,
+  guarded Escape behavior, and reduced-motion support.
+- Migrated task, context, attachment, calendar, project-settings,
+  confirmation, meeting, roadmap, and project-creation overlays without
+  redesigning their content.
+- Added component and Playwright coverage for keyboard focus, nested controls,
+  desktop dialog behavior, and internally scrollable 390 px sheets.
+
 ## v0.23.1 - 2026-06-27
 
 - Fixed project dashboards so already-open pages refresh after an invited

--- a/app/globals.css
+++ b/app/globals.css
@@ -104,3 +104,12 @@
 .form-focus-border-shell:has(:focus) {
   border-color: hsl(var(--ring) / 0.6) !important;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  [data-overlay-content="true"],
+  [data-overlay-content="true"]::backdrop {
+    animation: none !important;
+    transition: none !important;
+    transform: none !important;
+  }
+}

--- a/components/attachment-preview-modal.tsx
+++ b/components/attachment-preview-modal.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createPortal } from "react-dom";
 import { ExternalLink, X } from "lucide-react";
 import Image from "next/image";
 
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CardContent, CardHeader } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import {
   buildAttachmentInlineUrl,
   getAttachmentPreviewKind,
@@ -50,23 +50,25 @@ export function AttachmentPreviewModal({
     return null;
   }
 
-  return createPortal(
-    <div
-      className="fixed inset-0 z-[110] flex min-h-dvh w-screen items-center justify-center overscroll-y-contain bg-black/75 p-4"
-      onMouseDown={(event) => {
-        if (event.target === event.currentTarget) {
+  return (
+    <Dialog
+      open={Boolean(attachment)}
+      onOpenChange={(open) => {
+        if (!open) {
           onClose();
         }
       }}
     >
-      <Card
-        className="w-full max-w-4xl"
-        onMouseDown={(event) => event.stopPropagation()}
+      <DialogContent
+        aria-describedby={undefined}
+        presentation="centered"
+        className="z-[130] max-h-[calc(100dvh-2rem)] w-full max-w-4xl overflow-y-auto"
+        overlayClassName="z-[120] bg-black/75"
       >
         <CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0">
-          <CardTitle className="truncate text-base">
+          <DialogTitle className="truncate text-base">
             {attachment.name}
-          </CardTitle>
+          </DialogTitle>
           <div className="flex items-center gap-1">
             {previewUrl ? (
               <Button variant="ghost" size="sm" asChild>
@@ -81,7 +83,7 @@ export function AttachmentPreviewModal({
                 <a href={attachment.downloadUrl}>Download</a>
               </Button>
             ) : null}
-            <Button type="button" variant="ghost" size="icon" onClick={onClose}>
+            <Button type="button" variant="ghost" size="icon" onClick={onClose} aria-label="Close attachment preview">
               <X className="h-4 w-4" />
             </Button>
           </div>
@@ -114,8 +116,7 @@ export function AttachmentPreviewModal({
             </p>
           ) : null}
         </CardContent>
-      </Card>
-    </div>,
-    document.body
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/components/calendar-date-time-field.tsx
+++ b/components/calendar-date-time-field.tsx
@@ -214,7 +214,8 @@ export function CalendarDateTimeField({
           <div
             ref={popoverRef}
             data-calendar-popover="true"
-            className="fixed z-[120] max-h-[calc(100vh-24px)] overflow-y-auto rounded-md border border-border/70 bg-popover p-3 shadow-xl"
+            data-overlay-popover="true"
+            className="pointer-events-auto fixed z-[120] max-h-[calc(100vh-24px)] overflow-y-auto rounded-md border border-border/70 bg-popover p-3 shadow-xl"
             style={popoverPosition}
           >
             <div className="mb-2 flex items-center justify-between">

--- a/components/calendar-panel/calendar-event-modal.tsx
+++ b/components/calendar-panel/calendar-event-modal.tsx
@@ -1,9 +1,9 @@
-import { createPortal } from "react-dom";
 import { Trash2, X } from "lucide-react";
 
 import { CalendarDateTimeField } from "@/components/calendar-date-time-field";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CardContent, CardHeader } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { EmojiInputField, EmojiTextareaField } from "@/components/ui/emoji-field";
 
 interface CalendarEventModalProps {
@@ -69,30 +69,32 @@ export function CalendarEventModal({
     return null;
   }
 
-  return createPortal(
-    <div
-      data-calendar-popover-scope="true"
-      className="fixed inset-0 z-50 flex min-h-dvh w-screen items-end justify-center bg-black/70 p-0 sm:items-center sm:p-4"
-      onMouseDown={(mouseEvent) => {
-        if (mouseEvent.target === mouseEvent.currentTarget) {
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open && !isEventMutationPending) {
           onClose();
         }
       }}
     >
-      <Card
-        className="flex max-h-[100dvh] w-full max-w-lg flex-col overflow-hidden rounded-t-3xl sm:max-h-[calc(100vh-2rem)] sm:rounded-xl"
-        onMouseDown={(mouseEvent) => mouseEvent.stopPropagation()}
+      <DialogContent
+        aria-describedby={undefined}
+        data-calendar-popover-scope="true"
+        dismissible={!isEventMutationPending}
+        className="flex max-h-[100dvh] w-full max-w-lg flex-col overflow-hidden sm:max-h-[calc(100dvh-2rem)]"
       >
         <CardHeader className="flex shrink-0 flex-row items-center justify-between space-y-0">
-          <CardTitle className="text-lg">
+          <DialogTitle className="text-lg">
             {eventModalMode === "create" ? "Create calendar event" : "Edit calendar event"}
-          </CardTitle>
+          </DialogTitle>
           <Button
             type="button"
             variant="ghost"
             size="icon"
             onClick={onClose}
             disabled={isEventMutationPending}
+            aria-label="Close calendar event"
           >
             <X className="h-4 w-4" />
           </Button>
@@ -111,6 +113,7 @@ export function CalendarEventModal({
               </label>
               <EmojiInputField
                 id="calendar-event-summary"
+                autoFocus
                 value={eventSummary}
                 onChange={(event) => onEventSummaryChange(event.target.value)}
                 minLength={1}
@@ -275,8 +278,7 @@ export function CalendarEventModal({
             </div>
           </form>
         </CardContent>
-      </Card>
-    </div>,
-    document.body
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/components/context-panel/context-create-modal.tsx
+++ b/components/context-panel/context-create-modal.tsx
@@ -70,7 +70,11 @@ export function ContextCreateModal({
   );
 
   return (
-    <ContextModalFrame title="Add context card" onClose={onClose}>
+    <ContextModalFrame
+      title="Add context card"
+      onClose={onClose}
+      dismissible={!isCreatingCard}
+    >
       <form className="grid gap-4" onSubmit={(event) => void onSubmit(event)}>
         <div className="grid gap-2">
           <label htmlFor="context-create-title" className="text-sm font-medium">

--- a/components/context-panel/context-edit-modal.tsx
+++ b/components/context-panel/context-edit-modal.tsx
@@ -75,7 +75,11 @@ export function ContextEditModal({
   }
 
   return (
-    <ContextModalFrame title="Edit context card" onClose={onClose}>
+    <ContextModalFrame
+      title="Edit context card"
+      onClose={onClose}
+      dismissible={!isUpdatingCard && !isSubmittingAttachment}
+    >
       <form className="grid gap-4" onSubmit={(event) => void onSubmit(event)}>
         <input type="hidden" name="cardId" value={editingCard.id} />
         <div className="grid gap-2">

--- a/components/context-panel/context-modal-frame.tsx
+++ b/components/context-panel/context-modal-frame.tsx
@@ -1,8 +1,8 @@
-import { createPortal } from "react-dom";
 import { X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CardContent, CardHeader } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 
 interface ContextModalFrameProps {
   title: string;
@@ -15,32 +15,27 @@ export function ContextModalFrame({
   onClose,
   children,
 }: ContextModalFrameProps) {
-  if (typeof document === "undefined") {
-    return null;
-  }
-
-  return createPortal(
-    <div
-      className="fixed inset-0 z-[90] flex min-h-dvh w-screen items-end justify-center overflow-y-auto overscroll-y-contain bg-black/70 p-0 sm:items-center sm:p-4"
-      onMouseDown={(event) => {
-        if (event.target === event.currentTarget) {
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) {
           onClose();
         }
       }}
     >
-      <Card
-        className="flex max-h-[100dvh] w-full max-w-xl flex-col overflow-hidden rounded-t-3xl sm:max-h-[calc(100vh-2rem)] sm:rounded-2xl"
-        onMouseDown={(event) => event.stopPropagation()}
+      <DialogContent
+        aria-describedby={undefined}
+        className="flex max-h-[100dvh] w-full max-w-xl flex-col overflow-hidden sm:max-h-[calc(100dvh-2rem)] sm:rounded-2xl"
       >
         <CardHeader className="flex shrink-0 flex-row items-center justify-between space-y-0">
-          <CardTitle className="text-lg">{title}</CardTitle>
-          <Button type="button" variant="ghost" size="icon" onClick={onClose}>
+          <DialogTitle className="text-lg">{title}</DialogTitle>
+          <Button type="button" variant="ghost" size="icon" onClick={onClose} aria-label={`Close ${title}`}>
             <X className="h-4 w-4" />
           </Button>
         </CardHeader>
         <CardContent className="min-h-0 flex-1 overflow-y-auto">{children}</CardContent>
-      </Card>
-    </div>,
-    document.body
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/components/context-panel/context-modal-frame.tsx
+++ b/components/context-panel/context-modal-frame.tsx
@@ -8,29 +8,39 @@ interface ContextModalFrameProps {
   title: string;
   onClose: () => void;
   children: React.ReactNode;
+  dismissible?: boolean;
 }
 
 export function ContextModalFrame({
   title,
   onClose,
   children,
+  dismissible = true,
 }: ContextModalFrameProps) {
   return (
     <Dialog
       open
       onOpenChange={(open) => {
-        if (!open) {
+        if (!open && dismissible) {
           onClose();
         }
       }}
     >
       <DialogContent
         aria-describedby={undefined}
+        dismissible={dismissible}
         className="flex max-h-[100dvh] w-full max-w-xl flex-col overflow-hidden sm:max-h-[calc(100dvh-2rem)] sm:rounded-2xl"
       >
         <CardHeader className="flex shrink-0 flex-row items-center justify-between space-y-0">
           <DialogTitle className="text-lg">{title}</DialogTitle>
-          <Button type="button" variant="ghost" size="icon" onClick={onClose} aria-label={`Close ${title}`}>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={onClose}
+            aria-label={`Close ${title}`}
+            disabled={!dismissible}
+          >
             <X className="h-4 w-4" />
           </Button>
         </CardHeader>

--- a/components/context-panel/context-preview-modal.tsx
+++ b/components/context-panel/context-preview-modal.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { createPortal } from "react-dom";
 import { Paperclip, X } from "lucide-react";
 
 import type {
@@ -13,7 +12,8 @@ import {
   resolveAttachmentHref,
 } from "@/components/project-context-panel-utils";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CardContent, CardHeader } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { ATTACHMENT_KIND_LINK, isAttachmentPreviewable } from "@/lib/task-attachment";
 
 interface ContextPreviewModalProps {
@@ -35,26 +35,24 @@ export function ContextPreviewModal({
   onEdit,
   onPreviewAttachment,
 }: ContextPreviewModalProps) {
-  if (!isOpen || !card || typeof document === "undefined") {
-    return null;
-  }
-
-  return createPortal(
-    <div
-      className="fixed inset-0 z-[95] flex min-h-dvh w-screen items-end justify-center bg-black/70 p-0 sm:items-center sm:p-4"
-      onMouseDown={(event) => {
-        if (event.target === event.currentTarget) {
-          onClose();
-        }
-      }}
-    >
-      <Card
-        className="flex max-h-[100dvh] w-full max-w-2xl flex-col overflow-hidden rounded-t-3xl sm:max-h-[calc(100vh-2rem)] sm:rounded-2xl"
+  return (
+    <Dialog open={isOpen && card !== null}>
+      {card ? (
+      <DialogContent
+        aria-describedby={undefined}
+        className="flex max-h-[100dvh] w-full max-w-2xl flex-col overflow-hidden sm:max-h-[calc(100dvh-2rem)] sm:rounded-2xl"
         style={{ backgroundColor: card.color, borderColor: "rgb(15 23 42 / 0.2)" }}
-        onMouseDown={(event) => event.stopPropagation()}
+        onEscapeKeyDown={(event) => {
+          event.preventDefault();
+          onClose();
+        }}
+        onPointerDownOutside={(event) => {
+          event.preventDefault();
+          onClose();
+        }}
       >
         <CardHeader className="flex shrink-0 flex-row items-start justify-between gap-3 space-y-0">
-          <CardTitle
+          <DialogTitle
             className="text-xl text-slate-900"
             onDoubleClick={() => {
               if (!canEdit) {
@@ -65,7 +63,7 @@ export function ContextPreviewModal({
             }}
           >
             {card.title}
-          </CardTitle>
+          </DialogTitle>
           <Button
             type="button"
             variant="ghost"
@@ -144,8 +142,8 @@ export function ContextPreviewModal({
             </p>
           ) : null}
         </CardContent>
-      </Card>
-    </div>,
-    document.body
+      </DialogContent>
+      ) : null}
+    </Dialog>
   );
 }

--- a/components/create-project-dialog.tsx
+++ b/components/create-project-dialog.tsx
@@ -4,7 +4,8 @@ import { useState } from "react";
 import { PlusSquare, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CardContent, CardHeader } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { EmojiInputField, EmojiTextareaField } from "@/components/ui/emoji-field";
 
 interface CreateProjectDialogProps {
@@ -15,28 +16,21 @@ export function CreateProjectDialog({ action }: CreateProjectDialogProps) {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <>
-      <Button type="button" onClick={() => setIsOpen(true)} className="w-full sm:w-auto">
-        <PlusSquare className="h-4 w-4" />
-        Create project
-      </Button>
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button type="button" className="w-full sm:w-auto">
+          <PlusSquare className="h-4 w-4" />
+          Create project
+        </Button>
+      </DialogTrigger>
 
-      {isOpen ? (
-        <div
-          className="fixed inset-0 z-50 flex min-h-dvh w-screen items-end justify-center bg-black/70 p-0 sm:items-center sm:p-4"
-          onMouseDown={(event) => {
-            if (event.target === event.currentTarget) {
-              setIsOpen(false);
-            }
-          }}
-        >
-          <Card
-            className="flex max-h-[100dvh] w-full max-w-lg flex-col overflow-hidden rounded-t-3xl sm:max-h-[calc(100vh-2rem)] sm:rounded-xl"
-            onMouseDown={(event) => event.stopPropagation()}
-          >
+      <DialogContent
+        aria-describedby={undefined}
+        className="flex max-h-[100dvh] w-full max-w-lg flex-col overflow-hidden sm:max-h-[calc(100dvh-2rem)]"
+      >
             <CardHeader className="flex shrink-0 flex-row items-center justify-between space-y-0">
-              <CardTitle className="text-lg">Create project</CardTitle>
-              <Button type="button" variant="ghost" size="icon" onClick={() => setIsOpen(false)}>
+              <DialogTitle className="text-lg">Create project</DialogTitle>
+              <Button type="button" variant="ghost" size="icon" onClick={() => setIsOpen(false)} aria-label="Close create project">
                 <X className="h-4 w-4" />
               </Button>
             </CardHeader>
@@ -52,6 +46,7 @@ export function CreateProjectDialog({ action }: CreateProjectDialogProps) {
                   </label>
                   <EmojiInputField
                     id="create-name"
+                    autoFocus
                     name="name"
                     required
                     minLength={2}
@@ -90,9 +85,7 @@ export function CreateProjectDialog({ action }: CreateProjectDialogProps) {
                 </div>
               </form>
             </CardContent>
-          </Card>
-        </div>
-      ) : null}
-    </>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/components/create-task-dialog.tsx
+++ b/components/create-task-dialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
-import { createPortal } from "react-dom";
 import { Link2, Paperclip, PlusSquare, Trash2, Upload, X } from "lucide-react";
 import { useRouter } from "next/navigation";
 
@@ -24,7 +23,8 @@ import {
   FORM_FOCUS_BORDER_CLASS,
   FORM_FOCUS_BORDER_SHELL_CLASS,
 } from "@/components/ui/focus-border-styles";
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { CardContent, CardFooter, CardHeader } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { EmojiInputField } from "@/components/ui/emoji-field";
 import {
   MAX_TASK_LABELS,
@@ -394,33 +394,35 @@ export function CreateTaskDialog({
 
   return (
     <div className="space-y-2">
-      <Button
-        type="button"
-        size="sm"
-        className="h-10 w-full rounded-full px-4 sm:w-auto"
-        onClick={openDialog}
+      <Dialog
+        open={isOpen}
+        onOpenChange={(open) => {
+          if (open) {
+            openDialog();
+          } else if (!isSubmitting) {
+            closeDialog();
+          }
+        }}
       >
-        <PlusSquare className="h-4 w-4" />
-        New task
-      </Button>
-      {isOpen && typeof document !== "undefined"
-        ? createPortal(
-            <div
-              data-calendar-popover-scope="true"
-              className="fixed inset-0 z-[90] flex min-h-dvh w-screen items-end justify-center overflow-y-auto overscroll-y-contain bg-black/70 p-0 sm:items-center sm:p-4"
-              onMouseDown={(event) => {
-                if (event.target === event.currentTarget) {
-                  closeDialog();
-                }
-              }}
-            >
-              <Card
-                className="flex max-h-[100dvh] w-full max-w-xl flex-col overflow-hidden rounded-t-3xl sm:max-h-[calc(100vh-2rem)] sm:rounded-2xl"
-                onMouseDown={(event) => event.stopPropagation()}
-              >
+        <DialogTrigger asChild>
+          <Button
+            type="button"
+            size="sm"
+            className="h-10 w-full rounded-full px-4 sm:w-auto"
+          >
+            <PlusSquare className="h-4 w-4" />
+            New task
+          </Button>
+        </DialogTrigger>
+        <DialogContent
+          aria-describedby={undefined}
+          data-calendar-popover-scope="true"
+          dismissible={!isSubmitting}
+          className="flex max-h-[100dvh] w-full max-w-xl flex-col overflow-hidden sm:max-h-[calc(100dvh-2rem)] sm:rounded-2xl"
+        >
                 <CardHeader className="flex shrink-0 flex-row items-center justify-between space-y-0">
-                  <CardTitle className="text-lg">Create task</CardTitle>
-                  <Button type="button" variant="ghost" size="icon" onClick={closeDialog}>
+                  <DialogTitle className="text-lg">Create task</DialogTitle>
+                  <Button type="button" variant="ghost" size="icon" onClick={closeDialog} aria-label="Close task creation" disabled={isSubmitting}>
                     <X className="h-4 w-4" />
                   </Button>
                 </CardHeader>
@@ -433,6 +435,7 @@ export function CreateTaskDialog({
                         </label>
                         <EmojiInputField
                           id="task-title"
+                          autoFocus
                           name="title"
                           required
                           minLength={2}
@@ -741,11 +744,8 @@ export function CreateTaskDialog({
                     </div>
                   </CardFooter>
                 </form>
-              </Card>
-            </div>,
-            document.body
-          )
-        : null}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/components/kanban/related-task-field.tsx
+++ b/components/kanban/related-task-field.tsx
@@ -153,7 +153,8 @@ export function RelatedTaskSelector({
       typeof document !== "undefined"
         ? createPortal(
             <div
-              className="z-[120] rounded-md border border-border/70 bg-popover p-1 shadow-lg"
+              data-overlay-popover="true"
+              className="pointer-events-auto z-[120] rounded-md border border-border/70 bg-popover p-1 shadow-lg"
               style={{
                 position: "fixed",
                 top: dropdownPosition.top,

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -1,5 +1,4 @@
 import { type KeyboardEvent, useCallback, useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
 import {
   Archive,
   ArrowRightLeft,
@@ -50,7 +49,8 @@ import { Badge } from "@/components/ui/badge";
 import { AssigneeSelect } from "@/components/ui/assignee-select";
 import { AttachmentLinkComposer } from "@/components/ui/attachment-link-composer";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { EmojiInputField, EmojiTextareaField } from "@/components/ui/emoji-field";
 import { EmojiPickerButton } from "@/components/ui/emoji-picker-button";
 import { EpicSelect } from "@/components/ui/epic-select";
@@ -331,20 +331,23 @@ export function TaskDetailModal({
 
   return (
     <>
-      {createPortal(
-        <div
+      <Dialog
+        open={isOpen}
+        onOpenChange={(open) => {
+          if (!open && !isUpdatingTask && !isArchivingTask) {
+            onClose();
+          }
+        }}
+      >
+        <DialogContent
+          aria-describedby={undefined}
           data-calendar-popover-scope="true"
-          className="fixed inset-0 z-[90] flex min-h-dvh w-screen items-end justify-center overflow-y-auto overscroll-y-contain bg-black/70 p-0 sm:items-center sm:p-4"
-          onMouseDown={(event) => {
-            if (event.target === event.currentTarget) {
-              onClose();
-            }
-          }}
+          dismissible={!isUpdatingTask && !isArchivingTask}
+          className="flex max-h-[100dvh] w-full max-w-2xl flex-col overflow-hidden sm:max-h-[calc(100dvh-2rem)] sm:rounded-2xl"
         >
-          <Card
-            className="flex max-h-[100dvh] w-full max-w-2xl flex-col sm:max-h-[calc(100vh-2rem)] sm:rounded-2xl"
-            onMouseDown={(event) => event.stopPropagation()}
-          >
+            <DialogTitle className="sr-only">
+              {isEditing ? `Edit ${selectedTask.title}` : selectedTask.title}
+            </DialogTitle>
             <CardHeader
               className={cn(
                 "flex shrink-0 flex-col gap-3 space-y-0",
@@ -426,6 +429,7 @@ export function TaskDetailModal({
                   size="icon"
                   onClick={onClose}
                   aria-label="Close task"
+                  disabled={isUpdatingTask || isArchivingTask}
                 >
                   <X className="h-4 w-4" />
                 </Button>
@@ -534,10 +538,8 @@ export function TaskDetailModal({
                 </div>
               </div>
             </CardFooter>
-          </Card>
-        </div>,
-        document.body
-      )}
+        </DialogContent>
+      </Dialog>
       <AttachmentPreviewModal
         attachment={previewAttachment}
         onClose={() => onPreviewAttachmentChange(null)}

--- a/components/project-context-panel.tsx
+++ b/components/project-context-panel.tsx
@@ -624,6 +624,9 @@ export function ProjectContextPanel({
             : null;
 
         if (createdCard) {
+          setPreviewCardId((current) =>
+            current === optimisticCardId ? createdCard.id : current
+          );
           setLocalCards((previous) => [
             {
               ...createdCard,

--- a/components/project-dashboard/project-dashboard-owner-actions.tsx
+++ b/components/project-dashboard/project-dashboard-owner-actions.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { createPortal } from "react-dom";
 import { Bot, Settings2, Share2, Users, X } from "lucide-react";
 import { useRouter } from "next/navigation";
 
@@ -10,7 +9,8 @@ import { useToast } from "@/components/toast-provider";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { ProjectDashboardOwnerAgentAccessPanel } from "@/components/project-dashboard/project-dashboard-owner-agent-access-panel";
 import { ProjectDashboardOwnerAccessPanel } from "@/components/project-dashboard/project-dashboard-owner-access-panel";
 import { ProjectDashboardOwnerGeneralPanel } from "@/components/project-dashboard/project-dashboard-owner-general-panel";
@@ -943,20 +943,26 @@ export function ProjectDashboardOwnerActions({
         </Button>
       </div>
 
-      {isOpen && typeof document !== "undefined"
-        ? createPortal(
-            <div
-              className="fixed inset-0 z-[120] flex min-h-dvh w-screen items-end justify-center bg-black/70 p-0 sm:items-center sm:p-4"
-              onMouseDown={(event) => {
-                if (event.target === event.currentTarget) {
-                  closeModal();
-                }
-              }}
-            >
-              <Card
-                className="flex max-h-[100dvh] min-w-0 w-full max-w-4xl flex-col overflow-hidden rounded-t-3xl sm:max-h-[calc(100vh-2rem)] sm:rounded-2xl"
-                onMouseDown={(event) => event.stopPropagation()}
-              >
+      <Dialog
+        open={isOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            closeModal();
+          }
+        }}
+      >
+        <DialogContent
+          dismissible={
+            !isSavingProject &&
+            !isDeletingProject &&
+            !isCreatingAgentCredential &&
+            !mutatingAgentCredentialId &&
+            !sendingInvitationEmailId
+          }
+          className="z-[130] flex max-h-[100dvh] min-w-0 w-full max-w-4xl flex-col overflow-hidden sm:max-h-[calc(100dvh-2rem)] sm:rounded-2xl"
+          overlayClassName="z-[120]"
+        >
+                <DialogTitle className="sr-only">Project settings: {projectName}</DialogTitle>
                 <CardHeader className="flex flex-col gap-4 space-y-0 border-b border-border/60 sm:flex-row sm:items-start sm:justify-between">
                   <div className="space-y-2">
                     <div className="flex flex-wrap items-center gap-2">
@@ -969,9 +975,9 @@ export function ProjectDashboardOwnerActions({
                     </div>
                     <div className="space-y-1">
                       <CardTitle className="text-xl">{projectName}</CardTitle>
-                      <p className="text-sm text-muted-foreground">
+                      <DialogDescription>
                         Project details, invitations, contributors, and agent access.
-                      </p>
+                      </DialogDescription>
                     </div>
                   </div>
                   <Button
@@ -980,6 +986,7 @@ export function ProjectDashboardOwnerActions({
                     size="icon"
                     onClick={closeModal}
                     className="self-end sm:self-auto"
+                    aria-label="Close project settings"
                   >
                     <X className="h-4 w-4" />
                   </Button>
@@ -1095,11 +1102,8 @@ export function ProjectDashboardOwnerActions({
                     />
                   )}
                 </CardContent>
-              </Card>
-            </div>,
-            document.body
-          )
-        : null}
+        </DialogContent>
+      </Dialog>
 
       <ConfirmDialog
         isOpen={isDeleteDialogOpen}

--- a/components/project-dashboard/project-dashboard-owner-actions.tsx
+++ b/components/project-dashboard/project-dashboard-owner-actions.tsx
@@ -920,6 +920,13 @@ export function ProjectDashboardOwnerActions({
     }
   };
 
+  const isProjectSettingsDismissible =
+    !isSavingProject &&
+    !isDeletingProject &&
+    !isCreatingAgentCredential &&
+    !mutatingAgentCredentialId &&
+    !sendingInvitationEmailId;
+
   return (
     <>
       <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:flex-wrap sm:items-center">
@@ -952,13 +959,7 @@ export function ProjectDashboardOwnerActions({
         }}
       >
         <DialogContent
-          dismissible={
-            !isSavingProject &&
-            !isDeletingProject &&
-            !isCreatingAgentCredential &&
-            !mutatingAgentCredentialId &&
-            !sendingInvitationEmailId
-          }
+          dismissible={isProjectSettingsDismissible}
           className="z-[130] flex max-h-[100dvh] min-w-0 w-full max-w-4xl flex-col overflow-hidden sm:max-h-[calc(100dvh-2rem)] sm:rounded-2xl"
           overlayClassName="z-[120]"
         >
@@ -987,6 +988,7 @@ export function ProjectDashboardOwnerActions({
                     onClick={closeModal}
                     className="self-end sm:self-auto"
                     aria-label="Close project settings"
+                    disabled={!isProjectSettingsDismissible}
                   >
                     <X className="h-4 w-4" />
                   </Button>

--- a/components/project-meeting-notes-panel.tsx
+++ b/components/project-meeting-notes-panel.tsx
@@ -610,6 +610,7 @@ function MeetingDialogShell({
               className="h-9 w-9 rounded-full"
               onClick={onClose}
               aria-label={`Close ${title}`}
+              disabled={!dismissible}
             >
               <X className="h-4 w-4" />
             </Button>

--- a/components/project-meeting-notes-panel.tsx
+++ b/components/project-meeting-notes-panel.tsx
@@ -40,6 +40,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { EmojiInputField, EmojiTextareaField } from "@/components/ui/emoji-field";
 import { TokenInput } from "@/components/ui/token-input";
 import { useProjectSectionExpanded } from "@/lib/hooks/use-project-section-expanded";
@@ -503,7 +504,8 @@ function MeetingStatusSelect({
             <div
               ref={dropdownRef}
               role="listbox"
-              className="z-[140] overflow-hidden rounded-2xl border border-border/70 bg-popover p-1.5 shadow-[0_24px_70px_-32px_rgba(15,23,42,0.58)]"
+              data-overlay-popover="true"
+              className="pointer-events-auto z-[140] overflow-hidden rounded-2xl border border-border/70 bg-popover p-1.5 shadow-[0_24px_70px_-32px_rgba(15,23,42,0.58)]"
               style={{
                 position: "fixed",
                 top: dropdownPosition.top,
@@ -564,6 +566,7 @@ function MeetingDialogShell({
   children,
   footer,
   maxWidthClassName = "max-w-2xl",
+  dismissible = true,
 }: {
   title: string;
   subtitle?: string;
@@ -571,30 +574,33 @@ function MeetingDialogShell({
   children: ReactNode;
   footer?: ReactNode;
   maxWidthClassName?: string;
+  dismissible?: boolean;
 }) {
-  const content = (
-    <div
-      data-calendar-popover-scope="true"
-      className="fixed inset-0 z-[90] flex min-h-dvh w-screen items-end justify-center overflow-y-auto overscroll-y-contain bg-black/70 p-0 sm:items-center sm:p-4"
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open && dismissible) {
+          onClose();
+        }
+      }}
     >
-      <div aria-hidden="true" className="absolute inset-0" onMouseDown={onClose} />
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="meeting-dialog-title"
+      <DialogContent
+        data-calendar-popover-scope="true"
+        dismissible={dismissible}
         className={cn(
-          "relative z-10 flex max-h-[100dvh] w-full flex-col overflow-hidden rounded-t-3xl border border-border/70 bg-background shadow-[0_40px_120px_-44px_rgba(15,23,42,0.7)] sm:max-h-[calc(100vh-2rem)] sm:rounded-2xl",
+          "flex max-h-[100dvh] w-full flex-col overflow-hidden border-border/70 bg-background shadow-[0_40px_120px_-44px_rgba(15,23,42,0.7)] sm:max-h-[calc(100dvh-2rem)] sm:rounded-2xl",
           maxWidthClassName
         )}
       >
         <div className="border-b border-border/60 px-5 py-4 sm:px-6">
           <div className="flex items-start justify-between gap-4">
             <div className="space-y-1">
-              <h3 id="meeting-dialog-title" className="text-lg font-semibold text-foreground">
+              <DialogTitle className="text-lg font-semibold text-foreground">
                 {title}
-              </h3>
+              </DialogTitle>
               {subtitle ? (
-                <p className="text-sm leading-6 text-muted-foreground">{subtitle}</p>
+                <DialogDescription className="leading-6">{subtitle}</DialogDescription>
               ) : null}
             </div>
             <Button
@@ -620,15 +626,9 @@ function MeetingDialogShell({
             {footer}
           </div>
         ) : null}
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
-
-  if (typeof document === "undefined") {
-    return content;
-  }
-
-  return createPortal(content, document.body);
 }
 
 export function ProjectMeetingNotesPanel({
@@ -1436,6 +1436,7 @@ export function ProjectMeetingNotesPanel({
           title={prepareDialog.mode === "create" ? "Prepare meeting" : "Edit preparation"}
           subtitle="Set the meeting frame first. Outputs and todos are captured after opening the note."
           onClose={closePrepareDialog}
+          dismissible={!isSaving}
           footer={
             <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
               <Button
@@ -1463,6 +1464,7 @@ export function ProjectMeetingNotesPanel({
               </label>
               <EmojiInputField
                 id="meeting-title"
+                autoFocus
                 value={prepareDraft.title}
                 onChange={(event) =>
                   setPrepareDraft((current) => ({
@@ -1629,6 +1631,7 @@ export function ProjectMeetingNotesPanel({
           title={selectedNote.title}
           subtitle={formatMeetingTime(selectedNote.scheduledAt)}
           onClose={closeNoteDialog}
+          dismissible={!isSaving}
           maxWidthClassName="max-w-4xl"
           footer={
             canEdit ? (

--- a/components/project-roadmap-panel.tsx
+++ b/components/project-roadmap-panel.tsx
@@ -40,6 +40,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { EmojiInputField, EmojiTextareaField } from "@/components/ui/emoji-field";
 import {
   formatRoadmapTargetDateForDisplay,
@@ -508,7 +509,8 @@ function RoadmapSelectField({
             <div
               ref={dropdownRef}
               role="listbox"
-              className="z-[140] overflow-hidden rounded-2xl border border-border/70 bg-popover p-1.5 shadow-[0_24px_70px_-32px_rgba(15,23,42,0.58)]"
+              data-overlay-popover="true"
+              className="pointer-events-auto z-[140] overflow-hidden rounded-2xl border border-border/70 bg-popover p-1.5 shadow-[0_24px_70px_-32px_rgba(15,23,42,0.58)]"
               style={{
                 position: "fixed",
                 top: dropdownPosition.top,
@@ -609,6 +611,7 @@ function RoadmapEntityForm({
         </label>
         <EmojiInputField
           id="roadmap-entity-title"
+          autoFocus
           value={draft.title}
           onChange={(event) =>
             onChange({
@@ -736,6 +739,7 @@ function RoadmapDialogShell({
   subtitle,
   headerBadge,
   isOpen,
+  dismissible = true,
   onClose,
   children,
 }: {
@@ -743,6 +747,7 @@ function RoadmapDialogShell({
   subtitle?: string;
   headerBadge?: ReactNode;
   isOpen: boolean;
+  dismissible?: boolean;
   onClose: () => void;
   children: ReactNode;
 }) {
@@ -750,27 +755,30 @@ function RoadmapDialogShell({
     return null;
   }
 
-  const content = (
-    <div className="fixed inset-0 z-[90] flex min-h-dvh items-end justify-center overflow-y-auto overscroll-y-contain bg-black/70 p-0 sm:items-center sm:p-4">
-      <div aria-hidden="true" className="absolute inset-0" onMouseDown={onClose} />
-
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="roadmap-dialog-title"
-        className="relative z-10 flex max-h-[100dvh] w-full max-w-3xl flex-col overflow-hidden rounded-t-3xl border border-border/70 bg-background shadow-[0_40px_120px_-44px_rgba(15,23,42,0.7)] backdrop-blur sm:max-h-[calc(100vh-2rem)] sm:rounded-[2rem]"
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open && dismissible) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent
+        dismissible={dismissible}
+        className="flex max-h-[100dvh] w-full max-w-3xl flex-col overflow-hidden border-border/70 bg-background shadow-[0_40px_120px_-44px_rgba(15,23,42,0.7)] backdrop-blur sm:max-h-[calc(100dvh-2rem)] sm:rounded-[2rem]"
       >
         <div className="border-b border-border/60 bg-background px-5 py-4 sm:px-6 sm:py-5">
           <div className="flex items-start justify-between gap-4">
             <div className="space-y-1">
               <div className="flex flex-wrap items-center gap-2">
-                <h3 id="roadmap-dialog-title" className="text-xl font-semibold text-foreground">
+                <DialogTitle className="text-xl font-semibold text-foreground">
                   {title}
-                </h3>
+                </DialogTitle>
                 {headerBadge}
               </div>
               {subtitle ? (
-                <p className="text-sm leading-6 text-muted-foreground">{subtitle}</p>
+                <DialogDescription className="leading-6">{subtitle}</DialogDescription>
               ) : null}
             </div>
 
@@ -788,15 +796,9 @@ function RoadmapDialogShell({
         </div>
 
         <div className="min-h-0 overflow-y-auto px-5 py-5 sm:px-6 sm:py-6">{children}</div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
-
-  if (typeof document === "undefined") {
-    return content;
-  }
-
-  return createPortal(content, document.body);
 }
 
 function RoadmapEventDetailModal({
@@ -2295,6 +2297,7 @@ export function ProjectRoadmapPanel({
           ) : null
         }
         isOpen={eventDialog !== null}
+        dismissible={!isSubmittingEvent}
         onClose={closeEventDialog}
       >
         <RoadmapEntityForm

--- a/components/project-roadmap-panel.tsx
+++ b/components/project-roadmap-panel.tsx
@@ -789,6 +789,7 @@ function RoadmapDialogShell({
               className="h-9 w-9 rounded-full"
               onClick={onClose}
               aria-label={`Close ${title}`}
+              disabled={!dismissible}
             >
               <X className="h-4 w-4" />
             </Button>

--- a/components/ui/assignee-select.tsx
+++ b/components/ui/assignee-select.tsx
@@ -182,7 +182,8 @@ export function AssigneeSelect({
             <div
               ref={dropdownRef}
               role="listbox"
-              className="z-[140] overflow-hidden rounded-xl border border-border/70 bg-popover p-1 shadow-lg"
+              data-overlay-popover="true"
+              className="pointer-events-auto z-[140] overflow-hidden rounded-xl border border-border/70 bg-popover p-1 shadow-lg"
               style={{
                 position: "fixed",
                 top: dropdownPosition.top,

--- a/components/ui/confirm-dialog.tsx
+++ b/components/ui/confirm-dialog.tsx
@@ -1,9 +1,16 @@
 "use client";
 
-import { createPortal } from "react-dom";
+import { useRef } from "react";
 
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CardContent, CardHeader } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
 
 interface ConfirmDialogProps {
   isOpen: boolean;
@@ -24,28 +31,32 @@ export function ConfirmDialog({
   onConfirm,
   onCancel,
 }: ConfirmDialogProps) {
-  if (!isOpen || typeof document === "undefined") {
-    return null;
-  }
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
 
-  return createPortal(
-    <div
-      className="fixed inset-0 z-[120] flex min-h-dvh w-screen items-end justify-center bg-black/70 p-0 sm:items-center sm:p-4"
-      onMouseDown={(event) => {
-        if (event.target === event.currentTarget && !isConfirming) {
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open && !isConfirming) {
           onCancel();
         }
       }}
     >
-      <Card
-        className="w-full max-w-md rounded-t-3xl sm:rounded-xl"
-        onMouseDown={(event) => event.stopPropagation()}
+      <DialogContent
+        role="alertdialog"
+        className="z-[150] w-full max-w-md"
+        dismissible={!isConfirming}
+        overlayClassName="z-[140]"
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          cancelButtonRef.current?.focus();
+        }}
       >
         <CardHeader className="space-y-2">
-          <CardTitle className="text-lg">{title}</CardTitle>
+          <DialogTitle className="text-lg">{title}</DialogTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <p className="text-sm text-muted-foreground">{description}</p>
+          <DialogDescription>{description}</DialogDescription>
           <div className="flex flex-col-reverse gap-2 sm:flex-row sm:items-center">
             <Button
               type="button"
@@ -67,19 +78,20 @@ export function ConfirmDialog({
             >
               {isConfirming ? "Deleting..." : confirmLabel}
             </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              disabled={isConfirming}
-              className="w-full sm:w-auto"
-              onClick={onCancel}
-            >
-              Cancel
-            </Button>
+            <DialogClose asChild>
+              <Button
+                ref={cancelButtonRef}
+                type="button"
+                variant="ghost"
+                disabled={isConfirming}
+                className="w-full sm:w-auto"
+              >
+                Cancel
+              </Button>
+            </DialogClose>
           </div>
         </CardContent>
-      </Card>
-    </div>,
-    document.body
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogClose = DialogPrimitive.Close;
+
+const DialogOverlay = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-[90] bg-black/70",
+      "data-[state=open]:animate-in data-[state=open]:fade-in-0",
+      "data-[state=closed]:animate-out data-[state=closed]:fade-out-0",
+      "motion-reduce:animate-none motion-reduce:transition-none",
+      className
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+type DialogContentProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+  /** Keep Escape and outside-pointer dismissal disabled while a critical mutation is running. */
+  dismissible?: boolean;
+  overlayClassName?: string;
+  presentation?: "responsive-sheet" | "centered";
+};
+
+function isNestedOverlayControl(target: EventTarget | null): boolean {
+  return target instanceof Element && Boolean(target.closest('[data-overlay-popover="true"]'));
+}
+
+const DialogContent = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Content>,
+  DialogContentProps
+>(
+  (
+    {
+      children,
+      className,
+      dismissible = true,
+      onEscapeKeyDown,
+      onInteractOutside,
+      onPointerDownOutside,
+      overlayClassName,
+      presentation = "responsive-sheet",
+      ...props
+    },
+    ref
+  ) => (
+    <DialogPrimitive.Portal>
+      <DialogOverlay className={overlayClassName} />
+      <DialogPrimitive.Content
+        ref={ref}
+        aria-modal="true"
+        data-overlay-content="true"
+        className={cn(
+          "fixed left-1/2 z-[100] w-[calc(100%-2rem)] -translate-x-1/2 border border-border/60 bg-card text-card-foreground shadow-lg",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out",
+          "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",
+          "motion-reduce:animate-none motion-reduce:transition-none",
+          presentation === "responsive-sheet"
+            ? [
+                "bottom-0 w-full rounded-t-3xl",
+                "data-[state=open]:slide-in-from-bottom data-[state=closed]:slide-out-to-bottom",
+                "sm:bottom-auto sm:top-1/2 sm:w-[calc(100%-2rem)] sm:-translate-y-1/2 sm:rounded-xl",
+                "sm:data-[state=open]:zoom-in-95 sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:slide-in-from-bottom-0 sm:data-[state=closed]:slide-out-to-bottom-0",
+              ]
+            : [
+                "top-1/2 -translate-y-1/2 rounded-xl",
+                "data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95",
+              ],
+          className
+        )}
+        onEscapeKeyDown={(event) => {
+          onEscapeKeyDown?.(event);
+          if (!dismissible) {
+            event.preventDefault();
+          }
+        }}
+        onInteractOutside={(event) => {
+          onInteractOutside?.(event);
+          if (isNestedOverlayControl(event.detail.originalEvent.target)) {
+            event.preventDefault();
+          }
+        }}
+        onPointerDownOutside={(event) => {
+          onPointerDownOutside?.(event);
+          if (!dismissible) {
+            event.preventDefault();
+          }
+        }}
+        {...props}
+      >
+        {children}
+      </DialogPrimitive.Content>
+    </DialogPrimitive.Portal>
+  )
+);
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogTitle = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title ref={ref} className={cn("font-semibold", className)} {...props} />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/components/ui/emoji-picker-button.tsx
+++ b/components/ui/emoji-picker-button.tsx
@@ -304,7 +304,8 @@ export function EmojiPickerButton({
         ? createPortal(
             <div
               ref={panelRef}
-              className="fixed z-[120] overflow-hidden rounded-2xl border border-border/70 bg-background/96 shadow-2xl backdrop-blur"
+              data-overlay-popover="true"
+              className="pointer-events-auto fixed z-[120] overflow-hidden rounded-2xl border border-border/70 bg-background/96 shadow-2xl backdrop-blur"
               style={{
                 left: panelLayout.left,
                 top: panelLayout.top,

--- a/components/ui/epic-select.tsx
+++ b/components/ui/epic-select.tsx
@@ -182,7 +182,8 @@ export function EpicSelect({
             <div
               ref={dropdownRef}
               role="listbox"
-              className="z-[140] overflow-hidden rounded-xl border border-border/70 bg-popover p-1 shadow-lg"
+              data-overlay-popover="true"
+              className="pointer-events-auto z-[140] overflow-hidden rounded-xl border border-border/70 bg-popover p-1 shadow-lg"
               style={{
                 position: "fixed",
                 top: dropdownPosition.top,

--- a/components/ui/mention-autocomplete.tsx
+++ b/components/ui/mention-autocomplete.tsx
@@ -270,8 +270,9 @@ export function MentionAutocomplete({
       ref={panelRef}
       role="listbox"
       aria-label="Project members"
+      data-overlay-popover="true"
       className={cn(
-        "fixed z-[120] overflow-hidden rounded-xl border border-border/70 bg-background/95 shadow-[0_10px_24px_-22px_rgba(15,23,42,0.45)] backdrop-blur-sm",
+        "pointer-events-auto fixed z-[120] overflow-hidden rounded-xl border border-border/70 bg-background/95 shadow-[0_10px_24px_-22px_rgba(15,23,42,0.45)] backdrop-blur-sm",
         "transition-all duration-150 ease-out"
       )}
       style={{

--- a/docs/reports/task-270-ui-ux-assessment.md
+++ b/docs/reports/task-270-ui-ux-assessment.md
@@ -38,6 +38,15 @@ not recommended.
 | Responsive design | 5.5/10 | Layouts fit 390 px without horizontal page overflow, but mobile density and sequence are not sufficiently re-composed. |
 | Accessibility baseline | 4.5/10 | Visible labels and focus styles exist, but custom overlays lack a consistent dialog/focus contract and micro-text/touch sizes are risky. |
 
+### Remediation status
+
+- **F1 and overlay-specific F12 scope resolved by TASK-321 (2026-07-05):**
+  task, context, attachment, calendar, project-settings, confirmation, meeting,
+  roadmap, and project-creation overlays now use one accessible dialog/sheet
+  foundation with modal semantics, focus containment/restoration, guarded
+  Escape behavior, scroll isolation, nested-control support, and reduced-motion
+  handling. Whole-app motion outside overlays remains assigned to TASK-108.
+
 ## What is working
 
 1. **The interface has a recognizable visual language.** Lucide icons, neutral

--- a/docs/ui/accessible-overlays.md
+++ b/docs/ui/accessible-overlays.md
@@ -1,0 +1,31 @@
+# Accessible Overlay Contract
+
+NexusDash dialogs and responsive sheets use the shared primitives in
+`components/ui/dialog.tsx`. They are backed by Radix Dialog and retain the
+product's existing mobile bottom-sheet and desktop centered-dialog geometry.
+
+## Required structure
+
+- Wrap every overlay in `Dialog` and render its surface with `DialogContent`.
+- Provide exactly one `DialogTitle`; it may be visually hidden when the visible
+  heading must retain separate styling.
+- Use `DialogDescription` when supporting copy describes the dialog. Otherwise
+  pass `aria-describedby={undefined}` to `DialogContent`.
+- Give icon-only close buttons a specific accessible name.
+- Set `dismissible={false}` while a destructive or critical mutation must not be
+  interrupted. Disable the visible close/cancel controls for the same period.
+- Use `presentation="centered"` only for previews that should remain centered
+  on narrow screens. The default is a mobile sheet and desktop dialog.
+
+## Behavior supplied by the foundation
+
+- modal semantics and background isolation
+- safe initial focus, Tab/Shift+Tab containment, and trigger focus restoration
+- Escape and outside-pointer dismissal when `dismissible` is true
+- body scroll locking with internal content scrolling
+- nested portaled controls marked with `data-overlay-popover="true"`
+- entry/exit motion with an explicit no-animation/no-transform path for
+  `prefers-reduced-motion: reduce`
+
+Creation forms should put `autoFocus` on their first meaningful field. A
+destructive confirmation should explicitly focus its Cancel button.

--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,25 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-07-05 - TASK-321 accessible modal and sheet foundation
+
+- Replaced duplicated custom overlay roots with a shared Radix-backed dialog
+  and responsive-sheet foundation that centralizes modal semantics, focus
+  containment/restoration, Escape and outside-dismiss behavior, body scroll
+  isolation, mobile internal scrolling, and reduced motion.
+- Migrated task create/detail, project creation/settings, confirmations,
+  context create/edit/preview, attachment preview, calendar event, meeting, and
+  roadmap overlays. Marked portaled date, emoji, mention, epic, assignee, and
+  related-task controls so they remain interactive above modal isolation.
+- Browser validation found and fixed two integration regressions: reduced-motion
+  sheets retained their initial slide transform, and an optimistic context card
+  preview lost its selected ID when the server response replaced the optimistic
+  card.
+- Validation: lint, RLS inventory, 930 unit tests, coverage thresholds, build,
+  and all 11 Playwright tests passed, including focused desktop/390 px overlay
+  checks and the task, context, meeting, roadmap, calendar, auth, and attachment
+  smoke journeys.
+
 # 2026-07-05 - TASK-270 remediation queue and verification gate
 
 - Added TASK-323 as a dedicated production-readiness UX verification gate after

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexusdash",
-  "version": "0.23.1",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexusdash",
-      "version": "0.23.1",
+      "version": "0.24.0",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1079.0",
@@ -14,6 +14,7 @@
         "@hello-pangea/dnd": "^18.0.1",
         "@prisma/adapter-pg": "^7.8.0",
         "@prisma/client": "^7.8.0",
+        "@radix-ui/react-dialog": "^1.1.18",
         "@radix-ui/react-slot": "^1.3.0",
         "@types/pg": "^8.20.0",
         "class-variance-authority": "^0.7.1",
@@ -2100,6 +2101,468 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+      "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.18.tgz",
+      "integrity": "sha512-apa28mldjMgORmE6g/w3sCcA0Y9UAVeeDVoozN4i7kOw12mLl9RBchfzK3Nn6qxOWjrZhK1Lfy7f07kyzxtnBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.14",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.11",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-portal": "1.1.13",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-slot": "1.3.0",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/primitive": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+      "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+      "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.14.tgz",
+      "integrity": "sha512-4lUhWTWAjbDIqFrAPWJ3WqBOpO5YchVZ88X3nh6H9Lu5AFi5nCUeTPj3D8FSDmabmFeRe9ME0BDA4MwKTha5GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-effect-event": "0.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/primitive": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+      "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+      "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+      "integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.11.tgz",
+      "integrity": "sha512-Mn88Vg2whaRocGJNOH+DKFqYm6ySFPQaiwHNxZPyjn99B52KAEJWWY9NP83+nWdk2HM3rdov+STu9AG471Rt9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+      "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.13.tgz",
+      "integrity": "sha512-z3oXfmaHLJTF1wktbjgD6cn9jiEbq3WSondB10LIuIt2m2Ym4iJlrW04/euMwENDdWDdE7z+OuY7Qyp1YpRSwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+      "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
+      "integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-primitive": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
@@ -2198,6 +2661,21 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -3913,6 +4391,18 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -4784,6 +5274,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -5936,6 +6432,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-port-please": {
@@ -8507,6 +9012,75 @@
         }
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/readdirp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
@@ -9772,6 +10346,49 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexusdash",
-  "version": "0.23.1",
+  "version": "0.24.0",
   "private": true,
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0",
@@ -37,6 +37,7 @@
     "@hello-pangea/dnd": "^18.0.1",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
+    "@radix-ui/react-dialog": "^1.1.18",
     "@radix-ui/react-slot": "^1.3.0",
     "@types/pg": "^8.20.0",
     "class-variance-authority": "^0.7.1",

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -6,41 +6,35 @@ Last reviewed: 2026-07-05
 
 ## Pending
 ### Execution Queue (Now / Next)
-- ID: TASK-321
-  Title: Accessible modal and sheet foundation - semantics, focus lifecycle, keyboard behavior, and responsive overlays
-  Status: Now 1 - production-grade UI foundation
-  Rationale: Replace duplicated custom overlay behavior with shared accessible dialog/sheet primitives so task, context, project-settings, confirmation, meeting, roadmap, and attachment flows have correct modal semantics, named controls, focus containment/restoration, Escape handling, background isolation, and reduced-motion behavior.
-  Dependencies: TASK-270
-  Brief: `tasks/task-321-accessible-modal-sheet-foundation.md`
 - ID: TASK-322
   Title: Responsive authenticated app shell - primary navigation, utility placement, and safe feedback layers
-  Status: Next 2 - navigation and orientation foundation
+  Status: Now 1 - navigation and orientation foundation
   Rationale: Replace floating utility-only authenticated chrome with a responsive shell that exposes primary destinations and current location, demotes diagnostic metadata, meets mobile touch requirements, and prevents navigation, toasts, menus, and overlays from competing for the same fixed screen space. Preserve safe project/task origin state across account and notification detours so Project -> Notifications -> Account does not strand the user at the generic Projects list.
   Dependencies: TASK-270, TASK-321
   Brief: `tasks/task-322-responsive-authenticated-app-shell.md`
 - ID: TASK-100
   Title: Mobile UI/UX refinement - touch ergonomics, compact layouts, and small-screen polish
-  Status: Next 3 - mobile core-flow remediation
+  Status: Next 2 - mobile core-flow remediation
   Rationale: Re-prioritize the long mobile dashboard sequence, replace four vertically stacked Kanban columns with an intentional status-switching pattern, enforce 44px touch targets and readable secondary text, reduce task-sheet friction, and retain the existing Google Calendar narrow-viewport scope identified by TASK-270.
   Dependencies: TASK-091, TASK-079, TASK-096, TASK-270, TASK-321, TASK-322
 - ID: TASK-133
   Title: Task UI bug fixing - mini scrollbar and detail/edit modal polish
-  Status: Next 4 - daily task-flow clarity
+  Status: Next 3 - daily task-flow clarity
   Rationale: Separate task reading from editing, remove ambiguous Save/Edit states, and fix compact scrollbar/modal regressions so the highest-frequency execution flow is visually clear and predictable after the shared overlay foundation lands.
   Dependencies: TASK-076, TASK-113, TASK-270, TASK-321
 - ID: TASK-129
   Title: Login/home page UI polish - user-friendly, product-oriented entry experience
-  Status: Next 5 - entry and product-voice refinement
+  Status: Next 4 - entry and product-voice refinement
   Rationale: Replace session/provider architecture language with user outcomes, reduce the very long mobile first-visit path, improve visual hierarchy and CTA clarity, and keep returning-user sign-in friction low. TASK-270 finding F5 is the design brief.
   Dependencies: TASK-045, TASK-059, TASK-083, TASK-270
 - ID: TASK-108
   Title: Whole-app UI/UX refinement - global interaction, visual, and information-design polish
-  Status: Next 6 - cross-app convergence pass
+  Status: Next 5 - cross-app convergence pass
   Rationale: Use TASK-270 findings F6-F12 to normalize module hierarchy, metric semantics, read-only affordances, type/spacing tokens, empty states, toast policy, and reduced motion after the structural navigation, overlay, mobile, task, and entry work is complete.
   Dependencies: TASK-096, TASK-100, TASK-129, TASK-133, TASK-270, TASK-321, TASK-322
 - ID: TASK-323
   Title: Production-readiness UX verification - accessibility, navigation, responsive, role, and recovery sign-off
-  Status: Next 7 - blocked final verification gate
+  Status: Next 6 - blocked final verification gate
   Rationale: Re-audit the remediated product rather than assuming implementation tasks achieved production quality. Verify WCAG AA fundamentals, keyboard/screen-reader operation, owner/editor/viewer/invitee journeys, navigation state preservation, realistic data density, loading/error/empty recovery, responsive layouts, themes, and critical usability flows; produce a residual-risk sign-off report and focused defects for anything still below production grade.
   Dependencies: TASK-100, TASK-108, TASK-129, TASK-133, TASK-321, TASK-322
   Brief: `tasks/task-323-production-readiness-ux-verification.md`
@@ -104,6 +98,12 @@ Last reviewed: 2026-07-05
   Dependencies: TASK-051
 
 ## Completed
+- ID: TASK-321
+  Title: Accessible modal and sheet foundation - semantics, focus lifecycle, keyboard behavior, and responsive overlays
+  Status: Done (2026-07-05)
+  Rationale: Replaced duplicated custom overlays with a shared Radix-backed dialog/sheet contract covering modal semantics, named controls, focus containment/restoration, guarded Escape behavior, background isolation, nested controls, responsive internal scrolling, and reduced motion.
+  Dependencies: TASK-270
+  Brief: `tasks/task-321-accessible-modal-sheet-foundation.md`
 - ID: TASK-270
   Title: App UI/UX design assessment - product-wide heuristic audit and refinement roadmap
   Status: Done (2026-07-03)

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,9 +1,63 @@
 # Current Task
 
-## Status
-No active implementation task selected.
+## Task
 
-## Next Step
-Start with TASK-321, the first item in the prioritized execution queue in
-`tasks/backlog.md`. Replace this placeholder with its active task brief before
-implementation begins.
+- ID: TASK-321
+- Title: Accessible modal and sheet foundation
+- Status: Complete (2026-07-05)
+- Branch: `feature/321-accessible-modal-sheet-foundation`
+- Brief: [`task-321-accessible-modal-sheet-foundation.md`](./task-321-accessible-modal-sheet-foundation.md)
+
+## Objective
+
+Create and adopt a shared accessible overlay foundation so dialogs, sheets, and
+confirmation flows have consistent semantics, keyboard behavior, focus
+lifecycle, background isolation, and responsive presentation.
+
+## Scope
+
+- Provide shared dialog/sheet primitives with correct dialog semantics,
+  accessible names, focus containment/restoration, Escape handling, background
+  isolation, responsive presentation, named close controls, and reduced-motion
+  support.
+- Migrate create task, task detail/edit, project settings, confirmation, context
+  preview/edit/create, attachment preview, meeting, and roadmap overlays.
+- Add focused keyboard and accessibility regression coverage at desktop and
+  mobile widths.
+
+## Out Of Scope
+
+- Visual redesign of overlay content.
+- Task-specific information architecture owned by TASK-133.
+- Whole-app typography or color changes owned by TASK-108.
+
+## Acceptance Criteria
+
+1. Every migrated overlay has an accessible name, correct modal semantics, and
+   a named close/cancel path.
+2. Keyboard focus cannot move into obscured page content while an overlay is
+   open and returns to the trigger after close.
+3. Escape closes non-destructive overlays and does not interrupt an in-flight
+   destructive action.
+4. Background scrolling is prevented without breaking internal sheet scrolling
+   at 390 px.
+5. Overlay motion respects `prefers-reduced-motion`.
+6. Automated coverage verifies semantics, focus containment/restoration,
+   Escape, and representative nested controls.
+
+## Definition Of Done
+
+- Shared overlay primitives are implemented and documented.
+- In-scope overlays are migrated without behavior regressions.
+- Desktop/mobile keyboard checks and the required repository validation pass.
+- TASK-270 and TASK-321 tracking docs are updated.
+
+## Outcome
+
+- Shared Radix-backed dialog and responsive-sheet primitives are implemented
+  and documented in `docs/ui/accessible-overlays.md`.
+- All scoped overlays now share modal semantics, focus lifecycle, guarded
+  dismissal, background isolation, nested-control support, and reduced-motion
+  behavior.
+- Validation passed: lint, RLS inventory, 930 unit tests, coverage thresholds,
+  production build, and 11 Playwright tests at desktop/mobile widths.

--- a/tasks/task-321-accessible-modal-sheet-foundation.md
+++ b/tasks/task-321-accessible-modal-sheet-foundation.md
@@ -4,7 +4,7 @@
 TASK-321
 
 ## Status
-Pending — high-priority accessibility defect from TASK-270
+Done (2026-07-05)
 
 ## Objective
 Create and adopt a shared accessible overlay foundation so dialogs, sheets, and
@@ -50,3 +50,14 @@ lifecycle, background isolation, and responsive presentation.
 
 ## Dependencies
 - TASK-270
+
+## Outcome
+- Added the Radix-backed shared primitives in `components/ui/dialog.tsx` and
+  documented their usage in `docs/ui/accessible-overlays.md`.
+- Migrated all scoped overlays and preserved portaled date, emoji, mention,
+  epic, assignee, and related-task controls through an explicit nested-popover
+  contract.
+- Added component coverage for semantics, focus isolation/restoration, Escape,
+  protected in-flight state, and nested controls, plus desktop and 390 px
+  Playwright coverage for focus looping, scroll isolation, internal sheet
+  scrolling, and reduced motion.

--- a/tests/components/dialog-foundation.test.tsx
+++ b/tests/components/dialog-foundation.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+
+import React, { useState } from "react";
+import { act } from "react";
+import { createPortal } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function DialogHarness({ dismissible = true }: { dismissible?: boolean }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
+  return (
+    <div>
+      <button type="button" data-testid="background-action">
+        Background action
+      </button>
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <DialogTrigger asChild>
+          <Button type="button">Open dialog</Button>
+        </DialogTrigger>
+        <DialogContent
+          aria-describedby={undefined}
+          dismissible={dismissible}
+          className="max-w-md"
+        >
+          <DialogTitle>Accessible settings</DialogTitle>
+          <input aria-label="Project name" defaultValue="Apollo" />
+          <button type="button" onClick={() => setIsPopoverOpen(true)}>
+            Open options
+          </button>
+          <button type="button">Last action</button>
+          {isPopoverOpen
+            ? createPortal(
+                <button
+                  type="button"
+                  data-overlay-popover="true"
+                  onClick={() => setIsPopoverOpen(false)}
+                >
+                  Nested option
+                </button>,
+                document.body
+              )
+            : null}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function createTestRenderer() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  return { container, root };
+}
+
+async function renderWithRoot(root: Root, ui: React.ReactElement) {
+  await act(async () => {
+    root.render(ui);
+  });
+}
+
+async function click(element: Element | null) {
+  expect(element).not.toBeNull();
+  await act(async () => {
+    element?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+describe("accessible dialog foundation", () => {
+  beforeEach(() => {
+    vi.stubGlobal("PointerEvent", MouseEvent);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.unstubAllGlobals();
+  });
+
+  test("provides modal semantics, isolates focus, and restores the trigger after Escape", async () => {
+    const { container, root } = createTestRenderer();
+    await renderWithRoot(root, <DialogHarness />);
+
+    const trigger = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Open dialog"
+    );
+    await click(trigger ?? null);
+
+    const dialog = document.body.querySelector<HTMLElement>("[role='dialog']");
+    const titleId = dialog?.getAttribute("aria-labelledby");
+    expect(dialog?.getAttribute("aria-modal")).toBe("true");
+    expect(titleId).toBeTruthy();
+    expect(document.getElementById(titleId ?? "")?.textContent).toBe("Accessible settings");
+    expect(document.body.hasAttribute("data-scroll-locked")).toBe(true);
+    expect(dialog?.contains(document.activeElement)).toBe(true);
+
+    const backgroundAction = container.querySelector<HTMLElement>(
+      "[data-testid='background-action']"
+    );
+    await act(async () => {
+      backgroundAction?.focus();
+    });
+    expect(dialog?.contains(document.activeElement)).toBe(true);
+
+    await act(async () => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true })
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(document.body.querySelector("[role='dialog']")).toBeNull();
+    await expect.poll(() => document.activeElement === trigger).toBe(true);
+
+    await act(async () => root.unmount());
+  });
+
+  test("keeps in-flight dialogs open on Escape and accepts marked nested controls", async () => {
+    const { container, root } = createTestRenderer();
+    await renderWithRoot(root, <DialogHarness dismissible={false} />);
+
+    const trigger = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Open dialog"
+    );
+    await click(trigger ?? null);
+    await act(async () => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true })
+      );
+    });
+    expect(document.body.querySelector("[role='dialog']")).not.toBeNull();
+
+    const openOptions = Array.from(document.body.querySelectorAll("button")).find(
+      (button) => button.textContent === "Open options"
+    );
+    await click(openOptions ?? null);
+    const nestedOption = Array.from(document.body.querySelectorAll("button")).find(
+      (button) => button.textContent === "Nested option"
+    );
+    await click(nestedOption ?? null);
+    expect(document.body.querySelector("[role='dialog']")).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
+});

--- a/tests/e2e/accessible-overlays.spec.ts
+++ b/tests/e2e/accessible-overlays.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "@playwright/test";
+
+import { signInAsVerifiedUser } from "./helpers/auth-helpers";
+import {
+  createProjectFromProjectsPage,
+  openNewestProjectDashboard,
+  uniqueProjectName,
+} from "./helpers/project-helpers";
+
+test.describe("accessible overlay foundation", () => {
+  test.beforeEach(async ({ page }) => {
+    await signInAsVerifiedUser(page);
+    const projectName = uniqueProjectName("overlay-a11y");
+    await createProjectFromProjectsPage(page, projectName);
+    await openNewestProjectDashboard(page, projectName);
+  });
+
+  test("contains and restores keyboard focus with named modal semantics", async ({ page }) => {
+    const trigger = page.getByRole("button", { name: "New task" });
+    await trigger.focus();
+    await trigger.click();
+
+    const dialog = page.getByRole("dialog", { name: "Create task" });
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toHaveAttribute("aria-modal", "true");
+    await expect(page.locator("body")).toHaveAttribute("data-scroll-locked", "1");
+    await expect(page.locator("#task-title")).toBeFocused();
+
+    await page.keyboard.press("Shift+Tab");
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          Boolean(document.activeElement?.closest("[role='dialog']"))
+        )
+      )
+      .toBe(true);
+
+    await page.keyboard.press("Escape");
+    await expect(dialog).toBeHidden();
+    await expect(trigger).toBeFocused();
+  });
+
+  test("keeps the 390px sheet internally scrollable and removes overlay motion", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.getByRole("button", { name: "New task" }).click();
+
+    const dialog = page.getByRole("dialog", { name: "Create task" });
+    await expect(dialog).toBeVisible();
+    const geometry = await dialog.boundingBox();
+    expect(geometry).not.toBeNull();
+    expect(Math.round((geometry?.y ?? 0) + (geometry?.height ?? 0))).toBe(844);
+    expect(geometry?.width).toBeLessThanOrEqual(390);
+
+    const scrollResult = await dialog.evaluate((element) => {
+      const scrollRegion = Array.from(element.querySelectorAll<HTMLElement>("*"))
+        .find((candidate) => {
+          const style = getComputedStyle(candidate);
+          return style.overflowY === "auto" && candidate.scrollHeight > candidate.clientHeight;
+        });
+      if (!scrollRegion) return null;
+      scrollRegion.scrollTop = Math.min(200, scrollRegion.scrollHeight - scrollRegion.clientHeight);
+      return { scrollTop: scrollRegion.scrollTop, animationDuration: getComputedStyle(element).animationDuration };
+    });
+
+    expect(scrollResult?.scrollTop).toBeGreaterThan(0);
+    expect(scrollResult?.animationDuration).toBe("0s");
+    await expect(page.locator("body")).toHaveAttribute("data-scroll-locked", "1");
+  });
+});

--- a/tests/e2e/accessible-overlays.spec.ts
+++ b/tests/e2e/accessible-overlays.spec.ts
@@ -49,7 +49,8 @@ test.describe("accessible overlay foundation", () => {
     await expect(dialog).toBeVisible();
     const geometry = await dialog.boundingBox();
     expect(geometry).not.toBeNull();
-    expect(Math.round((geometry?.y ?? 0) + (geometry?.height ?? 0))).toBe(844);
+    const bottomEdge = (geometry?.y ?? 0) + (geometry?.height ?? 0);
+    expect(Math.abs(bottomEdge - 844)).toBeLessThanOrEqual(1);
     expect(geometry?.width).toBeLessThanOrEqual(390);
 
     const scrollResult = await dialog.evaluate((element) => {


### PR DESCRIPTION
## Summary

- add a shared Radix-backed accessible dialog and responsive-sheet foundation
- migrate task, context, attachment, calendar, project settings, confirmation, meeting, roadmap, and project creation overlays
- preserve nested portaled controls, guarded in-flight dismissal, mobile internal scrolling, and reduced-motion behavior
- add component and Playwright regression coverage and document the overlay contract

## Why

TASK-270 found that custom overlays lacked consistent modal semantics, focus containment/restoration, named close paths, background isolation, and reduced-motion behavior. TASK-321 centralizes that contract without redesigning overlay content.

## Validation

- `npm run lint`
- `npm run rls:check`
- `npm test` (930 passed, 2 skipped)
- `npm run test:coverage` (all thresholds passed)
- `npm run build`
- `npm run test:e2e` (11 passed)
- agent-browser production-page visual/console check (content rendered, no framework overlay, no captured console errors)
