### PR TITLE
TASK-324 Queue unified user hub navigation rework

### DIFF
--- a/journal.md
+++ b/journal.md
@@ -2651,3 +2651,15 @@ Low-value entries to avoid going forward:
   and 390 px mobile screenshots are stored under
   `.tmp/task322-refinement/`; the visual pass also tightened desktop summary
   typography so Meeting notes and Not connected remain readable at 1440 px.
+
+# 2026-07-16 - TASK-324 user hub navigation queued
+
+- Added TASK-324 as the first item in the UI/UX execution queue after the
+  TASK-322 shell redesign exposed remaining disorder in the avatar menu and
+  account navigation hierarchy.
+- Chose a single shared user hub with route-backed Account, Settings, and
+  Notifications tabs. This preserves deep links, browser history, unread state,
+  and contextual return paths while still presenting one coherent personal
+  space.
+- Scoped the retained avatar menu as a concise launcher: identity, one user-hub
+  entry, secondary appearance/diagnostics, and a separated logout action.

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -2,35 +2,41 @@
 
 Use this file to capture tasks discovered during development. Each entry should include: ID, title, rationale, dependencies.
 
-Last reviewed: 2026-07-06
+Last reviewed: 2026-07-16
 
 ## Pending
 ### Execution Queue (Now / Next)
+- ID: TASK-324
+  Title: Unified user hub and avatar-menu navigation rework
+  Status: Now 1 - account navigation consolidation
+  Rationale: Replace the disordered avatar-menu destination list with a calmer entry into one coherent user hub. The hub should present Account, Settings, and Notifications as three persistent, route-backed tabs so the experience feels like one page while preserving deep links, browser history, unread state, and safe return-to-project behavior. Keep the avatar control, but reduce its menu to identity, one clear user-hub entry, appearance/diagnostics, and a spatially separated logout action; avoid duplicating the same account destinations across the menu, sidebar, and page chrome.
+  Dependencies: TASK-270, TASK-321, TASK-322
+  Brief: `tasks/task-324-unified-user-hub-navigation.md`
 - ID: TASK-100
   Title: Mobile UI/UX refinement - touch ergonomics, compact layouts, and small-screen polish
-  Status: Now 1 - mobile core-flow remediation
+  Status: Next 2 - mobile core-flow remediation
   Rationale: Re-prioritize the long mobile dashboard sequence, replace four vertically stacked Kanban columns with an intentional status-switching pattern, enforce 44px touch targets and readable secondary text, reduce task-sheet friction, and retain the existing Google Calendar narrow-viewport scope identified by TASK-270.
   Dependencies: TASK-091, TASK-079, TASK-096, TASK-270, TASK-321, TASK-322
 - ID: TASK-133
   Title: Task UI bug fixing - mini scrollbar and detail/edit modal polish
-  Status: Next 2 - daily task-flow clarity
+  Status: Next 3 - daily task-flow clarity
   Rationale: Separate task reading from editing, remove ambiguous Save/Edit states, and fix compact scrollbar/modal regressions so the highest-frequency execution flow is visually clear and predictable after the shared overlay foundation lands.
   Dependencies: TASK-076, TASK-113, TASK-270, TASK-321
 - ID: TASK-129
   Title: Login/home page UI polish - user-friendly, product-oriented entry experience
-  Status: Next 3 - entry and product-voice refinement
+  Status: Next 4 - entry and product-voice refinement
   Rationale: Replace session/provider architecture language with user outcomes, reduce the very long mobile first-visit path, improve visual hierarchy and CTA clarity, and keep returning-user sign-in friction low. TASK-270 finding F5 is the design brief.
   Dependencies: TASK-045, TASK-059, TASK-083, TASK-270
 - ID: TASK-108
   Title: Whole-app UI/UX refinement - global interaction, visual, and information-design polish
-  Status: Next 4 - cross-app convergence pass
+  Status: Next 5 - cross-app convergence pass
   Rationale: Use TASK-270 findings F6-F12 to normalize module hierarchy, metric semantics, read-only affordances, type/spacing tokens, empty states, toast policy, and reduced motion after the structural navigation, overlay, mobile, task, and entry work is complete.
-  Dependencies: TASK-096, TASK-100, TASK-129, TASK-133, TASK-270, TASK-321, TASK-322
+  Dependencies: TASK-096, TASK-100, TASK-129, TASK-133, TASK-270, TASK-321, TASK-322, TASK-324
 - ID: TASK-323
   Title: Production-readiness UX verification - accessibility, navigation, responsive, role, and recovery sign-off
-  Status: Next 5 - blocked final verification gate
+  Status: Next 6 - blocked final verification gate
   Rationale: Re-audit the remediated product rather than assuming implementation tasks achieved production quality. Verify WCAG AA fundamentals, keyboard/screen-reader operation, owner/editor/viewer/invitee journeys, navigation state preservation, realistic data density, loading/error/empty recovery, responsive layouts, themes, and critical usability flows; produce a residual-risk sign-off report and focused defects for anything still below production grade.
-  Dependencies: TASK-100, TASK-108, TASK-129, TASK-133, TASK-321, TASK-322
+  Dependencies: TASK-100, TASK-108, TASK-129, TASK-133, TASK-321, TASK-322, TASK-324
   Brief: `tasks/task-323-production-readiness-ux-verification.md`
 ### Deferred (Intentional)
 - ID: TASK-102

--- a/tasks/task-323-production-readiness-ux-verification.md
+++ b/tasks/task-323-production-readiness-ux-verification.md
@@ -4,7 +4,7 @@
 TASK-323
 
 ## Status
-Blocked — final verification after TASK-321/322/100/133/129/108
+Blocked — final verification after TASK-321/322/324/100/133/129/108
 
 ## Objective
 Determine whether the remediated NexusDash experience meets a defensible
@@ -14,6 +14,7 @@ tasks for any remaining critical or high-severity gaps.
 ## Prerequisites
 - TASK-321 accessible modal and sheet foundation
 - TASK-322 responsive authenticated app shell and navigation
+- TASK-324 unified user hub and avatar-menu navigation rework
 - TASK-100 mobile UI/UX refinement
 - TASK-133 task detail/edit polish
 - TASK-129 login/home polish
@@ -70,3 +71,4 @@ tasks for any remaining critical or high-severity gaps.
 - TASK-133
 - TASK-321
 - TASK-322
+- TASK-324

--- a/tasks/task-324-unified-user-hub-navigation.md
+++ b/tasks/task-324-unified-user-hub-navigation.md
@@ -1,0 +1,81 @@
+# TASK-324 - Unified user hub and avatar-menu navigation rework
+
+## Status
+
+Pending - first item in the UI/UX execution queue.
+
+## Objective
+
+Turn the current collection of account destinations into one coherent user
+space, while simplifying the retained avatar menu into a concise launcher
+rather than a second navigation system.
+
+## Product Direction
+
+- Keep the user avatar as the persistent personal entry point.
+- Make `/account` the shared user hub with one stable header and three visible
+  destinations: Account, Settings, and Notifications.
+- Present those destinations as semantic, route-backed tabs or segmented
+  navigation. They should feel like views of one page while retaining distinct
+  URLs, deep links, browser history, unread state, and safe `returnTo` context.
+- Remove duplicated Account, Settings, and Notifications rows from the avatar
+  menu. Replace them with one clearly named user-hub action.
+- Keep appearance controls and repository/version diagnostics secondary in the
+  menu, and separate logout visually and semantically from ordinary navigation.
+- Reuse the authenticated shell and established NexusDash visual language
+  rather than introducing another competing navigation layer.
+
+## Scope
+
+- Audit the current avatar menu and `/account/**` information architecture.
+- Build a shared responsive user-hub header/navigation treatment across
+  Account, Settings, and Notifications.
+- Preserve the existing route contract or provide safe redirects if route
+  normalization is required.
+- Preserve notification unread indicators and contextual return paths from
+  projects, tasks, and notification targets.
+- Define desktop and mobile behavior, including narrow-screen tab labels,
+  focus order, content insets, and 44 px minimum targets.
+- Cover active state, keyboard operation, accessible naming, focus visibility,
+  light/dark themes, and loading/empty/error states.
+- Update the avatar menu so personal identity is clear without crowding the
+  menu with repeated destination links.
+
+## Out Of Scope
+
+- Redesigning the underlying account forms or changing account data behavior.
+- Changing notification delivery, read/resolved semantics, or email dispatch.
+- Replacing the global Projects/Inbox navigation established by TASK-322.
+- Adding new profile, preference, or notification-setting capabilities.
+
+## Acceptance Criteria
+
+1. Account, Settings, and Notifications are visibly available from one shared
+   user-hub navigation surface on desktop and mobile.
+2. Each hub view has a stable internal URL and supports refresh, deep linking,
+   browser Back/Forward, and contextual `returnTo` behavior.
+3. The active hub view is visually distinct and announced semantically without
+   relying on color alone.
+4. The avatar menu retains the user identity and provides one clear route into
+   the user hub without duplicating all three hub destinations.
+5. Appearance/diagnostic utilities remain available but visually subordinate;
+   logout is separated from navigation and cannot be mistaken for a tab.
+6. Notification unread state remains discoverable from the avatar entry point
+   and the Notifications tab without creating competing primary actions.
+7. All interactive targets are at least 44 px, keyboard reachable, visibly
+   focused, and usable at 375 px without clipping or horizontal page overflow.
+8. Account routes retain the responsive authenticated shell and do not obscure
+   page content, feedback, dialogs, or fixed navigation.
+
+## Definition Of Done
+
+- The shared user hub and simplified avatar menu are implemented using reusable
+  components and established semantic design tokens.
+- Focused component tests cover tab semantics, active state, unread state, menu
+  composition, and safe contextual URLs.
+- Playwright covers desktop/mobile hub switching, direct entry, browser history,
+  notification deep links, and return-to-project continuity.
+- Light/dark and 375/768/1024/1440 px visual walkthroughs pass without overflow,
+  collision, or ambiguous current location.
+- Required repository validation is green, tracking documentation is updated,
+  and the task ships through its dedicated feature branch and pull request.


### PR DESCRIPTION
## What changed

- adds TASK-324 as the first UI/UX execution-queue item
- defines a shared, route-backed user hub for Account, Settings, and Notifications
- scopes the retained avatar menu as a concise launcher rather than duplicate navigation
- makes TASK-323 production-readiness verification depend on the user-hub rework
- records the product/navigation decision in the execution journal

## Why

The TASK-322 shell improved global navigation, but the avatar menu still mixes destinations, utilities, diagnostics, and session actions. A shared user hub preserves the user's simple three-view concept while route-backed tabs retain deep links, browser history, unread state, and safe return-to-project behavior.

## User impact

No runtime behavior changes in this planning PR. TASK-324 is now the next executable UI/UX task with explicit responsive, accessibility, routing, and validation criteria.

## Validation

- `git diff --check`
- verified TASK-324 queue ordering, dependencies, brief link, and production-readiness dependency