### PR TITLE
fix: harden Dependabot repair-agent health handling

### DIFF
--- a/.github/workflows/dependabot-repair-agent.yml
+++ b/.github/workflows/dependabot-repair-agent.yml
@@ -17,14 +17,80 @@ on:
         description: "Force a targeted rerun even if the PR already has a repair marker"
         required: false
         default: "false"
+      healthcheck_only:
+        description: "Validate Copilot CLI authentication without processing a Dependabot PR"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: dependabot-repair-agent
   cancel-in-progress: false
 
+env:
+  COPILOT_CLI_VERSION: "1.0.73"
+
 jobs:
+  copilot-auth-healthcheck:
+    name: Validate Copilot repair authentication
+    if: github.event_name == 'workflow_dispatch' && inputs.healthcheck_only == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository without persisted credentials
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Install pinned Copilot CLI
+        run: npm install -g "@github/copilot@${COPILOT_CLI_VERSION}"
+
+      - name: Validate Copilot token
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_ACTIONS_TOKEN }}
+        run: |
+          if [[ -z "$COPILOT_GITHUB_TOKEN" ]]; then
+            echo "COPILOT_ACTIONS_TOKEN is missing." >&2
+            exit 1
+          fi
+
+          STATUS="$(curl --silent --show-error \
+            --output "$RUNNER_TEMP/copilot-token-user.json" \
+            --write-out '%{http_code}' \
+            --header "Authorization: Bearer $COPILOT_GITHUB_TOKEN" \
+            --header "Accept: application/vnd.github+json" \
+            https://api.github.com/user)"
+          if [[ "$STATUS" != "200" ]]; then
+            echo "COPILOT_ACTIONS_TOKEN failed GitHub authentication (HTTP $STATUS)." >&2
+            exit 1
+          fi
+
+      - name: Exercise Copilot request permission
+        env:
+          COPILOT_ALLOW_ALL: "true"
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_ACTIONS_TOKEN }}
+        run: |
+          OUTPUT="$(copilot \
+            --prompt "Reply with exactly COPILOT_AUTH_OK. Do not use tools." \
+            --no-ask-user \
+            --silent)"
+          if [[ "$OUTPUT" != *"COPILOT_AUTH_OK"* ]]; then
+            echo "Copilot authenticated but did not complete the health-check request." >&2
+            exit 1
+          fi
+          echo "Copilot CLI authentication and request permission are healthy."
+
   scan-red-prs:
     name: Scan red Dependabot PRs
+    if: github.event_name != 'workflow_dispatch' || inputs.healthcheck_only != true
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -114,6 +180,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -135,8 +202,8 @@ jobs:
             echo "REPAIR_AGENT_BACKUP_PATH=$BASE_DIR/dependabot-repair.agent.backup.md"
           } >> "$GITHUB_ENV"
 
-      - name: Install Copilot CLI
-        run: npm install -g @github/copilot
+      - name: Install pinned Copilot CLI
+        run: npm install -g "@github/copilot@${COPILOT_CLI_VERSION}"
 
       - name: Configure git identity
         run: |
@@ -156,14 +223,19 @@ jobs:
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_ACTIONS_TOKEN }}
         run: |
           if [[ -z "$COPILOT_GITHUB_TOKEN" ]]; then
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            {
-              echo "### Dependabot repair lane skipped"
-              echo ""
-              echo "Missing repository secret \`COPILOT_ACTIONS_TOKEN\`."
-              echo "Create a fine-grained PAT with Copilot Requests permission to activate the scheduled Copilot repair lane."
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 0
+            echo "COPILOT_ACTIONS_TOKEN is missing." >&2
+            exit 1
+          fi
+
+          STATUS="$(curl --silent --show-error \
+            --output "$RUNNER_TEMP/copilot-token-user.json" \
+            --write-out '%{http_code}' \
+            --header "Authorization: Bearer $COPILOT_GITHUB_TOKEN" \
+            --header "Accept: application/vnd.github+json" \
+            https://api.github.com/user)"
+          if [[ "$STATUS" != "200" ]]; then
+            echo "COPILOT_ACTIONS_TOKEN failed GitHub authentication (HTTP $STATUS)." >&2
+            exit 1
           fi
 
           echo "ready=true" >> "$GITHUB_OUTPUT"
@@ -215,13 +287,12 @@ jobs:
           cp "$REPAIR_AGENT_SPEC_PATH" "$REPAIR_AGENT_TARGET_PATH"
 
       - name: Run Copilot repair agent
+        id: copilot
         if: steps.preflight.outputs.ready == 'true'
         continue-on-error: true
         env:
           COPILOT_ALLOW_ALL: "true"
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_ACTIONS_TOKEN }}
-          GH_TOKEN: ${{ github.token }}
-          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -o pipefail
           PROMPT="$(cat "$REPAIR_CONTEXT_DIR/prompt.md")"
@@ -231,7 +302,7 @@ jobs:
             --silent 2>&1 | tee "$REPAIR_CONTEXT_DIR/copilot-output.log"
 
       - name: Restore repair agent spec
-        if: steps.preflight.outputs.ready == 'true'
+        if: always() && steps.preflight.outputs.ready == 'true'
         run: |
           if [[ -f "$REPAIR_AGENT_BACKUP_PATH" ]]; then
             cp "$REPAIR_AGENT_BACKUP_PATH" "$REPAIR_AGENT_TARGET_PATH"
@@ -241,7 +312,7 @@ jobs:
           fi
 
       - name: Inspect Copilot repair outputs
-        if: steps.preflight.outputs.ready == 'true'
+        if: always() && steps.preflight.outputs.ready == 'true'
         run: |
           ls -la "$REPAIR_CONTEXT_DIR"
           if [[ -f "$REPAIR_CONTEXT_DIR/result.json" ]]; then
@@ -250,8 +321,26 @@ jobs:
             echo "No result.json produced by Copilot."
           fi
 
+      - name: Validate Copilot repair result contract
+        id: result-contract
+        if: always() && steps.preflight.outputs.ready == 'true' && steps.copilot.outcome != 'skipped'
+        run: |
+          if python "$REPAIR_ORCHESTRATOR_PATH" validate-result \
+            --result-path "$REPAIR_CONTEXT_DIR/result.json" \
+            --copilot-output-path "$REPAIR_CONTEXT_DIR/copilot-output.log"; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure git authentication for deterministic finalization
+        if: always() && steps.preflight.outputs.ready == 'true' && steps.copilot.outcome != 'skipped'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh auth setup-git
+
       - name: Finalize superseding PR workflow
-        if: steps.preflight.outputs.ready == 'true'
+        if: always() && steps.preflight.outputs.ready == 'true' && steps.copilot.outcome != 'skipped'
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -267,3 +356,18 @@ jobs:
             --baseline-sha "$REPAIR_BASELINE_SHA" \
             --result-path "$REPAIR_CONTEXT_DIR/result.json" \
             --copilot-output-path "$REPAIR_CONTEXT_DIR/copilot-output.log"
+
+      - name: Assert repair-agent health
+        if: always() && steps.preflight.outputs.ready == 'true' && steps.copilot.outcome != 'skipped'
+        env:
+          COPILOT_OUTCOME: ${{ steps.copilot.outcome }}
+          RESULT_VALID: ${{ steps.result-contract.outputs.valid }}
+        run: |
+          if [[ "$RESULT_VALID" != "true" ]]; then
+            echo "Copilot did not produce a valid repair decision; failing the workflow so operators are alerted." >&2
+            exit 1
+          fi
+
+          if [[ "$COPILOT_OUTCOME" != "success" ]]; then
+            echo "::warning::Copilot exited non-zero after producing a valid structured result."
+          fi

--- a/scripts/dependabot_repair_agent.py
+++ b/scripts/dependabot_repair_agent.py
@@ -17,6 +17,7 @@ from typing import Any
 ROOT = Path(os.environ.get("GITHUB_WORKSPACE") or Path(__file__).resolve().parents[1]).resolve()
 REPO = os.environ.get("GITHUB_REPOSITORY", "").strip()
 MARKER_PREFIX = "<!-- dependabot-repair-agent:"
+ERROR_MARKER_PREFIX = "<!-- dependabot-repair-agent-error:"
 DEPENDABOT_LOGINS = {"app/dependabot", "dependabot[bot]"}
 OPEN_DEPENDABOT_SCAN_FETCH_LIMIT = 1000
 REQUIRED_CHECK_NAMES = {
@@ -271,30 +272,89 @@ def inferred_result_from_copilot_output(path: Path | None) -> dict[str, Any] | N
     }
 
 
-def load_result(path: Path, *, copilot_output_path: Path | None = None) -> dict[str, Any]:
+def validate_result_payload(payload: Any) -> dict[str, Any] | None:
+    if not isinstance(payload, dict):
+        return None
+
+    decision = payload.get("decision")
+    summary = payload.get("summary")
+    validation = payload.get("validation")
+    if decision not in {"fixed", "defer"}:
+        return None
+    if not isinstance(summary, str) or not summary.strip():
+        return None
+    if not isinstance(validation, list) or not all(isinstance(item, str) for item in validation):
+        return None
+
+    return {
+        "decision": decision,
+        "summary": summary.strip(),
+        "validation": [item.strip() for item in validation if item.strip()],
+    }
+
+
+def load_result_with_status(
+    path: Path,
+    *,
+    copilot_output_path: Path | None = None,
+) -> tuple[dict[str, Any], bool, str]:
     if not path.exists():
         inferred = inferred_result_from_copilot_output(copilot_output_path)
-        if inferred:
-            return inferred
+        validated_inferred = validate_result_payload(inferred)
+        if validated_inferred:
+            return validated_inferred, True, "copilot-output"
 
-        return {
-            "decision": "defer",
-            "summary": default_result_summary(),
-            "validation": [],
-        }
+        return (
+            {
+                "decision": "defer",
+                "summary": default_result_summary(),
+                "validation": [],
+            },
+            False,
+            "missing",
+        )
 
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        payload = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError:
         inferred = inferred_result_from_copilot_output(copilot_output_path)
-        if inferred:
-            return inferred
+        validated_inferred = validate_result_payload(inferred)
+        if validated_inferred:
+            return validated_inferred, True, "copilot-output"
 
-        return {
+        return (
+            {
+                "decision": "defer",
+                "summary": default_result_summary(),
+                "validation": [],
+            },
+            False,
+            "invalid-json",
+        )
+
+    validated_payload = validate_result_payload(payload)
+    if validated_payload:
+        return validated_payload, True, "result-file"
+
+    inferred = inferred_result_from_copilot_output(copilot_output_path)
+    validated_inferred = validate_result_payload(inferred)
+    if validated_inferred:
+        return validated_inferred, True, "copilot-output"
+
+    return (
+        {
             "decision": "defer",
             "summary": default_result_summary(),
             "validation": [],
-        }
+        },
+        False,
+        "invalid-schema",
+    )
+
+
+def load_result(path: Path, *, copilot_output_path: Path | None = None) -> dict[str, Any]:
+    result, _, _ = load_result_with_status(path, copilot_output_path=copilot_output_path)
+    return result
 
 
 def working_tree_has_changes() -> bool:
@@ -452,6 +512,23 @@ def cmd_prepare(args: argparse.Namespace) -> int:
     prompt_path.parent.mkdir(parents=True, exist_ok=True)
     prompt_path.write_text(prompt_text(prompt_pr, Path(args.result_path), log_path), encoding="utf-8")
     return 0
+
+
+def cmd_validate_result(args: argparse.Namespace) -> int:
+    result, valid, source = load_result_with_status(
+        Path(args.result_path),
+        copilot_output_path=Path(args.copilot_output_path) if args.copilot_output_path else None,
+    )
+    print(
+        json.dumps(
+            {
+                "valid": valid,
+                "source": source,
+                "decision": result.get("decision"),
+            }
+        )
+    )
+    return 0 if valid else 1
 
 
 def commit_changes(commit_message: str) -> None:
@@ -814,14 +891,32 @@ def comment_manual_review(original_pr_number: int, marker: str, summary: str) ->
     )
 
 
+def comment_infrastructure_failure(original_pr_number: int, marker: str, source: str) -> None:
+    comment(
+        original_pr_number,
+        "\n".join(
+            [
+                marker,
+                "The scheduled Copilot repair lane did not produce a valid machine-readable result.",
+                f"Result status: `{source}`.",
+                "This is an automation failure, not a dependency decision. The PR remains eligible for a later retry.",
+            ]
+        ),
+    )
+
+
 def cmd_finalize(args: argparse.Namespace) -> int:
     original_pr = fetch_pr(args.pr_number)
     result_path = Path(args.result_path)
     copilot_output_path = Path(args.copilot_output_path) if args.copilot_output_path else None
-    result = load_result(result_path, copilot_output_path=copilot_output_path)
+    result, has_structured_result, result_source = load_result_with_status(
+        result_path,
+        copilot_output_path=copilot_output_path,
+    )
     summary = (result.get("summary") or "No summary was produced.").strip()
     validation = [str(item).strip() for item in result.get("validation") or [] if str(item).strip()]
-    marker = f"{MARKER_PREFIX}pr-{args.pr_number}:{args.head_sha} -->"
+    marker_prefix = MARKER_PREFIX if has_structured_result else ERROR_MARKER_PREFIX
+    marker = f"{marker_prefix}pr-{args.pr_number}:{args.head_sha} -->"
     replacement_branch = args.replacement_branch
     expected_branch = replacement_branch_name(args.pr_number, args.head_sha)
 
@@ -861,6 +956,10 @@ def cmd_finalize(args: argparse.Namespace) -> int:
     branch_head_commit = current_head_commit()
     has_uncommitted_changes = working_tree_has_changes()
     has_new_commit = branch_head_commit != args.baseline_sha
+
+    if not has_structured_result and not has_uncommitted_changes and not has_new_commit:
+        comment_infrastructure_failure(args.pr_number, marker, result_source)
+        return 0
 
     if result.get("decision") != "fixed":
         if not result_path.exists() and (has_uncommitted_changes or has_new_commit):
@@ -960,6 +1059,14 @@ def build_parser() -> argparse.ArgumentParser:
     prepare.add_argument("--result-path", required=True)
     prepare.add_argument("--log-path", required=True)
     prepare.set_defaults(func=cmd_prepare)
+
+    validate_result = subparsers.add_parser(
+        "validate-result",
+        help="Validate the machine-readable Copilot repair result.",
+    )
+    validate_result.add_argument("--result-path", required=True)
+    validate_result.add_argument("--copilot-output-path")
+    validate_result.set_defaults(func=cmd_validate_result)
 
     finalize = subparsers.add_parser("finalize", help="Create/comment/close PRs based on Copilot result.")
     finalize.add_argument("--pr-number", type=int, required=True)

--- a/scripts/test_dependabot_repair_agent.py
+++ b/scripts/test_dependabot_repair_agent.py
@@ -1,0 +1,87 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import dependabot_repair_agent as agent
+
+
+class ResultContractTests(unittest.TestCase):
+    def test_accepts_valid_fixed_result(self) -> None:
+        payload = {
+            "decision": "fixed",
+            "summary": "Applied the compatibility repair.",
+            "validation": ["npm test"],
+        }
+
+        self.assertEqual(agent.validate_result_payload(payload), payload)
+
+    def test_rejects_invalid_result_shapes(self) -> None:
+        invalid_payloads = [
+            [],
+            {"decision": "unknown", "summary": "Nope", "validation": []},
+            {"decision": "defer", "summary": "", "validation": []},
+            {"decision": "fixed", "summary": "Done", "validation": "npm test"},
+            {"decision": "fixed", "summary": "Done", "validation": [1]},
+        ]
+
+        for payload in invalid_payloads:
+            with self.subTest(payload=payload):
+                self.assertIsNone(agent.validate_result_payload(payload))
+
+    def test_loads_valid_result_file(self) -> None:
+        payload = {
+            "decision": "defer",
+            "summary": "Upstream support is not ready.",
+            "validation": [],
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            result_path = Path(directory) / "result.json"
+            result_path.write_text(json.dumps(payload), encoding="utf-8")
+
+            result, valid, source = agent.load_result_with_status(result_path)
+
+        self.assertTrue(valid)
+        self.assertEqual(source, "result-file")
+        self.assertEqual(result, payload)
+
+    def test_recovers_structured_result_from_copilot_output(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            result_path = Path(directory) / "result.json"
+            output_path = Path(directory) / "copilot-output.log"
+            output_path.write_text(
+                'Repair complete. {"decision":"fixed","summary":"Updated config.",'
+                '"validation":["npm test"]}',
+                encoding="utf-8",
+            )
+
+            result, valid, source = agent.load_result_with_status(
+                result_path,
+                copilot_output_path=output_path,
+            )
+
+        self.assertTrue(valid)
+        self.assertEqual(source, "copilot-output")
+        self.assertEqual(result["decision"], "fixed")
+        self.assertEqual(result["validation"], ["npm test"])
+
+    def test_missing_result_is_reported_as_infrastructure_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            result, valid, source = agent.load_result_with_status(Path(directory) / "result.json")
+
+        self.assertFalse(valid)
+        self.assertEqual(source, "missing")
+        self.assertEqual(result["decision"], "defer")
+
+
+class RetryMarkerTests(unittest.TestCase):
+    def test_infrastructure_marker_does_not_match_terminal_marker(self) -> None:
+        head_sha = "abc123"
+        terminal_marker = f"{agent.MARKER_PREFIX}pr-42:{head_sha} -->"
+        infrastructure_marker = f"{agent.ERROR_MARKER_PREFIX}pr-42:{head_sha} -->"
+
+        self.assertNotIn(terminal_marker, infrastructure_marker)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- add a manual Copilot authentication health-check mode
- validate the repository secret before repair work begins
- pin the Copilot CLI version used by automation
- validate the agent's machine-readable result contract
- distinguish retryable infrastructure failures from terminal dependency decisions
- fail the workflow visibly when Copilot produces no valid result
- keep repository credentials out of the model-driven repair step
- add focused Python tests for result validation and retry markers

## Root cause
`COPILOT_ACTIONS_TOKEN` expired, while the existing preflight only checked that the secret was nonempty. Copilot authentication failures were hidden by `continue-on-error`, converted into ordinary `defer` comments, and marked PR heads as handled so scheduled retries stopped.

## Validation
- `python -m unittest discover -s scripts -p 'test_dependabot_repair_agent.py' -v`
- workflow YAML parsed with PyYAML
- `git diff --check`

## Live verification
After this PR exists, the new `healthcheck_only` workflow-dispatch path will be run against the regenerated secret.