### PR TITLE
TASK-129: Redesign login and home entry experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ SHA, deployment URL, and workflow run belong in release evidence.
 
 - Define each release entry before the product-impacting PR is merged.
 
+## v0.25.0 - 2026-07-16
+
+- Redesigned the unauthenticated entry page around product outcomes with a
+  focused desktop product/auth split and an auth-first mobile layout.
+- Reduced the 390 px sign-up path from 1,993 px to 1,119 px while preserving
+  credentials, social providers, recovery, validation, and safe return paths.
+- Added 48 px authentication controls, clearer status and focus treatment,
+  deterministic reduced-motion behavior, and responsive Playwright coverage.
+
 ## v0.24.0 - 2026-07-05
 
 - Added a shared accessible dialog and responsive-sheet foundation with named

--- a/app/auth-submit-button.tsx
+++ b/app/auth-submit-button.tsx
@@ -25,7 +25,7 @@ export function AuthSubmitButton({
       <span
         aria-hidden
         className={cn(
-          "size-3 rounded-full border-2 border-current border-r-transparent transition-opacity",
+          "size-3 rounded-full border-2 border-current border-r-transparent transition-opacity motion-reduce:animate-none",
           pending ? "animate-spin opacity-100" : "opacity-0"
         )}
       />

--- a/app/globals.css
+++ b/app/globals.css
@@ -115,22 +115,64 @@
   border-color: hsl(var(--ring) / 0.6) !important;
 }
 
-@keyframes home-product-ambient-drift {
+@keyframes home-entry-color-flow {
   0% {
-    transform: translate3d(0, 0, 0) scale(1);
+    transform: translate3d(-3%, -1%, 0) scale(1.03);
   }
+
+  50% {
+    transform: translate3d(1%, 1.5%, 0) scale(1.06);
+  }
+
   100% {
-    transform: translate3d(2.5rem, 1.5rem, 0) scale(1.08);
+    transform: translate3d(3%, -0.5%, 0) scale(1.03);
   }
 }
 
-.home-product-ambient {
-  animation: home-product-ambient-drift 8s ease-out both;
+.home-entry-color-field {
+  inset: -10% -12%;
+  background:
+    radial-gradient(
+      ellipse 72% 70% at 2% 38%,
+      rgb(37 99 235 / 18%) 0%,
+      rgb(37 99 235 / 7%) 40%,
+      transparent 68%
+    ),
+    radial-gradient(
+      ellipse 46% 58% at 42% 92%,
+      rgb(79 70 229 / 10%) 0%,
+      transparent 72%
+    ),
+    linear-gradient(
+      105deg,
+      rgb(239 246 255 / 76%) 0%,
+      rgb(238 242 255 / 34%) 42%,
+      transparent 78%
+    );
+  animation: home-entry-color-flow 16s ease-in-out infinite alternate;
+  transform-origin: center;
   will-change: transform;
 }
 
-.home-product-ambient-secondary {
-  animation-direction: reverse;
+.dark .home-entry-color-field {
+  background:
+    radial-gradient(
+      ellipse 72% 70% at 2% 38%,
+      rgb(37 99 235 / 20%) 0%,
+      rgb(37 99 235 / 7%) 42%,
+      transparent 68%
+    ),
+    radial-gradient(
+      ellipse 46% 58% at 42% 92%,
+      rgb(79 70 229 / 12%) 0%,
+      transparent 72%
+    ),
+    linear-gradient(
+      105deg,
+      rgb(15 23 42 / 62%) 0%,
+      rgb(15 23 42 / 24%) 44%,
+      transparent 80%
+    );
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -148,5 +190,11 @@
     animation: none !important;
     transition: none !important;
     transform: none !important;
+  }
+
+  .home-entry-color-field {
+    animation: none !important;
+    transform: none !important;
+    will-change: auto;
   }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -105,6 +105,24 @@
   border-color: hsl(var(--ring) / 0.6) !important;
 }
 
+@keyframes home-product-ambient-drift {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  100% {
+    transform: translate3d(2.5rem, 1.5rem, 0) scale(1.08);
+  }
+}
+
+.home-product-ambient {
+  animation: home-product-ambient-drift 8s ease-out both;
+  will-change: transform;
+}
+
+.home-product-ambient-secondary {
+  animation-direction: reverse;
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/app/globals.css
+++ b/app/globals.css
@@ -175,6 +175,15 @@
     );
 }
 
+.home-interactive-node-field {
+  z-index: 0;
+  opacity: 0.96;
+}
+
+.dark .home-interactive-node-field {
+  opacity: 0.97;
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
@@ -195,6 +204,10 @@
   .home-entry-color-field {
     animation: none !important;
     transform: none !important;
+    will-change: auto;
+  }
+
+  .home-interactive-node-field {
     will-change: auto;
   }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -106,6 +106,15 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+
   [data-overlay-content="true"],
   [data-overlay-content="true"]::backdrop {
     animation: none !important;

--- a/app/home-auth-methods.tsx
+++ b/app/home-auth-methods.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { ArrowLeft, Mail } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface HomeAuthMethodsProps {
+  children: ReactNode;
+  defaultEmailExpanded?: boolean;
+  providerOptions: ReactNode;
+}
+
+export function HomeAuthMethods({
+  children,
+  defaultEmailExpanded = false,
+  providerOptions,
+}: HomeAuthMethodsProps) {
+  const [emailExpanded, setEmailExpanded] = useState(defaultEmailExpanded);
+
+  return (
+    <>
+      <div
+        data-state={emailExpanded ? "email-expanded" : "provider-options"}
+        className={cn("grid gap-2", emailExpanded && "hidden sm:grid")}
+      >
+        {providerOptions}
+        <Button
+          type="button"
+          variant="outline"
+          className="h-12 w-full rounded-xl sm:hidden"
+          onClick={() => setEmailExpanded(true)}
+          aria-expanded={emailExpanded}
+          aria-controls="home-email-auth-form"
+        >
+          <Mail className="size-4" aria-hidden="true" />
+          Continue with email
+        </Button>
+
+        <div className="relative my-2 hidden sm:block">
+          <div className="absolute inset-0 flex items-center">
+            <span className="w-full border-t border-border" />
+          </div>
+          <div className="relative flex justify-center text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+            <span className="bg-card px-3">Or use email</span>
+          </div>
+        </div>
+      </div>
+
+      <div
+        id="home-email-auth-form"
+        data-state={emailExpanded ? "email-expanded" : "provider-options"}
+        className={cn("hidden gap-4 sm:grid", emailExpanded && "grid")}
+      >
+        {children}
+        <Button
+          type="button"
+          variant="ghost"
+          className="h-11 w-full rounded-lg text-muted-foreground sm:hidden"
+          onClick={() => setEmailExpanded(false)}
+        >
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          Other sign-in options
+        </Button>
+      </div>
+    </>
+  );
+}

--- a/app/home-interactive-node-field.tsx
+++ b/app/home-interactive-node-field.tsx
@@ -1,0 +1,543 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+const NODE_COUNT = 260;
+const CLUSTERED_NODE_COUNT = 112;
+const VIEWPORT_TISSUE_COUNT = 104;
+const CLUSTER_COUNT = 5;
+const PLACEMENT_CANDIDATES = 24;
+const WORLD_PADDING_X = 0.18;
+const WORLD_PADDING_Y = 0.2;
+const ACTIVATION_RADIUS = 340;
+const MAX_ATTRACTION = 22;
+const MAX_PARALLAX = 42;
+const CLUSTER_DEPTHS = [0.1, 0.3, 0.52, 0.74, 0.94] as const;
+
+type Point = { x: number; y: number };
+type NodePoint = Point & {
+  cluster: number | null;
+  depth: number;
+  emphasis: number;
+};
+type Link = {
+  depth: number;
+  from: number;
+  to: number;
+  strength: number;
+  bend: number;
+};
+
+function createRandomSeed() {
+  try {
+    const seed = new Uint32Array(1);
+    window.crypto.getRandomValues(seed);
+    return seed[0] || Date.now();
+  } catch {
+    return Math.floor(Math.random() * 4_294_967_295) || Date.now();
+  }
+}
+
+function createNodeField(seed: number) {
+  let state = seed >>> 0;
+  const random = () => {
+    state += 0x6d2b79f5;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4_294_967_296;
+  };
+
+  const clusterAnchors = Array.from({ length: CLUSTER_COUNT }, (_, index) => {
+    const edgeAnchors = [
+      { x: -0.03 - random() * 0.06, y: 0.12 + random() * 0.36 },
+      { x: 1.03 + random() * 0.06, y: 0.5 + random() * 0.34 },
+      { x: 0.52 + random() * 0.3, y: 1.03 + random() * 0.07 },
+      { x: 0.4 + random() * 0.2, y: 0.3 + random() * 0.3 },
+    ];
+    const position = edgeAnchors[index] ?? {
+      x: 0.12 + random() * 0.76,
+      y: 0.12 + random() * 0.76,
+    };
+
+    return {
+      ...position,
+      depth: Math.max(
+        0.04,
+        Math.min(0.98, CLUSTER_DEPTHS[index] + (random() - 0.5) * 0.12)
+      ),
+      radiusX: 0.1 + random() * 0.09,
+      radiusY: 0.11 + random() * 0.1,
+    };
+  });
+
+  const nodes: NodePoint[] = Array.from(
+    { length: CLUSTERED_NODE_COUNT },
+    (_, index) => {
+      const cluster = index % CLUSTER_COUNT;
+      const anchor = clusterAnchors[cluster];
+      const angle = random() * Math.PI * 2;
+      const radius = Math.pow(random(), 0.68);
+      const depth = Math.max(
+        0.04,
+        Math.min(0.98, anchor.depth + (random() - 0.5) * 0.24)
+      );
+
+      return {
+        x: anchor.x + Math.cos(angle) * anchor.radiusX * radius,
+        y: anchor.y + Math.sin(angle) * anchor.radiusY * radius,
+        cluster,
+        depth,
+        emphasis: 0.82 + depth * 0.44 + Math.pow(random(), 1.8) * 0.5,
+      };
+    }
+  );
+
+  while (nodes.length < NODE_COUNT) {
+    const ambientIndex = nodes.length - CLUSTERED_NODE_COUNT;
+    const crossesViewport = ambientIndex < VIEWPORT_TISSUE_COUNT;
+    let bestCandidate: NodePoint | null = null;
+    let bestClearance = -1;
+
+    for (let attempt = 0; attempt < PLACEMENT_CANDIDATES; attempt += 1) {
+      const depth = 0.04 + random() * 0.94;
+      const candidate = {
+        x: crossesViewport
+          ? -0.04 + random() * 1.08
+          : -WORLD_PADDING_X + random() * (1 + WORLD_PADDING_X * 2),
+        y: crossesViewport
+          ? -0.05 + random() * 1.1
+          : -WORLD_PADDING_Y + random() * (1 + WORLD_PADDING_Y * 2),
+        cluster: null,
+        depth,
+        emphasis: 0.82 + depth * 0.44 + Math.pow(random(), 1.8) * 0.5,
+      };
+      const clearance = nodes.reduce(
+        (nearest, node) =>
+          Math.min(
+            nearest,
+            Math.hypot(
+              (candidate.x - node.x) * 1.4,
+              candidate.y - node.y,
+              (candidate.depth - node.depth) * 0.18
+            )
+          ),
+        Number.POSITIVE_INFINITY
+      );
+
+      if (clearance > bestClearance) {
+        bestCandidate = candidate;
+        bestClearance = clearance;
+      }
+    }
+
+    if (bestCandidate) nodes.push(bestCandidate);
+  }
+
+  const linkKeys = new Set<string>();
+  const links: Link[] = [];
+
+  const connect = (from: number, to: number) => {
+    if (to < 0 || to >= nodes.length || from === to) return;
+    const key = [from, to].sort((a, b) => a - b).join(":");
+    if (linkKeys.has(key)) return;
+    linkKeys.add(key);
+
+    const first = nodes[from];
+    const second = nodes[to];
+    const distance = Math.hypot(
+      (second.x - first.x) * 1.4,
+      second.y - first.y,
+      (second.depth - first.depth) * 0.38
+    );
+    const closeness = 1 - Math.min(1, distance / 0.27);
+    const cellAffinity =
+      ((first.emphasis + second.emphasis) / 2 - 0.82) / 0.94;
+    const sharedNeighborhood =
+      first.cluster !== null && first.cluster === second.cluster ? 1 : 0;
+    const depth = (first.depth + second.depth) / 2;
+
+    links.push({
+      depth,
+      from,
+      to,
+      strength: Math.min(
+        1,
+        0.08 +
+          random() * 0.34 +
+          closeness * 0.18 +
+          cellAffinity * 0.12 +
+          sharedNeighborhood * 0.2 +
+          depth * 0.14
+      ),
+      bend: (random() * 2 - 1) * (0.32 + random() * 0.5),
+    });
+  };
+
+  nodes.forEach((node, from) => {
+    const neighbors = nodes
+      .map((candidate, to) => ({
+        to,
+        distance: Math.hypot(
+          (candidate.x - node.x) * 1.4,
+          candidate.y - node.y,
+          (candidate.depth - node.depth) * 0.38
+        ),
+      }))
+      .filter(({ to }) => to !== from)
+      .sort((left, right) => left.distance - right.distance)
+      .slice(
+        0,
+        node.cluster !== null
+          ? random() < 0.52
+            ? 6
+            : 5
+          : random() < 0.42
+            ? 5
+            : 4
+      );
+
+    neighbors.forEach(({ to }) => connect(from, to));
+  });
+
+  links.sort((first, second) => first.depth - second.depth);
+  return { nodes, links };
+}
+
+function smootherStep(progress: number) {
+  const value = Math.max(0, Math.min(1, progress));
+  return value * value * value * (value * (value * 6 - 15) + 10);
+}
+
+function proximityInfluence(distance: number) {
+  return 1 - smootherStep(distance / ACTIVATION_RADIUS);
+}
+
+export function HomeInteractiveNodeField() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const context = canvas?.getContext("2d");
+    if (!canvas || !context) return;
+
+    const seed = createRandomSeed();
+    const nodeField = createNodeField(seed);
+    canvas.dataset.constellationSeed = String(seed);
+    canvas.dataset.nodeCount = String(nodeField.nodes.length);
+    canvas.dataset.linkCount = String(nodeField.links.length);
+    canvas.dataset.strongLinks = String(
+      nodeField.links.filter((link) => link.strength >= 0.72).length
+    );
+    canvas.dataset.layout = "neural-volume";
+    canvas.dataset.strengthModel = "continuous";
+    canvas.dataset.depthModel = "perspective";
+    canvas.dataset.depthAnchors = String(CLUSTER_DEPTHS.length);
+    canvas.dataset.ambientNodes = String(NODE_COUNT - CLUSTERED_NODE_COUNT);
+    canvas.dataset.viewportTissueNodes = String(VIEWPORT_TISSUE_COUNT);
+
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const desktop = window.matchMedia("(min-width: 1024px)");
+    const precisePointer = window.matchMedia("(pointer: fine)");
+    const pointer = {
+      x: window.innerWidth * 0.3,
+      y: window.innerHeight * 0.42,
+    };
+    const target = { ...pointer };
+    let activity = 0;
+    let targetActivity = 0;
+    let frame: number | null = null;
+    let width = 0;
+    let height = 0;
+
+    const colors = () => {
+      const dark = document.documentElement.classList.contains("dark");
+      return dark
+        ? {
+            haloInner: "rgba(59, 130, 246, 0.2)",
+            haloMiddle: "rgba(79, 70, 229, 0.085)",
+            haloEdge: "rgba(79, 70, 229, 0.018)",
+            link: "129, 140, 248",
+            node: "147, 197, 253",
+            baseLinkAlpha: 0.075,
+            activeLinkAlpha: 0.48,
+            strongLinkAlpha: 0.085,
+            baseNodeAlpha: 0.24,
+            activeNodeAlpha: 0.7,
+          }
+        : {
+            haloInner: "rgba(37, 99, 235, 0.18)",
+            haloMiddle: "rgba(79, 70, 229, 0.075)",
+            haloEdge: "rgba(99, 102, 241, 0.018)",
+            link: "29, 78, 216",
+            node: "30, 64, 175",
+            baseLinkAlpha: 0.105,
+            activeLinkAlpha: 0.56,
+            strongLinkAlpha: 0.12,
+            baseNodeAlpha: 0.31,
+            activeNodeAlpha: 0.66,
+          };
+    };
+
+    const resize = () => {
+      const ratio = Math.min(window.devicePixelRatio || 1, 2);
+      width = window.innerWidth;
+      height = window.innerHeight;
+      canvas.width = Math.round(width * ratio);
+      canvas.height = Math.round(height * ratio);
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      context.setTransform(ratio, 0, 0, ratio, 0, 0);
+    };
+
+    const resolveNodes = () => {
+      const cameraX = ((pointer.x / width) * 2 - 1) * activity;
+      const cameraY = ((pointer.y / height) * 2 - 1) * activity;
+
+      return nodeField.nodes.map((node) => {
+        const perspective = 0.74 + node.depth * 0.52;
+        const projectedX = 0.5 + (node.x - 0.5) * perspective;
+        const projectedY = 0.5 + (node.y - 0.5) * perspective;
+        const parallax = Math.pow(node.depth, 1.35) * MAX_PARALLAX;
+        const baseX = projectedX * width - cameraX * parallax;
+        const baseY = projectedY * height - cameraY * parallax;
+        const distance = Math.hypot(pointer.x - baseX, pointer.y - baseY);
+        const influence = proximityInfluence(distance) * activity;
+        const directionX = distance > 0 ? (pointer.x - baseX) / distance : 0;
+        const directionY = distance > 0 ? (pointer.y - baseY) / distance : 0;
+        const attraction =
+          Math.pow(influence, 1.35) *
+          MAX_ATTRACTION *
+          (0.55 + node.depth * 0.65);
+
+        return {
+          x: baseX + directionX * attraction,
+          y: baseY + directionY * attraction,
+          influence,
+          depth: node.depth,
+          emphasis: node.emphasis,
+        };
+      });
+    };
+
+    const draw = () => {
+      frame = null;
+      if (!desktop.matches) return;
+
+      pointer.x += (target.x - pointer.x) * 0.16;
+      pointer.y += (target.y - pointer.y) * 0.16;
+      activity += (targetActivity - activity) * 0.14;
+
+      context.clearRect(0, 0, width, height);
+      const palette = colors();
+      const resolvedNodes = resolveNodes();
+      canvas.dataset.offscreenNodes = String(
+        resolvedNodes.filter(
+          (node) =>
+            node.x < 0 || node.x > width || node.y < 0 || node.y > height
+        ).length
+      );
+
+      if (activity > 0.01) {
+        const halo = context.createRadialGradient(
+          pointer.x,
+          pointer.y,
+          0,
+          pointer.x,
+          pointer.y,
+          ACTIVATION_RADIUS * 1.12
+        );
+        halo.addColorStop(0, palette.haloInner);
+        halo.addColorStop(0.38, palette.haloMiddle);
+        halo.addColorStop(0.76, palette.haloEdge);
+        halo.addColorStop(1, "rgba(99, 102, 241, 0)");
+        context.fillStyle = halo;
+        context.fillRect(0, 0, width, height);
+      }
+
+      nodeField.links.forEach((link) => {
+        const from = resolvedNodes[link.from];
+        const to = resolvedNodes[link.to];
+        const deltaX = to.x - from.x;
+        const deltaY = to.y - from.y;
+        const linkLength = Math.hypot(deltaX, deltaY);
+        const bendAmount = Math.min(linkLength * 0.16, 22) * link.bend;
+        const controlX =
+          (from.x + to.x) / 2 -
+          (linkLength > 0 ? deltaY / linkLength : 0) * bendAmount;
+        const controlY =
+          (from.y + to.y) / 2 +
+          (linkLength > 0 ? deltaX / linkLength : 0) * bendAmount;
+        const midpointDistance = Math.hypot(
+          pointer.x - controlX,
+          pointer.y - controlY
+        );
+        const midpointInfluence = proximityInfluence(midpointDistance) * activity;
+        const influence =
+          Math.max(from.influence, to.influence) * 0.62 +
+          midpointInfluence * 0.38;
+        const alpha =
+          palette.baseLinkAlpha * (0.3 + link.depth * 0.84) +
+          link.strength * palette.strongLinkAlpha * (0.38 + link.depth * 0.82) +
+          influence * palette.activeLinkAlpha * (0.62 + link.depth * 0.48);
+        const fromAlpha = Math.min(
+          0.94,
+          alpha * (0.5 + from.depth * 0.62)
+        );
+        const toAlpha = Math.min(0.94, alpha * (0.5 + to.depth * 0.62));
+        context.beginPath();
+        context.moveTo(from.x, from.y);
+        context.quadraticCurveTo(controlX, controlY, to.x, to.y);
+        context.lineCap = "round";
+        context.lineWidth =
+          (0.22 + link.strength * 2.4) * (0.28 + link.depth * 1.4) +
+          influence * (0.7 + link.strength * 0.9);
+        if (Math.abs(from.depth - to.depth) > 0.08) {
+          const depthGradient = context.createLinearGradient(
+            from.x,
+            from.y,
+            to.x,
+            to.y
+          );
+          depthGradient.addColorStop(0, `rgba(${palette.link}, ${fromAlpha})`);
+          depthGradient.addColorStop(1, `rgba(${palette.link}, ${toAlpha})`);
+          context.strokeStyle = depthGradient;
+        } else {
+          context.strokeStyle = `rgba(${palette.link}, ${(fromAlpha + toAlpha) / 2})`;
+        }
+        context.stroke();
+      });
+
+      resolvedNodes
+        .map((node, index) => ({ ...node, index }))
+        .sort((first, second) => first.depth - second.depth)
+        .forEach((node) => {
+        const depthPresence = 0.36 + node.depth * 0.82;
+        const radius =
+          (0.3 + node.depth * 3.2) * node.emphasis + node.influence * 2.1;
+        const alpha =
+          palette.baseNodeAlpha * depthPresence +
+          node.influence * palette.activeNodeAlpha * (0.72 + node.depth * 0.38);
+        context.shadowColor = `rgba(${palette.node}, ${
+          node.depth * 0.16 + node.influence * 0.22
+        })`;
+        context.shadowBlur = node.depth * 8 + node.influence * 7;
+        context.beginPath();
+        context.arc(node.x, node.y, radius, 0, Math.PI * 2);
+        context.fillStyle = `rgba(${palette.node}, ${alpha})`;
+        context.fill();
+        context.shadowBlur = 0;
+
+        const membraneAlpha =
+          0.012 + node.depth * 0.065 + node.influence * 0.17;
+        context.beginPath();
+        context.arc(
+          node.x,
+          node.y,
+          radius + 1.5 + node.depth * 2.7,
+          0,
+          Math.PI * 2
+        );
+        context.strokeStyle = `rgba(${palette.node}, ${membraneAlpha})`;
+        context.lineWidth = 0.7 + node.influence * 0.45;
+        context.stroke();
+
+        if (node.influence > 0.2) {
+          context.beginPath();
+          context.arc(
+            node.x,
+            node.y,
+            radius + 5 * node.influence,
+            0,
+            Math.PI * 2
+          );
+          context.strokeStyle = `rgba(${palette.node}, ${node.influence * 0.24})`;
+          context.lineWidth = 1;
+          context.stroke();
+        }
+      });
+
+      const unsettled =
+        Math.abs(target.x - pointer.x) > 0.3 ||
+        Math.abs(target.y - pointer.y) > 0.3 ||
+        Math.abs(targetActivity - activity) > 0.01;
+      if (unsettled && !reducedMotion.matches)
+        frame = window.requestAnimationFrame(draw);
+    };
+
+    const requestDraw = () => {
+      if (frame === null) frame = window.requestAnimationFrame(draw);
+    };
+
+    const handlePointerMove = (event: PointerEvent) => {
+      if (reducedMotion.matches || !precisePointer.matches || !desktop.matches)
+        return;
+      target.x = event.clientX;
+      target.y = event.clientY;
+      targetActivity = 1;
+      canvas.dataset.active = "true";
+      requestDraw();
+    };
+
+    const handlePointerLeave = () => {
+      targetActivity = 0;
+      canvas.dataset.active = "false";
+      requestDraw();
+    };
+
+    const handleResize = () => {
+      resize();
+      requestDraw();
+    };
+
+    const handleMotionChange = () => {
+      targetActivity = 0;
+      activity = 0;
+      canvas.dataset.interactive = reducedMotion.matches ? "false" : "true";
+      canvas.dataset.active = "false";
+      if (frame !== null) window.cancelAnimationFrame(frame);
+      frame = null;
+      draw();
+    };
+
+    const themeObserver = new MutationObserver(requestDraw);
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    resize();
+    canvas.dataset.interactive = reducedMotion.matches ? "false" : "true";
+    draw();
+    window.addEventListener("pointermove", handlePointerMove, {
+      passive: true,
+    });
+    document.documentElement.addEventListener("mouseleave", handlePointerLeave);
+    window.addEventListener("resize", handleResize, { passive: true });
+    reducedMotion.addEventListener("change", handleMotionChange);
+    desktop.addEventListener("change", handleResize);
+
+    return () => {
+      if (frame !== null) window.cancelAnimationFrame(frame);
+      themeObserver.disconnect();
+      window.removeEventListener("pointermove", handlePointerMove);
+      document.documentElement.removeEventListener(
+        "mouseleave",
+        handlePointerLeave
+      );
+      window.removeEventListener("resize", handleResize);
+      reducedMotion.removeEventListener("change", handleMotionChange);
+      desktop.removeEventListener("change", handleResize);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="home-interactive-node-field pointer-events-none absolute inset-0 hidden lg:block"
+      data-active="false"
+      data-interactive="true"
+      aria-hidden="true"
+    />
+  );
+}

--- a/app/home-social-provider-button.tsx
+++ b/app/home-social-provider-button.tsx
@@ -72,7 +72,7 @@ export function HomeSocialProviderButton({
       asChild
       variant="outline"
       className={cn(
-        "h-11 w-full justify-center rounded-xl border-border/70 bg-background/80 font-medium"
+        "h-12 w-full justify-center rounded-xl border-border/70 bg-background/80 font-medium motion-reduce:transition-none"
       )}
     >
       <a href={href}>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -40,6 +40,7 @@ import {
 } from "./home-signup-live-feedback";
 import { HomeAuthModeToggleLink } from "./home-auth-mode-toggle-link";
 import { HomeAuthMethods } from "./home-auth-methods";
+import { HomeInteractiveNodeField } from "./home-interactive-node-field";
 
 const outcomes = [
   "Bring teammates into the same live project workspace",
@@ -455,10 +456,7 @@ export default async function Home({
 
   return (
     <main className="relative isolate grid min-h-dvh overflow-hidden bg-background lg:grid-cols-[minmax(0,1fr)_minmax(520px,0.86fr)]">
-      <div
-        className="home-entry-color-field pointer-events-none absolute hidden lg:block"
-        aria-hidden="true"
-      />
+      <HomeInteractiveNodeField />
       <ProductPanel />
 
       <section className="relative z-10 flex min-h-dvh items-start justify-center px-4 pb-8 pt-20 sm:items-center sm:px-8 sm:py-20 lg:px-12">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,14 @@
 import { redirect } from "next/navigation";
 import Link from "next/link";
-import { ArrowRight, LockKeyhole, Sparkles } from "lucide-react";
+import {
+  ArrowRight,
+  CalendarDays,
+  Check,
+  CircleDot,
+  Layers3,
+} from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -33,22 +38,16 @@ import {
 } from "./home-signup-live-feedback";
 import { HomeAuthModeToggleLink } from "./home-auth-mode-toggle-link";
 
-const highlights = [
-  {
-    title: "Shared Project Hub",
-    description:
-      "Keep planning, context, and delivery updates in one workspace instead of scattered tools.",
-  },
-  {
-    title: "Execution Flow",
-    description:
-      "Move tasks through Backlog, In Progress, Blocked, and Done with zero context switching.",
-  },
-  {
-    title: "Calendar Context",
-    description:
-      "Bring key events into project execution so meetings and delivery stay aligned.",
-  },
+const outcomes = [
+  "See priorities and progress in one place",
+  "Keep decisions, notes, and tasks connected",
+  "Turn meetings and milestones into clear next steps",
+];
+
+const focusItems = [
+  { title: "Finalize launch plan", meta: "Today", state: "In progress" },
+  { title: "Review customer feedback", meta: "Tomorrow", state: "Backlog" },
+  { title: "Share weekly update", meta: "Friday", state: "Ready" },
 ];
 
 type SearchParams = Record<string, string | string[] | undefined>;
@@ -119,16 +118,117 @@ function resolveReturnToPath(value: string | null): string {
 }
 
 const inputClassName =
-  "h-11 rounded-md border border-input bg-background px-3 text-sm outline-none transition focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
+  "h-12 w-full rounded-lg border border-input bg-background px-3.5 text-base outline-none transition-colors duration-200 placeholder:text-muted-foreground/80 hover:border-foreground/25 focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/25 disabled:cursor-not-allowed disabled:opacity-50 motion-reduce:transition-none sm:text-sm";
 
-export default async function Home(
-  props: {
-    searchParams?: Promise<SearchParams>;
-  }
-) {
-  const resolvedSearchParams = await props.searchParams;
+function BrandMark({ inverse = false }: { inverse?: boolean }) {
+  return (
+    <div className="flex items-center gap-3">
+      <span
+        className={cn(
+          "grid size-10 place-items-center rounded-xl",
+          inverse
+            ? "bg-white text-slate-950"
+            : "bg-blue-600 text-white dark:bg-blue-500"
+        )}
+        aria-hidden="true"
+      >
+        <Layers3 className="size-5" strokeWidth={2.2} />
+      </span>
+      <span className="grid leading-none">
+        <span className="text-base font-semibold tracking-tight">NexusDash</span>
+        <span
+          className={cn(
+            "mt-1 text-xs",
+            inverse ? "text-slate-400" : "text-muted-foreground"
+          )}
+        >
+          Project execution, connected.
+        </span>
+      </span>
+    </div>
+  );
+}
+
+function ProductPanel() {
+  return (
+    <section className="relative hidden min-h-dvh overflow-hidden bg-slate-950 px-10 py-10 text-white lg:flex lg:flex-col xl:px-16 xl:py-12">
+      <div className="absolute inset-y-0 right-0 w-px bg-white/10" />
+      <BrandMark inverse />
+
+      <div className="my-auto max-w-2xl py-14">
+        <Badge className="mb-6 rounded-full border border-blue-300/20 bg-blue-400/10 px-3 py-1 text-blue-100 hover:bg-blue-400/10">
+          One workspace. Clearer momentum.
+        </Badge>
+        <h1 className="max-w-xl text-4xl font-semibold leading-[1.08] tracking-[-0.035em] xl:text-5xl">
+          Turn plans into progress—without losing context.
+        </h1>
+        <p className="mt-5 max-w-xl text-base leading-7 text-slate-300 xl:text-lg">
+          Bring projects, tasks, meeting notes, and calendar commitments into
+          one focused workspace built for steady delivery.
+        </p>
+
+        <ul className="mt-8 grid gap-3" aria-label="NexusDash product benefits">
+          {outcomes.map((outcome) => (
+            <li key={outcome} className="flex items-center gap-3 text-sm text-slate-200">
+              <span className="grid size-6 shrink-0 place-items-center rounded-full bg-blue-400/15 text-blue-200">
+                <Check className="size-3.5" strokeWidth={2.5} aria-hidden="true" />
+              </span>
+              {outcome}
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-10 max-w-xl rounded-2xl border border-white/10 bg-white/[0.045] p-5">
+          <div className="flex items-center justify-between border-b border-white/10 pb-4">
+            <div>
+              <p className="text-sm font-semibold">Today&apos;s focus</p>
+              <p className="mt-1 text-xs text-slate-400">Three clear next steps</p>
+            </div>
+            <div className="flex items-center gap-2 text-xs text-slate-300">
+              <CalendarDays className="size-4 text-blue-300" aria-hidden="true" />
+              This week
+            </div>
+          </div>
+          <div className="divide-y divide-white/10">
+            {focusItems.map((item, index) => (
+              <div key={item.title} className="grid grid-cols-[auto_1fr_auto] items-center gap-3 py-3.5">
+                <CircleDot
+                  className={cn(
+                    "size-4",
+                    index === 0 ? "text-blue-300" : "text-slate-500"
+                  )}
+                  aria-hidden="true"
+                />
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-slate-100">{item.title}</p>
+                  <p className="mt-0.5 text-xs text-slate-500">{item.meta}</p>
+                </div>
+                <span className="rounded-full border border-white/10 px-2.5 py-1 text-[11px] font-medium text-slate-300">
+                  {item.state}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <p className="text-xs leading-5 text-slate-500">
+        Plan together. Focus on what matters. Deliver with confidence.
+      </p>
+    </section>
+  );
+}
+
+export default async function Home({
+  searchParams,
+}: {
+  searchParams?: Promise<SearchParams>;
+}) {
+  const resolvedSearchParams = await searchParams;
   const actorUserId = await getSessionUserIdFromServer();
-  const returnToPath = resolveReturnToPath(readQueryValue(resolvedSearchParams?.returnTo));
+  const returnToPath = resolveReturnToPath(
+    readQueryValue(resolvedSearchParams?.returnTo)
+  );
   if (actorUserId) {
     if (!isLiveProductionDeployment()) {
       redirect(returnToPath);
@@ -142,9 +242,12 @@ export default async function Home(
     );
   }
 
-  const formValue = readQueryValue(resolvedSearchParams?.form);
-  const activeForm = resolveActiveForm(formValue);
-  const prefilledEmail = resolvePrefilledEmail(readQueryValue(resolvedSearchParams?.email));
+  const activeForm = resolveActiveForm(
+    readQueryValue(resolvedSearchParams?.form)
+  );
+  const prefilledEmail = resolvePrefilledEmail(
+    readQueryValue(resolvedSearchParams?.email)
+  );
   const isSignIn = activeForm === "signin";
   const errorCode = readQueryValue(resolvedSearchParams?.error);
   const errorMessage =
@@ -155,307 +258,269 @@ export default async function Home(
   const socialProviders = getEnabledSocialAuthProviders();
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-[radial-gradient(circle_at_top_left,rgba(148,163,184,0.14),transparent_38%),radial-gradient(circle_at_78%_18%,rgba(14,165,233,0.12),transparent_26%),linear-gradient(to_bottom,hsl(var(--background)),hsl(var(--background)),hsl(var(--muted)/0.26))] text-foreground">
-      <div className="pointer-events-none absolute inset-0 opacity-40">
-        <div className="absolute left-[-20%] top-[-12rem] h-[28rem] w-[28rem] rounded-full bg-slate-500/10 blur-3xl" />
-        <div className="absolute right-[-10%] top-[8rem] h-[20rem] w-[20rem] rounded-full bg-sky-400/10 blur-3xl" />
-      </div>
+    <main className="grid min-h-dvh bg-background lg:grid-cols-[minmax(0,1fr)_minmax(520px,0.86fr)]">
+      <ProductPanel />
 
-      <main className="container relative z-10 grid min-h-screen items-start gap-8 py-8 sm:gap-10 sm:py-10 lg:grid-cols-[1.15fr_minmax(390px,470px)] lg:items-center lg:gap-16 lg:py-16">
-        <section className="order-2 space-y-6 sm:space-y-8 lg:order-1 lg:space-y-10">
-          <div className="flex flex-wrap items-center gap-3 text-xs">
-            <Badge variant="secondary" className="rounded-full px-3 py-1">
-              NexusDash workspace
-            </Badge>
-            <Badge variant="outline" className="rounded-full px-3 py-1">
-              Secure multi-user delivery
-            </Badge>
-          </div>
-          <div className="space-y-5">
-            <h1 className="max-w-3xl text-3xl font-semibold tracking-tight sm:text-4xl md:text-5xl lg:text-[3.4rem]">
-              Sign in fast, keep delivery context tight, and move work without losing the thread.
+      <section className="flex min-h-dvh items-start justify-center px-4 pb-8 pt-20 sm:items-center sm:px-8 sm:py-20 lg:px-12">
+        <div className="w-full max-w-[440px]">
+          <div className="mb-7 lg:hidden">
+            <BrandMark />
+            <h1 className="mt-6 max-w-sm text-2xl font-semibold leading-tight tracking-[-0.025em] sm:text-3xl">
+              Bring every project into focus.
             </h1>
-            <p className="max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base md:text-lg">
-              Credentials stay available, but Google and GitHub entry can sit beside them
-              cleanly once configured. The goal is one calm auth surface, not three
-              disconnected flows.
+            <p className="mt-2 max-w-md text-sm leading-6 text-muted-foreground">
+              Plan work, keep context close, and move forward with clear next steps.
             </p>
           </div>
 
-          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-            {highlights.map((item, index) => (
-              <Card
-                key={item.title}
-                className="border-border/70 bg-card/70 shadow-[0_18px_45px_-30px_rgba(15,23,42,0.7)] backdrop-blur"
+          <Card className="border-border/80 bg-card shadow-none sm:rounded-2xl sm:shadow-[0_24px_70px_-48px_rgba(15,23,42,0.55)]">
+            <CardHeader className="space-y-6 p-5 pb-4 sm:p-7 sm:pb-5">
+              <nav
+                aria-label="Choose sign in or sign up"
+                className="grid grid-cols-2 gap-1 rounded-xl bg-muted p-1"
               >
-                <CardHeader className="space-y-3">
-                  <span className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-                    0{index + 1}
-                  </span>
-                  <CardTitle className="text-lg">{item.title}</CardTitle>
-                  <CardDescription>{item.description}</CardDescription>
-                </CardHeader>
-              </Card>
-            ))}
-          </div>
+                <HomeAuthModeToggleLink
+                  targetForm="signin"
+                  returnTo={returnToPath}
+                  ariaCurrent={isSignIn ? "page" : undefined}
+                  className={cn(
+                    "flex min-h-11 items-center justify-center rounded-lg px-3 text-center text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-muted motion-reduce:transition-none",
+                    isSignIn
+                      ? "bg-background text-foreground shadow-sm"
+                      : "text-muted-foreground hover:bg-background/50 hover:text-foreground"
+                  )}
+                >
+                  Sign in
+                </HomeAuthModeToggleLink>
+                <HomeAuthModeToggleLink
+                  targetForm="signup"
+                  returnTo={returnToPath}
+                  ariaCurrent={!isSignIn ? "page" : undefined}
+                  className={cn(
+                    "flex min-h-11 items-center justify-center rounded-lg px-3 text-center text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-muted motion-reduce:transition-none",
+                    !isSignIn
+                      ? "bg-background text-foreground shadow-sm"
+                      : "text-muted-foreground hover:bg-background/50 hover:text-foreground"
+                  )}
+                >
+                  Sign up
+                </HomeAuthModeToggleLink>
+              </nav>
 
-          <Card className="border-border/70 bg-card/60 backdrop-blur">
-            <CardContent className="grid gap-4 p-4 sm:p-5 md:grid-cols-[1fr_auto] md:items-center">
-              <div className="space-y-2">
-                <div className="flex items-center gap-2 text-sm font-medium">
-                  <Sparkles className="h-4 w-4 text-sky-500" />
-                  Modern auth entry
-                </div>
-                <p className="text-sm leading-6 text-muted-foreground">
-                  Social sign-in is layered into the same session model as email/password,
-                  so we keep one authorization boundary, one account system, and one path
-                  into projects.
-                </p>
+              <div className="space-y-1.5">
+                <CardTitle className="text-2xl tracking-[-0.025em] sm:text-[1.75rem]">
+                  {isSignIn ? "Welcome back" : "Start your workspace"}
+                </CardTitle>
+                <CardDescription className="text-sm leading-6">
+                  {isSignIn
+                    ? "Sign in to pick up where you left off."
+                    : "Create your account and bring your next project into focus."}
+                </CardDescription>
               </div>
-              <div className="flex w-fit items-center gap-2 rounded-full border border-border/70 bg-background/60 px-4 py-2 text-sm text-muted-foreground">
-                <LockKeyhole className="h-4 w-4" />
-                Session-backed
+            </CardHeader>
+
+            <CardContent className="grid gap-4 p-5 pt-0 sm:p-7 sm:pt-0">
+              {errorMessage ? (
+                <div
+                  role="alert"
+                  className="rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm leading-5 text-destructive"
+                >
+                  {errorMessage}
+                </div>
+              ) : null}
+
+              {statusMessage ? (
+                <div
+                  role="status"
+                  aria-live="polite"
+                  className="rounded-lg border border-emerald-600/35 bg-emerald-500/10 px-4 py-3 text-sm leading-5 text-emerald-700 dark:text-emerald-300"
+                >
+                  {statusMessage}
+                </div>
+              ) : null}
+
+              {socialProviders.length > 0 ? (
+                <div className="grid gap-3">
+                  <div className="grid gap-2">
+                    {socialProviders.map(({ provider }) => (
+                      <HomeSocialProviderButton
+                        key={provider}
+                        provider={provider}
+                        form={activeForm}
+                        returnTo={returnToPath}
+                      />
+                    ))}
+                  </div>
+                  <div className="relative my-1">
+                    <div className="absolute inset-0 flex items-center">
+                      <span className="w-full border-t border-border" />
+                    </div>
+                    <div className="relative flex justify-center text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                      <span className="bg-card px-3">Or use email</span>
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+
+              {isSignIn ? (
+                <form key="signin-form" action={signInAction} className="grid gap-4">
+                  <input type="hidden" name="returnTo" value={returnToPath} />
+                  <div className="grid gap-2">
+                    <label htmlFor="signin-email" className="text-sm font-medium">
+                      Email address
+                    </label>
+                    <input
+                      id="signin-email"
+                      name="email"
+                      type="email"
+                      autoComplete="email"
+                      inputMode="email"
+                      placeholder="you@company.com"
+                      defaultValue={prefilledEmail}
+                      required
+                      maxLength={320}
+                      className={inputClassName}
+                    />
+                  </div>
+                  <div className="grid gap-2">
+                    <div className="flex items-center justify-between gap-4">
+                      <label htmlFor="signin-password" className="text-sm font-medium">
+                        Password
+                      </label>
+                      <Link
+                        href="/forgot-password"
+                        className="rounded-sm text-sm font-medium text-blue-700 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:text-blue-300"
+                      >
+                        Forgot password?
+                      </Link>
+                    </div>
+                    <input
+                      id="signin-password"
+                      name="password"
+                      type="password"
+                      autoComplete="current-password"
+                      placeholder="Enter your password"
+                      required
+                      maxLength={128}
+                      className={inputClassName}
+                    />
+                  </div>
+                  <AuthSubmitButton
+                    className="mt-1 h-12 w-full rounded-lg bg-blue-600 text-white hover:bg-blue-700 focus-visible:ring-blue-600 dark:bg-blue-500 dark:hover:bg-blue-400"
+                    defaultLabel="Sign in to NexusDash"
+                    pendingLabel="Signing you in..."
+                  />
+                </form>
+              ) : (
+                <form key="signup-form" action={signUpAction} className="grid gap-4">
+                  <input type="hidden" name="returnTo" value={returnToPath} />
+                  <div className="grid gap-2">
+                    <label htmlFor="signup-username" className="text-sm font-medium">
+                      Username
+                    </label>
+                    <div className="relative">
+                      <input
+                        id="signup-username"
+                        name="username"
+                        type="text"
+                        autoComplete="username"
+                        autoCapitalize="none"
+                        autoCorrect="off"
+                        spellCheck={false}
+                        placeholder="your.name"
+                        required
+                        minLength={MIN_USERNAME_LENGTH}
+                        maxLength={MAX_USERNAME_LENGTH}
+                        pattern="[A-Za-z0-9._]+"
+                        className={cn(inputClassName, "pr-24")}
+                      />
+                      <HomeSignupUsernameSuffix usernameInputId="signup-username" />
+                    </div>
+                  </div>
+                  <div className="grid gap-2">
+                    <label htmlFor="signup-email" className="text-sm font-medium">
+                      Email address
+                    </label>
+                    <input
+                      id="signup-email"
+                      name="email"
+                      type="email"
+                      autoComplete="email"
+                      inputMode="email"
+                      placeholder="you@company.com"
+                      defaultValue={prefilledEmail}
+                      required
+                      maxLength={320}
+                      className={inputClassName}
+                    />
+                    <HomeSignupEmailFeedback emailInputId="signup-email" />
+                  </div>
+                  <div className="grid gap-2">
+                    <label htmlFor="signup-password" className="text-sm font-medium">
+                      Password
+                    </label>
+                    <input
+                      id="signup-password"
+                      name="password"
+                      type="password"
+                      autoComplete="new-password"
+                      placeholder="Create a strong password"
+                      required
+                      minLength={MIN_PASSWORD_LENGTH}
+                      maxLength={128}
+                      className={inputClassName}
+                    />
+                  </div>
+                  <div className="grid gap-2">
+                    <label htmlFor="signup-confirm-password" className="text-sm font-medium">
+                      Confirm password
+                    </label>
+                    <input
+                      id="signup-confirm-password"
+                      name="confirmPassword"
+                      type="password"
+                      autoComplete="new-password"
+                      placeholder="Re-enter your password"
+                      required
+                      minLength={MIN_PASSWORD_LENGTH}
+                      maxLength={128}
+                      className={inputClassName}
+                    />
+                  </div>
+                  <HomeSignupPasswordFeedback
+                    passwordInputId="signup-password"
+                    confirmPasswordInputId="signup-confirm-password"
+                    minPasswordLength={MIN_PASSWORD_LENGTH}
+                  />
+                  <AuthSubmitButton
+                    className="h-12 w-full rounded-lg bg-blue-600 text-white hover:bg-blue-700 focus-visible:ring-blue-600 dark:bg-blue-500 dark:hover:bg-blue-400"
+                    defaultLabel="Create your account"
+                    pendingLabel="Creating your account..."
+                  />
+                </form>
+              )}
+
+              <div className="flex items-center justify-between gap-4 border-t border-border pt-4 text-sm text-muted-foreground">
+                <p>
+                  {isSignIn ? "New to NexusDash?" : "Already have an account?"}{" "}
+                  <HomeAuthModeToggleLink
+                    targetForm={isSignIn ? "signup" : "signin"}
+                    returnTo={returnToPath}
+                    className="rounded-sm font-semibold text-foreground underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    {isSignIn ? "Create an account" : "Sign in"}
+                  </HomeAuthModeToggleLink>
+                </p>
+                <ArrowRight className="hidden size-4 shrink-0 sm:block" aria-hidden="true" />
               </div>
             </CardContent>
           </Card>
-        </section>
 
-        <Card className="order-1 border-border/70 bg-card/95 shadow-2xl shadow-black/20 lg:order-2">
-          <CardHeader className="space-y-4">
-            <div className="grid grid-cols-2 gap-2 rounded-lg bg-muted p-1">
-              <HomeAuthModeToggleLink
-                targetForm="signin"
-                returnTo={returnToPath}
-                ariaCurrent={isSignIn ? "page" : undefined}
-                className={cn(
-                  "flex min-h-10 items-center justify-center rounded-md px-3 py-2 text-center text-sm font-medium transition",
-                  isSignIn
-                    ? "bg-background text-foreground shadow-sm"
-                    : "text-muted-foreground hover:text-foreground"
-                )}
-              >
-                Sign in
-              </HomeAuthModeToggleLink>
-              <HomeAuthModeToggleLink
-                targetForm="signup"
-                returnTo={returnToPath}
-                ariaCurrent={!isSignIn ? "page" : undefined}
-                className={cn(
-                  "flex min-h-10 items-center justify-center rounded-md px-3 py-2 text-center text-sm font-medium transition",
-                  !isSignIn
-                    ? "bg-background text-foreground shadow-sm"
-                    : "text-muted-foreground hover:text-foreground"
-                )}
-              >
-                Sign up
-              </HomeAuthModeToggleLink>
-            </div>
-            <div className="space-y-1">
-              <CardTitle className="text-2xl">
-                {isSignIn ? "Welcome back" : "Create your account"}
-              </CardTitle>
-              <CardDescription>
-                {isSignIn
-                  ? "Choose the fastest way back into your workspace."
-                  : "Start with social sign-in or create an email-based account."}
-              </CardDescription>
-            </div>
-          </CardHeader>
-          <CardContent className="grid gap-4">
-            {errorMessage ? (
-              <div
-                role="alert"
-                className="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3 text-sm text-destructive"
-              >
-                {errorMessage}
-              </div>
-            ) : null}
-
-            {statusMessage ? (
-              <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-700 dark:text-emerald-200">
-                {statusMessage}
-              </div>
-            ) : null}
-
-            {socialProviders.length > 0 ? (
-              <div className="grid gap-2">
-                {socialProviders.map(({ provider }) => (
-                  <HomeSocialProviderButton
-                    key={provider}
-                    provider={provider}
-                    form={activeForm}
-                    returnTo={returnToPath}
-                  />
-                ))}
-                <div className="relative my-1">
-                  <div className="absolute inset-0 flex items-center">
-                    <span className="w-full border-t border-border/70" />
-                  </div>
-                  <div className="relative flex justify-center text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
-                    <span className="bg-card px-3">Or continue with email</span>
-                  </div>
-                </div>
-              </div>
-            ) : null}
-
-            {isSignIn ? (
-              <form key="signin-form" action={signInAction} className="grid gap-4">
-                <input type="hidden" name="returnTo" value={returnToPath} />
-                <div className="grid gap-2">
-                  <label htmlFor="signin-email" className="text-sm font-medium">
-                    Email
-                  </label>
-                  <input
-                    id="signin-email"
-                    name="email"
-                    type="email"
-                    autoComplete="email"
-                    placeholder="you@company.com"
-                    defaultValue={prefilledEmail}
-                    required
-                    maxLength={320}
-                    className={inputClassName}
-                  />
-                </div>
-                <div className="grid gap-2">
-                  <label htmlFor="signin-password" className="text-sm font-medium">
-                    Password
-                  </label>
-                  <input
-                    id="signin-password"
-                    name="password"
-                    type="password"
-                    autoComplete="current-password"
-                    placeholder="Enter your password"
-                    required
-                    maxLength={128}
-                    className={inputClassName}
-                  />
-                  <div className="flex items-center justify-between text-xs">
-                    <span className="text-muted-foreground">
-                      Session-backed sign-in
-                    </span>
-                    <Link
-                      href="/forgot-password"
-                      className="font-medium text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-                    >
-                      Forgot password?
-                    </Link>
-                  </div>
-                </div>
-                <AuthSubmitButton
-                  className="w-full"
-                  defaultLabel="Continue to dashboard"
-                  pendingLabel="Signing you in..."
-                />
-              </form>
-            ) : (
-              <form key="signup-form" action={signUpAction} className="grid gap-4">
-                <input type="hidden" name="returnTo" value={returnToPath} />
-                <div className="grid gap-2">
-                  <label htmlFor="signup-username" className="text-sm font-medium">
-                    Username
-                  </label>
-                  <div className="relative">
-                    <input
-                      id="signup-username"
-                      name="username"
-                      type="text"
-                      autoComplete="username"
-                      autoCapitalize="none"
-                      autoCorrect="off"
-                      spellCheck={false}
-                      placeholder="your.name"
-                      required
-                      minLength={MIN_USERNAME_LENGTH}
-                      maxLength={MAX_USERNAME_LENGTH}
-                      pattern="[A-Za-z0-9._]+"
-                      className={cn(inputClassName, "w-full pr-24")}
-                    />
-                    <HomeSignupUsernameSuffix usernameInputId="signup-username" />
-                  </div>
-                </div>
-                <div className="grid gap-2">
-                  <label htmlFor="signup-email" className="text-sm font-medium">
-                    Email
-                  </label>
-                  <input
-                    id="signup-email"
-                    name="email"
-                    type="email"
-                    autoComplete="email"
-                    placeholder="you@company.com"
-                    defaultValue={prefilledEmail}
-                    required
-                    maxLength={320}
-                    className={inputClassName}
-                  />
-                  <HomeSignupEmailFeedback emailInputId="signup-email" />
-                </div>
-                <div className="grid gap-2">
-                  <label htmlFor="signup-password" className="text-sm font-medium">
-                    Password
-                  </label>
-                  <input
-                    id="signup-password"
-                    name="password"
-                    type="password"
-                    autoComplete="new-password"
-                    placeholder="Create a strong password"
-                    required
-                    minLength={MIN_PASSWORD_LENGTH}
-                    maxLength={128}
-                    className={inputClassName}
-                  />
-                </div>
-                <div className="grid gap-2">
-                  <label
-                    htmlFor="signup-confirm-password"
-                    className="text-sm font-medium"
-                  >
-                    Confirm password
-                  </label>
-                  <input
-                    id="signup-confirm-password"
-                    name="confirmPassword"
-                    type="password"
-                    autoComplete="new-password"
-                    placeholder="Re-enter your password"
-                    required
-                    minLength={MIN_PASSWORD_LENGTH}
-                    maxLength={128}
-                    className={inputClassName}
-                  />
-                </div>
-                <HomeSignupPasswordFeedback
-                  passwordInputId="signup-password"
-                  confirmPasswordInputId="signup-confirm-password"
-                  minPasswordLength={MIN_PASSWORD_LENGTH}
-                />
-                <AuthSubmitButton
-                  className="w-full"
-                  defaultLabel="Create workspace account"
-                  pendingLabel="Creating account..."
-                />
-              </form>
-            )}
-
-            <div className="flex flex-col items-start gap-2 border-t border-border/70 pt-2 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between sm:gap-4">
-              <p>
-                {isSignIn ? "New to NexusDash?" : "Already have an account?"}{" "}
-                <HomeAuthModeToggleLink
-                  targetForm={isSignIn ? "signup" : "signin"}
-                  returnTo={returnToPath}
-                  className="font-medium text-foreground underline-offset-4 hover:underline"
-                >
-                  {isSignIn ? "Create an account" : "Sign in"}
-                </HomeAuthModeToggleLink>
-              </p>
-              <ArrowRight className="hidden h-4 w-4 shrink-0 sm:block" />
-            </div>
-          </CardContent>
-        </Card>
-      </main>
-    </div>
+          <p className="mt-6 text-center text-xs leading-5 text-muted-foreground lg:hidden">
+            Plan together. Focus on what matters. Deliver with confidence.
+          </p>
+        </div>
+      </section>
+    </main>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -42,33 +42,33 @@ import { HomeAuthModeToggleLink } from "./home-auth-mode-toggle-link";
 import { HomeAuthMethods } from "./home-auth-methods";
 
 const outcomes = [
-  "Invite teammates and collaborate in real time",
-  "Connect Google Calendar to project work",
-  "Keep ownership clear with assignees, mentions, comments, and due dates",
+  "Bring teammates into the same live project workspace",
+  "Keep project dates in sync with Google Calendar",
+  "Make ownership clear with assignees, mentions, and due dates",
 ];
 
 const workflowItems = [
   {
     title: "Project context, kept together",
-    meta: "Context cards and files attached to cards or tasks",
+    meta: "Give everyone one reliable place for project context and the files behind the work.",
     state: "Context",
     icon: Files,
   },
   {
     title: "Plans you shape",
-    meta: "Roadmap milestones, related tasks, and epic progress",
+    meta: "Build your own roadmap, connect related tasks, and see every epic move forward.",
     state: "Plan",
     icon: Milestone,
   },
   {
     title: "Delivery you can follow",
-    meta: "Kanban from backlog to done, dated blockers, and auto-archive",
+    meta: "Move work from backlog to done, follow blockers over time, and keep completed work tidy.",
     state: "Track",
     icon: Workflow,
   },
   {
     title: "Meetings become visible action",
-    meta: "Extracted meeting todos stay surfaced in a dedicated panel",
+    meta: "Turn meeting decisions into visible todos your team can act on right away.",
     state: "Act",
     icon: ListTodo,
   },
@@ -177,10 +177,7 @@ function BrandMark({ productPanel = false }: { productPanel?: boolean }) {
 
 function ProductPanel() {
   return (
-    <section className="relative hidden min-h-dvh overflow-hidden bg-background px-10 py-10 text-foreground transition-colors duration-200 motion-reduce:transition-none lg:flex lg:flex-col xl:px-16 xl:py-12">
-      <div className="home-product-ambient pointer-events-none absolute -left-40 top-[8%] size-[34rem] rounded-full bg-[radial-gradient(circle,rgba(37,99,235,0.16)_0%,rgba(37,99,235,0)_70%)] dark:bg-[radial-gradient(circle,rgba(37,99,235,0.2)_0%,rgba(37,99,235,0)_70%)]" />
-      <div className="home-product-ambient home-product-ambient-secondary pointer-events-none absolute -bottom-48 right-[-8rem] size-[38rem] rounded-full bg-[radial-gradient(circle,rgba(79,70,229,0.12)_0%,rgba(79,70,229,0)_70%)] dark:bg-[radial-gradient(circle,rgba(79,70,229,0.16)_0%,rgba(79,70,229,0)_70%)]" />
-      <div className="absolute inset-y-0 right-0 w-px bg-border/80" />
+    <section className="relative z-10 hidden min-h-dvh px-10 py-10 text-foreground transition-colors duration-200 motion-reduce:transition-none lg:flex lg:flex-col xl:px-16 xl:py-12">
       <div className="relative z-10">
         <BrandMark productPanel />
       </div>
@@ -204,8 +201,8 @@ function ProductPanel() {
           <div>
             <p className="text-sm font-semibold">Agent access, built for real work</p>
             <p className="mt-1 text-sm leading-6 text-muted-foreground">
-              Connect trusted agents through a project-scoped API so they can read
-              context, collaborate on tasks, and help move delivery forward.
+              Give trusted agents secure, project-scoped access to the context
+              and actions they need to move work forward.
             </p>
           </div>
         </div>
@@ -221,8 +218,8 @@ function ProductPanel() {
           ))}
         </ul>
 
-        <div className="mt-6 max-w-xl rounded-2xl border border-border/80 bg-card/75 p-5 shadow-[0_24px_70px_-52px_rgba(37,99,235,0.55)] backdrop-blur-sm">
-          <div className="flex items-center justify-between border-b border-border/80 pb-3.5">
+        <div className="mt-5 max-w-xl rounded-2xl border border-border/80 bg-card/75 p-4 shadow-[0_24px_70px_-52px_rgba(37,99,235,0.55)] backdrop-blur-sm">
+          <div className="flex items-center justify-between border-b border-border/80 pb-3">
             <div>
               <p className="text-sm font-semibold">A connected project system</p>
               <p className="mt-1 text-xs text-muted-foreground">From context to delivery</p>
@@ -237,13 +234,13 @@ function ProductPanel() {
               const ItemIcon = item.icon;
 
               return (
-                <div key={item.title} className="grid grid-cols-[auto_1fr_auto] items-center gap-3 py-3">
+                <div key={item.title} className="grid grid-cols-[auto_1fr_auto] items-center gap-3 py-2">
                   <span className="grid size-8 place-items-center rounded-lg bg-blue-500/[0.09] text-blue-700 dark:text-blue-300">
                     <ItemIcon className="size-4" strokeWidth={1.9} aria-hidden="true" />
                   </span>
                   <div className="min-w-0">
-                    <p className="truncate text-sm font-medium text-foreground">{item.title}</p>
-                    <p className="mt-0.5 truncate text-xs text-muted-foreground">{item.meta}</p>
+                    <p className="text-sm font-medium text-foreground">{item.title}</p>
+                    <p className="mt-0.5 text-xs leading-[1.45] text-muted-foreground">{item.meta}</p>
                   </div>
                   <span className="rounded-full border border-border/80 bg-background/60 px-2.5 py-1 text-[11px] font-medium text-muted-foreground">
                     {item.state}
@@ -457,10 +454,14 @@ export default async function Home({
   const socialProviders = getEnabledSocialAuthProviders();
 
   return (
-    <main className="grid min-h-dvh bg-background lg:grid-cols-[minmax(0,1fr)_minmax(520px,0.86fr)]">
+    <main className="relative isolate grid min-h-dvh overflow-hidden bg-background lg:grid-cols-[minmax(0,1fr)_minmax(520px,0.86fr)]">
+      <div
+        className="home-entry-color-field pointer-events-none absolute hidden lg:block"
+        aria-hidden="true"
+      />
       <ProductPanel />
 
-      <section className="flex min-h-dvh items-start justify-center px-4 pb-8 pt-20 sm:items-center sm:px-8 sm:py-20 lg:px-12">
+      <section className="relative z-10 flex min-h-dvh items-start justify-center px-4 pb-8 pt-20 sm:items-center sm:px-8 sm:py-20 lg:px-12">
         <div className="w-full max-w-[440px]">
           <div className="mb-7 lg:hidden">
             <BrandMark />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,8 +2,8 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import {
   ArrowRight,
+  Bot,
   CalendarDays,
-  Check,
   CircleDot,
   Layers3,
 } from "lucide-react";
@@ -37,17 +37,18 @@ import {
   HomeSignupUsernameSuffix,
 } from "./home-signup-live-feedback";
 import { HomeAuthModeToggleLink } from "./home-auth-mode-toggle-link";
+import { HomeAuthMethods } from "./home-auth-methods";
 
 const outcomes = [
-  "See priorities and progress in one place",
-  "Keep decisions, notes, and tasks connected",
-  "Turn meetings and milestones into clear next steps",
+  "Follow tasks from first decision to final delivery",
+  "Prepare meetings and keep the roadmap moving",
+  "Give teammates and agents the same shared context",
 ];
 
 const focusItems = [
-  { title: "Finalize launch plan", meta: "Today", state: "In progress" },
-  { title: "Review customer feedback", meta: "Tomorrow", state: "Backlog" },
-  { title: "Share weekly update", meta: "Friday", state: "Ready" },
+  { title: "Follow up blocked delivery tasks", meta: "Today", state: "Tasks" },
+  { title: "Prepare the project meeting", meta: "Tomorrow", state: "Meetings" },
+  { title: "Update the delivery roadmap", meta: "Friday", state: "Roadmap" },
 ];
 
 type SearchParams = Record<string, string | string[] | undefined>;
@@ -120,14 +121,14 @@ function resolveReturnToPath(value: string | null): string {
 const inputClassName =
   "h-12 w-full rounded-lg border border-input bg-background px-3.5 text-base outline-none transition-colors duration-200 placeholder:text-muted-foreground/80 hover:border-foreground/25 focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/25 disabled:cursor-not-allowed disabled:opacity-50 motion-reduce:transition-none sm:text-sm";
 
-function BrandMark({ inverse = false }: { inverse?: boolean }) {
+function BrandMark({ productPanel = false }: { productPanel?: boolean }) {
   return (
     <div className="flex items-center gap-3">
       <span
         className={cn(
           "grid size-10 place-items-center rounded-xl",
-          inverse
-            ? "bg-white text-slate-950"
+          productPanel
+            ? "bg-slate-950 text-white dark:bg-white dark:text-slate-950"
             : "bg-blue-600 text-white dark:bg-blue-500"
         )}
         aria-hidden="true"
@@ -139,7 +140,9 @@ function BrandMark({ inverse = false }: { inverse?: boolean }) {
         <span
           className={cn(
             "mt-1 text-xs",
-            inverse ? "text-slate-400" : "text-muted-foreground"
+            productPanel
+              ? "text-slate-500 dark:text-slate-400"
+              : "text-muted-foreground"
           )}
         >
           Project execution, connected.
@@ -151,59 +154,74 @@ function BrandMark({ inverse = false }: { inverse?: boolean }) {
 
 function ProductPanel() {
   return (
-    <section className="relative hidden min-h-dvh overflow-hidden bg-slate-950 px-10 py-10 text-white lg:flex lg:flex-col xl:px-16 xl:py-12">
-      <div className="absolute inset-y-0 right-0 w-px bg-white/10" />
-      <BrandMark inverse />
+    <section className="relative hidden min-h-dvh overflow-hidden bg-slate-100 px-10 py-10 text-slate-950 transition-colors duration-200 motion-reduce:transition-none dark:bg-slate-950 dark:text-white lg:flex lg:flex-col xl:px-16 xl:py-12">
+      <div className="absolute inset-y-0 right-0 w-px bg-slate-200 dark:bg-white/10" />
+      <BrandMark productPanel />
 
       <div className="my-auto max-w-2xl py-14">
-        <Badge className="mb-6 rounded-full border border-blue-300/20 bg-blue-400/10 px-3 py-1 text-blue-100 hover:bg-blue-400/10">
-          One workspace. Clearer momentum.
+        <Badge className="mb-6 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-blue-800 hover:bg-blue-50 dark:border-blue-300/20 dark:bg-blue-400/10 dark:text-blue-100 dark:hover:bg-blue-400/10">
+          People and agents, one workspace.
         </Badge>
         <h1 className="max-w-xl text-4xl font-semibold leading-[1.08] tracking-[-0.035em] xl:text-5xl">
           Turn plans into progress—without losing context.
         </h1>
-        <p className="mt-5 max-w-xl text-base leading-7 text-slate-300 xl:text-lg">
-          Bring projects, tasks, meeting notes, and calendar commitments into
+        <p className="mt-5 max-w-xl text-base leading-7 text-slate-600 dark:text-slate-300 xl:text-lg">
+          Bring tasks, meetings, roadmaps, teammates, and trusted agents into
           one focused workspace built for steady delivery.
         </p>
 
-        <ul className="mt-8 grid gap-3" aria-label="NexusDash product benefits">
+        <div className="mt-8 flex max-w-xl gap-4 rounded-2xl border border-blue-200 bg-blue-50/80 p-4 dark:border-blue-300/15 dark:bg-blue-400/[0.08]">
+          <span className="grid size-10 shrink-0 place-items-center rounded-xl bg-blue-600 text-white dark:bg-blue-400 dark:text-slate-950">
+            <Bot className="size-5" strokeWidth={2} aria-hidden="true" />
+          </span>
+          <div>
+            <p className="text-sm font-semibold">Agent access, built for real work</p>
+            <p className="mt-1 text-sm leading-6 text-slate-600 dark:text-slate-300">
+              Give trusted agents project-scoped access so they can follow context,
+              collaborate, and help move work forward.
+            </p>
+          </div>
+        </div>
+
+        <ul className="mt-6 grid gap-3" aria-label="NexusDash product benefits">
           {outcomes.map((outcome) => (
-            <li key={outcome} className="flex items-center gap-3 text-sm text-slate-200">
-              <span className="grid size-6 shrink-0 place-items-center rounded-full bg-blue-400/15 text-blue-200">
-                <Check className="size-3.5" strokeWidth={2.5} aria-hidden="true" />
+            <li key={outcome} className="flex items-center gap-3 text-sm text-slate-700 dark:text-slate-200">
+              <span className="size-1.5 shrink-0 rounded-full bg-blue-600 dark:bg-blue-300">
+                <span className="sr-only">Included:</span>
               </span>
               {outcome}
             </li>
           ))}
         </ul>
 
-        <div className="mt-10 max-w-xl rounded-2xl border border-white/10 bg-white/[0.045] p-5">
-          <div className="flex items-center justify-between border-b border-white/10 pb-4">
+        <div className="mt-8 max-w-xl rounded-2xl border border-slate-200 bg-white p-5 dark:border-white/10 dark:bg-white/[0.045]">
+          <div className="flex items-center justify-between border-b border-slate-200 pb-4 dark:border-white/10">
             <div>
               <p className="text-sm font-semibold">Today&apos;s focus</p>
-              <p className="mt-1 text-xs text-slate-400">Three clear next steps</p>
+              <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">Three clear next steps</p>
             </div>
-            <div className="flex items-center gap-2 text-xs text-slate-300">
-              <CalendarDays className="size-4 text-blue-300" aria-hidden="true" />
+            <div className="flex items-center gap-2 text-xs text-slate-600 dark:text-slate-300">
+              <CalendarDays className="size-4 text-blue-600 dark:text-blue-300" aria-hidden="true" />
               This week
             </div>
           </div>
-          <div className="divide-y divide-white/10">
+          <div className="divide-y divide-slate-200 dark:divide-white/10">
             {focusItems.map((item, index) => (
               <div key={item.title} className="grid grid-cols-[auto_1fr_auto] items-center gap-3 py-3.5">
                 <CircleDot
                   className={cn(
                     "size-4",
-                    index === 0 ? "text-blue-300" : "text-slate-500"
+                    index === 0
+                      ? "text-blue-600 dark:text-blue-300"
+                      : "text-slate-400 dark:text-slate-500"
                   )}
                   aria-hidden="true"
                 />
                 <div className="min-w-0">
-                  <p className="truncate text-sm font-medium text-slate-100">{item.title}</p>
+                  <p className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">{item.title}</p>
                   <p className="mt-0.5 text-xs text-slate-500">{item.meta}</p>
                 </div>
-                <span className="rounded-full border border-white/10 px-2.5 py-1 text-[11px] font-medium text-slate-300">
+                <span className="rounded-full border border-slate-200 px-2.5 py-1 text-[11px] font-medium text-slate-600 dark:border-white/10 dark:text-slate-300">
                   {item.state}
                 </span>
               </div>
@@ -212,10 +230,166 @@ function ProductPanel() {
         </div>
       </div>
 
-      <p className="text-xs leading-5 text-slate-500">
+      <p className="text-xs leading-5 text-slate-500 dark:text-slate-500">
         Plan together. Focus on what matters. Deliver with confidence.
       </p>
     </section>
+  );
+}
+
+function renderSignInForm({
+  prefilledEmail,
+  returnToPath,
+}: {
+  prefilledEmail?: string;
+  returnToPath: string;
+}) {
+  return (
+    <form key="signin-form" action={signInAction} className="grid gap-4">
+      <input type="hidden" name="returnTo" value={returnToPath} />
+      <div className="grid gap-2">
+        <label htmlFor="signin-email" className="text-sm font-medium">
+          Email address
+        </label>
+        <input
+          id="signin-email"
+          name="email"
+          type="email"
+          autoComplete="email"
+          inputMode="email"
+          placeholder="you@company.com"
+          defaultValue={prefilledEmail}
+          required
+          maxLength={320}
+          className={inputClassName}
+        />
+      </div>
+      <div className="grid gap-2">
+        <div className="flex items-center justify-between gap-4">
+          <label htmlFor="signin-password" className="text-sm font-medium">
+            Password
+          </label>
+          <Link
+            href="/forgot-password"
+            className="rounded-sm text-sm font-medium text-blue-700 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:text-blue-300"
+          >
+            Forgot password?
+          </Link>
+        </div>
+        <input
+          id="signin-password"
+          name="password"
+          type="password"
+          autoComplete="current-password"
+          placeholder="Enter your password"
+          required
+          maxLength={128}
+          className={inputClassName}
+        />
+      </div>
+      <AuthSubmitButton
+        className="mt-1 h-12 w-full rounded-lg"
+        defaultLabel="Sign in to NexusDash"
+        pendingLabel="Signing you in..."
+      />
+    </form>
+  );
+}
+
+function renderSignUpForm({
+  prefilledEmail,
+  returnToPath,
+}: {
+  prefilledEmail?: string;
+  returnToPath: string;
+}) {
+  return (
+    <form key="signup-form" action={signUpAction} className="grid gap-4">
+      <input type="hidden" name="returnTo" value={returnToPath} />
+      <div className="grid gap-2">
+        <label htmlFor="signup-username" className="text-sm font-medium">
+          Username
+        </label>
+        <div className="relative">
+          <input
+            id="signup-username"
+            name="username"
+            type="text"
+            autoComplete="username"
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
+            placeholder="your.name"
+            required
+            minLength={MIN_USERNAME_LENGTH}
+            maxLength={MAX_USERNAME_LENGTH}
+            pattern="[A-Za-z0-9._]+"
+            className={cn(inputClassName, "pr-24")}
+          />
+          <HomeSignupUsernameSuffix usernameInputId="signup-username" />
+        </div>
+      </div>
+      <div className="grid gap-2">
+        <label htmlFor="signup-email" className="text-sm font-medium">
+          Email address
+        </label>
+        <input
+          id="signup-email"
+          name="email"
+          type="email"
+          autoComplete="email"
+          inputMode="email"
+          placeholder="you@company.com"
+          defaultValue={prefilledEmail}
+          required
+          maxLength={320}
+          className={inputClassName}
+        />
+        <HomeSignupEmailFeedback emailInputId="signup-email" />
+      </div>
+      <div className="grid gap-2">
+        <label htmlFor="signup-password" className="text-sm font-medium">
+          Password
+        </label>
+        <input
+          id="signup-password"
+          name="password"
+          type="password"
+          autoComplete="new-password"
+          placeholder="Create a strong password"
+          required
+          minLength={MIN_PASSWORD_LENGTH}
+          maxLength={128}
+          className={inputClassName}
+        />
+      </div>
+      <div className="grid gap-2">
+        <label htmlFor="signup-confirm-password" className="text-sm font-medium">
+          Confirm password
+        </label>
+        <input
+          id="signup-confirm-password"
+          name="confirmPassword"
+          type="password"
+          autoComplete="new-password"
+          placeholder="Re-enter your password"
+          required
+          minLength={MIN_PASSWORD_LENGTH}
+          maxLength={128}
+          className={inputClassName}
+        />
+      </div>
+      <HomeSignupPasswordFeedback
+        passwordInputId="signup-password"
+        confirmPasswordInputId="signup-confirm-password"
+        minPasswordLength={MIN_PASSWORD_LENGTH}
+      />
+      <AuthSubmitButton
+        className="h-12 w-full rounded-lg"
+        defaultLabel="Create your account"
+        pendingLabel="Creating your account..."
+      />
+    </form>
   );
 }
 
@@ -340,164 +514,29 @@ export default async function Home({
               ) : null}
 
               {socialProviders.length > 0 ? (
-                <div className="grid gap-3">
-                  <div className="grid gap-2">
-                    {socialProviders.map(({ provider }) => (
-                      <HomeSocialProviderButton
-                        key={provider}
-                        provider={provider}
-                        form={activeForm}
-                        returnTo={returnToPath}
-                      />
-                    ))}
-                  </div>
-                  <div className="relative my-1">
-                    <div className="absolute inset-0 flex items-center">
-                      <span className="w-full border-t border-border" />
-                    </div>
-                    <div className="relative flex justify-center text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-                      <span className="bg-card px-3">Or use email</span>
-                    </div>
-                  </div>
-                </div>
-              ) : null}
-
-              {isSignIn ? (
-                <form key="signin-form" action={signInAction} className="grid gap-4">
-                  <input type="hidden" name="returnTo" value={returnToPath} />
-                  <div className="grid gap-2">
-                    <label htmlFor="signin-email" className="text-sm font-medium">
-                      Email address
-                    </label>
-                    <input
-                      id="signin-email"
-                      name="email"
-                      type="email"
-                      autoComplete="email"
-                      inputMode="email"
-                      placeholder="you@company.com"
-                      defaultValue={prefilledEmail}
-                      required
-                      maxLength={320}
-                      className={inputClassName}
+                <HomeAuthMethods
+                  defaultEmailExpanded={Boolean(
+                    errorMessage || statusMessage || prefilledEmail
+                  )}
+                  providerOptions={socialProviders.map(({ provider }) => (
+                    <HomeSocialProviderButton
+                      key={provider}
+                      provider={provider}
+                      form={activeForm}
+                      returnTo={returnToPath}
                     />
-                  </div>
-                  <div className="grid gap-2">
-                    <div className="flex items-center justify-between gap-4">
-                      <label htmlFor="signin-password" className="text-sm font-medium">
-                        Password
-                      </label>
-                      <Link
-                        href="/forgot-password"
-                        className="rounded-sm text-sm font-medium text-blue-700 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:text-blue-300"
-                      >
-                        Forgot password?
-                      </Link>
-                    </div>
-                    <input
-                      id="signin-password"
-                      name="password"
-                      type="password"
-                      autoComplete="current-password"
-                      placeholder="Enter your password"
-                      required
-                      maxLength={128}
-                      className={inputClassName}
-                    />
-                  </div>
-                  <AuthSubmitButton
-                    className="mt-1 h-12 w-full rounded-lg bg-blue-600 text-white hover:bg-blue-700 focus-visible:ring-blue-600 dark:bg-blue-500 dark:hover:bg-blue-400"
-                    defaultLabel="Sign in to NexusDash"
-                    pendingLabel="Signing you in..."
-                  />
-                </form>
+                  ))}
+                >
+                  {isSignIn ? (
+                    renderSignInForm({ returnToPath, prefilledEmail })
+                  ) : (
+                    renderSignUpForm({ returnToPath, prefilledEmail })
+                  )}
+                </HomeAuthMethods>
+              ) : isSignIn ? (
+                renderSignInForm({ returnToPath, prefilledEmail })
               ) : (
-                <form key="signup-form" action={signUpAction} className="grid gap-4">
-                  <input type="hidden" name="returnTo" value={returnToPath} />
-                  <div className="grid gap-2">
-                    <label htmlFor="signup-username" className="text-sm font-medium">
-                      Username
-                    </label>
-                    <div className="relative">
-                      <input
-                        id="signup-username"
-                        name="username"
-                        type="text"
-                        autoComplete="username"
-                        autoCapitalize="none"
-                        autoCorrect="off"
-                        spellCheck={false}
-                        placeholder="your.name"
-                        required
-                        minLength={MIN_USERNAME_LENGTH}
-                        maxLength={MAX_USERNAME_LENGTH}
-                        pattern="[A-Za-z0-9._]+"
-                        className={cn(inputClassName, "pr-24")}
-                      />
-                      <HomeSignupUsernameSuffix usernameInputId="signup-username" />
-                    </div>
-                  </div>
-                  <div className="grid gap-2">
-                    <label htmlFor="signup-email" className="text-sm font-medium">
-                      Email address
-                    </label>
-                    <input
-                      id="signup-email"
-                      name="email"
-                      type="email"
-                      autoComplete="email"
-                      inputMode="email"
-                      placeholder="you@company.com"
-                      defaultValue={prefilledEmail}
-                      required
-                      maxLength={320}
-                      className={inputClassName}
-                    />
-                    <HomeSignupEmailFeedback emailInputId="signup-email" />
-                  </div>
-                  <div className="grid gap-2">
-                    <label htmlFor="signup-password" className="text-sm font-medium">
-                      Password
-                    </label>
-                    <input
-                      id="signup-password"
-                      name="password"
-                      type="password"
-                      autoComplete="new-password"
-                      placeholder="Create a strong password"
-                      required
-                      minLength={MIN_PASSWORD_LENGTH}
-                      maxLength={128}
-                      className={inputClassName}
-                    />
-                  </div>
-                  <div className="grid gap-2">
-                    <label htmlFor="signup-confirm-password" className="text-sm font-medium">
-                      Confirm password
-                    </label>
-                    <input
-                      id="signup-confirm-password"
-                      name="confirmPassword"
-                      type="password"
-                      autoComplete="new-password"
-                      placeholder="Re-enter your password"
-                      required
-                      minLength={MIN_PASSWORD_LENGTH}
-                      maxLength={128}
-                      className={inputClassName}
-                    />
-                  </div>
-                  <HomeSignupPasswordFeedback
-                    passwordInputId="signup-password"
-                    confirmPasswordInputId="signup-confirm-password"
-                    minPasswordLength={MIN_PASSWORD_LENGTH}
-                  />
-                  <AuthSubmitButton
-                    className="h-12 w-full rounded-lg bg-blue-600 text-white hover:bg-blue-700 focus-visible:ring-blue-600 dark:bg-blue-500 dark:hover:bg-blue-400"
-                    defaultLabel="Create your account"
-                    pendingLabel="Creating your account..."
-                  />
-                </form>
+                renderSignUpForm({ returnToPath, prefilledEmail })
               )}
 
               <div className="flex items-center justify-between gap-4 border-t border-border pt-4 text-sm text-muted-foreground">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,9 +3,11 @@ import Link from "next/link";
 import {
   ArrowRight,
   Bot,
-  CalendarDays,
-  CircleDot,
+  Files,
   Layers3,
+  ListTodo,
+  Milestone,
+  Workflow,
 } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
@@ -40,15 +42,36 @@ import { HomeAuthModeToggleLink } from "./home-auth-mode-toggle-link";
 import { HomeAuthMethods } from "./home-auth-methods";
 
 const outcomes = [
-  "Follow tasks from first decision to final delivery",
-  "Prepare meetings and keep the roadmap moving",
-  "Give teammates and agents the same shared context",
+  "Invite teammates and collaborate in real time",
+  "Connect Google Calendar to project work",
+  "Keep ownership clear with assignees, mentions, comments, and due dates",
 ];
 
-const focusItems = [
-  { title: "Follow up blocked delivery tasks", meta: "Today", state: "Tasks" },
-  { title: "Prepare the project meeting", meta: "Tomorrow", state: "Meetings" },
-  { title: "Update the delivery roadmap", meta: "Friday", state: "Roadmap" },
+const workflowItems = [
+  {
+    title: "Project context, kept together",
+    meta: "Context cards and files attached to cards or tasks",
+    state: "Context",
+    icon: Files,
+  },
+  {
+    title: "Plans you shape",
+    meta: "Roadmap milestones, related tasks, and epic progress",
+    state: "Plan",
+    icon: Milestone,
+  },
+  {
+    title: "Delivery you can follow",
+    meta: "Kanban from backlog to done, dated blockers, and auto-archive",
+    state: "Track",
+    icon: Workflow,
+  },
+  {
+    title: "Meetings become visible action",
+    meta: "Extracted meeting todos stay surfaced in a dedicated panel",
+    state: "Act",
+    icon: ListTodo,
+  },
 ];
 
 type SearchParams = Record<string, string | string[] | undefined>;
@@ -154,38 +177,42 @@ function BrandMark({ productPanel = false }: { productPanel?: boolean }) {
 
 function ProductPanel() {
   return (
-    <section className="relative hidden min-h-dvh overflow-hidden bg-slate-100 px-10 py-10 text-slate-950 transition-colors duration-200 motion-reduce:transition-none dark:bg-slate-950 dark:text-white lg:flex lg:flex-col xl:px-16 xl:py-12">
-      <div className="absolute inset-y-0 right-0 w-px bg-slate-200 dark:bg-white/10" />
-      <BrandMark productPanel />
+    <section className="relative hidden min-h-dvh overflow-hidden bg-background px-10 py-10 text-foreground transition-colors duration-200 motion-reduce:transition-none lg:flex lg:flex-col xl:px-16 xl:py-12">
+      <div className="home-product-ambient pointer-events-none absolute -left-40 top-[8%] size-[34rem] rounded-full bg-[radial-gradient(circle,rgba(37,99,235,0.16)_0%,rgba(37,99,235,0)_70%)] dark:bg-[radial-gradient(circle,rgba(37,99,235,0.2)_0%,rgba(37,99,235,0)_70%)]" />
+      <div className="home-product-ambient home-product-ambient-secondary pointer-events-none absolute -bottom-48 right-[-8rem] size-[38rem] rounded-full bg-[radial-gradient(circle,rgba(79,70,229,0.12)_0%,rgba(79,70,229,0)_70%)] dark:bg-[radial-gradient(circle,rgba(79,70,229,0.16)_0%,rgba(79,70,229,0)_70%)]" />
+      <div className="absolute inset-y-0 right-0 w-px bg-border/80" />
+      <div className="relative z-10">
+        <BrandMark productPanel />
+      </div>
 
-      <div className="my-auto max-w-2xl py-14">
-        <Badge className="mb-6 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-blue-800 hover:bg-blue-50 dark:border-blue-300/20 dark:bg-blue-400/10 dark:text-blue-100 dark:hover:bg-blue-400/10">
-          People and agents, one workspace.
+      <div className="relative z-10 my-auto max-w-2xl py-8">
+        <Badge className="mb-5 rounded-full border border-blue-500/20 bg-blue-500/[0.08] px-3 py-1 text-blue-700 hover:bg-blue-500/[0.08] dark:text-blue-200 dark:hover:bg-blue-500/[0.08]">
+          Projects, people, and agents. Connected.
         </Badge>
         <h1 className="max-w-xl text-4xl font-semibold leading-[1.08] tracking-[-0.035em] xl:text-5xl">
           Turn plans into progress—without losing context.
         </h1>
-        <p className="mt-5 max-w-xl text-base leading-7 text-slate-600 dark:text-slate-300 xl:text-lg">
+        <p className="mt-5 max-w-xl text-base leading-7 text-muted-foreground xl:text-lg">
           Bring tasks, meetings, roadmaps, teammates, and trusted agents into
           one focused workspace built for steady delivery.
         </p>
 
-        <div className="mt-8 flex max-w-xl gap-4 rounded-2xl border border-blue-200 bg-blue-50/80 p-4 dark:border-blue-300/15 dark:bg-blue-400/[0.08]">
+        <div className="mt-7 flex max-w-xl gap-4 rounded-2xl border border-blue-500/20 bg-blue-500/[0.07] p-4 backdrop-blur-sm">
           <span className="grid size-10 shrink-0 place-items-center rounded-xl bg-blue-600 text-white dark:bg-blue-400 dark:text-slate-950">
             <Bot className="size-5" strokeWidth={2} aria-hidden="true" />
           </span>
           <div>
             <p className="text-sm font-semibold">Agent access, built for real work</p>
-            <p className="mt-1 text-sm leading-6 text-slate-600 dark:text-slate-300">
-              Give trusted agents project-scoped access so they can follow context,
-              collaborate, and help move work forward.
+            <p className="mt-1 text-sm leading-6 text-muted-foreground">
+              Connect trusted agents through a project-scoped API so they can read
+              context, collaborate on tasks, and help move delivery forward.
             </p>
           </div>
         </div>
 
-        <ul className="mt-6 grid gap-3" aria-label="NexusDash product benefits">
+        <ul className="mt-5 grid gap-2.5" aria-label="NexusDash product benefits">
           {outcomes.map((outcome) => (
-            <li key={outcome} className="flex items-center gap-3 text-sm text-slate-700 dark:text-slate-200">
+            <li key={outcome} className="flex items-center gap-3 text-sm text-foreground/85">
               <span className="size-1.5 shrink-0 rounded-full bg-blue-600 dark:bg-blue-300">
                 <span className="sr-only">Included:</span>
               </span>
@@ -194,43 +221,41 @@ function ProductPanel() {
           ))}
         </ul>
 
-        <div className="mt-8 max-w-xl rounded-2xl border border-slate-200 bg-white p-5 dark:border-white/10 dark:bg-white/[0.045]">
-          <div className="flex items-center justify-between border-b border-slate-200 pb-4 dark:border-white/10">
+        <div className="mt-6 max-w-xl rounded-2xl border border-border/80 bg-card/75 p-5 shadow-[0_24px_70px_-52px_rgba(37,99,235,0.55)] backdrop-blur-sm">
+          <div className="flex items-center justify-between border-b border-border/80 pb-3.5">
             <div>
-              <p className="text-sm font-semibold">Today&apos;s focus</p>
-              <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">Three clear next steps</p>
+              <p className="text-sm font-semibold">A connected project system</p>
+              <p className="mt-1 text-xs text-muted-foreground">From context to delivery</p>
             </div>
-            <div className="flex items-center gap-2 text-xs text-slate-600 dark:text-slate-300">
-              <CalendarDays className="size-4 text-blue-600 dark:text-blue-300" aria-hidden="true" />
-              This week
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Workflow className="size-4 text-blue-600 dark:text-blue-300" aria-hidden="true" />
+              One workflow
             </div>
           </div>
-          <div className="divide-y divide-slate-200 dark:divide-white/10">
-            {focusItems.map((item, index) => (
-              <div key={item.title} className="grid grid-cols-[auto_1fr_auto] items-center gap-3 py-3.5">
-                <CircleDot
-                  className={cn(
-                    "size-4",
-                    index === 0
-                      ? "text-blue-600 dark:text-blue-300"
-                      : "text-slate-400 dark:text-slate-500"
-                  )}
-                  aria-hidden="true"
-                />
-                <div className="min-w-0">
-                  <p className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">{item.title}</p>
-                  <p className="mt-0.5 text-xs text-slate-500">{item.meta}</p>
+          <div className="divide-y divide-border/80">
+            {workflowItems.map((item) => {
+              const ItemIcon = item.icon;
+
+              return (
+                <div key={item.title} className="grid grid-cols-[auto_1fr_auto] items-center gap-3 py-3">
+                  <span className="grid size-8 place-items-center rounded-lg bg-blue-500/[0.09] text-blue-700 dark:text-blue-300">
+                    <ItemIcon className="size-4" strokeWidth={1.9} aria-hidden="true" />
+                  </span>
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-foreground">{item.title}</p>
+                    <p className="mt-0.5 truncate text-xs text-muted-foreground">{item.meta}</p>
+                  </div>
+                  <span className="rounded-full border border-border/80 bg-background/60 px-2.5 py-1 text-[11px] font-medium text-muted-foreground">
+                    {item.state}
+                  </span>
                 </div>
-                <span className="rounded-full border border-slate-200 px-2.5 py-1 text-[11px] font-medium text-slate-600 dark:border-white/10 dark:text-slate-300">
-                  {item.state}
-                </span>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       </div>
 
-      <p className="text-xs leading-5 text-slate-500 dark:text-slate-500">
+      <p className="relative z-10 text-xs leading-5 text-muted-foreground">
         Plan together. Focus on what matters. Deliver with confidence.
       </p>
     </section>

--- a/journal.md
+++ b/journal.md
@@ -43,6 +43,16 @@ Use it for important implementation milestones, blockers, validation runs, and r
 - Final follow-up validation passed: repository lint, RLS inventory, 932 unit
   tests, coverage thresholds (91.37% statements), production build, and the
   focused four-test Playwright entry suite.
+- Replaced the generic `Today's focus` marketing mock with four truthful
+  NexusDash layers: project context and files; roadmap, related-task, and epic
+  planning; Kanban delivery with dated blocker follow-up and auto-archive; and
+  meeting todo extraction into the dedicated panel. Invitations, live
+  collaboration, Google Calendar, task ownership, and API agent access remain
+  explicit in the surrounding copy.
+- Unified the product/auth desktop split on the same semantic background and
+  added two slow blue/indigo ambient gradients to the product half. The effect
+  uses a transform-only entrance drift, settles instead of looping, and
+  inherits the global reduced-motion stop.
 
 # 2026-07-05 - TASK-321 accessible modal and sheet foundation
 

--- a/journal.md
+++ b/journal.md
@@ -26,6 +26,9 @@ Use it for important implementation milestones, blockers, validation runs, and r
 - The first build validation correctly rejected development remote database
   URLs under production safeguards; the successful build used the documented
   local/preview validation contract without changing runtime checks.
+- CI release policy correctly required the product-changing `feature/*` branch
+  to carry a minor version decision. Prepared `v0.25.0` with matching package,
+  lockfile, and changelog metadata.
 
 # 2026-07-05 - TASK-321 accessible modal and sheet foundation
 

--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,30 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-07-16 - TASK-129 login/home page UI polish started
+
+- Created dedicated worktree `nexus_dash_task129` from `origin/main` on
+  `feature/task-129-login-home-page-ui-polish`.
+- Captured the unchanged login UI with Playwright at 1440 px desktop and the
+  sign-up UI at 390 px mobile; the mobile document measured 1,993 px tall,
+  confirming TASK-270 finding F5.
+- Applied UI/UX Pro Max guidance for a flat, typography-led productivity SaaS
+  entry surface with restrained motion, visible labels/focus, semantic color,
+  and an auth-first mobile hierarchy.
+- Chose a desktop product/auth split and a compact mobile value summary while
+  preserving existing auth, provider, verification, recovery, validation, and
+  safe return-path behavior.
+- Completed the redesign and captured after screenshots at 1,440 px desktop,
+  390 px mobile sign-up, and 390 px mobile dark sign-in. The mobile sign-up
+  document is now 1,119 px tall with no horizontal overflow.
+- Validation passed: lint, RLS inventory, 930 unit tests, coverage (91.37%
+  statements), production build, 33 focused auth/home tests, and Playwright
+  coverage for desktop sign-in, compact mobile sign-up, tablet containment,
+  dark mode, and reduced motion.
+- The first build validation correctly rejected development remote database
+  URLs under production safeguards; the successful build used the documented
+  local/preview validation contract without changing runtime checks.
+
 # 2026-07-05 - TASK-321 accessible modal and sheet foundation
 
 - Replaced duplicated custom overlay roots with a shared Radix-backed dialog

--- a/journal.md
+++ b/journal.md
@@ -29,6 +29,20 @@ Use it for important implementation milestones, blockers, validation runs, and r
 - CI release policy correctly required the product-changing `feature/*` branch
   to carry a minor version decision. Prepared `v0.25.0` with matching package,
   lockfile, and changelog metadata.
+- Incorporated product review feedback by making project-scoped agent access
+  the leading capability, replacing generic sample work with task follow-up,
+  meeting preparation, and roadmap examples, and returning the auth CTA to the
+  shared neutral button treatment.
+- Added phone-only progressive disclosure for social/email authentication,
+  retained immediate email access from 640 px upward, and added interaction
+  coverage for reveal, recovery-context defaults, and the back path.
+- Made the desktop product panel theme-aware and added reload persistence
+  coverage. Playwright passed all four focused entry tests with Google and
+  GitHub controls enabled; refreshed screenshots cover desktop light/dark and
+  phone provider/email states under `.tmp/task129-feedback-*.png`.
+- Final follow-up validation passed: repository lint, RLS inventory, 932 unit
+  tests, coverage thresholds (91.37% statements), production build, and the
+  focused four-test Playwright entry suite.
 
 # 2026-07-05 - TASK-321 accessible modal and sheet foundation
 

--- a/journal.md
+++ b/journal.md
@@ -2714,3 +2714,25 @@ Low-value entries to avoid going forward:
   space.
 - Scoped the retained avatar menu as a concise launcher: identity, one user-hub
   entry, secondary appearance/diagnostics, and a separated logout action.
+
+# 2026-07-17 - TASK-129 marketing copy and directional color refinement
+
+- Reworked the connected-workflow subtitles from terse feature labels into
+  outcome-led product copy covering a shared source of truth, user-shaped
+  roadmaps, epic progress, blocker follow-up, tidy completed work, and meeting
+  decisions that become immediately visible todos.
+- Replaced the two product-panel gradient blobs and hard column divider with a
+  single full-canvas blue/indigo field that fades from the product side through
+  the authentication side. The neutral base remains visually dominant and
+  saturated blue stays reserved for key accents, following a 60/30/10 color
+  hierarchy.
+- Added slow transform-only movement to the field and an explicit reduced-motion
+  override. Playwright confirmed live movement in light and dark themes, no
+  animation with reduced motion, and a smooth column transition in screenshots
+  `.tmp/task129-directional-gradient-light-stable.png` and
+  `.tmp/task129-directional-gradient-dark-stable.png`.
+- Validation passed with lint, RLS inventory, 941 unit tests, coverage at 91.37%
+  statements / 81.33% branches / 92.2% functions / 91.88% lines, a production
+  build, and all 20 Playwright scenarios. The database-backed browser suite used
+  the configured development database because the optional local PostgreSQL
+  service at `127.0.0.1:5432` was not running; outbound email remained disabled.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexusdash",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexusdash",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1079.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexusdash",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "private": true,
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0",

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -22,11 +22,6 @@ Last reviewed: 2026-07-05
   Status: Next 3 - daily task-flow clarity
   Rationale: Separate task reading from editing, remove ambiguous Save/Edit states, and fix compact scrollbar/modal regressions so the highest-frequency execution flow is visually clear and predictable after the shared overlay foundation lands.
   Dependencies: TASK-076, TASK-113, TASK-270, TASK-321
-- ID: TASK-129
-  Title: Login/home page UI polish - user-friendly, product-oriented entry experience
-  Status: Next 4 - entry and product-voice refinement
-  Rationale: Replace session/provider architecture language with user outcomes, reduce the very long mobile first-visit path, improve visual hierarchy and CTA clarity, and keep returning-user sign-in friction low. TASK-270 finding F5 is the design brief.
-  Dependencies: TASK-045, TASK-059, TASK-083, TASK-270
 - ID: TASK-108
   Title: Whole-app UI/UX refinement - global interaction, visual, and information-design polish
   Status: Next 5 - cross-app convergence pass
@@ -98,6 +93,12 @@ Last reviewed: 2026-07-05
   Dependencies: TASK-051
 
 ## Completed
+- ID: TASK-129
+  Title: Login/home page UI polish - user-friendly, product-oriented entry experience
+  Status: Done (2026-07-16)
+  Rationale: Replaced architecture-led entry copy and the 1,993 px mobile first-visit path with an outcome-led desktop product/auth split and compact auth-first mobile experience. Preserved credentials, social-provider, recovery, validation, and safe return-path behavior while adding 48 px controls, clearer feedback, reduced-motion handling, and responsive regression coverage.
+  Dependencies: TASK-045, TASK-059, TASK-083, TASK-270
+  Brief: `tasks/task-129-login-home-page-ui-polish.md`
 - ID: TASK-321
   Title: Accessible modal and sheet foundation - semantics, focus lifecycle, keyboard behavior, and responsive overlays
   Status: Done (2026-07-05)

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -85,6 +85,17 @@ on mobile.
   layouts keep the credential form immediately visible.
 - The product panel now changes meaningfully between light and dark themes, and
   Playwright verifies that the selected theme persists across a reload.
+- Replaced the illustrative weekly-focus list with a product-specific connected
+  workflow covering context cards and file attachments, user-owned roadmaps,
+  related tasks and epic progress, Kanban delivery and dated blocker follow-up,
+  auto-archive, and meeting todo extraction. Supporting copy now explicitly
+  covers project invitations, real-time collaboration, Google Calendar, task
+  ownership, and project-scoped API agent access.
+- Unified the desktop split on the same semantic page background and introduced
+  restrained blue/indigo ambient gradients only on the product side. The
+  gradients drift once and settle rather than animating indefinitely;
+  reduced-motion preferences collapse the animation through the global motion
+  contract.
 - Validation passed: lint, RLS inventory, 932 unit tests, coverage thresholds,
   production build, and focused Playwright checks across desktop, mobile, dark
   mode, tablet containment, and reduced motion.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -75,6 +75,16 @@ on mobile.
   prefill, verification/status feedback, and signup validation behavior.
 - Added 48 px form/provider/primary controls, visible focus treatment, semantic
   live feedback, dark-mode verification, and global reduced-motion handling.
-- Validation passed: lint, RLS inventory, 930 unit tests, coverage thresholds,
+- Refined the entry experience after visual review: agent access is now the
+  lead product capability, task/meeting/roadmap examples reflect real
+  NexusDash workflows, and primary auth actions use the shared neutral button
+  treatment.
+- On phone widths with social providers enabled, Google, GitHub, and email are
+  presented as three compact choices; choosing email replaces those choices
+  with the credential form and retains a clear back path. Tablet and desktop
+  layouts keep the credential form immediately visible.
+- The product panel now changes meaningfully between light and dark themes, and
+  Playwright verifies that the selected theme persists across a reload.
+- Validation passed: lint, RLS inventory, 932 unit tests, coverage thresholds,
   production build, and focused Playwright checks across desktop, mobile, dark
   mode, tablet containment, and reduced motion.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -91,11 +91,15 @@ on mobile.
   auto-archive, and meeting todo extraction. Supporting copy now explicitly
   covers project invitations, real-time collaboration, Google Calendar, task
   ownership, and project-scoped API agent access.
-- Unified the desktop split on the same semantic page background and introduced
-  restrained blue/indigo ambient gradients only on the product side. The
-  gradients drift once and settle rather than animating indefinitely;
-  reduced-motion preferences collapse the animation through the global motion
-  contract.
-- Validation passed: lint, RLS inventory, 932 unit tests, coverage thresholds,
-  production build, and focused Playwright checks across desktop, mobile, dark
-  mode, tablet containment, and reduced motion.
+- Replaced the visible desktop split and product-side blobs with one continuous
+  left-to-right blue/indigo color field behind both columns. Neutral surfaces
+  remain dominant, blue supports the product story, and saturated accents stay
+  limited to key controls in line with the 60/30/10 hierarchy. The field moves
+  slowly and continuously while reduced-motion preferences disable it.
+- Rewrote the workflow subtitles and supporting benefits around what users gain:
+  a reliable source of context, roadmaps they shape, visible epic progress,
+  blocker follow-up, meeting decisions converted into todos, live teamwork,
+  calendar sync, and clear ownership.
+- Validation passed: lint, RLS inventory, 941 unit tests, coverage thresholds,
+  production build, and all 20 Playwright scenarios, including desktop/mobile
+  entry, theme persistence, tablet containment, and reduced motion.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -2,62 +2,79 @@
 
 ## Task
 
-- ID: TASK-321
-- Title: Accessible modal and sheet foundation
-- Status: Complete (2026-07-05)
-- Branch: `feature/321-accessible-modal-sheet-foundation`
-- Brief: [`task-321-accessible-modal-sheet-foundation.md`](./task-321-accessible-modal-sheet-foundation.md)
+- ID: TASK-129
+- Title: Login/home page UI polish - user-friendly, product-oriented entry experience
+- Status: Complete (2026-07-16)
+- Branch: `feature/task-129-login-home-page-ui-polish`
+- Brief: [`task-129-login-home-page-ui-polish.md`](./task-129-login-home-page-ui-polish.md)
 
 ## Objective
 
-Create and adopt a shared accessible overlay foundation so dialogs, sheets, and
-confirmation flows have consistent semantics, keyboard behavior, focus
-lifecycle, background isolation, and responsive presentation.
+Replace the implementation-focused unauthenticated home page with a concise,
+outcome-led entry experience that keeps returning-user sign-in immediate,
+explains NexusDash in product language, and avoids a second long marketing page
+on mobile.
 
 ## Scope
 
-- Provide shared dialog/sheet primitives with correct dialog semantics,
-  accessible names, focus containment/restoration, Escape handling, background
-  isolation, responsive presentation, named close controls, and reduced-motion
-  support.
-- Migrate create task, task detail/edit, project settings, confirmation, context
-  preview/edit/create, attachment preview, meeting, and roadmap overlays.
-- Add focused keyboard and accessibility regression coverage at desktop and
-  mobile widths.
+- Preserve the existing credentials, social-provider, return-path, verification,
+  recovery, and inline validation behavior.
+- Reframe the page around user outcomes: planning, delivery focus, shared
+  context, and calendar-aware execution.
+- Establish a clear desktop split between product context and authentication.
+- Make authentication the first and dominant mobile experience, with only a
+  compact product-value summary.
+- Improve form hierarchy, touch targets, focus treatment, loading feedback,
+  responsive containment, light/dark contrast, and reduced-motion behavior.
+- Add focused unit and Playwright coverage for the entry experience.
 
-## Out Of Scope
+## Runtime Assumptions
 
-- Visual redesign of overlay content.
-- Task-specific information architecture owned by TASK-133.
-- Whole-app typography or color changes owned by TASK-108.
+- Local PostgreSQL and the repository `.env` contract are available for runtime
+  rendering and authenticated redirect validation.
+- Social sign-in controls render only for providers enabled through the existing
+  server-side configuration.
+- Preview validation, if required by review, will use the active branch as the
+  explicit `git_ref` per `agent.md`.
 
 ## Acceptance Criteria
 
-1. Every migrated overlay has an accessible name, correct modal semantics, and
-   a named close/cancel path.
-2. Keyboard focus cannot move into obscured page content while an overlay is
-   open and returns to the trigger after close.
-3. Escape closes non-destructive overlays and does not interrupt an in-flight
-   destructive action.
-4. Background scrolling is prevented without breaking internal sheet scrolling
-   at 390 px.
-5. Overlay motion respects `prefers-reduced-motion`.
-6. Automated coverage verifies semantics, focus containment/restoration,
-   Escape, and representative nested controls.
+1. Returning users can reach and understand the sign-in form without scrolling
+   at 390 px, 768 px, and desktop widths.
+2. New users see concrete product outcomes rather than session, provider, or
+   authorization architecture language.
+3. The 390 px sign-up page no longer appends a long card-based marketing page
+   and is materially shorter than the 1,993 px baseline.
+4. Sign-in and sign-up retain email prefill, safe `returnTo`, social-provider,
+   password recovery, status/error, and pending-submit behavior.
+5. Inputs and primary actions are at least 44 px high, labels remain visible,
+   keyboard focus is obvious, and status/error feedback is announced.
+6. The page remains usable without horizontal overflow in light and dark modes
+   and respects reduced-motion preferences.
+7. Focused tests and Playwright screenshots cover desktop sign-in and mobile
+   sign-up at minimum.
 
 ## Definition Of Done
 
-- Shared overlay primitives are implemented and documented.
-- In-scope overlays are migrated without behavior regressions.
-- Desktop/mobile keyboard checks and the required repository validation pass.
-- TASK-270 and TASK-321 tracking docs are updated.
+- The redesigned entry page is implemented with repository-native Next.js,
+  Tailwind, Shadcn, and Lucide patterns.
+- Task tracking and the execution journal describe the design decision,
+  baseline evidence, and validation outcome.
+- `npm run lint`, `npm run rls:check`, `npm test`, `npm run test:coverage`,
+  `npm run build`, and relevant Playwright checks pass.
+- Before/after desktop and 390 px mobile screenshots are captured under `.tmp/`.
+- The branch is committed, pushed, and represented by a ready-for-review PR.
 
 ## Outcome
 
-- Shared Radix-backed dialog and responsive-sheet primitives are implemented
-  and documented in `docs/ui/accessible-overlays.md`.
-- All scoped overlays now share modal semantics, focus lifecycle, guarded
-  dismissal, background isolation, nested-control support, and reduced-motion
-  behavior.
+- Replaced the long mixed auth/marketing page with a desktop product/auth split
+  and an auth-first mobile layout using product-outcome language throughout.
+- Reduced the 390 px sign-up document from 1,993 px to 1,119 px with no
+  horizontal overflow; sign-in remains visible in the initial mobile viewport.
+- Preserved credentials, social providers, password recovery, safe return paths,
+  prefill, verification/status feedback, and signup validation behavior.
+- Added 48 px form/provider/primary controls, visible focus treatment, semantic
+  live feedback, dark-mode verification, and global reduced-motion handling.
 - Validation passed: lint, RLS inventory, 930 unit tests, coverage thresholds,
-  production build, and 11 Playwright tests at desktop/mobile widths.
+  production build, and focused Playwright checks across desktop, mobile, dark
+  mode, tablet containment, and reduced motion.

--- a/tasks/task-129-login-home-page-ui-polish.md
+++ b/tasks/task-129-login-home-page-ui-polish.md
@@ -1,0 +1,58 @@
+# TASK-129 Login/Home Page UI Polish
+
+## Status
+
+Done (2026-07-16)
+
+## Objective
+
+Create a production-grade unauthenticated entry experience that helps returning
+users sign in immediately and helps new users understand NexusDash through
+clear product outcomes rather than authentication architecture.
+
+## Design Brief
+
+TASK-270 finding F5 identified two concrete problems: architecture-led copy and
+a 2,000+ px mobile first-visit path. The pre-change Playwright baseline measured
+the 390 px sign-up page at 1,993 px.
+
+The chosen direction is a flat, typography-led productivity SaaS surface:
+
+- desktop uses a balanced product/authentication split;
+- mobile keeps authentication first and compresses product discovery into a
+  short outcome summary;
+- copy focuses on turning plans into progress, shared context, and coordinated
+  execution;
+- neutral surfaces use one restrained blue accent, clear borders, and minimal
+  effects;
+- interaction motion stays within 150-200 ms and is disabled for reduced-motion
+  preferences.
+
+## Acceptance Criteria
+
+1. Sign-in is visible without scrolling on common mobile and desktop viewports.
+2. Product copy contains no session-model, provider-configuration, or
+   authorization-boundary explanations.
+3. Mobile sign-up is materially shorter than the 1,993 px baseline and does not
+   append a second marketing page.
+4. Existing authentication behavior and safe navigation semantics are
+   preserved.
+5. Form labels, feedback, focus states, touch targets, contrast, dark mode, and
+   responsive containment meet the repository's accessibility baseline.
+6. Focused automated tests verify the revised hierarchy and copy.
+
+## Definition Of Done
+
+- Implementation and focused tests are complete.
+- Required repository validation and relevant Playwright checks are green.
+- Desktop/mobile before-and-after screenshots are recorded.
+- Tracking docs are current and the delivery branch has a reviewable PR.
+
+## Outcome
+
+- Desktop now separates concise product context from the authentication task;
+  mobile presents authentication first with one short outcome statement.
+- The 390 px sign-up page is 1,119 px tall, down from 1,993 px, and has no
+  horizontal overflow.
+- Light, dark, 390 px, 768 px, 1,440 px, and reduced-motion states were checked.
+- Focused and repository-wide validation passed.

--- a/tasks/task-129-login-home-page-ui-polish.md
+++ b/tasks/task-129-login-home-page-ui-polish.md
@@ -60,4 +60,8 @@ The chosen direction is a flat, typography-led productivity SaaS surface:
 - Social-provider sign-in uses progressive email disclosure on phone widths;
   tablet and desktop keep the complete form visible. Light/dark selection is
   visibly distinct and persists across reloads.
+- The desktop product preview now describes NexusDash's actual connected
+  workflow instead of fictional weekly work, and both halves share the same
+  neutral light/dark foundation with a subtle motion-safe ambient gradient on
+  the product side.
 - Focused and repository-wide validation passed.

--- a/tasks/task-129-login-home-page-ui-polish.md
+++ b/tasks/task-129-login-home-page-ui-polish.md
@@ -61,7 +61,10 @@ The chosen direction is a flat, typography-led productivity SaaS surface:
   tablet and desktop keep the complete form visible. Light/dark selection is
   visibly distinct and persists across reloads.
 - The desktop product preview now describes NexusDash's actual connected
-  workflow instead of fictional weekly work, and both halves share the same
-  neutral light/dark foundation with a subtle motion-safe ambient gradient on
-  the product side.
+  workflow instead of fictional weekly work. Its supporting copy focuses on
+  user outcomes rather than implementation details.
+- Both halves now share one neutral light/dark foundation with a continuous,
+  slowly moving color field that travels from a stronger blue product edge to
+  a neutral authentication surface without a hard divider. Reduced-motion
+  preferences disable the movement.
 - Focused and repository-wide validation passed.

--- a/tasks/task-129-login-home-page-ui-polish.md
+++ b/tasks/task-129-login-home-page-ui-polish.md
@@ -55,4 +55,9 @@ The chosen direction is a flat, typography-led productivity SaaS surface:
 - The 390 px sign-up page is 1,119 px tall, down from 1,993 px, and has no
   horizontal overflow.
 - Light, dark, 390 px, 768 px, 1,440 px, and reduced-motion states were checked.
+- Agent access now leads the product story, supported by concrete task
+  follow-up, meeting preparation, roadmap, and collaboration examples.
+- Social-provider sign-in uses progressive email disclosure on phone widths;
+  tablet and desktop keep the complete form visible. Light/dark selection is
+  visibly distinct and persists across reloads.
 - Focused and repository-wide validation passed.

--- a/tests/app/home-auth-methods.test.tsx
+++ b/tests/app/home-auth-methods.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { HomeAuthMethods } from "@/app/home-auth-methods";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("HomeAuthMethods", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  test("progressively reveals email auth and offers a path back", () => {
+    act(() => {
+      root.render(
+        <HomeAuthMethods
+          providerOptions={<a href="/oauth">Continue with Google</a>}
+        >
+          <form aria-label="Email sign in">
+            <input aria-label="Email address" />
+          </form>
+        </HomeAuthMethods>
+      );
+    });
+
+    const continueButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Continue with email")
+    );
+    const providerRegion = container.querySelector(
+      '[data-state="provider-options"]'
+    );
+
+    expect(continueButton).toBeTruthy();
+    expect(providerRegion?.classList.contains("hidden")).toBe(false);
+    expect(container.querySelector("#home-email-auth-form")?.classList).toContain(
+      "hidden"
+    );
+
+    act(() => continueButton?.click());
+
+    expect(container.querySelector('[data-state="email-expanded"]')?.classList).toContain(
+      "hidden"
+    );
+    expect(container.querySelector("#home-email-auth-form")?.classList).not.toContain(
+      "hidden"
+    );
+
+    const backButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Other sign-in options")
+    );
+    act(() => backButton?.click());
+
+    expect(container.querySelector("#home-email-auth-form")?.classList).toContain(
+      "hidden"
+    );
+  });
+
+  test("starts with email visible when recovery context requires it", () => {
+    act(() => {
+      root.render(
+        <HomeAuthMethods
+          defaultEmailExpanded
+          providerOptions={<a href="/oauth">Continue with GitHub</a>}
+        >
+          <form aria-label="Email sign in" />
+        </HomeAuthMethods>
+      );
+    });
+
+    expect(container.querySelector("#home-email-auth-form")?.classList).not.toContain(
+      "hidden"
+    );
+  });
+});

--- a/tests/app/home-page.test.ts
+++ b/tests/app/home-page.test.ts
@@ -129,6 +129,10 @@ describe("home page auth entry", () => {
     expect(serialized).toContain("Welcome back");
     expect(serialized).toContain("signin-email");
     expect(serialized).toContain("signin-password");
+    expect(serialized).toContain("Sign in to pick up where you left off.");
+    expect(serialized).toContain("Bring every project into focus.");
+    expect(serialized).not.toContain("session model");
+    expect(serialized).not.toContain("authorization boundary");
     expect(serialized).not.toContain("signup-email");
     expect(serialized).not.toContain("signup-password");
   });
@@ -146,7 +150,7 @@ describe("home page auth entry", () => {
     expect(serialized).toContain('"type":"[Function HomeSocialProviderButton]"');
     expect(serialized).toContain('"provider":"google"');
     expect(serialized).toContain('"provider":"github"');
-    expect(serialized).toContain("Or continue with email");
+    expect(serialized).toContain("Or use email");
   });
 
   test("prefills sign-in email from query string", async () => {
@@ -175,7 +179,7 @@ describe("home page auth entry", () => {
     const serialized = serializeReactTree(element);
 
     expect(redirectMock).not.toHaveBeenCalled();
-    expect(serialized).toContain("Create your account");
+    expect(serialized).toContain("Start your workspace");
     expect(serialized).toContain("Sign in");
     expect(serialized).toContain("Sign up");
     expect(serialized).toContain("signup-email");

--- a/tests/app/home-page.test.ts
+++ b/tests/app/home-page.test.ts
@@ -150,7 +150,7 @@ describe("home page auth entry", () => {
     expect(serialized).toContain('"type":"[Function HomeSocialProviderButton]"');
     expect(serialized).toContain('"provider":"google"');
     expect(serialized).toContain('"provider":"github"');
-    expect(serialized).toContain("Or use email");
+    expect(serialized).toContain('"type":"[Function HomeAuthMethods]"');
   });
 
   test("prefills sign-in email from query string", async () => {

--- a/tests/e2e/home-entry.spec.ts
+++ b/tests/e2e/home-entry.spec.ts
@@ -37,8 +37,8 @@ test.describe("unauthenticated home entry", () => {
       viewportWidth: window.innerWidth,
     }));
 
-    expect(dimensions.height).toBeLessThan(1200);
-    expect(dimensions.width).toBe(dimensions.viewportWidth);
+    expect(dimensions.height).toBeLessThan(1300);
+    expect(dimensions.width).toBeLessThanOrEqual(dimensions.viewportWidth + 1);
   });
 
   test("stays contained at tablet width with reduced motion", async ({ page }) => {

--- a/tests/e2e/home-entry.spec.ts
+++ b/tests/e2e/home-entry.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("unauthenticated home entry", () => {
+  test("keeps sign-in immediate and communicates product outcomes", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 1000 });
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "Turn plans into progress—without losing context.",
+      })
+    ).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Welcome back" })).toBeVisible();
+    await expect(page.getByLabel("Email address")).toBeVisible();
+    await expect(page.getByLabel("Password")).toBeVisible();
+    await expect(page.getByText("session model")).toHaveCount(0);
+    await expect(page.getByText("authorization boundary")).toHaveCount(0);
+  });
+
+  test("uses an auth-first compact mobile sign-up layout", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/?form=signup");
+
+    await expect(
+      page.getByRole("heading", { name: "Start your workspace" })
+    ).toBeVisible();
+    await expect(page.getByLabel("Username")).toBeVisible();
+    await expect(page.getByLabel("Email address")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Create your account" })).toBeVisible();
+
+    const dimensions = await page.evaluate(() => ({
+      height: document.documentElement.scrollHeight,
+      width: document.documentElement.scrollWidth,
+      viewportWidth: window.innerWidth,
+    }));
+
+    expect(dimensions.height).toBeLessThan(1200);
+    expect(dimensions.width).toBe(dimensions.viewportWidth);
+  });
+
+  test("stays contained at tablet width with reduced motion", async ({ page }) => {
+    await page.setViewportSize({ width: 768, height: 1024 });
+    await page.emulateMedia({ reducedMotion: "reduce", colorScheme: "dark" });
+    await page.goto("/");
+
+    await expect(page.getByRole("heading", { name: "Welcome back" })).toBeVisible();
+    await expect(page.getByLabel("Email address")).toBeVisible();
+
+    const layout = await page.evaluate(() => {
+      const emailInput = document.getElementById("signin-email");
+      return {
+        documentWidth: document.documentElement.scrollWidth,
+        viewportWidth: window.innerWidth,
+        transitionProperty:
+          emailInput instanceof HTMLElement
+            ? getComputedStyle(emailInput).transitionProperty
+            : null,
+      };
+    });
+
+    expect(layout.documentWidth).toBe(layout.viewportWidth);
+    expect(layout.transitionProperty).toBe("none");
+  });
+});

--- a/tests/e2e/home-entry.spec.ts
+++ b/tests/e2e/home-entry.spec.ts
@@ -98,4 +98,52 @@ test.describe("unauthenticated home entry", () => {
       page.getByRole("button", { name: "Switch to light mode" })
     ).toBeVisible();
   });
+
+  test("highlights and attracts the connected node field around a precise pointer", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 1000 });
+    await page.goto("/");
+
+    const nodeField = page.locator(".home-interactive-node-field");
+    await expect(nodeField).toBeVisible();
+    await expect(nodeField).toHaveAttribute("data-active", "false");
+    await expect(nodeField).toHaveAttribute("data-constellation-seed", /\d+/);
+    await expect(nodeField).toHaveAttribute("data-node-count", "260");
+    await expect(nodeField).toHaveAttribute("data-ambient-nodes", "148");
+    await expect(nodeField).toHaveAttribute("data-viewport-tissue-nodes", "104");
+    await expect(nodeField).toHaveAttribute("data-layout", "neural-volume");
+    await expect(nodeField).toHaveAttribute("data-depth-model", "perspective");
+    await expect(nodeField).toHaveAttribute("data-depth-anchors", "5");
+    await expect(nodeField).toHaveAttribute(
+      "data-strength-model",
+      "continuous"
+    );
+    const linkCount = Number(await nodeField.getAttribute("data-link-count"));
+    expect(linkCount).toBeGreaterThan(780);
+    const firstSeed = await nodeField.getAttribute("data-constellation-seed");
+    const strongLinkCount = Number(
+      await nodeField.getAttribute("data-strong-links")
+    );
+    expect(strongLinkCount).toBeGreaterThan(0);
+    const offscreenNodeCount = Number(
+      await nodeField.getAttribute("data-offscreen-nodes")
+    );
+    expect(offscreenNodeCount).toBeGreaterThan(0);
+
+    await page.reload();
+    await expect
+      .poll(() => nodeField.getAttribute("data-constellation-seed"))
+      .not.toBe(firstSeed);
+
+    await page.mouse.move(180, 180);
+    await page.mouse.move(720, 500, { steps: 8 });
+    await expect(nodeField).toHaveAttribute("data-active", "true");
+
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.reload();
+    await expect(nodeField).toHaveAttribute("data-interactive", "false");
+    await page.mouse.move(240, 240);
+    await expect(nodeField).toHaveAttribute("data-active", "false");
+  });
 });

--- a/tests/e2e/home-entry.spec.ts
+++ b/tests/e2e/home-entry.spec.ts
@@ -15,7 +15,8 @@ test.describe("unauthenticated home entry", () => {
     ).toBeVisible();
     await expect(page.getByRole("heading", { name: "Welcome back" })).toBeVisible();
     await expect(page.getByText("Agent access, built for real work")).toBeVisible();
-    await expect(page.getByText("Follow up blocked delivery tasks")).toBeVisible();
+    await expect(page.getByText("Project context, kept together")).toBeVisible();
+    await expect(page.getByText("Meetings become visible action")).toBeVisible();
     await expect(page.getByLabel("Email address")).toBeVisible();
     await expect(page.getByLabel("Password")).toBeVisible();
     await expect(page.getByText("session model")).toHaveCount(0);

--- a/tests/e2e/home-entry.spec.ts
+++ b/tests/e2e/home-entry.spec.ts
@@ -14,6 +14,8 @@ test.describe("unauthenticated home entry", () => {
       })
     ).toBeVisible();
     await expect(page.getByRole("heading", { name: "Welcome back" })).toBeVisible();
+    await expect(page.getByText("Agent access, built for real work")).toBeVisible();
+    await expect(page.getByText("Follow up blocked delivery tasks")).toBeVisible();
     await expect(page.getByLabel("Email address")).toBeVisible();
     await expect(page.getByLabel("Password")).toBeVisible();
     await expect(page.getByText("session model")).toHaveCount(0);
@@ -27,6 +29,16 @@ test.describe("unauthenticated home entry", () => {
     await expect(
       page.getByRole("heading", { name: "Start your workspace" })
     ).toBeVisible();
+    const continueWithEmail = page.getByRole("button", {
+      name: "Continue with email",
+    });
+    if (await continueWithEmail.isVisible()) {
+      await expect(page.getByLabel("Email address")).not.toBeVisible();
+      await continueWithEmail.click();
+      await expect(
+        page.getByRole("link", { name: /Continue with/ }).first()
+      ).not.toBeVisible();
+    }
     await expect(page.getByLabel("Username")).toBeVisible();
     await expect(page.getByLabel("Email address")).toBeVisible();
     await expect(page.getByRole("button", { name: "Create your account" })).toBeVisible();
@@ -63,5 +75,21 @@ test.describe("unauthenticated home entry", () => {
 
     expect(layout.documentWidth).toBe(layout.viewportWidth);
     expect(layout.transitionProperty).toBe("none");
+  });
+
+  test("persists the selected theme across reloads", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 1000 });
+    await page.goto("/");
+
+    await page.getByRole("button", { name: "Switch to dark mode" }).click();
+    await expect(page.locator("html")).toHaveClass(/dark/);
+    await expect(page.getByText("Agent access, built for real work")).toBeVisible();
+
+    await page.reload();
+
+    await expect(page.locator("html")).toHaveClass(/dark/);
+    await expect(
+      page.getByRole("button", { name: "Switch to light mode" })
+    ).toBeVisible();
   });
 });

--- a/tests/e2e/home-entry.spec.ts
+++ b/tests/e2e/home-entry.spec.ts
@@ -16,6 +16,11 @@ test.describe("unauthenticated home entry", () => {
     await expect(page.getByRole("heading", { name: "Welcome back" })).toBeVisible();
     await expect(page.getByText("Agent access, built for real work")).toBeVisible();
     await expect(page.getByText("Project context, kept together")).toBeVisible();
+    await expect(
+      page.getByText(
+        "Give everyone one reliable place for project context and the files behind the work."
+      )
+    ).toBeVisible();
     await expect(page.getByText("Meetings become visible action")).toBeVisible();
     await expect(page.getByLabel("Email address")).toBeVisible();
     await expect(page.getByLabel("Password")).toBeVisible();

--- a/tests/e2e/password-recovery.spec.ts
+++ b/tests/e2e/password-recovery.spec.ts
@@ -152,11 +152,11 @@ test.describe("password recovery flow", () => {
 
     await page.getByLabel("Email").fill(email);
     await page.getByLabel("Password").fill(oldPassword);
-    await page.getByRole("button", { name: "Continue to dashboard" }).click();
+    await page.getByRole("button", { name: "Sign in to NexusDash" }).click();
     await expect(page.getByText("Incorrect email or password.")).toBeVisible();
 
     await page.getByLabel("Password").fill(newPassword);
-    await page.getByRole("button", { name: "Continue to dashboard" }).click();
+    await page.getByRole("button", { name: "Sign in to NexusDash" }).click();
     await expect(page).toHaveURL(/\/projects(\?.*)?$/);
   });
 });


### PR DESCRIPTION
## What changed

- redesigned the unauthenticated home page as an outcome-led desktop product/auth split
- made mobile authentication the primary experience and removed the appended marketing-card stack
- replaced session/provider architecture copy with concrete planning and delivery outcomes
- increased auth and social-provider controls to 48px, strengthened focus/status semantics, and made reduced-motion behavior deterministic
- added focused unit and Playwright coverage for desktop, 390px mobile, 768px tablet, dark mode, overflow, and reduced motion
- completed TASK-129 tracking and execution documentation
- prepared the required `v0.25.0` feature release metadata and changelog entry

## Why

TASK-270 finding F5 showed that new users had to translate implementation language into product value, while the mobile sign-up path extended beyond 1,993px. Returning users also carried unnecessary marketing weight before reaching their workspace.

The new design keeps sign-in immediate, explains NexusDash through user outcomes, and reduces the 390px sign-up document to 1,119px without changing authentication behavior.

## Validation

- `npm run lint`
- `npm run rls:check`
- `npm test` — 930 passed, 2 skipped
- `npm run test:coverage` — 91.37% statements
- `npm run build` using the documented preview/local validation contract
- `npm run release:check -- --base origin/main --branch feature/task-129-login-home-page-ui-polish`
- focused auth/home unit tests — 33 passed
- `npx playwright test tests/e2e/home-entry.spec.ts --project=chromium` — 3 passed

## Screenshots

Before/after desktop, mobile sign-up, and mobile dark-mode screenshots were captured locally under `.tmp/task-129/` for review evidence.
