### PR TITLE
TASK-129 preview: Interactive Node Field background

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -175,6 +175,15 @@
     );
 }
 
+.home-interactive-node-field {
+  z-index: 0;
+  opacity: 0.9;
+}
+
+.dark .home-interactive-node-field {
+  opacity: 0.95;
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
@@ -195,6 +204,10 @@
   .home-entry-color-field {
     animation: none !important;
     transform: none !important;
+    will-change: auto;
+  }
+
+  .home-interactive-node-field {
     will-change: auto;
   }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -177,11 +177,11 @@
 
 .home-interactive-node-field {
   z-index: 0;
-  opacity: 0.9;
+  opacity: 0.96;
 }
 
 .dark .home-interactive-node-field {
-  opacity: 0.95;
+  opacity: 0.97;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/app/home-interactive-node-field.tsx
+++ b/app/home-interactive-node-field.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+const NODE_COUNT = 54;
+const ACTIVATION_RADIUS = 240;
+const MAX_ATTRACTION = 18;
+
+type Point = { x: number; y: number };
+type NodePoint = Point & { emphasis: number };
+type Link = { from: number; to: number; weight: number };
+
+function createNodeField() {
+  let seed = 129;
+  const random = () => {
+    seed = (seed * 16807) % 2147483647;
+    return (seed - 1) / 2147483646;
+  };
+
+  const nodes = Array.from({ length: NODE_COUNT }, (_, index): NodePoint => ({
+    x: 0.025 + random() * 0.95,
+    y: 0.04 + random() * 0.92,
+    emphasis: index % 11 === 0 ? 1.45 : index % 5 === 0 ? 1.2 : 1,
+  }));
+  const linkKeys = new Set<string>();
+  const links: Link[] = [];
+
+  nodes.forEach((node, from) => {
+    const neighbors = nodes
+      .map((candidate, to) => ({
+        to,
+        distance: Math.hypot(candidate.x - node.x, candidate.y - node.y),
+      }))
+      .filter(({ to }) => to !== from)
+      .sort((a, b) => a.distance - b.distance)
+      .slice(0, from % 4 === 0 ? 3 : 2);
+
+    neighbors.forEach(({ to }) => {
+      const key = [from, to].sort((a, b) => a - b).join(":");
+      if (linkKeys.has(key)) return;
+      linkKeys.add(key);
+      links.push({
+        from,
+        to,
+        weight:
+          (from + to) % 9 === 0 ? 2.4 : (from + to) % 4 === 0 ? 1.45 : 0.8,
+      });
+    });
+  });
+
+  return { nodes, links };
+}
+
+const nodeField = createNodeField();
+
+export function HomeInteractiveNodeField() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const context = canvas?.getContext("2d");
+    if (!canvas || !context) return;
+
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const desktop = window.matchMedia("(min-width: 1024px)");
+    const precisePointer = window.matchMedia("(pointer: fine)");
+    const pointer = {
+      x: window.innerWidth * 0.3,
+      y: window.innerHeight * 0.42,
+    };
+    const target = { ...pointer };
+    let activity = 0;
+    let targetActivity = 0;
+    let frame: number | null = null;
+    let width = 0;
+    let height = 0;
+
+    const colors = () => {
+      const dark = document.documentElement.classList.contains("dark");
+      return dark
+        ? {
+            haloInner: "rgba(59, 130, 246, 0.18)",
+            haloOuter: "rgba(79, 70, 229, 0)",
+            link: "129, 140, 248",
+            node: "147, 197, 253",
+          }
+        : {
+            haloInner: "rgba(37, 99, 235, 0.13)",
+            haloOuter: "rgba(99, 102, 241, 0)",
+            link: "37, 99, 235",
+            node: "29, 78, 216",
+          };
+    };
+
+    const resize = () => {
+      const ratio = Math.min(window.devicePixelRatio || 1, 2);
+      width = window.innerWidth;
+      height = window.innerHeight;
+      canvas.width = Math.round(width * ratio);
+      canvas.height = Math.round(height * ratio);
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      context.setTransform(ratio, 0, 0, ratio, 0, 0);
+    };
+
+    const resolveNodes = () =>
+      nodeField.nodes.map((node) => {
+        const baseX = node.x * width;
+        const baseY = node.y * height;
+        const distance = Math.hypot(pointer.x - baseX, pointer.y - baseY);
+        const influence =
+          Math.max(0, 1 - distance / ACTIVATION_RADIUS) * activity;
+        const directionX = distance > 0 ? (pointer.x - baseX) / distance : 0;
+        const directionY = distance > 0 ? (pointer.y - baseY) / distance : 0;
+        const attraction = influence * influence * MAX_ATTRACTION;
+
+        return {
+          x: baseX + directionX * attraction,
+          y: baseY + directionY * attraction,
+          influence,
+          emphasis: node.emphasis,
+        };
+      });
+
+    const draw = () => {
+      frame = null;
+      if (!desktop.matches) return;
+
+      pointer.x += (target.x - pointer.x) * 0.16;
+      pointer.y += (target.y - pointer.y) * 0.16;
+      activity += (targetActivity - activity) * 0.14;
+
+      context.clearRect(0, 0, width, height);
+      const palette = colors();
+      const resolvedNodes = resolveNodes();
+
+      if (activity > 0.01) {
+        const halo = context.createRadialGradient(
+          pointer.x,
+          pointer.y,
+          0,
+          pointer.x,
+          pointer.y,
+          ACTIVATION_RADIUS * 1.35
+        );
+        halo.addColorStop(0, palette.haloInner);
+        halo.addColorStop(1, palette.haloOuter);
+        context.fillStyle = halo;
+        context.fillRect(0, 0, width, height);
+      }
+
+      nodeField.links.forEach((link) => {
+        const from = resolvedNodes[link.from];
+        const to = resolvedNodes[link.to];
+        const influence = Math.max(from.influence, to.influence);
+        const alpha = 0.095 + influence * 0.5;
+        context.beginPath();
+        context.moveTo(from.x, from.y);
+        context.lineTo(to.x, to.y);
+        context.lineWidth = link.weight + influence * 0.75;
+        context.strokeStyle = `rgba(${palette.link}, ${alpha})`;
+        context.stroke();
+      });
+
+      resolvedNodes.forEach((node) => {
+        const radius = 1.35 * node.emphasis + node.influence * 1.9;
+        const alpha = 0.24 + node.influence * 0.7;
+        context.beginPath();
+        context.arc(node.x, node.y, radius, 0, Math.PI * 2);
+        context.fillStyle = `rgba(${palette.node}, ${alpha})`;
+        context.fill();
+
+        if (node.influence > 0.2) {
+          context.beginPath();
+          context.arc(
+            node.x,
+            node.y,
+            radius + 5 * node.influence,
+            0,
+            Math.PI * 2
+          );
+          context.strokeStyle = `rgba(${palette.node}, ${node.influence * 0.24})`;
+          context.lineWidth = 1;
+          context.stroke();
+        }
+      });
+
+      const unsettled =
+        Math.abs(target.x - pointer.x) > 0.3 ||
+        Math.abs(target.y - pointer.y) > 0.3 ||
+        Math.abs(targetActivity - activity) > 0.01;
+      if (unsettled && !reducedMotion.matches)
+        frame = window.requestAnimationFrame(draw);
+    };
+
+    const requestDraw = () => {
+      if (frame === null) frame = window.requestAnimationFrame(draw);
+    };
+
+    const handlePointerMove = (event: PointerEvent) => {
+      if (reducedMotion.matches || !precisePointer.matches || !desktop.matches)
+        return;
+      target.x = event.clientX;
+      target.y = event.clientY;
+      targetActivity = 1;
+      canvas.dataset.active = "true";
+      requestDraw();
+    };
+
+    const handlePointerLeave = () => {
+      targetActivity = 0;
+      canvas.dataset.active = "false";
+      requestDraw();
+    };
+
+    const handleResize = () => {
+      resize();
+      requestDraw();
+    };
+
+    const handleMotionChange = () => {
+      targetActivity = 0;
+      activity = 0;
+      canvas.dataset.interactive = reducedMotion.matches ? "false" : "true";
+      canvas.dataset.active = "false";
+      if (frame !== null) window.cancelAnimationFrame(frame);
+      frame = null;
+      draw();
+    };
+
+    const themeObserver = new MutationObserver(requestDraw);
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    resize();
+    canvas.dataset.interactive = reducedMotion.matches ? "false" : "true";
+    draw();
+    window.addEventListener("pointermove", handlePointerMove, {
+      passive: true,
+    });
+    document.documentElement.addEventListener("mouseleave", handlePointerLeave);
+    window.addEventListener("resize", handleResize, { passive: true });
+    reducedMotion.addEventListener("change", handleMotionChange);
+    desktop.addEventListener("change", handleResize);
+
+    return () => {
+      if (frame !== null) window.cancelAnimationFrame(frame);
+      themeObserver.disconnect();
+      window.removeEventListener("pointermove", handlePointerMove);
+      document.documentElement.removeEventListener(
+        "mouseleave",
+        handlePointerLeave
+      );
+      window.removeEventListener("resize", handleResize);
+      reducedMotion.removeEventListener("change", handleMotionChange);
+      desktop.removeEventListener("change", handleResize);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="home-interactive-node-field pointer-events-none absolute inset-0 hidden lg:block"
+      data-active="false"
+      data-interactive="true"
+      aria-hidden="true"
+    />
+  );
+}

--- a/app/home-interactive-node-field.tsx
+++ b/app/home-interactive-node-field.tsx
@@ -2,15 +2,17 @@
 
 import { useEffect, useRef } from "react";
 
-const NODE_COUNT = 208;
+const NODE_COUNT = 260;
 const CLUSTERED_NODE_COUNT = 112;
+const VIEWPORT_TISSUE_COUNT = 104;
 const CLUSTER_COUNT = 5;
 const PLACEMENT_CANDIDATES = 24;
 const WORLD_PADDING_X = 0.18;
 const WORLD_PADDING_Y = 0.2;
 const ACTIVATION_RADIUS = 340;
 const MAX_ATTRACTION = 22;
-const MAX_PARALLAX = 30;
+const MAX_PARALLAX = 42;
+const CLUSTER_DEPTHS = [0.1, 0.3, 0.52, 0.74, 0.94] as const;
 
 type Point = { x: number; y: number };
 type NodePoint = Point & {
@@ -60,7 +62,10 @@ function createNodeField(seed: number) {
 
     return {
       ...position,
-      depth: 0.18 + random() * 0.76,
+      depth: Math.max(
+        0.04,
+        Math.min(0.98, CLUSTER_DEPTHS[index] + (random() - 0.5) * 0.12)
+      ),
       radiusX: 0.1 + random() * 0.09,
       radiusY: 0.11 + random() * 0.1,
     };
@@ -75,7 +80,7 @@ function createNodeField(seed: number) {
       const radius = Math.pow(random(), 0.68);
       const depth = Math.max(
         0.04,
-        Math.min(0.98, anchor.depth + (random() - 0.5) * 0.34)
+        Math.min(0.98, anchor.depth + (random() - 0.5) * 0.24)
       );
 
       return {
@@ -89,14 +94,20 @@ function createNodeField(seed: number) {
   );
 
   while (nodes.length < NODE_COUNT) {
+    const ambientIndex = nodes.length - CLUSTERED_NODE_COUNT;
+    const crossesViewport = ambientIndex < VIEWPORT_TISSUE_COUNT;
     let bestCandidate: NodePoint | null = null;
     let bestClearance = -1;
 
     for (let attempt = 0; attempt < PLACEMENT_CANDIDATES; attempt += 1) {
       const depth = 0.04 + random() * 0.94;
       const candidate = {
-        x: -WORLD_PADDING_X + random() * (1 + WORLD_PADDING_X * 2),
-        y: -WORLD_PADDING_Y + random() * (1 + WORLD_PADDING_Y * 2),
+        x: crossesViewport
+          ? -0.04 + random() * 1.08
+          : -WORLD_PADDING_X + random() * (1 + WORLD_PADDING_X * 2),
+        y: crossesViewport
+          ? -0.05 + random() * 1.1
+          : -WORLD_PADDING_Y + random() * (1 + WORLD_PADDING_Y * 2),
         cluster: null,
         depth,
         emphasis: 0.82 + depth * 0.44 + Math.pow(random(), 1.8) * 0.5,
@@ -221,7 +232,9 @@ export function HomeInteractiveNodeField() {
     canvas.dataset.layout = "neural-volume";
     canvas.dataset.strengthModel = "continuous";
     canvas.dataset.depthModel = "perspective";
+    canvas.dataset.depthAnchors = String(CLUSTER_DEPTHS.length);
     canvas.dataset.ambientNodes = String(NODE_COUNT - CLUSTERED_NODE_COUNT);
+    canvas.dataset.viewportTissueNodes = String(VIEWPORT_TISSUE_COUNT);
 
     const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
     const desktop = window.matchMedia("(min-width: 1024px)");
@@ -282,17 +295,20 @@ export function HomeInteractiveNodeField() {
       const cameraY = ((pointer.y / height) * 2 - 1) * activity;
 
       return nodeField.nodes.map((node) => {
-        const perspective = 0.78 + node.depth * 0.42;
+        const perspective = 0.74 + node.depth * 0.52;
         const projectedX = 0.5 + (node.x - 0.5) * perspective;
         const projectedY = 0.5 + (node.y - 0.5) * perspective;
-        const parallax = node.depth * MAX_PARALLAX;
+        const parallax = Math.pow(node.depth, 1.35) * MAX_PARALLAX;
         const baseX = projectedX * width - cameraX * parallax;
         const baseY = projectedY * height - cameraY * parallax;
         const distance = Math.hypot(pointer.x - baseX, pointer.y - baseY);
         const influence = proximityInfluence(distance) * activity;
         const directionX = distance > 0 ? (pointer.x - baseX) / distance : 0;
         const directionY = distance > 0 ? (pointer.y - baseY) / distance : 0;
-        const attraction = Math.pow(influence, 1.35) * MAX_ATTRACTION;
+        const attraction =
+          Math.pow(influence, 1.35) *
+          MAX_ATTRACTION *
+          (0.55 + node.depth * 0.65);
 
         return {
           x: baseX + directionX * attraction,
@@ -364,34 +380,31 @@ export function HomeInteractiveNodeField() {
           palette.baseLinkAlpha * (0.3 + link.depth * 0.84) +
           link.strength * palette.strongLinkAlpha * (0.38 + link.depth * 0.82) +
           influence * palette.activeLinkAlpha * (0.62 + link.depth * 0.48);
-        const depthGradient = context.createLinearGradient(
-          from.x,
-          from.y,
-          to.x,
-          to.y
+        const fromAlpha = Math.min(
+          0.94,
+          alpha * (0.5 + from.depth * 0.62)
         );
-        depthGradient.addColorStop(
-          0,
-          `rgba(${palette.link}, ${Math.min(
-            0.94,
-            alpha * (0.5 + from.depth * 0.62)
-          )})`
-        );
-        depthGradient.addColorStop(
-          1,
-          `rgba(${palette.link}, ${Math.min(
-            0.94,
-            alpha * (0.5 + to.depth * 0.62)
-          )})`
-        );
+        const toAlpha = Math.min(0.94, alpha * (0.5 + to.depth * 0.62));
         context.beginPath();
         context.moveTo(from.x, from.y);
         context.quadraticCurveTo(controlX, controlY, to.x, to.y);
         context.lineCap = "round";
         context.lineWidth =
-          (0.22 + link.strength * 2.4) * (0.38 + link.depth * 1.22) +
+          (0.22 + link.strength * 2.4) * (0.28 + link.depth * 1.4) +
           influence * (0.7 + link.strength * 0.9);
-        context.strokeStyle = depthGradient;
+        if (Math.abs(from.depth - to.depth) > 0.08) {
+          const depthGradient = context.createLinearGradient(
+            from.x,
+            from.y,
+            to.x,
+            to.y
+          );
+          depthGradient.addColorStop(0, `rgba(${palette.link}, ${fromAlpha})`);
+          depthGradient.addColorStop(1, `rgba(${palette.link}, ${toAlpha})`);
+          context.strokeStyle = depthGradient;
+        } else {
+          context.strokeStyle = `rgba(${palette.link}, ${(fromAlpha + toAlpha) / 2})`;
+        }
         context.stroke();
       });
 
@@ -401,7 +414,7 @@ export function HomeInteractiveNodeField() {
         .forEach((node) => {
         const depthPresence = 0.36 + node.depth * 0.82;
         const radius =
-          (0.42 + node.depth * 2.75) * node.emphasis + node.influence * 2.1;
+          (0.3 + node.depth * 3.2) * node.emphasis + node.influence * 2.1;
         const alpha =
           palette.baseNodeAlpha * depthPresence +
           node.influence * palette.activeNodeAlpha * (0.72 + node.depth * 0.38);

--- a/app/home-interactive-node-field.tsx
+++ b/app/home-interactive-node-field.tsx
@@ -2,10 +2,10 @@
 
 import { useEffect, useRef } from "react";
 
-const NODE_COUNT = 64;
+const NODE_COUNT = 96;
 const ACTIVATION_RADIUS = 340;
 const MAX_ATTRACTION = 22;
-const MIN_NODE_DISTANCE = 0.064;
+const MIN_NODE_DISTANCE = 0.048;
 
 type Point = { x: number; y: number };
 type NodePoint = Point & { emphasis: number };
@@ -81,7 +81,7 @@ function createNodeField(seed: number) {
       }))
       .filter(({ to }) => to !== from)
       .sort((a, b) => a.distance - b.distance)
-      .slice(0, random() < 0.2 ? 4 : 3);
+      .slice(0, random() < 0.55 ? 5 : 4);
 
     neighbors.forEach(({ to }) => {
       const key = [from, to].sort((a, b) => a - b).join(":");

--- a/app/home-interactive-node-field.tsx
+++ b/app/home-interactive-node-field.tsx
@@ -2,10 +2,10 @@
 
 import { useEffect, useRef } from "react";
 
-const NODE_COUNT = 54;
+const NODE_COUNT = 64;
 const ACTIVATION_RADIUS = 340;
 const MAX_ATTRACTION = 22;
-const MIN_NODE_DISTANCE = 0.072;
+const MIN_NODE_DISTANCE = 0.064;
 
 type Point = { x: number; y: number };
 type NodePoint = Point & { emphasis: number };
@@ -81,7 +81,7 @@ function createNodeField(seed: number) {
       }))
       .filter(({ to }) => to !== from)
       .sort((a, b) => a.distance - b.distance)
-      .slice(0, random() < 0.28 ? 3 : 2);
+      .slice(0, random() < 0.2 ? 4 : 3);
 
     neighbors.forEach(({ to }) => {
       const key = [from, to].sort((a, b) => a - b).join(":");
@@ -126,6 +126,8 @@ export function HomeInteractiveNodeField() {
     const seed = createRandomSeed();
     const nodeField = createNodeField(seed);
     canvas.dataset.constellationSeed = String(seed);
+    canvas.dataset.nodeCount = String(nodeField.nodes.length);
+    canvas.dataset.linkCount = String(nodeField.links.length);
     canvas.dataset.strongLinks = String(
       nodeField.links.filter((link) => link.prominence === 1).length
     );

--- a/app/home-interactive-node-field.tsx
+++ b/app/home-interactive-node-field.tsx
@@ -2,10 +2,10 @@
 
 import { useEffect, useRef } from "react";
 
-const NODE_COUNT = 156;
+const NODE_COUNT = 208;
 const CLUSTERED_NODE_COUNT = 112;
 const CLUSTER_COUNT = 5;
-const PLACEMENT_CANDIDATES = 28;
+const PLACEMENT_CANDIDATES = 24;
 const WORLD_PADDING_X = 0.18;
 const WORLD_PADDING_Y = 0.2;
 const ACTIVATION_RADIUS = 340;
@@ -108,7 +108,7 @@ function createNodeField(seed: number) {
             Math.hypot(
               (candidate.x - node.x) * 1.4,
               candidate.y - node.y,
-              (candidate.depth - node.depth) * 0.38
+              (candidate.depth - node.depth) * 0.18
             )
           ),
         Number.POSITIVE_INFINITY
@@ -182,8 +182,8 @@ function createNodeField(seed: number) {
             ? 6
             : 5
           : random() < 0.42
-            ? 4
-            : 3
+            ? 5
+            : 4
       );
 
     neighbors.forEach(({ to }) => connect(from, to));
@@ -221,6 +221,7 @@ export function HomeInteractiveNodeField() {
     canvas.dataset.layout = "neural-volume";
     canvas.dataset.strengthModel = "continuous";
     canvas.dataset.depthModel = "perspective";
+    canvas.dataset.ambientNodes = String(NODE_COUNT - CLUSTERED_NODE_COUNT);
 
     const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
     const desktop = window.matchMedia("(min-width: 1024px)");
@@ -360,8 +361,8 @@ export function HomeInteractiveNodeField() {
           Math.max(from.influence, to.influence) * 0.62 +
           midpointInfluence * 0.38;
         const alpha =
-          palette.baseLinkAlpha * (0.22 + link.depth * 0.92) +
-          link.strength * palette.strongLinkAlpha * (0.3 + link.depth * 0.9) +
+          palette.baseLinkAlpha * (0.3 + link.depth * 0.84) +
+          link.strength * palette.strongLinkAlpha * (0.38 + link.depth * 0.82) +
           influence * palette.activeLinkAlpha * (0.62 + link.depth * 0.48);
         const depthGradient = context.createLinearGradient(
           from.x,
@@ -373,14 +374,14 @@ export function HomeInteractiveNodeField() {
           0,
           `rgba(${palette.link}, ${Math.min(
             0.94,
-            alpha * (0.42 + from.depth * 0.72)
+            alpha * (0.5 + from.depth * 0.62)
           )})`
         );
         depthGradient.addColorStop(
           1,
           `rgba(${palette.link}, ${Math.min(
             0.94,
-            alpha * (0.42 + to.depth * 0.72)
+            alpha * (0.5 + to.depth * 0.62)
           )})`
         );
         context.beginPath();
@@ -398,7 +399,7 @@ export function HomeInteractiveNodeField() {
         .map((node, index) => ({ ...node, index }))
         .sort((first, second) => first.depth - second.depth)
         .forEach((node) => {
-        const depthPresence = 0.28 + node.depth * 0.9;
+        const depthPresence = 0.36 + node.depth * 0.82;
         const radius =
           (0.42 + node.depth * 2.75) * node.emphasis + node.influence * 2.1;
         const alpha =

--- a/app/home-interactive-node-field.tsx
+++ b/app/home-interactive-node-field.tsx
@@ -2,14 +2,24 @@
 
 import { useEffect, useRef } from "react";
 
-const NODE_COUNT = 96;
-const PLACEMENT_CANDIDATES = 36;
+const NODE_COUNT = 156;
+const CLUSTERED_NODE_COUNT = 112;
+const CLUSTER_COUNT = 5;
+const PLACEMENT_CANDIDATES = 28;
+const WORLD_PADDING_X = 0.18;
+const WORLD_PADDING_Y = 0.2;
 const ACTIVATION_RADIUS = 340;
 const MAX_ATTRACTION = 22;
+const MAX_PARALLAX = 30;
 
 type Point = { x: number; y: number };
-type NodePoint = Point & { emphasis: number };
+type NodePoint = Point & {
+  cluster: number | null;
+  depth: number;
+  emphasis: number;
+};
 type Link = {
+  depth: number;
   from: number;
   to: number;
   strength: number;
@@ -36,16 +46,60 @@ function createNodeField(seed: number) {
     return ((value ^ (value >>> 14)) >>> 0) / 4_294_967_296;
   };
 
-  const nodes: NodePoint[] = [];
+  const clusterAnchors = Array.from({ length: CLUSTER_COUNT }, (_, index) => {
+    const edgeAnchors = [
+      { x: -0.03 - random() * 0.06, y: 0.12 + random() * 0.36 },
+      { x: 1.03 + random() * 0.06, y: 0.5 + random() * 0.34 },
+      { x: 0.52 + random() * 0.3, y: 1.03 + random() * 0.07 },
+      { x: 0.4 + random() * 0.2, y: 0.3 + random() * 0.3 },
+    ];
+    const position = edgeAnchors[index] ?? {
+      x: 0.12 + random() * 0.76,
+      y: 0.12 + random() * 0.76,
+    };
+
+    return {
+      ...position,
+      depth: 0.18 + random() * 0.76,
+      radiusX: 0.1 + random() * 0.09,
+      radiusY: 0.11 + random() * 0.1,
+    };
+  });
+
+  const nodes: NodePoint[] = Array.from(
+    { length: CLUSTERED_NODE_COUNT },
+    (_, index) => {
+      const cluster = index % CLUSTER_COUNT;
+      const anchor = clusterAnchors[cluster];
+      const angle = random() * Math.PI * 2;
+      const radius = Math.pow(random(), 0.68);
+      const depth = Math.max(
+        0.04,
+        Math.min(0.98, anchor.depth + (random() - 0.5) * 0.34)
+      );
+
+      return {
+        x: anchor.x + Math.cos(angle) * anchor.radiusX * radius,
+        y: anchor.y + Math.sin(angle) * anchor.radiusY * radius,
+        cluster,
+        depth,
+        emphasis: 0.82 + depth * 0.44 + Math.pow(random(), 1.8) * 0.5,
+      };
+    }
+  );
+
   while (nodes.length < NODE_COUNT) {
     let bestCandidate: NodePoint | null = null;
     let bestClearance = -1;
 
     for (let attempt = 0; attempt < PLACEMENT_CANDIDATES; attempt += 1) {
+      const depth = 0.04 + random() * 0.94;
       const candidate = {
-        x: 0.025 + random() * 0.95,
-        y: 0.04 + random() * 0.92,
-        emphasis: 0.92 + Math.pow(random(), 1.65) * 0.68,
+        x: -WORLD_PADDING_X + random() * (1 + WORLD_PADDING_X * 2),
+        y: -WORLD_PADDING_Y + random() * (1 + WORLD_PADDING_Y * 2),
+        cluster: null,
+        depth,
+        emphasis: 0.82 + depth * 0.44 + Math.pow(random(), 1.8) * 0.5,
       };
       const clearance = nodes.reduce(
         (nearest, node) =>
@@ -53,7 +107,8 @@ function createNodeField(seed: number) {
             nearest,
             Math.hypot(
               (candidate.x - node.x) * 1.4,
-              candidate.y - node.y
+              candidate.y - node.y,
+              (candidate.depth - node.depth) * 0.38
             )
           ),
         Number.POSITIVE_INFINITY
@@ -79,19 +134,32 @@ function createNodeField(seed: number) {
 
     const first = nodes[from];
     const second = nodes[to];
-    const distance = Math.hypot(second.x - first.x, second.y - first.y);
-    const closeness = 1 - Math.min(1, distance / 0.19);
+    const distance = Math.hypot(
+      (second.x - first.x) * 1.4,
+      second.y - first.y,
+      (second.depth - first.depth) * 0.38
+    );
+    const closeness = 1 - Math.min(1, distance / 0.27);
     const cellAffinity =
-      ((first.emphasis + second.emphasis) / 2 - 0.92) / 0.68;
+      ((first.emphasis + second.emphasis) / 2 - 0.82) / 0.94;
+    const sharedNeighborhood =
+      first.cluster !== null && first.cluster === second.cluster ? 1 : 0;
+    const depth = (first.depth + second.depth) / 2;
 
     links.push({
+      depth,
       from,
       to,
       strength: Math.min(
-        0.98,
-        0.14 + random() * 0.46 + closeness * 0.2 + cellAffinity * 0.18
+        1,
+        0.08 +
+          random() * 0.34 +
+          closeness * 0.18 +
+          cellAffinity * 0.12 +
+          sharedNeighborhood * 0.2 +
+          depth * 0.14
       ),
-      bend: (random() * 2 - 1) * (0.35 + random() * 0.35),
+      bend: (random() * 2 - 1) * (0.32 + random() * 0.5),
     });
   };
 
@@ -101,16 +169,27 @@ function createNodeField(seed: number) {
         to,
         distance: Math.hypot(
           (candidate.x - node.x) * 1.4,
-          candidate.y - node.y
+          candidate.y - node.y,
+          (candidate.depth - node.depth) * 0.38
         ),
       }))
       .filter(({ to }) => to !== from)
       .sort((left, right) => left.distance - right.distance)
-      .slice(0, random() < 0.48 ? 4 : 3);
+      .slice(
+        0,
+        node.cluster !== null
+          ? random() < 0.52
+            ? 6
+            : 5
+          : random() < 0.42
+            ? 4
+            : 3
+      );
 
     neighbors.forEach(({ to }) => connect(from, to));
   });
 
+  links.sort((first, second) => first.depth - second.depth);
   return { nodes, links };
 }
 
@@ -139,8 +218,9 @@ export function HomeInteractiveNodeField() {
     canvas.dataset.strongLinks = String(
       nodeField.links.filter((link) => link.strength >= 0.72).length
     );
-    canvas.dataset.layout = "balanced-neural";
+    canvas.dataset.layout = "neural-volume";
     canvas.dataset.strengthModel = "continuous";
+    canvas.dataset.depthModel = "perspective";
 
     const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
     const desktop = window.matchMedia("(min-width: 1024px)");
@@ -196,10 +276,17 @@ export function HomeInteractiveNodeField() {
       context.setTransform(ratio, 0, 0, ratio, 0, 0);
     };
 
-    const resolveNodes = () =>
-      nodeField.nodes.map((node) => {
-        const baseX = node.x * width;
-        const baseY = node.y * height;
+    const resolveNodes = () => {
+      const cameraX = ((pointer.x / width) * 2 - 1) * activity;
+      const cameraY = ((pointer.y / height) * 2 - 1) * activity;
+
+      return nodeField.nodes.map((node) => {
+        const perspective = 0.78 + node.depth * 0.42;
+        const projectedX = 0.5 + (node.x - 0.5) * perspective;
+        const projectedY = 0.5 + (node.y - 0.5) * perspective;
+        const parallax = node.depth * MAX_PARALLAX;
+        const baseX = projectedX * width - cameraX * parallax;
+        const baseY = projectedY * height - cameraY * parallax;
         const distance = Math.hypot(pointer.x - baseX, pointer.y - baseY);
         const influence = proximityInfluence(distance) * activity;
         const directionX = distance > 0 ? (pointer.x - baseX) / distance : 0;
@@ -210,9 +297,11 @@ export function HomeInteractiveNodeField() {
           x: baseX + directionX * attraction,
           y: baseY + directionY * attraction,
           influence,
+          depth: node.depth,
           emphasis: node.emphasis,
         };
       });
+    };
 
     const draw = () => {
       frame = null;
@@ -225,6 +314,12 @@ export function HomeInteractiveNodeField() {
       context.clearRect(0, 0, width, height);
       const palette = colors();
       const resolvedNodes = resolveNodes();
+      canvas.dataset.offscreenNodes = String(
+        resolvedNodes.filter(
+          (node) =>
+            node.x < 0 || node.x > width || node.y < 0 || node.y > height
+        ).length
+      );
 
       if (activity > 0.01) {
         const halo = context.createRadialGradient(
@@ -265,35 +360,67 @@ export function HomeInteractiveNodeField() {
           Math.max(from.influence, to.influence) * 0.62 +
           midpointInfluence * 0.38;
         const alpha =
-          palette.baseLinkAlpha +
-          link.strength * palette.strongLinkAlpha +
-          influence * palette.activeLinkAlpha;
+          palette.baseLinkAlpha * (0.22 + link.depth * 0.92) +
+          link.strength * palette.strongLinkAlpha * (0.3 + link.depth * 0.9) +
+          influence * palette.activeLinkAlpha * (0.62 + link.depth * 0.48);
+        const depthGradient = context.createLinearGradient(
+          from.x,
+          from.y,
+          to.x,
+          to.y
+        );
+        depthGradient.addColorStop(
+          0,
+          `rgba(${palette.link}, ${Math.min(
+            0.94,
+            alpha * (0.42 + from.depth * 0.72)
+          )})`
+        );
+        depthGradient.addColorStop(
+          1,
+          `rgba(${palette.link}, ${Math.min(
+            0.94,
+            alpha * (0.42 + to.depth * 0.72)
+          )})`
+        );
         context.beginPath();
         context.moveTo(from.x, from.y);
         context.quadraticCurveTo(controlX, controlY, to.x, to.y);
         context.lineCap = "round";
         context.lineWidth =
-          0.58 + link.strength * 1.45 + influence * (0.78 + link.strength * 0.58);
-        context.strokeStyle = `rgba(${palette.link}, ${Math.min(0.94, alpha)})`;
+          (0.22 + link.strength * 2.4) * (0.38 + link.depth * 1.22) +
+          influence * (0.7 + link.strength * 0.9);
+        context.strokeStyle = depthGradient;
         context.stroke();
       });
 
-      resolvedNodes.forEach((node) => {
-        const radius = 1.35 * node.emphasis + node.influence * 1.9;
+      resolvedNodes
+        .map((node, index) => ({ ...node, index }))
+        .sort((first, second) => first.depth - second.depth)
+        .forEach((node) => {
+        const depthPresence = 0.28 + node.depth * 0.9;
+        const radius =
+          (0.42 + node.depth * 2.75) * node.emphasis + node.influence * 2.1;
         const alpha =
-          palette.baseNodeAlpha + node.influence * palette.activeNodeAlpha;
+          palette.baseNodeAlpha * depthPresence +
+          node.influence * palette.activeNodeAlpha * (0.72 + node.depth * 0.38);
+        context.shadowColor = `rgba(${palette.node}, ${
+          node.depth * 0.16 + node.influence * 0.22
+        })`;
+        context.shadowBlur = node.depth * 8 + node.influence * 7;
         context.beginPath();
         context.arc(node.x, node.y, radius, 0, Math.PI * 2);
         context.fillStyle = `rgba(${palette.node}, ${alpha})`;
         context.fill();
+        context.shadowBlur = 0;
 
         const membraneAlpha =
-          0.025 + (node.emphasis - 0.92) * 0.07 + node.influence * 0.16;
+          0.012 + node.depth * 0.065 + node.influence * 0.17;
         context.beginPath();
         context.arc(
           node.x,
           node.y,
-          radius + 2.2 + node.emphasis * 0.7,
+          radius + 1.5 + node.depth * 2.7,
           0,
           Math.PI * 2
         );

--- a/app/home-interactive-node-field.tsx
+++ b/app/home-interactive-node-field.tsx
@@ -3,25 +3,73 @@
 import { useEffect, useRef } from "react";
 
 const NODE_COUNT = 54;
-const ACTIVATION_RADIUS = 240;
-const MAX_ATTRACTION = 18;
+const ACTIVATION_RADIUS = 340;
+const MAX_ATTRACTION = 22;
+const MIN_NODE_DISTANCE = 0.072;
 
 type Point = { x: number; y: number };
 type NodePoint = Point & { emphasis: number };
-type Link = { from: number; to: number; weight: number };
+type Link = {
+  from: number;
+  to: number;
+  prominence: number;
+  weight: number;
+};
 
-function createNodeField() {
-  let seed = 129;
+function createRandomSeed() {
+  try {
+    const seed = new Uint32Array(1);
+    window.crypto.getRandomValues(seed);
+    return seed[0] || Date.now();
+  } catch {
+    return Math.floor(Math.random() * 4_294_967_295) || Date.now();
+  }
+}
+
+function createNodeField(seed: number) {
+  let state = seed >>> 0;
   const random = () => {
-    seed = (seed * 16807) % 2147483647;
-    return (seed - 1) / 2147483646;
+    state += 0x6d2b79f5;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4_294_967_296;
   };
 
-  const nodes = Array.from({ length: NODE_COUNT }, (_, index): NodePoint => ({
-    x: 0.025 + random() * 0.95,
-    y: 0.04 + random() * 0.92,
-    emphasis: index % 11 === 0 ? 1.45 : index % 5 === 0 ? 1.2 : 1,
-  }));
+  const nodes: NodePoint[] = [];
+  while (nodes.length < NODE_COUNT) {
+    let candidate: NodePoint | null = null;
+
+    for (let attempt = 0; attempt < 120; attempt += 1) {
+      const emphasisRoll = random();
+      const proposed = {
+        x: 0.025 + random() * 0.95,
+        y: 0.04 + random() * 0.92,
+        emphasis: emphasisRoll < 0.12 ? 1.5 : emphasisRoll < 0.32 ? 1.2 : 1,
+      };
+      const relaxedDistance = MIN_NODE_DISTANCE * (attempt > 80 ? 0.72 : 1);
+      const clearsNeighbors = nodes.every((node) =>
+        Math.hypot(
+          (proposed.x - node.x) * 1.15,
+          proposed.y - node.y
+        ) > relaxedDistance
+      );
+
+      if (clearsNeighbors) {
+        candidate = proposed;
+        break;
+      }
+    }
+
+    nodes.push(
+      candidate ?? {
+        x: 0.025 + random() * 0.95,
+        y: 0.04 + random() * 0.92,
+        emphasis: 1,
+      }
+    );
+  }
+
   const linkKeys = new Set<string>();
   const links: Link[] = [];
 
@@ -33,17 +81,24 @@ function createNodeField() {
       }))
       .filter(({ to }) => to !== from)
       .sort((a, b) => a.distance - b.distance)
-      .slice(0, from % 4 === 0 ? 3 : 2);
+      .slice(0, random() < 0.28 ? 3 : 2);
 
     neighbors.forEach(({ to }) => {
       const key = [from, to].sort((a, b) => a - b).join(":");
       if (linkKeys.has(key)) return;
       linkKeys.add(key);
+      const prominenceRoll = random();
+      const prominence =
+        links.length % 7 === 0 || prominenceRoll < 0.12
+          ? 1
+          : prominenceRoll < 0.42
+            ? 0.45
+            : 0;
       links.push({
         from,
         to,
-        weight:
-          (from + to) % 9 === 0 ? 2.4 : (from + to) % 4 === 0 ? 1.45 : 0.8,
+        prominence,
+        weight: 0.75 + prominence * 1.65,
       });
     });
   });
@@ -51,7 +106,14 @@ function createNodeField() {
   return { nodes, links };
 }
 
-const nodeField = createNodeField();
+function smootherStep(progress: number) {
+  const value = Math.max(0, Math.min(1, progress));
+  return value * value * value * (value * (value * 6 - 15) + 10);
+}
+
+function proximityInfluence(distance: number) {
+  return 1 - smootherStep(distance / ACTIVATION_RADIUS);
+}
 
 export function HomeInteractiveNodeField() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -60,6 +122,13 @@ export function HomeInteractiveNodeField() {
     const canvas = canvasRef.current;
     const context = canvas?.getContext("2d");
     if (!canvas || !context) return;
+
+    const seed = createRandomSeed();
+    const nodeField = createNodeField(seed);
+    canvas.dataset.constellationSeed = String(seed);
+    canvas.dataset.strongLinks = String(
+      nodeField.links.filter((link) => link.prominence === 1).length
+    );
 
     const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
     const desktop = window.matchMedia("(min-width: 1024px)");
@@ -79,16 +148,28 @@ export function HomeInteractiveNodeField() {
       const dark = document.documentElement.classList.contains("dark");
       return dark
         ? {
-            haloInner: "rgba(59, 130, 246, 0.18)",
-            haloOuter: "rgba(79, 70, 229, 0)",
+            haloInner: "rgba(59, 130, 246, 0.2)",
+            haloMiddle: "rgba(79, 70, 229, 0.085)",
+            haloEdge: "rgba(79, 70, 229, 0.018)",
             link: "129, 140, 248",
             node: "147, 197, 253",
+            baseLinkAlpha: 0.075,
+            activeLinkAlpha: 0.48,
+            strongLinkAlpha: 0.085,
+            baseNodeAlpha: 0.24,
+            activeNodeAlpha: 0.7,
           }
         : {
-            haloInner: "rgba(37, 99, 235, 0.13)",
-            haloOuter: "rgba(99, 102, 241, 0)",
-            link: "37, 99, 235",
-            node: "29, 78, 216",
+            haloInner: "rgba(37, 99, 235, 0.18)",
+            haloMiddle: "rgba(79, 70, 229, 0.075)",
+            haloEdge: "rgba(99, 102, 241, 0.018)",
+            link: "29, 78, 216",
+            node: "30, 64, 175",
+            baseLinkAlpha: 0.105,
+            activeLinkAlpha: 0.56,
+            strongLinkAlpha: 0.12,
+            baseNodeAlpha: 0.31,
+            activeNodeAlpha: 0.66,
           };
     };
 
@@ -108,11 +189,10 @@ export function HomeInteractiveNodeField() {
         const baseX = node.x * width;
         const baseY = node.y * height;
         const distance = Math.hypot(pointer.x - baseX, pointer.y - baseY);
-        const influence =
-          Math.max(0, 1 - distance / ACTIVATION_RADIUS) * activity;
+        const influence = proximityInfluence(distance) * activity;
         const directionX = distance > 0 ? (pointer.x - baseX) / distance : 0;
         const directionY = distance > 0 ? (pointer.y - baseY) / distance : 0;
-        const attraction = influence * influence * MAX_ATTRACTION;
+        const attraction = Math.pow(influence, 1.35) * MAX_ATTRACTION;
 
         return {
           x: baseX + directionX * attraction,
@@ -141,10 +221,12 @@ export function HomeInteractiveNodeField() {
           0,
           pointer.x,
           pointer.y,
-          ACTIVATION_RADIUS * 1.35
+          ACTIVATION_RADIUS * 1.12
         );
         halo.addColorStop(0, palette.haloInner);
-        halo.addColorStop(1, palette.haloOuter);
+        halo.addColorStop(0.38, palette.haloMiddle);
+        halo.addColorStop(0.76, palette.haloEdge);
+        halo.addColorStop(1, "rgba(99, 102, 241, 0)");
         context.fillStyle = halo;
         context.fillRect(0, 0, width, height);
       }
@@ -152,19 +234,30 @@ export function HomeInteractiveNodeField() {
       nodeField.links.forEach((link) => {
         const from = resolvedNodes[link.from];
         const to = resolvedNodes[link.to];
-        const influence = Math.max(from.influence, to.influence);
-        const alpha = 0.095 + influence * 0.5;
+        const midpointDistance = Math.hypot(
+          pointer.x - (from.x + to.x) / 2,
+          pointer.y - (from.y + to.y) / 2
+        );
+        const midpointInfluence = proximityInfluence(midpointDistance) * activity;
+        const influence =
+          Math.max(from.influence, to.influence) * 0.62 +
+          midpointInfluence * 0.38;
+        const alpha =
+          palette.baseLinkAlpha +
+          link.prominence * palette.strongLinkAlpha +
+          influence * palette.activeLinkAlpha;
         context.beginPath();
         context.moveTo(from.x, from.y);
         context.lineTo(to.x, to.y);
-        context.lineWidth = link.weight + influence * 0.75;
+        context.lineWidth = link.weight + influence * (0.85 + link.prominence * 0.45);
         context.strokeStyle = `rgba(${palette.link}, ${alpha})`;
         context.stroke();
       });
 
       resolvedNodes.forEach((node) => {
         const radius = 1.35 * node.emphasis + node.influence * 1.9;
-        const alpha = 0.24 + node.influence * 0.7;
+        const alpha =
+          palette.baseNodeAlpha + node.influence * palette.activeNodeAlpha;
         context.beginPath();
         context.arc(node.x, node.y, radius, 0, Math.PI * 2);
         context.fillStyle = `rgba(${palette.node}, ${alpha})`;

--- a/app/home-interactive-node-field.tsx
+++ b/app/home-interactive-node-field.tsx
@@ -3,17 +3,17 @@
 import { useEffect, useRef } from "react";
 
 const NODE_COUNT = 96;
+const PLACEMENT_CANDIDATES = 36;
 const ACTIVATION_RADIUS = 340;
 const MAX_ATTRACTION = 22;
-const MIN_NODE_DISTANCE = 0.048;
 
 type Point = { x: number; y: number };
 type NodePoint = Point & { emphasis: number };
 type Link = {
   from: number;
   to: number;
-  prominence: number;
-  weight: number;
+  strength: number;
+  bend: number;
 };
 
 function createRandomSeed() {
@@ -38,69 +38,77 @@ function createNodeField(seed: number) {
 
   const nodes: NodePoint[] = [];
   while (nodes.length < NODE_COUNT) {
-    let candidate: NodePoint | null = null;
+    let bestCandidate: NodePoint | null = null;
+    let bestClearance = -1;
 
-    for (let attempt = 0; attempt < 120; attempt += 1) {
-      const emphasisRoll = random();
-      const proposed = {
+    for (let attempt = 0; attempt < PLACEMENT_CANDIDATES; attempt += 1) {
+      const candidate = {
         x: 0.025 + random() * 0.95,
         y: 0.04 + random() * 0.92,
-        emphasis: emphasisRoll < 0.12 ? 1.5 : emphasisRoll < 0.32 ? 1.2 : 1,
+        emphasis: 0.92 + Math.pow(random(), 1.65) * 0.68,
       };
-      const relaxedDistance = MIN_NODE_DISTANCE * (attempt > 80 ? 0.72 : 1);
-      const clearsNeighbors = nodes.every((node) =>
-        Math.hypot(
-          (proposed.x - node.x) * 1.15,
-          proposed.y - node.y
-        ) > relaxedDistance
+      const clearance = nodes.reduce(
+        (nearest, node) =>
+          Math.min(
+            nearest,
+            Math.hypot(
+              (candidate.x - node.x) * 1.4,
+              candidate.y - node.y
+            )
+          ),
+        Number.POSITIVE_INFINITY
       );
 
-      if (clearsNeighbors) {
-        candidate = proposed;
-        break;
+      if (clearance > bestClearance) {
+        bestCandidate = candidate;
+        bestClearance = clearance;
       }
     }
 
-    nodes.push(
-      candidate ?? {
-        x: 0.025 + random() * 0.95,
-        y: 0.04 + random() * 0.92,
-        emphasis: 1,
-      }
-    );
+    if (bestCandidate) nodes.push(bestCandidate);
   }
 
   const linkKeys = new Set<string>();
   const links: Link[] = [];
 
+  const connect = (from: number, to: number) => {
+    if (to < 0 || to >= nodes.length || from === to) return;
+    const key = [from, to].sort((a, b) => a - b).join(":");
+    if (linkKeys.has(key)) return;
+    linkKeys.add(key);
+
+    const first = nodes[from];
+    const second = nodes[to];
+    const distance = Math.hypot(second.x - first.x, second.y - first.y);
+    const closeness = 1 - Math.min(1, distance / 0.19);
+    const cellAffinity =
+      ((first.emphasis + second.emphasis) / 2 - 0.92) / 0.68;
+
+    links.push({
+      from,
+      to,
+      strength: Math.min(
+        0.98,
+        0.14 + random() * 0.46 + closeness * 0.2 + cellAffinity * 0.18
+      ),
+      bend: (random() * 2 - 1) * (0.35 + random() * 0.35),
+    });
+  };
+
   nodes.forEach((node, from) => {
     const neighbors = nodes
       .map((candidate, to) => ({
         to,
-        distance: Math.hypot(candidate.x - node.x, candidate.y - node.y),
+        distance: Math.hypot(
+          (candidate.x - node.x) * 1.4,
+          candidate.y - node.y
+        ),
       }))
       .filter(({ to }) => to !== from)
-      .sort((a, b) => a.distance - b.distance)
-      .slice(0, random() < 0.55 ? 5 : 4);
+      .sort((left, right) => left.distance - right.distance)
+      .slice(0, random() < 0.48 ? 4 : 3);
 
-    neighbors.forEach(({ to }) => {
-      const key = [from, to].sort((a, b) => a - b).join(":");
-      if (linkKeys.has(key)) return;
-      linkKeys.add(key);
-      const prominenceRoll = random();
-      const prominence =
-        links.length % 7 === 0 || prominenceRoll < 0.12
-          ? 1
-          : prominenceRoll < 0.42
-            ? 0.45
-            : 0;
-      links.push({
-        from,
-        to,
-        prominence,
-        weight: 0.75 + prominence * 1.65,
-      });
-    });
+    neighbors.forEach(({ to }) => connect(from, to));
   });
 
   return { nodes, links };
@@ -129,8 +137,10 @@ export function HomeInteractiveNodeField() {
     canvas.dataset.nodeCount = String(nodeField.nodes.length);
     canvas.dataset.linkCount = String(nodeField.links.length);
     canvas.dataset.strongLinks = String(
-      nodeField.links.filter((link) => link.prominence === 1).length
+      nodeField.links.filter((link) => link.strength >= 0.72).length
     );
+    canvas.dataset.layout = "balanced-neural";
+    canvas.dataset.strengthModel = "continuous";
 
     const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
     const desktop = window.matchMedia("(min-width: 1024px)");
@@ -236,9 +246,19 @@ export function HomeInteractiveNodeField() {
       nodeField.links.forEach((link) => {
         const from = resolvedNodes[link.from];
         const to = resolvedNodes[link.to];
+        const deltaX = to.x - from.x;
+        const deltaY = to.y - from.y;
+        const linkLength = Math.hypot(deltaX, deltaY);
+        const bendAmount = Math.min(linkLength * 0.16, 22) * link.bend;
+        const controlX =
+          (from.x + to.x) / 2 -
+          (linkLength > 0 ? deltaY / linkLength : 0) * bendAmount;
+        const controlY =
+          (from.y + to.y) / 2 +
+          (linkLength > 0 ? deltaX / linkLength : 0) * bendAmount;
         const midpointDistance = Math.hypot(
-          pointer.x - (from.x + to.x) / 2,
-          pointer.y - (from.y + to.y) / 2
+          pointer.x - controlX,
+          pointer.y - controlY
         );
         const midpointInfluence = proximityInfluence(midpointDistance) * activity;
         const influence =
@@ -246,13 +266,15 @@ export function HomeInteractiveNodeField() {
           midpointInfluence * 0.38;
         const alpha =
           palette.baseLinkAlpha +
-          link.prominence * palette.strongLinkAlpha +
+          link.strength * palette.strongLinkAlpha +
           influence * palette.activeLinkAlpha;
         context.beginPath();
         context.moveTo(from.x, from.y);
-        context.lineTo(to.x, to.y);
-        context.lineWidth = link.weight + influence * (0.85 + link.prominence * 0.45);
-        context.strokeStyle = `rgba(${palette.link}, ${alpha})`;
+        context.quadraticCurveTo(controlX, controlY, to.x, to.y);
+        context.lineCap = "round";
+        context.lineWidth =
+          0.58 + link.strength * 1.45 + influence * (0.78 + link.strength * 0.58);
+        context.strokeStyle = `rgba(${palette.link}, ${Math.min(0.94, alpha)})`;
         context.stroke();
       });
 
@@ -264,6 +286,20 @@ export function HomeInteractiveNodeField() {
         context.arc(node.x, node.y, radius, 0, Math.PI * 2);
         context.fillStyle = `rgba(${palette.node}, ${alpha})`;
         context.fill();
+
+        const membraneAlpha =
+          0.025 + (node.emphasis - 0.92) * 0.07 + node.influence * 0.16;
+        context.beginPath();
+        context.arc(
+          node.x,
+          node.y,
+          radius + 2.2 + node.emphasis * 0.7,
+          0,
+          Math.PI * 2
+        );
+        context.strokeStyle = `rgba(${palette.node}, ${membraneAlpha})`;
+        context.lineWidth = 0.7 + node.influence * 0.45;
+        context.stroke();
 
         if (node.influence > 0.2) {
           context.beginPath();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -40,6 +40,7 @@ import {
 } from "./home-signup-live-feedback";
 import { HomeAuthModeToggleLink } from "./home-auth-mode-toggle-link";
 import { HomeAuthMethods } from "./home-auth-methods";
+import { HomeInteractiveNodeField } from "./home-interactive-node-field";
 
 const outcomes = [
   "Bring teammates into the same live project workspace",
@@ -455,10 +456,7 @@ export default async function Home({
 
   return (
     <main className="relative isolate grid min-h-dvh overflow-hidden bg-background lg:grid-cols-[minmax(0,1fr)_minmax(520px,0.86fr)]">
-      <div
-        className="home-entry-color-field pointer-events-none absolute hidden lg:block"
-        aria-hidden="true"
-      />
+      <HomeInteractiveNodeField />
       <ProductPanel />
 
       <section className="relative z-10 flex min-h-dvh items-start justify-center px-4 pb-8 pt-20 sm:items-center sm:px-8 sm:py-20 lg:px-12">

--- a/tests/e2e/home-entry.spec.ts
+++ b/tests/e2e/home-entry.spec.ts
@@ -110,8 +110,13 @@ test.describe("unauthenticated home entry", () => {
     await expect(nodeField).toHaveAttribute("data-active", "false");
     await expect(nodeField).toHaveAttribute("data-constellation-seed", /\d+/);
     await expect(nodeField).toHaveAttribute("data-node-count", "96");
+    await expect(nodeField).toHaveAttribute("data-layout", "balanced-neural");
+    await expect(nodeField).toHaveAttribute(
+      "data-strength-model",
+      "continuous"
+    );
     const linkCount = Number(await nodeField.getAttribute("data-link-count"));
-    expect(linkCount).toBeGreaterThan(235);
+    expect(linkCount).toBeGreaterThan(180);
     const firstSeed = await nodeField.getAttribute("data-constellation-seed");
     const strongLinkCount = Number(
       await nodeField.getAttribute("data-strong-links")
@@ -123,7 +128,8 @@ test.describe("unauthenticated home entry", () => {
       .poll(() => nodeField.getAttribute("data-constellation-seed"))
       .not.toBe(firstSeed);
 
-    await page.mouse.move(720, 500);
+    await page.mouse.move(180, 180);
+    await page.mouse.move(720, 500, { steps: 8 });
     await expect(nodeField).toHaveAttribute("data-active", "true");
 
     await page.emulateMedia({ reducedMotion: "reduce" });

--- a/tests/e2e/home-entry.spec.ts
+++ b/tests/e2e/home-entry.spec.ts
@@ -109,19 +109,24 @@ test.describe("unauthenticated home entry", () => {
     await expect(nodeField).toBeVisible();
     await expect(nodeField).toHaveAttribute("data-active", "false");
     await expect(nodeField).toHaveAttribute("data-constellation-seed", /\d+/);
-    await expect(nodeField).toHaveAttribute("data-node-count", "96");
-    await expect(nodeField).toHaveAttribute("data-layout", "balanced-neural");
+    await expect(nodeField).toHaveAttribute("data-node-count", "156");
+    await expect(nodeField).toHaveAttribute("data-layout", "neural-volume");
+    await expect(nodeField).toHaveAttribute("data-depth-model", "perspective");
     await expect(nodeField).toHaveAttribute(
       "data-strength-model",
       "continuous"
     );
     const linkCount = Number(await nodeField.getAttribute("data-link-count"));
-    expect(linkCount).toBeGreaterThan(180);
+    expect(linkCount).toBeGreaterThan(350);
     const firstSeed = await nodeField.getAttribute("data-constellation-seed");
     const strongLinkCount = Number(
       await nodeField.getAttribute("data-strong-links")
     );
     expect(strongLinkCount).toBeGreaterThan(0);
+    const offscreenNodeCount = Number(
+      await nodeField.getAttribute("data-offscreen-nodes")
+    );
+    expect(offscreenNodeCount).toBeGreaterThan(0);
 
     await page.reload();
     await expect

--- a/tests/e2e/home-entry.spec.ts
+++ b/tests/e2e/home-entry.spec.ts
@@ -109,16 +109,18 @@ test.describe("unauthenticated home entry", () => {
     await expect(nodeField).toBeVisible();
     await expect(nodeField).toHaveAttribute("data-active", "false");
     await expect(nodeField).toHaveAttribute("data-constellation-seed", /\d+/);
-    await expect(nodeField).toHaveAttribute("data-node-count", "208");
-    await expect(nodeField).toHaveAttribute("data-ambient-nodes", "96");
+    await expect(nodeField).toHaveAttribute("data-node-count", "260");
+    await expect(nodeField).toHaveAttribute("data-ambient-nodes", "148");
+    await expect(nodeField).toHaveAttribute("data-viewport-tissue-nodes", "104");
     await expect(nodeField).toHaveAttribute("data-layout", "neural-volume");
     await expect(nodeField).toHaveAttribute("data-depth-model", "perspective");
+    await expect(nodeField).toHaveAttribute("data-depth-anchors", "5");
     await expect(nodeField).toHaveAttribute(
       "data-strength-model",
       "continuous"
     );
     const linkCount = Number(await nodeField.getAttribute("data-link-count"));
-    expect(linkCount).toBeGreaterThan(600);
+    expect(linkCount).toBeGreaterThan(780);
     const firstSeed = await nodeField.getAttribute("data-constellation-seed");
     const strongLinkCount = Number(
       await nodeField.getAttribute("data-strong-links")

--- a/tests/e2e/home-entry.spec.ts
+++ b/tests/e2e/home-entry.spec.ts
@@ -109,6 +109,9 @@ test.describe("unauthenticated home entry", () => {
     await expect(nodeField).toBeVisible();
     await expect(nodeField).toHaveAttribute("data-active", "false");
     await expect(nodeField).toHaveAttribute("data-constellation-seed", /\d+/);
+    await expect(nodeField).toHaveAttribute("data-node-count", "64");
+    const linkCount = Number(await nodeField.getAttribute("data-link-count"));
+    expect(linkCount).toBeGreaterThan(90);
     const firstSeed = await nodeField.getAttribute("data-constellation-seed");
     const strongLinkCount = Number(
       await nodeField.getAttribute("data-strong-links")

--- a/tests/e2e/home-entry.spec.ts
+++ b/tests/e2e/home-entry.spec.ts
@@ -108,6 +108,17 @@ test.describe("unauthenticated home entry", () => {
     const nodeField = page.locator(".home-interactive-node-field");
     await expect(nodeField).toBeVisible();
     await expect(nodeField).toHaveAttribute("data-active", "false");
+    await expect(nodeField).toHaveAttribute("data-constellation-seed", /\d+/);
+    const firstSeed = await nodeField.getAttribute("data-constellation-seed");
+    const strongLinkCount = Number(
+      await nodeField.getAttribute("data-strong-links")
+    );
+    expect(strongLinkCount).toBeGreaterThan(0);
+
+    await page.reload();
+    await expect
+      .poll(() => nodeField.getAttribute("data-constellation-seed"))
+      .not.toBe(firstSeed);
 
     await page.mouse.move(720, 500);
     await expect(nodeField).toHaveAttribute("data-active", "true");

--- a/tests/e2e/home-entry.spec.ts
+++ b/tests/e2e/home-entry.spec.ts
@@ -109,9 +109,9 @@ test.describe("unauthenticated home entry", () => {
     await expect(nodeField).toBeVisible();
     await expect(nodeField).toHaveAttribute("data-active", "false");
     await expect(nodeField).toHaveAttribute("data-constellation-seed", /\d+/);
-    await expect(nodeField).toHaveAttribute("data-node-count", "64");
+    await expect(nodeField).toHaveAttribute("data-node-count", "96");
     const linkCount = Number(await nodeField.getAttribute("data-link-count"));
-    expect(linkCount).toBeGreaterThan(90);
+    expect(linkCount).toBeGreaterThan(235);
     const firstSeed = await nodeField.getAttribute("data-constellation-seed");
     const strongLinkCount = Number(
       await nodeField.getAttribute("data-strong-links")

--- a/tests/e2e/home-entry.spec.ts
+++ b/tests/e2e/home-entry.spec.ts
@@ -109,7 +109,8 @@ test.describe("unauthenticated home entry", () => {
     await expect(nodeField).toBeVisible();
     await expect(nodeField).toHaveAttribute("data-active", "false");
     await expect(nodeField).toHaveAttribute("data-constellation-seed", /\d+/);
-    await expect(nodeField).toHaveAttribute("data-node-count", "156");
+    await expect(nodeField).toHaveAttribute("data-node-count", "208");
+    await expect(nodeField).toHaveAttribute("data-ambient-nodes", "96");
     await expect(nodeField).toHaveAttribute("data-layout", "neural-volume");
     await expect(nodeField).toHaveAttribute("data-depth-model", "perspective");
     await expect(nodeField).toHaveAttribute(
@@ -117,7 +118,7 @@ test.describe("unauthenticated home entry", () => {
       "continuous"
     );
     const linkCount = Number(await nodeField.getAttribute("data-link-count"));
-    expect(linkCount).toBeGreaterThan(350);
+    expect(linkCount).toBeGreaterThan(600);
     const firstSeed = await nodeField.getAttribute("data-constellation-seed");
     const strongLinkCount = Number(
       await nodeField.getAttribute("data-strong-links")

--- a/tests/e2e/home-entry.spec.ts
+++ b/tests/e2e/home-entry.spec.ts
@@ -98,4 +98,24 @@ test.describe("unauthenticated home entry", () => {
       page.getByRole("button", { name: "Switch to light mode" })
     ).toBeVisible();
   });
+
+  test("highlights and attracts the connected node field around a precise pointer", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 1000 });
+    await page.goto("/");
+
+    const nodeField = page.locator(".home-interactive-node-field");
+    await expect(nodeField).toBeVisible();
+    await expect(nodeField).toHaveAttribute("data-active", "false");
+
+    await page.mouse.move(720, 500);
+    await expect(nodeField).toHaveAttribute("data-active", "true");
+
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.reload();
+    await expect(nodeField).toHaveAttribute("data-interactive", "false");
+    await page.mouse.move(240, 240);
+    await expect(nodeField).toHaveAttribute("data-active", "false");
+  });
 });


### PR DESCRIPTION
## Comparison purpose

Preview-only interaction experiment stacked on PR #368. Please do not merge until a background direction is selected.

## What changed

- Generates a fresh 260-cell neural volume for every page load using a browser-random seed.
- Places the network in a virtual world larger than the viewport, with partially off-screen neighborhoods and connections that enter and leave the camera crop.
- Builds five uneven neural neighborhoods plus a 148-cell ambient tissue layer, including 104 cells biased through the visible camera slice to fill ultra-wide voids.
- Anchors the five neighborhoods from far to near across the full depth range, then adds continuous local variation so depth remains organic rather than stepped.
- Expands perspective, foreground scale, connection weight, cursor attraction, and parallax separation while preserving reduced-motion behavior.
- Gives distant nodes and paths a slightly stronger visibility floor so quieter depth planes remain legible between foreground neighborhoods.
- Projects continuous node depth into perspective scale, opacity, glow, connection weight, endpoint gradients, cursor parallax, and attraction.
- Connects neighborhoods with gently curved, axon-like paths; foreground synapses become materially stronger while distant tissue recedes.
- Expands the pointer response to a 340 px field with smootherstep falloff, local node attraction, progressive path highlighting, and soma-like membrane rings.
- Keeps independently calibrated light/dark palettes and draws only during interaction and settling; reduced-motion users receive a static network.
- Keeps authentication, product copy, layout, and mobile behavior unchanged.
- Adds Playwright coverage for randomized generation, neural-volume projection, off-screen continuation, continuous strength, pointer activation, theme persistence, and reduced motion.

## Validation

- `npm run lint`
- Focused home unit suite: 35/35
- Production build
- Home-entry Playwright suite: 5/5
- Ultra-wide random sampling across 20 reloads: 800–836 links, 815.85 average, at least 146 strong paths and 87 off-screen cells per seed
- Visual QA at 1440×1000 and 2048×1024 in both themes
- Prior branch-wide validation: RLS inventory, full 941-test suite, and coverage thresholds all green
