### PR TITLE
TASK-334: Add alpha product-state indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ SHA, deployment URL, and workflow run belong in release evidence.
 
 - Define each release entry before the product-impacting PR is merged.
 
+## v0.28.0 - 2026-07-26
+
+- Added a subtle `Alpha` product-state label to the persistent desktop and
+  compact-mobile NexusDash wordmarks.
+- Included the alpha state in the brand links' accessible names and kept the
+  disclosure text-based, token-driven, and non-interactive.
+- Added focused component and responsive browser coverage for desktop/mobile
+  presence, accessible naming, and compact-header containment.
+
 ## v0.27.0 - 2026-07-23
 
 - Unified Account, Settings, and Notifications behind one shared responsive

--- a/components/authenticated-app-shell-client.tsx
+++ b/components/authenticated-app-shell-client.tsx
@@ -7,6 +7,7 @@ import { Bell, FolderKanban, LayoutDashboard } from "lucide-react";
 
 import { AccountMenu } from "@/components/account-menu";
 import { NotificationLiveUpdates } from "@/components/notification-live-updates";
+import { ProductStateBadge } from "@/components/product-state-badge";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { useCurrentAppPath } from "@/lib/hooks/use-current-app-path";
 import {
@@ -142,13 +143,18 @@ export function AuthenticatedAppShellClient({
         <Link
           href="/projects"
           className="mx-4 mt-4 flex min-h-14 items-center gap-3 rounded-xl px-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          aria-label="NexusDash projects"
+          aria-label="NexusDash alpha — projects"
         >
           <span className="grid h-10 w-10 place-items-center rounded-xl bg-primary text-base font-bold text-primary-foreground shadow-sm">
             N
           </span>
-          <span>
-            <span className="block text-base font-semibold tracking-tight">NexusDash</span>
+          <span className="min-w-0">
+            <span className="flex items-start gap-1.5">
+              <span className="block text-base font-semibold tracking-tight">
+                NexusDash
+              </span>
+              <ProductStateBadge className="mt-0.5" />
+            </span>
             <span className="block text-xs text-muted-foreground">Project workspace</span>
           </span>
         </Link>
@@ -211,10 +217,15 @@ export function AuthenticatedAppShellClient({
           <Link
             href="/projects"
             className="flex min-h-11 min-w-0 items-center gap-2 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            aria-label="NexusDash projects"
+            aria-label="NexusDash alpha — projects"
           >
             <span className="grid h-9 w-9 shrink-0 place-items-center rounded-xl bg-primary text-sm font-bold text-primary-foreground">N</span>
-            <span className="truncate text-base font-semibold tracking-tight">NexusDash</span>
+            <span className="flex min-w-0 items-start gap-1.5">
+              <span className="truncate text-base font-semibold tracking-tight">
+                NexusDash
+              </span>
+              <ProductStateBadge className="mt-0.5" />
+            </span>
           </Link>
           <div className="ml-auto flex items-center gap-2">
             <ThemeToggle compact />

--- a/components/product-state-badge.tsx
+++ b/components/product-state-badge.tsx
@@ -1,0 +1,19 @@
+import { cn } from "@/lib/utils";
+
+interface ProductStateBadgeProps {
+  className?: string;
+}
+
+export function ProductStateBadge({ className }: ProductStateBadgeProps) {
+  return (
+    <span
+      data-product-state="alpha"
+      className={cn(
+        "inline-flex shrink-0 items-center rounded-full border border-primary/25 bg-primary/10 px-1.5 py-0.5 text-[9px] font-bold uppercase leading-none tracking-[0.12em] text-primary",
+        className
+      )}
+    >
+      Alpha
+    </span>
+  );
+}

--- a/journal.md
+++ b/journal.md
@@ -2835,3 +2835,6 @@ Low-value entries to avoid going forward:
   768, 1024, and 1440 px under `.tmp/task334-alpha-indicator/`; the automated
   walkthrough also confirmed one visible badge, no page overflow, and no
   compact-header collision at every breakpoint.
+- Committed the reviewable implementation as `3d18212`, pushed
+  `feature/task-334-alpha-product-state-indicator`, and opened ready-for-review
+  PR #388.

--- a/journal.md
+++ b/journal.md
@@ -2844,3 +2844,6 @@ Low-value entries to avoid going forward:
   made the Playwright test create the optional output directory recursively.
   Focused lint and the eight-combination alpha Playwright walkthrough passed
   after the change.
+- Replied to and resolved the Copilot thread in commit `5b81bbe`; the refreshed
+  branch, Quality Core, E2E Smoke, Tenant Isolation, and Container Image checks
+  all passed on PR #388.

--- a/journal.md
+++ b/journal.md
@@ -2838,3 +2838,9 @@ Low-value entries to avoid going forward:
 - Committed the reviewable implementation as `3d18212`, pushed
   `feature/task-334-alpha-product-state-indicator`, and opened ready-for-review
   PR #388.
+- GitHub branch, Quality Core, E2E Smoke, Tenant Isolation, and Container Image
+  checks passed. Copilot's initial review raised one actionable test-harness
+  comment; aligned the screenshot env var with the `TASK_334_*` convention and
+  made the Playwright test create the optional output directory recursively.
+  Focused lint and the eight-combination alpha Playwright walkthrough passed
+  after the change.

--- a/journal.md
+++ b/journal.md
@@ -2813,3 +2813,25 @@ Low-value entries to avoid going forward:
   build, and all 20 Playwright scenarios. The database-backed browser suite used
   the configured development database because the optional local PostgreSQL
   service at `127.0.0.1:5432` was not running; outbound email remained disabled.
+
+# 2026-07-26 - TASK-334 alpha product-state indicator started
+
+- Took ownership of TASK-334 on
+  `feature/task-334-alpha-product-state-indicator`, created from the latest
+  `origin/main`.
+- Scoped the disclosure to a reusable, non-interactive `Alpha` label attached
+  to both authenticated shell wordmarks, with the product state included in
+  each brand link's accessible name.
+- Kept the treatment intentionally subtle, token-driven, and responsive so it
+  communicates maturity without competing with navigation or compact mobile
+  header actions.
+- Implemented the reusable badge in both authenticated wordmarks, included the
+  alpha state in their accessible names, and prepared release `v0.28.0`.
+- Validation passed: lint, RLS inventory, release policy, 948 unit/API tests
+  with 2 skipped, coverage at 91.37% statements / 81.33% branches / 92.2%
+  functions / 91.88% lines, the local-safe production build, and all 24
+  Playwright scenarios.
+- Captured and visually reviewed the disclosure in light/dark themes at 375,
+  768, 1024, and 1440 px under `.tmp/task334-alpha-indicator/`; the automated
+  walkthrough also confirmed one visible badge, no page overflow, and no
+  compact-header collision at every breakpoint.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexusdash",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexusdash",
-      "version": "0.27.0",
+      "version": "0.28.0",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1079.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexusdash",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "private": true,
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0",

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -75,7 +75,7 @@ Last reviewed: 2026-07-26
   Dependencies: TASK-043, TASK-322, TASK-324
 - ID: TASK-334
   Title: Alpha product-state indicator - subtle branding-level disclosure
-  Status: In Review
+  Status: Complete (2026-07-26)
   Rationale: Make the product's alpha status visible without competing with primary navigation, starting with a small accessible label attached to the NexusDash brand area near the top left and adapting the treatment intentionally for the compact mobile shell.
   Dependencies: TASK-313, TASK-322
 - ID: TASK-335

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -75,7 +75,7 @@ Last reviewed: 2026-07-26
   Dependencies: TASK-043, TASK-322, TASK-324
 - ID: TASK-334
   Title: Alpha product-state indicator - subtle branding-level disclosure
-  Status: Next 14 - product maturity communication
+  Status: In Review
   Rationale: Make the product's alpha status visible without competing with primary navigation, starting with a small accessible label attached to the NexusDash brand area near the top left and adapting the treatment intentionally for the compact mobile shell.
   Dependencies: TASK-313, TASK-322
 - ID: TASK-335

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,7 +4,7 @@
 
 - ID: TASK-334
 - Title: Alpha product-state indicator - subtle branding-level disclosure
-- Status: In review
+- Status: Complete (2026-07-26)
 - Branch: `feature/task-334-alpha-product-state-indicator`
 - Pull request: [#388](https://github.com/dorianagaesse/nexus_dash/pull/388)
 - Brief:
@@ -92,3 +92,6 @@ authenticated shell wordmark.
 - `npx playwright test`: all 24 scenarios passed.
 - Light/dark screenshots at 375, 768, 1024, and 1440 px were captured and
   visually reviewed under `.tmp/task334-alpha-indicator/`.
+- GitHub branch, Quality Core, E2E Smoke, Tenant Isolation, and Container Image
+  checks passed on the review-fix head. Copilot's one actionable
+  screenshot-harness comment was applied, answered, and resolved.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -6,7 +6,7 @@
 - Title: Alpha product-state indicator - subtle branding-level disclosure
 - Status: In review
 - Branch: `feature/task-334-alpha-product-state-indicator`
-- Pull request: Pending
+- Pull request: [#388](https://github.com/dorianagaesse/nexus_dash/pull/388)
 - Brief:
   [`task-334-alpha-product-state-indicator.md`](./task-334-alpha-product-state-indicator.md)
 

--- a/tasks/task-334-alpha-product-state-indicator.md
+++ b/tasks/task-334-alpha-product-state-indicator.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-In review.
+Complete (2026-07-26).
 
 ## Objective
 

--- a/tasks/task-334-alpha-product-state-indicator.md
+++ b/tasks/task-334-alpha-product-state-indicator.md
@@ -1,20 +1,21 @@
-# Current Task
+# TASK-334 - Alpha product-state indicator
 
-## Task
+## Status
 
-- ID: TASK-334
-- Title: Alpha product-state indicator - subtle branding-level disclosure
-- Status: In review
-- Branch: `feature/task-334-alpha-product-state-indicator`
-- Pull request: Pending
-- Brief:
-  [`task-334-alpha-product-state-indicator.md`](./task-334-alpha-product-state-indicator.md)
+In review.
 
 ## Objective
 
 Make NexusDash's alpha maturity visible at the brand level without competing
 with navigation or primary work, using a small accessible label attached to the
 authenticated shell wordmark.
+
+## Rationale
+
+Users should understand that the product is still evolving before they rely on
+it as a finished service. The disclosure belongs with the persistent brand
+rather than in a transient notice, and it must remain legible without making
+the compact mobile header feel crowded.
 
 ## Scope
 
@@ -27,6 +28,18 @@ authenticated shell wordmark.
   dimensions, header actions, and navigation hierarchy.
 - Verify light/dark readability and containment at 375, 768, 1024, and 1440 px.
 - Add focused component and browser coverage for the disclosure.
+
+## Out Of Scope
+
+- Changing the release-version policy.
+- Adding dismissible banners, onboarding copy, warnings, or feature-level
+  instability notices.
+- Redesigning the NexusDash logo, authenticated navigation, or account menu.
+
+## Dependencies
+
+- TASK-313
+- TASK-322
 
 ## Runtime Assumptions
 
@@ -64,31 +77,3 @@ authenticated shell wordmark.
 - Tracking documentation and release metadata are updated as required, the
   branch is committed and pushed, and a ready-for-review PR is open with
   initial automated review/check feedback handled before handoff.
-
-## Outcome
-
-- Added a reusable, non-interactive `Alpha` badge using existing semantic
-  foreground, background, and border tokens.
-- Attached the badge to the top-right of the NexusDash wordmark in both the
-  desktop sidebar and compact mobile header.
-- Included the alpha state in both brand links' accessible names while
-  preserving their destination, focus treatment, and navigation hierarchy.
-- Added component coverage for both rendered disclosures and Playwright
-  coverage across light/dark 375, 768, 1024, and 1440 px shells, including
-  mobile action-collision and horizontal-overflow checks.
-- Prepared product release `v0.28.0` with matching package and changelog data.
-
-## Validation
-
-- `npm run lint` passed.
-- `npm run rls:check` passed.
-- `npm test`: 948 passed, 2 skipped.
-- `npm run test:coverage`: 91.37% statements, 81.33% branches, 92.2%
-  functions, 91.88% lines.
-- `npm run build` passed with the repository's local-safe production
-  validation environment.
-- `npm run release:check -- --base origin/main --branch
-  feature/task-334-alpha-product-state-indicator` passed for `v0.28.0`.
-- `npx playwright test`: all 24 scenarios passed.
-- Light/dark screenshots at 375, 768, 1024, and 1440 px were captured and
-  visually reviewed under `.tmp/task334-alpha-indicator/`.

--- a/tests/components/authenticated-app-shell.test.tsx
+++ b/tests/components/authenticated-app-shell.test.tsx
@@ -56,6 +56,10 @@ describe("authenticated app shell", () => {
     expect(result).toContain("lg:pl-64");
     expect(result).toContain("z-[var(--layer-shell)]");
     expect(result).toContain("Skip to main content");
+    expect(result.match(/data-product-state="alpha"/g)).toHaveLength(2);
+    expect(
+      result.match(/aria-label="NexusDash alpha — projects"/g)
+    ).toHaveLength(2);
     expect(result).toContain(
       "/account/notifications?returnTo=%2Fprojects%2Fproject-1%3FtaskId%3Dtask-7"
     );

--- a/tests/e2e/authenticated-app-shell.spec.ts
+++ b/tests/e2e/authenticated-app-shell.spec.ts
@@ -1,3 +1,4 @@
+import { mkdir } from "node:fs/promises";
 import path from "node:path";
 
 import { expect, test } from "@playwright/test";
@@ -210,13 +211,17 @@ test.describe("responsive authenticated app shell", () => {
     await signInAsVerifiedUser(page);
     await page.goto("/projects");
 
-    const screenshotDirectory = process.env.TASK334_SCREENSHOT_DIR?.trim();
+    const screenshotDirectory = process.env.TASK_334_SCREENSHOT_DIR?.trim();
     const viewports = [
       { width: 375, height: 812, shell: "mobile" },
       { width: 768, height: 900, shell: "mobile" },
       { width: 1024, height: 900, shell: "desktop" },
       { width: 1440, height: 900, shell: "desktop" },
     ] as const;
+
+    if (screenshotDirectory) {
+      await mkdir(path.resolve(screenshotDirectory), { recursive: true });
+    }
 
     for (const theme of ["light", "dark"] as const) {
       await page.evaluate((nextTheme) => {

--- a/tests/e2e/authenticated-app-shell.spec.ts
+++ b/tests/e2e/authenticated-app-shell.spec.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import { expect, test } from "@playwright/test";
 
 import { prisma } from "../../lib/prisma";
@@ -202,6 +204,77 @@ test.describe("responsive authenticated app shell", () => {
     await expect(page).toHaveURL(/\/projects$/);
   });
 
+  test("discloses the alpha state across responsive shells and themes", async ({
+    page,
+  }) => {
+    await signInAsVerifiedUser(page);
+    await page.goto("/projects");
+
+    const screenshotDirectory = process.env.TASK334_SCREENSHOT_DIR?.trim();
+    const viewports = [
+      { width: 375, height: 812, shell: "mobile" },
+      { width: 768, height: 900, shell: "mobile" },
+      { width: 1024, height: 900, shell: "desktop" },
+      { width: 1440, height: 900, shell: "desktop" },
+    ] as const;
+
+    for (const theme of ["light", "dark"] as const) {
+      await page.evaluate((nextTheme) => {
+        window.localStorage.setItem("nexusdash-theme", nextTheme);
+        document.documentElement.classList.toggle("dark", nextTheme === "dark");
+      }, theme);
+
+      for (const viewport of viewports) {
+        await page.setViewportSize(viewport);
+        const shell =
+          viewport.shell === "desktop"
+            ? page.locator("aside:visible")
+            : page.locator("header:visible");
+        const brand = shell.getByRole("link", {
+          name: "NexusDash alpha — projects",
+        });
+
+        await expect(brand).toBeVisible();
+        await expect(
+          brand.locator('[data-product-state="alpha"]')
+        ).toHaveText("Alpha");
+        await expect(
+          page.locator('[data-product-state="alpha"]:visible')
+        ).toHaveCount(1);
+
+        const brandBox = await brand.boundingBox();
+        expect(brandBox).not.toBeNull();
+        expect(brandBox!.x).toBeGreaterThanOrEqual(0);
+        expect(brandBox!.x + brandBox!.width).toBeLessThanOrEqual(
+          viewport.width
+        );
+        expect(
+          await page.evaluate(
+            () => document.documentElement.scrollWidth <= innerWidth
+          )
+        ).toBe(true);
+
+        if (viewport.shell === "mobile") {
+          const headerActions = brand.locator("xpath=following-sibling::div[1]");
+          const headerActionsBox = await headerActions.boundingBox();
+          expect(headerActionsBox).not.toBeNull();
+          expect(brandBox!.x + brandBox!.width).toBeLessThanOrEqual(
+            headerActionsBox!.x
+          );
+        }
+
+        if (screenshotDirectory) {
+          await page.screenshot({
+            path: path.resolve(
+              screenshotDirectory,
+              `${theme}-${viewport.width}.png`
+            ),
+          });
+        }
+      }
+    }
+  });
+
   test("fits labeled controls and reserved content at 390px", async ({
     page,
   }) => {
@@ -212,6 +285,13 @@ test.describe("responsive authenticated app shell", () => {
     const mobileNavigation = page.locator(
       "nav[aria-label='Primary navigation']:visible"
     );
+    const mobileBrand = page
+      .locator("header:visible")
+      .getByRole("link", { name: "NexusDash alpha — projects" });
+    await expect(mobileBrand).toBeVisible();
+    await expect(
+      mobileBrand.locator('[data-product-state="alpha"]')
+    ).toHaveText("Alpha");
     await expect(mobileNavigation).toBeVisible();
     await expect(mobileNavigation.getByRole("link")).toHaveCount(2);
     await expect(page.getByRole("button", { name: /Switch to .* mode/ })).toBeVisible();
@@ -262,6 +342,14 @@ test.describe("responsive authenticated app shell", () => {
         () => document.documentElement.scrollWidth <= innerWidth
       )
     ).toBe(true);
+
+    const brandBox = await mobileBrand.boundingBox();
+    const themeToggleBox = await page
+      .getByRole("button", { name: /Switch to .* mode/ })
+      .boundingBox();
+    expect(brandBox).not.toBeNull();
+    expect(themeToggleBox).not.toBeNull();
+    expect(brandBox!.x + brandBox!.width).toBeLessThanOrEqual(themeToggleBox!.x);
 
     const navigationBox = await mobileNavigation.boundingBox();
     const mainBox = await page.locator("#app-main-content").boundingBox();


### PR DESCRIPTION
## Summary

- add a reusable, non-interactive `Alpha` badge to the persistent desktop and compact-mobile NexusDash wordmarks
- include the product state in both brand links' accessible names while preserving the existing navigation behavior
- add component and responsive Playwright coverage across light/dark 375, 768, 1024, and 1440 px shells
- prepare the required `v0.28.0` feature release metadata and task documentation

## Why

NexusDash is still in alpha. The product should communicate that maturity persistently without introducing a competing banner, control, or navigation element.

## Validation

- `npm run lint`
- `npm run rls:check`
- `npm test` — 948 passed, 2 skipped
- `npm run test:coverage` — 91.37% statements, 81.33% branches, 92.2% functions, 91.88% lines
- `npm run build` with the repository's local-safe production validation environment
- `npm run release:check -- --base origin/main --branch feature/task-334-alpha-product-state-indicator`
- `npx playwright test` — 24 passed
- visual review of light/dark screenshots at 375, 768, 1024, and 1440 px

Closes TASK-334.