### PR TITLE
TASK-332: Replace mobile todo popup with workspace navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ SHA, deployment URL, and workflow run belong in release evidence.
 
 - Define each release entry before the product-impacting PR is merged.
 
+## v0.28.0 - 2026-07-26
+
+- Replaced the obstructive mobile meeting-todo popup with a dedicated,
+  protected `/todos` workspace destination in the adaptive primary navigation.
+- Added access-safe cross-project todo aggregation, overdue-first open work,
+  recent completed work, URL-backed status and project filters, and source
+  meeting deep links.
+- Preserved owner/editor completion controls and viewer read-only treatment,
+  kept the project quick panel on desktop, and removed it from mobile layout
+  and accessibility navigation.
+- Added three-item mobile navigation with safe-area clearance, open/overdue
+  badge context, 44 px controls, narrow-screen containment, and responsive
+  Playwright coverage.
+
 ## v0.27.0 - 2026-07-23
 
 - Unified Account, Settings, and Notifications behind one shared responsive

--- a/adr/decisions.md
+++ b/adr/decisions.md
@@ -16,6 +16,26 @@ Keep UI-only or task-only notes in `journal.md`.
 
 ## Active Decisions
 
+## 2026-07-26 - Promote meeting todos to an adaptive workspace destination
+- Status: Accepted
+- Context: The project-scoped floating todo panel covered meeting and project
+  context on phone-sized screens, created a nested scroll region, and could not
+  accommodate planned project and assignee filtering. A floating action button
+  would conventionally suggest creation and add another safe-area collision.
+- Decision: Make `/todos` a stable authenticated destination in both the
+  desktop sidebar and mobile bottom navigation. Aggregate only projects
+  available to the actor under RLS, preserve project and source-meeting
+  context, store Open/Completed and project filters in the URL, hide the quick
+  panel below the desktop breakpoint, and retain the existing authorized
+  mutation endpoint.
+- Consequences: Mobile users get an unobstructed, deep-linkable todo workflow
+  that can grow with assignees and richer filters. The app shell performs one
+  lightweight open-todo summary read for its badge, while desktop users retain
+  the project-scoped quick panel.
+- Links: `tasks/task-332-mobile-todo-navigation.md`, `app/todos/`,
+  `lib/services/workspace-meeting-todo-service.ts`,
+  `components/authenticated-app-shell-client.tsx`
+
 ## 2026-06-08 - Store meeting notes as first-class project records
 - Status: Accepted
 - Context: TASK-098 needs meeting preparation inputs, after-meeting outputs,

--- a/app/projects/[projectId]/page.tsx
+++ b/app/projects/[projectId]/page.tsx
@@ -126,6 +126,12 @@ export default async function ProjectDashboardPage({
   const status = readQueryValue(resolvedSearchParams?.status);
   const error = readQueryValue(resolvedSearchParams?.error);
   const initialTaskId = readQueryValue(resolvedSearchParams?.taskId);
+  const initialMeetingNoteId = readQueryValue(
+    resolvedSearchParams?.meetingNoteId
+  );
+  const initialMeetingTodoId = readQueryValue(
+    resolvedSearchParams?.meetingTodoId
+  );
   const actorRole =
     project.ownerId === actorUserId ? "owner" : (project.memberships[0]?.role ?? "viewer");
   const canEditProjectContent = actorRole === "owner" || actorRole === "editor";
@@ -258,6 +264,8 @@ export default async function ProjectDashboardPage({
           projectId={project.id}
           actorUserId={actorUserId}
           canEdit={canEditProjectContent}
+          initialMeetingNoteId={initialMeetingNoteId}
+          initialMeetingTodoId={initialMeetingTodoId}
         />
       </Suspense>
 

--- a/app/projects/[projectId]/project-meeting-notes-panel-section.tsx
+++ b/app/projects/[projectId]/project-meeting-notes-panel-section.tsx
@@ -16,6 +16,8 @@ interface ProjectMeetingNotesPanelSectionProps {
   projectId: string;
   actorUserId: string;
   canEdit: boolean;
+  initialMeetingNoteId?: string | null;
+  initialMeetingTodoId?: string | null;
 }
 
 function serializeMeetingNote(
@@ -37,6 +39,8 @@ export async function ProjectMeetingNotesPanelSection({
   projectId,
   actorUserId,
   canEdit,
+  initialMeetingNoteId,
+  initialMeetingTodoId,
 }: ProjectMeetingNotesPanelSectionProps) {
   const notes = await listProjectMeetingNotes({
     projectId,
@@ -48,6 +52,8 @@ export async function ProjectMeetingNotesPanelSection({
       projectId={projectId}
       canEdit={canEdit}
       notes={notes.map((note) => serializeMeetingNote(note))}
+      initialMeetingNoteId={initialMeetingNoteId}
+      initialMeetingTodoId={initialMeetingTodoId}
     />
   );
 }

--- a/app/todos/layout.tsx
+++ b/app/todos/layout.tsx
@@ -1,0 +1,11 @@
+import { AuthenticatedAppShell } from "@/components/authenticated-app-shell";
+
+export const dynamic = "force-dynamic";
+
+export default async function TodosLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <AuthenticatedAppShell>{children}</AuthenticatedAppShell>;
+}

--- a/app/todos/page.tsx
+++ b/app/todos/page.tsx
@@ -1,0 +1,70 @@
+import { unstable_noStore as noStore } from "next/cache";
+import { ListTodo } from "lucide-react";
+
+import {
+  WorkspaceMeetingTodos,
+  type WorkspaceMeetingTodoItem,
+} from "@/components/meeting-todos/workspace-meeting-todos";
+import { Badge } from "@/components/ui/badge";
+import { requireVerifiedSessionUserIdFromServer } from "@/lib/auth/server-guard";
+import { logServerError } from "@/lib/observability/logger";
+import { listWorkspaceMeetingTodos } from "@/lib/services/workspace-meeting-todo-service";
+
+export const dynamic = "force-dynamic";
+
+function serializeTodo(
+  todo: Awaited<ReturnType<typeof listWorkspaceMeetingTodos>>["open"][number]
+): WorkspaceMeetingTodoItem {
+  return {
+    id: todo.id,
+    content: todo.content,
+    completedAt: todo.completedAt?.toISOString() ?? null,
+    updatedAt: todo.updatedAt.toISOString(),
+    isOverdue: todo.isOverdue,
+    meeting: {
+      ...todo.meeting,
+      scheduledAt: todo.meeting.scheduledAt?.toISOString() ?? null,
+    },
+    project: todo.project,
+  };
+}
+
+export default async function TodosPage() {
+  noStore();
+  const actorUserId = await requireVerifiedSessionUserIdFromServer();
+  let initialTodos: WorkspaceMeetingTodoItem[] = [];
+  let loadError: string | null = null;
+
+  try {
+    const todos = await listWorkspaceMeetingTodos({ actorUserId });
+    initialTodos = [...todos.open, ...todos.completed].map(serializeTodo);
+  } catch (error) {
+    logServerError("TodosPage.listWorkspaceMeetingTodos", error);
+    loadError = "meeting-todos-list-failed";
+  }
+
+  return (
+    <main className="container py-6 sm:py-10">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+        <div className="space-y-4">
+          <Badge variant="secondary" className="w-fit gap-1.5">
+            <ListTodo className="h-3.5 w-3.5" aria-hidden />
+            Workspace todos
+          </Badge>
+          <div className="space-y-2">
+            <h1 className="text-3xl font-semibold tracking-tight">Todos</h1>
+            <p className="max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">
+              Review meeting follow-ups across your projects without losing
+              their project and meeting context.
+            </p>
+          </div>
+        </div>
+
+        <WorkspaceMeetingTodos
+          initialTodos={initialTodos}
+          loadError={loadError}
+        />
+      </div>
+    </main>
+  );
+}

--- a/components/authenticated-app-shell-client.tsx
+++ b/components/authenticated-app-shell-client.tsx
@@ -3,14 +3,13 @@
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 import type { ReactNode } from "react";
-import { Bell, FolderKanban, LayoutDashboard } from "lucide-react";
+import { Bell, FolderKanban, LayoutDashboard, ListTodo } from "lucide-react";
 
 import { AccountMenu } from "@/components/account-menu";
 import { NotificationLiveUpdates } from "@/components/notification-live-updates";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { useCurrentAppPath } from "@/lib/hooks/use-current-app-path";
 import {
-  AUTHENTICATED_DESTINATIONS,
   buildAuthenticatedDestinationHref,
   isDestinationCurrent,
   resolveContextualReturnDestination,
@@ -18,6 +17,7 @@ import {
 } from "@/lib/navigation/authenticated-shell";
 import { useNotificationRealtimeSnapshot } from "@/lib/notification-realtime-client";
 import type { NotificationRealtimeSnapshot } from "@/lib/notification-realtime-types";
+import type { WorkspaceMeetingTodoNavigationSummary } from "@/lib/services/workspace-meeting-todo-service";
 import { cn } from "@/lib/utils";
 
 const NAVIGATION_ITEMS: Array<{
@@ -27,13 +27,19 @@ const NAVIGATION_ITEMS: Array<{
   icon: typeof FolderKanban;
 }> = [
   {
-    href: AUTHENTICATED_DESTINATIONS[0],
+    href: "/projects",
     label: "Projects",
     mobileLabel: "Projects",
     icon: FolderKanban,
   },
   {
-    href: AUTHENTICATED_DESTINATIONS[1],
+    href: "/todos",
+    label: "Todos",
+    mobileLabel: "Todos",
+    icon: ListTodo,
+  },
+  {
+    href: "/account/notifications",
     label: "Inbox",
     mobileLabel: "Inbox",
     icon: Bell,
@@ -45,6 +51,7 @@ interface AuthenticatedAppShellClientProps {
   usernameTag: string | null;
   avatarSeed: string | null;
   initialNotificationSnapshot: NotificationRealtimeSnapshot;
+  initialMeetingTodoSummary?: WorkspaceMeetingTodoNavigationSummary;
   notificationBanner: ReactNode;
   children: ReactNode;
 }
@@ -54,6 +61,7 @@ export function AuthenticatedAppShellClient({
   usernameTag,
   avatarSeed,
   initialNotificationSnapshot,
+  initialMeetingTodoSummary = { openCount: 0, overdueCount: 0 },
   notificationBanner,
   children,
 }: AuthenticatedAppShellClientProps) {
@@ -82,10 +90,24 @@ export function AuthenticatedAppShellClient({
           ? false
           : isDestinationCurrent(pathname, item.href);
       const href = buildAuthenticatedDestinationHref(item.href, currentPath);
-      const unread =
+      const badgeCount =
         item.href === "/account/notifications"
           ? notificationSnapshot.unreadCount
-          : 0;
+          : item.href === "/todos"
+            ? initialMeetingTodoSummary.openCount
+            : 0;
+      const badgeLabel =
+        item.href === "/account/notifications"
+          ? `${notificationSnapshot.unreadCount} unread notifications`
+          : item.href === "/todos"
+            ? `${initialMeetingTodoSummary.openCount} open todos${
+                initialMeetingTodoSummary.overdueCount > 0
+                  ? `, ${initialMeetingTodoSummary.overdueCount} overdue`
+                  : ""
+              }`
+            : "";
+      const hasOverdueTodos =
+        item.href === "/todos" && initialMeetingTodoSummary.overdueCount > 0;
 
       return (
         <Link
@@ -110,10 +132,19 @@ export function AuthenticatedAppShellClient({
           ) : null}
           <span className="relative grid h-7 w-7 shrink-0 place-items-center">
             <Icon className="h-5 w-5" strokeWidth={isCurrent ? 2.25 : 1.8} aria-hidden />
-            {unread > 0 ? (
-              <span className="absolute -right-1 -top-1 grid min-h-4 min-w-4 place-items-center rounded-full bg-destructive px-1 text-[9px] font-bold leading-none text-destructive-foreground ring-2 ring-background">
-                <span className="sr-only">{unread} unread notifications</span>
-                <span aria-hidden>{unread > 99 ? "99+" : unread}</span>
+            {badgeCount > 0 ? (
+              <span
+                className={cn(
+                  "absolute -right-1 -top-1 grid min-h-4 min-w-4 place-items-center rounded-full px-1 text-[9px] font-bold leading-none ring-2 ring-background",
+                  item.href === "/account/notifications"
+                    ? "bg-destructive text-destructive-foreground"
+                    : hasOverdueTodos
+                      ? "bg-amber-600 text-white dark:bg-amber-500 dark:text-slate-950"
+                      : "bg-primary text-primary-foreground"
+                )}
+              >
+                <span className="sr-only">{badgeLabel}</span>
+                <span aria-hidden>{badgeCount > 99 ? "99+" : badgeCount}</span>
               </span>
             ) : null}
           </span>
@@ -247,7 +278,7 @@ export function AuthenticatedAppShellClient({
 
       <nav
         aria-label="Primary navigation"
-        className="fixed inset-x-3 bottom-[calc(0.5rem+env(safe-area-inset-bottom))] z-[var(--layer-shell)] grid grid-cols-2 rounded-2xl border border-border/70 bg-background/95 p-1.5 shadow-[0_16px_40px_-12px_rgba(15,23,42,0.35)] backdrop-blur lg:hidden"
+        className="fixed inset-x-3 bottom-[calc(0.5rem+env(safe-area-inset-bottom))] z-[var(--layer-shell)] grid grid-cols-3 rounded-2xl border border-border/70 bg-background/95 p-1.5 shadow-[0_16px_40px_-12px_rgba(15,23,42,0.35)] backdrop-blur lg:hidden"
       >
         {navigation(true)}
       </nav>

--- a/components/authenticated-app-shell.tsx
+++ b/components/authenticated-app-shell.tsx
@@ -5,6 +5,10 @@ import { NotificationAwarenessBanner } from "@/components/notification-awareness
 import { requireVerifiedSessionUserIdFromServer } from "@/lib/auth/server-guard";
 import { getInitialNotificationRealtimeSnapshotForUser } from "@/lib/notification-realtime-server";
 import { getAccountIdentitySummary } from "@/lib/services/account-identity-service";
+import {
+  getWorkspaceMeetingTodoNavigationSummary,
+  type WorkspaceMeetingTodoNavigationSummary,
+} from "@/lib/services/workspace-meeting-todo-service";
 import type { NotificationRealtimeSnapshot } from "@/lib/notification-realtime-types";
 
 interface AuthenticatedAppShellIdentity {
@@ -17,20 +21,34 @@ export async function AuthenticatedAppShell({
   children,
   initialIdentity,
   initialNotificationSnapshot,
+  initialMeetingTodoSummary,
 }: {
   children: React.ReactNode;
   initialIdentity?: AuthenticatedAppShellIdentity | null;
   initialNotificationSnapshot?: NotificationRealtimeSnapshot;
+  initialMeetingTodoSummary?: WorkspaceMeetingTodoNavigationSummary;
 }) {
   noStore();
   let identity = initialIdentity;
   let notificationSnapshot = initialNotificationSnapshot;
+  let meetingTodoSummary = initialMeetingTodoSummary;
 
-  if (identity === undefined || notificationSnapshot === undefined) {
+  if (
+    identity === undefined ||
+    notificationSnapshot === undefined ||
+    meetingTodoSummary === undefined
+  ) {
     const actorUserId = await requireVerifiedSessionUserIdFromServer();
-    [identity, notificationSnapshot] = await Promise.all([
-      getAccountIdentitySummary(actorUserId),
-      getInitialNotificationRealtimeSnapshotForUser(actorUserId),
+    [identity, notificationSnapshot, meetingTodoSummary] = await Promise.all([
+      identity === undefined
+        ? getAccountIdentitySummary(actorUserId)
+        : Promise.resolve(identity),
+      notificationSnapshot === undefined
+        ? getInitialNotificationRealtimeSnapshotForUser(actorUserId)
+        : Promise.resolve(notificationSnapshot),
+      meetingTodoSummary === undefined
+        ? getWorkspaceMeetingTodoNavigationSummary(actorUserId)
+        : Promise.resolve(meetingTodoSummary),
     ]);
   }
 
@@ -40,6 +58,7 @@ export async function AuthenticatedAppShell({
       usernameTag={identity?.usernameTag ?? null}
       avatarSeed={identity?.avatarSeed ?? null}
       initialNotificationSnapshot={notificationSnapshot}
+      initialMeetingTodoSummary={meetingTodoSummary}
       notificationBanner={
         <NotificationAwarenessBanner initialSnapshot={notificationSnapshot} />
       }

--- a/components/meeting-todos/meeting-todo-side-panel.tsx
+++ b/components/meeting-todos/meeting-todo-side-panel.tsx
@@ -202,7 +202,7 @@ export function MeetingTodoSidePanel({
       role="region"
       aria-labelledby="meeting-todo-panel-title"
       className={cn(
-        "fixed right-4 top-1/2 z-[var(--layer-floating)] w-[calc(100vw-2rem)] max-w-[22rem] -translate-y-1/2 rounded-2xl border border-border/70 bg-background/95 shadow-[0_22px_70px_-34px_rgba(15,23,42,0.75)] backdrop-blur supports-[backdrop-filter]:bg-background/85 sm:right-6",
+        "fixed right-4 top-1/2 z-[var(--layer-floating)] hidden w-[calc(100vw-2rem)] max-w-[22rem] -translate-y-1/2 rounded-2xl border border-border/70 bg-background/95 shadow-[0_22px_70px_-34px_rgba(15,23,42,0.75)] backdrop-blur supports-[backdrop-filter]:bg-background/85 sm:right-6 lg:block",
         "print:hidden"
       )}
     >

--- a/components/meeting-todos/workspace-meeting-todos.tsx
+++ b/components/meeting-todos/workspace-meeting-todos.tsx
@@ -390,7 +390,7 @@ export function WorkspaceMeetingTodos({
                 )}
               >
                 {itemView}
-                <span className="tabular-nums text-xs" aria-label={`${count} ${itemView}`}>
+                <span className="tabular-nums text-xs">
                   {count}
                 </span>
               </Link>

--- a/components/meeting-todos/workspace-meeting-todos.tsx
+++ b/components/meeting-todos/workspace-meeting-todos.tsx
@@ -1,0 +1,504 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  CalendarDays,
+  Check,
+  CheckCircle2,
+  Circle,
+  ExternalLink,
+  FolderKanban,
+  LoaderCircle,
+  RotateCcw,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { isMeetingTodoOverdueAt } from "@/lib/meeting-todo";
+import { cn } from "@/lib/utils";
+
+export interface WorkspaceMeetingTodoItem {
+  id: string;
+  content: string;
+  completedAt: string | null;
+  updatedAt: string;
+  isOverdue: boolean;
+  meeting: {
+    id: string;
+    title: string;
+    scheduledAt: string | null;
+    status: string;
+  };
+  project: {
+    id: string;
+    name: string;
+    role: "owner" | "editor" | "viewer";
+    canEdit: boolean;
+  };
+}
+
+interface WorkspaceMeetingTodosProps {
+  initialTodos: WorkspaceMeetingTodoItem[];
+  loadError?: string | null;
+}
+
+type TodoView = "open" | "completed";
+
+function normalizeView(value: string | null): TodoView {
+  return value === "completed" ? "completed" : "open";
+}
+
+function buildTodosHref(view: TodoView, projectId: string): string {
+  const searchParams = new URLSearchParams();
+  if (view === "completed") {
+    searchParams.set("view", view);
+  }
+  if (projectId !== "all") {
+    searchParams.set("project", projectId);
+  }
+
+  const query = searchParams.toString();
+  return query ? `/todos?${query}` : "/todos";
+}
+
+function formatMeetingDate(value: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat("en", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  }).format(date);
+}
+
+function groupTodosByProject(todos: WorkspaceMeetingTodoItem[]) {
+  const groups = new Map<
+    string,
+    {
+      project: WorkspaceMeetingTodoItem["project"];
+      todos: WorkspaceMeetingTodoItem[];
+    }
+  >();
+
+  for (const todo of todos) {
+    const group = groups.get(todo.project.id);
+    if (group) {
+      group.todos.push(todo);
+      continue;
+    }
+
+    groups.set(todo.project.id, {
+      project: todo.project,
+      todos: [todo],
+    });
+  }
+
+  return Array.from(groups.values());
+}
+
+function TodoCompletionControl({
+  todo,
+  isPending,
+  onSetCompleted,
+}: {
+  todo: WorkspaceMeetingTodoItem;
+  isPending: boolean;
+  onSetCompleted: (todo: WorkspaceMeetingTodoItem, completed: boolean) => void;
+}) {
+  const isCompleted = todo.completedAt !== null;
+
+  if (!todo.project.canEdit) {
+    return (
+      <span
+        className="grid h-11 w-11 shrink-0 place-items-center rounded-full border border-border bg-muted/40 text-muted-foreground"
+        title="View-only project"
+      >
+        {isCompleted ? (
+          <CheckCircle2 className="h-5 w-5 text-emerald-600" aria-hidden />
+        ) : (
+          <Circle className="h-5 w-5" aria-hidden />
+        )}
+        <span className="sr-only">
+          {isCompleted ? "Completed todo" : "Open todo"}, view only
+        </span>
+      </span>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      disabled={isPending}
+      onClick={() => onSetCompleted(todo, !isCompleted)}
+      aria-label={`${isCompleted ? "Reopen" : "Complete"} todo: ${todo.content}`}
+      className={cn(
+        "grid h-11 w-11 shrink-0 touch-manipulation place-items-center rounded-full border transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-wait disabled:opacity-60",
+        isCompleted
+          ? "border-emerald-500/35 bg-emerald-500/10 text-emerald-700 hover:bg-emerald-500/20 dark:text-emerald-200"
+          : "border-border bg-background text-muted-foreground hover:border-primary/45 hover:bg-primary/5 hover:text-foreground"
+      )}
+    >
+      {isPending ? (
+        <LoaderCircle className="h-5 w-5 animate-spin" aria-hidden />
+      ) : isCompleted ? (
+        <RotateCcw className="h-5 w-5" aria-hidden />
+      ) : (
+        <Check className="h-5 w-5" aria-hidden />
+      )}
+    </button>
+  );
+}
+
+function TodoRow({
+  todo,
+  isPending,
+  onSetCompleted,
+}: {
+  todo: WorkspaceMeetingTodoItem;
+  isPending: boolean;
+  onSetCompleted: (todo: WorkspaceMeetingTodoItem, completed: boolean) => void;
+}) {
+  const meetingDate = formatMeetingDate(todo.meeting.scheduledAt);
+  const isCompleted = todo.completedAt !== null;
+  const meetingHref = `/projects/${todo.project.id}?meetingNoteId=${encodeURIComponent(
+    todo.meeting.id
+  )}&meetingTodoId=${encodeURIComponent(todo.id)}`;
+
+  return (
+    <li
+      className={cn(
+        "flex gap-3 border-t border-border/60 px-4 py-4 first:border-t-0 sm:px-5",
+        todo.isOverdue && "bg-amber-500/[0.07]"
+      )}
+    >
+      <TodoCompletionControl
+        todo={todo}
+        isPending={isPending}
+        onSetCompleted={onSetCompleted}
+      />
+      <div className="min-w-0 flex-1">
+        <p
+          className={cn(
+            "break-words text-sm font-medium leading-6 text-foreground [overflow-wrap:anywhere] sm:text-[15px]",
+            isCompleted && "text-muted-foreground line-through"
+          )}
+        >
+          {todo.content}
+        </p>
+
+        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs text-muted-foreground">
+          <Link
+            href={meetingHref}
+            className="inline-flex min-h-11 items-center gap-1.5 rounded-lg py-2 font-medium underline-offset-4 transition-colors hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <span className="max-w-[16rem] truncate">{todo.meeting.title}</span>
+            <ExternalLink className="h-3.5 w-3.5 shrink-0" aria-hidden />
+          </Link>
+          {meetingDate ? (
+            <span className="inline-flex items-center gap-1.5">
+              <CalendarDays className="h-3.5 w-3.5" aria-hidden />
+              {meetingDate}
+            </span>
+          ) : null}
+        </div>
+
+        <div className="mt-1 flex flex-wrap items-center gap-2">
+          {todo.isOverdue ? (
+            <Badge
+              variant="outline"
+              className="gap-1 border-amber-500/35 bg-amber-500/10 text-amber-700 dark:text-amber-200"
+            >
+              <AlertTriangle className="h-3.5 w-3.5" aria-hidden />
+              Overdue
+            </Badge>
+          ) : null}
+          {!todo.project.canEdit ? (
+            <Badge variant="secondary">View only</Badge>
+          ) : null}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+export function WorkspaceMeetingTodos({
+  initialTodos,
+  loadError = null,
+}: WorkspaceMeetingTodosProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const view = normalizeView(searchParams.get("view"));
+  const requestedProjectId = searchParams.get("project") ?? "all";
+  const [todos, setTodos] = useState(initialTodos);
+  const [pendingActionId, setPendingActionId] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [mutationError, setMutationError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setTodos(initialTodos);
+  }, [initialTodos]);
+
+  const projects = useMemo(() => {
+    const byId = new Map<string, WorkspaceMeetingTodoItem["project"]>();
+    for (const todo of todos) {
+      byId.set(todo.project.id, todo.project);
+    }
+
+    return Array.from(byId.values()).sort((left, right) =>
+      left.name.localeCompare(right.name)
+    );
+  }, [todos]);
+  const selectedProjectId = projects.some(
+    (project) => project.id === requestedProjectId
+  )
+    ? requestedProjectId
+    : "all";
+  const openTodos = useMemo(
+    () => todos.filter((todo) => todo.completedAt === null),
+    [todos]
+  );
+  const completedTodos = useMemo(
+    () => todos.filter((todo) => todo.completedAt !== null),
+    [todos]
+  );
+  const overdueCount = useMemo(
+    () => openTodos.filter((todo) => todo.isOverdue).length,
+    [openTodos]
+  );
+  const sourceTodos = view === "completed" ? completedTodos : openTodos;
+  const visibleTodos =
+    selectedProjectId === "all"
+      ? sourceTodos
+      : sourceTodos.filter((todo) => todo.project.id === selectedProjectId);
+  const groups = useMemo(
+    () => groupTodosByProject(visibleTodos),
+    [visibleTodos]
+  );
+
+  const setTodoCompleted = async (
+    todo: WorkspaceMeetingTodoItem,
+    completed: boolean
+  ) => {
+    if (!todo.project.canEdit || pendingActionId) {
+      return;
+    }
+
+    setPendingActionId(todo.id);
+    setMutationError(null);
+    setFeedback(null);
+
+    try {
+      const response = await fetch(
+        `/api/projects/${todo.project.id}/meeting-notes/${todo.meeting.id}/actions/${todo.id}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ completed }),
+        }
+      );
+      const payload = (await response.json().catch(() => null)) as
+        | { error?: string }
+        | null;
+
+      if (!response.ok) {
+        throw new Error(payload?.error ?? "meeting-todo-update-failed");
+      }
+
+      const updatedAt = new Date().toISOString();
+      setTodos((current) =>
+        current.map((entry) =>
+          entry.id === todo.id
+            ? {
+                ...entry,
+                completedAt: completed ? updatedAt : null,
+                updatedAt,
+                isOverdue: completed
+                  ? false
+                  : isMeetingTodoOverdueAt({
+                      scheduledAt: entry.meeting.scheduledAt,
+                      completedAt: null,
+                      meetingStatus: entry.meeting.status,
+                      referenceNowMs: Date.now(),
+                    }),
+              }
+            : entry
+        )
+      );
+      setFeedback(completed ? "Todo completed." : "Todo reopened.");
+      router.refresh();
+    } catch {
+      setMutationError("Could not update this todo. Check your access and retry.");
+    } finally {
+      setPendingActionId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <section
+        aria-label="Todo summary"
+        className="grid grid-cols-2 gap-3 sm:max-w-xl"
+      >
+        <div className="rounded-2xl border border-border/70 bg-card/70 px-4 py-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+            Open
+          </p>
+          <p className="mt-1 text-2xl font-semibold tabular-nums">
+            {openTodos.length}
+          </p>
+        </div>
+        <div className="rounded-2xl border border-amber-500/30 bg-amber-500/[0.07] px-4 py-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-amber-700 dark:text-amber-200">
+            Overdue
+          </p>
+          <p className="mt-1 text-2xl font-semibold tabular-nums text-amber-700 dark:text-amber-100">
+            {overdueCount}
+          </p>
+        </div>
+      </section>
+
+      <div className="flex flex-col gap-4 rounded-2xl border border-border/70 bg-card/70 p-3 sm:flex-row sm:items-end sm:justify-between sm:p-4">
+        <nav
+          aria-label="Todo views"
+          className="grid grid-cols-2 rounded-xl bg-muted/70 p-1"
+        >
+          {(["open", "completed"] as const).map((itemView) => {
+            const isCurrent = view === itemView;
+            const count =
+              itemView === "open" ? openTodos.length : completedTodos.length;
+            return (
+              <Link
+                key={itemView}
+                href={buildTodosHref(itemView, selectedProjectId)}
+                aria-current={isCurrent ? "page" : undefined}
+                className={cn(
+                  "inline-flex min-h-11 min-w-0 touch-manipulation items-center justify-center gap-2 rounded-lg px-3 text-sm font-medium capitalize transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  isCurrent
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                {itemView}
+                <span className="tabular-nums text-xs" aria-label={`${count} ${itemView}`}>
+                  {count}
+                </span>
+              </Link>
+            );
+          })}
+        </nav>
+
+        <label className="grid min-w-0 max-w-full gap-1.5 text-sm font-medium sm:min-w-56">
+          Project
+          <select
+            value={selectedProjectId}
+            onChange={(event) =>
+              router.push(buildTodosHref(view, event.target.value))
+            }
+            className="min-h-11 w-full min-w-0 max-w-full rounded-xl border border-input bg-background px-3 text-base outline-none transition focus-visible:ring-2 focus-visible:ring-ring sm:text-sm"
+          >
+            <option value="all">All projects</option>
+            {projects.map((project) => (
+              <option key={project.id} value={project.id}>
+                {project.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div aria-live="polite" aria-atomic="true">
+        {feedback ? (
+          <div className="rounded-xl border border-emerald-500/35 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-700 dark:text-emerald-200">
+            {feedback}
+          </div>
+        ) : null}
+      </div>
+      {loadError || mutationError ? (
+        <div
+          role="alert"
+          className="rounded-xl border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+        >
+          {mutationError ?? "Could not load meeting todos. Refresh to retry."}
+        </div>
+      ) : null}
+
+      {groups.length > 0 ? (
+        <div className="space-y-4">
+          {groups.map((group) => (
+            <section
+              key={group.project.id}
+              aria-labelledby={`todo-project-${group.project.id}`}
+              className="overflow-hidden rounded-2xl border border-border/70 bg-card/80"
+            >
+              <header className="flex min-h-14 items-center justify-between gap-3 border-b border-border/60 bg-muted/25 px-4 py-2 sm:px-5">
+                <div className="flex min-w-0 items-center gap-2">
+                  <FolderKanban
+                    className="h-4.5 w-4.5 shrink-0 text-muted-foreground"
+                    aria-hidden
+                  />
+                  <h2
+                    id={`todo-project-${group.project.id}`}
+                    className="truncate text-sm font-semibold"
+                  >
+                    {group.project.name}
+                  </h2>
+                  <Badge variant="secondary" className="shrink-0 tabular-nums">
+                    {group.todos.length}
+                  </Badge>
+                </div>
+                <Link
+                  href={`/projects/${group.project.id}`}
+                  className="inline-flex min-h-11 shrink-0 items-center rounded-lg px-2 text-xs font-medium text-muted-foreground underline-offset-4 transition-colors hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  Open project
+                </Link>
+              </header>
+              <ul>
+                {group.todos.map((todo) => (
+                  <TodoRow
+                    key={todo.id}
+                    todo={todo}
+                    isPending={pendingActionId === todo.id}
+                    onSetCompleted={(entry, completed) => {
+                      void setTodoCompleted(entry, completed);
+                    }}
+                  />
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-2xl border border-dashed border-border bg-card/55 px-6 py-12 text-center">
+          <CheckCircle2
+            className="mx-auto h-10 w-10 text-emerald-600"
+            aria-hidden
+          />
+          <h2 className="mt-4 text-base font-semibold">
+            {view === "open" ? "All caught up" : "No completed todos yet"}
+          </h2>
+          <p className="mx-auto mt-2 max-w-md text-sm leading-6 text-muted-foreground">
+            {view === "open"
+              ? selectedProjectId === "all"
+                ? "There are no open meeting todos across your projects."
+                : "There are no open meeting todos in this project."
+              : selectedProjectId === "all"
+                ? "Completed meeting todos will appear here."
+                : "This project has no completed meeting todos."}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/project-meeting-notes-panel.tsx
+++ b/components/project-meeting-notes-panel.tsx
@@ -64,6 +64,8 @@ interface ProjectMeetingNotesPanelProps {
   projectId: string;
   canEdit: boolean;
   notes: ProjectMeetingNotePanelNote[];
+  initialMeetingNoteId?: string | null;
+  initialMeetingTodoId?: string | null;
 }
 
 interface DraftAction {
@@ -636,7 +638,11 @@ export function ProjectMeetingNotesPanel({
   projectId,
   canEdit,
   notes,
+  initialMeetingNoteId = null,
+  initialMeetingTodoId = null,
 }: ProjectMeetingNotesPanelProps) {
+  const initialSelectedNote =
+    notes.find((note) => note.id === initialMeetingNoteId) ?? null;
   const { pushToast } = useToast();
   const { isExpanded, setIsExpanded } = useProjectSectionExpanded({
     projectId,
@@ -650,12 +656,20 @@ export function ProjectMeetingNotesPanel({
   const [referenceNowMs] = useState(() => Date.now());
   const [query, setQuery] = useState("");
   const [selectedLabelFilters, setSelectedLabelFilters] = useState<string[]>([]);
-  const [listView, setListView] = useState<MeetingListView>("active");
-  const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
+  const [listView, setListView] = useState<MeetingListView>(
+    initialSelectedNote?.status === "done" ? "archived" : "active"
+  );
+  const [selectedNoteId, setSelectedNoteId] = useState<string | null>(
+    initialSelectedNote?.id ?? null
+  );
   const [prepareDialog, setPrepareDialog] = useState<PrepareDialogState | null>(null);
   const [prepareDraft, setPrepareDraft] =
     useState<PrepareDraft>(EMPTY_PREPARE_DRAFT);
-  const [notesDraft, setNotesDraft] = useState<NotesDraft>(EMPTY_NOTES_DRAFT);
+  const [notesDraft, setNotesDraft] = useState<NotesDraft>(() =>
+    initialSelectedNote
+      ? buildNotesDraftFromNote(initialSelectedNote)
+      : EMPTY_NOTES_DRAFT
+  );
   const [draftError, setDraftError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [pendingDeleteNoteId, setPendingDeleteNoteId] = useState<string | null>(null);
@@ -671,6 +685,39 @@ export function ProjectMeetingNotesPanel({
       current && sortedNotes.some((note) => note.id === current) ? current : null
     );
   }, [notes]);
+
+  useEffect(() => {
+    if (!initialMeetingNoteId) {
+      return;
+    }
+
+    const initialNote = localNotes.find(
+      (note) => note.id === initialMeetingNoteId
+    );
+    if (!initialNote) {
+      return;
+    }
+
+    setIsExpanded(true);
+    setListView(initialNote.status === "done" ? "archived" : "active");
+    setSelectedNoteId(initialNote.id);
+    setNotesDraft(buildNotesDraftFromNote(initialNote));
+    setDraftError(null);
+  }, [initialMeetingNoteId, localNotes, setIsExpanded]);
+
+  useEffect(() => {
+    if (!selectedNoteId || !initialMeetingTodoId) {
+      return;
+    }
+
+    const frame = window.requestAnimationFrame(() => {
+      document
+        .getElementById(`meeting-todo-${initialMeetingTodoId}`)
+        ?.scrollIntoView({ block: "center" });
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [initialMeetingTodoId, selectedNoteId]);
 
   useEffect(() => {
     const handleProjectActivity = (event: Event) => {
@@ -1788,7 +1835,15 @@ export function ProjectMeetingNotesPanel({
                       notesDraft.actions.map((action, index) => {
                         const isComplete = action.completedAt != null;
                         return (
-                          <div key={action.id} className="flex items-center gap-2">
+                          <div
+                            key={action.id}
+                            id={`meeting-todo-${action.id}`}
+                            className={cn(
+                              "flex items-center gap-2 rounded-lg",
+                              action.id === initialMeetingTodoId &&
+                                "bg-primary/10 p-1 ring-2 ring-primary/35"
+                            )}
+                          >
                             <button
                               type="button"
                               disabled={!canEdit || isSaving}

--- a/journal.md
+++ b/journal.md
@@ -2813,3 +2813,25 @@ Low-value entries to avoid going forward:
   build, and all 20 Playwright scenarios. The database-backed browser suite used
   the configured development database because the optional local PostgreSQL
   service at `127.0.0.1:5432` was not running; outbound email remained disabled.
+
+# 2026-07-26 - TASK-332 mobile meeting-todo navigation
+
+- Audited the expanded project todo popup at an iPhone 14 Pro CSS viewport
+  (393 x 852): its 352 x 371 px surface covered project context, nested a
+  320 px scroll area around 680 px of content, and exposed 28 px controls.
+- Selected a stable Todos destination over a floating action button because it
+  communicates navigation clearly, avoids another fixed safe-area collision,
+  and provides room for planned project and assignee capabilities.
+- Added `/todos`, adaptive Projects/Todos/Inbox navigation, actor-RLS-scoped
+  workspace aggregation, URL-backed views and project filters, source-meeting
+  deep links, access-aware completion, and open/overdue badge context.
+- Removed the floating panel from mobile layout and accessibility navigation
+  while retaining it as the project-scoped desktop quick panel. A 393 x 852
+  Playwright pass found and fixed native select intrinsic-width overflow caused
+  by long project names.
+- Full local validation passed: RLS inventory, least-privilege role setup and
+  PostgreSQL tenant-isolation matrix; lint; 134 passing Vitest files with 956
+  passing tests (2 files/tests skipped); coverage at 91.37% statements, 81.33%
+  branches, 92.2% functions, and 91.88% lines; production build; and all 24
+  Playwright scenarios. Light 393 x 852, dark 375 x 812, and desktop 1280 x
+  900 screenshots are stored under `.tmp/`.

--- a/journal.md
+++ b/journal.md
@@ -2835,3 +2835,6 @@ Low-value entries to avoid going forward:
   branches, 92.2% functions, and 91.88% lines; production build; and all 24
   Playwright scenarios. Light 393 x 852, dark 375 x 812, and desktop 1280 x
   900 screenshots are stored under `.tmp/`.
+- Published implementation commit
+  `0c679aaee83e27d24c138f9851844939f228375d` and opened ready-for-review
+  [PR #390](https://github.com/dorianagaesse/nexus_dash/pull/390).

--- a/journal.md
+++ b/journal.md
@@ -2838,3 +2838,9 @@ Low-value entries to avoid going forward:
 - Published implementation commit
   `0c679aaee83e27d24c138f9851844939f228375d` and opened ready-for-review
   [PR #390](https://github.com/dorianagaesse/nexus_dash/pull/390).
+- Addressed all three initial Copilot review threads: reverted `project.md`
+  because feature PRs do not maintain that snapshot, removed the duplicated
+  accessible count label from the Open/Completed switcher, and changed the
+  shell badge query to select only meeting status/date plus open-action counts.
+  Four focused test files (14 tests), lint, production build, and six focused
+  Playwright shell/todo scenarios passed after the review fixes.

--- a/lib/meeting-todo.ts
+++ b/lib/meeting-todo.ts
@@ -14,13 +14,32 @@ export interface ProjectMeetingTodo {
   urgencyTimestamp: number;
 }
 
-function toTimestamp(value: string | null): number | null {
+type MeetingTodoDateValue = Date | string | null;
+
+function toTimestamp(value: MeetingTodoDateValue): number | null {
   if (!value) {
     return null;
   }
 
-  const timestamp = new Date(value).getTime();
+  const timestamp = value instanceof Date ? value.getTime() : new Date(value).getTime();
   return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+export function isMeetingTodoOverdueAt(input: {
+  scheduledAt: MeetingTodoDateValue;
+  completedAt: MeetingTodoDateValue;
+  meetingStatus: string;
+  referenceNowMs: number;
+}): boolean {
+  if (input.completedAt || input.meetingStatus === "done") {
+    return false;
+  }
+
+  const scheduledAtMs = toTimestamp(input.scheduledAt);
+  return (
+    scheduledAtMs !== null &&
+    input.referenceNowMs - scheduledAtMs >= MEETING_TODO_OVERDUE_GRACE_MS
+  );
 }
 
 export function isMeetingTodoOverdue(
@@ -28,15 +47,12 @@ export function isMeetingTodoOverdue(
   action: ProjectMeetingNotePanelAction,
   referenceNowMs: number
 ): boolean {
-  if (action.completedAt || note.status === "done") {
-    return false;
-  }
-
-  const scheduledAtMs = toTimestamp(note.scheduledAt);
-  return (
-    scheduledAtMs !== null &&
-    referenceNowMs - scheduledAtMs >= MEETING_TODO_OVERDUE_GRACE_MS
-  );
+  return isMeetingTodoOverdueAt({
+    scheduledAt: note.scheduledAt,
+    completedAt: action.completedAt,
+    meetingStatus: note.status,
+    referenceNowMs,
+  });
 }
 
 export function buildProjectMeetingTodos(

--- a/lib/navigation/authenticated-shell.ts
+++ b/lib/navigation/authenticated-shell.ts
@@ -2,6 +2,7 @@ import { appendQueryToPath, normalizeReturnToPath } from "@/lib/navigation/retur
 
 export const AUTHENTICATED_DESTINATIONS = [
   "/projects",
+  "/todos",
   "/account/notifications",
   "/account",
   "/account/settings",
@@ -17,6 +18,7 @@ function isAllowedReturnPath(path: string): boolean {
   return (
     pathname === "/projects" ||
     pathname.startsWith("/projects/") ||
+    pathname === "/todos" ||
     pathname === "/account/notifications"
   );
 }
@@ -47,7 +49,7 @@ export function buildAuthenticatedDestinationHref(
   destination: AuthenticatedDestination,
   currentPath: string
 ): string {
-  if (destination === "/projects") {
+  if (destination === "/projects" || destination === "/todos") {
     return destination;
   }
 
@@ -94,6 +96,10 @@ export function resolveContextualReturnDestination(
     return { href, label: "Return to project" };
   }
 
+  if (href === "/todos") {
+    return { href, label: "Todos" };
+  }
+
   if (href === "/projects") {
     return { href, label: "Projects" };
   }
@@ -107,6 +113,9 @@ export function isDestinationCurrent(
 ): boolean {
   if (destination === "/projects") {
     return pathname === "/projects" || pathname.startsWith("/projects/");
+  }
+  if (destination === "/todos") {
+    return pathname === destination;
   }
   if (destination === "/account/settings") {
     return pathname === destination || pathname.startsWith(`${destination}/`);

--- a/lib/services/workspace-meeting-todo-service.ts
+++ b/lib/services/workspace-meeting-todo-service.ts
@@ -1,0 +1,193 @@
+import { ProjectMembershipRole } from "@prisma/client";
+
+import { isMeetingTodoOverdueAt } from "@/lib/meeting-todo";
+import {
+  buildProjectPrincipalWhere,
+  hasRequiredRole,
+} from "@/lib/services/project-access-service";
+import { withActorRlsContext } from "@/lib/services/rls-context";
+
+export interface WorkspaceMeetingTodoSummary {
+  id: string;
+  content: string;
+  completedAt: Date | null;
+  updatedAt: Date;
+  isOverdue: boolean;
+  urgencyTimestamp: number;
+  meeting: {
+    id: string;
+    title: string;
+    scheduledAt: Date | null;
+    status: string;
+  };
+  project: {
+    id: string;
+    name: string;
+    role: ProjectMembershipRole;
+    canEdit: boolean;
+  };
+}
+
+export interface WorkspaceMeetingTodoNavigationSummary {
+  openCount: number;
+  overdueCount: number;
+}
+
+function normalizeActorUserId(value: string | null | undefined): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function timestamp(value: Date | null): number {
+  return value?.getTime() ?? 0;
+}
+
+async function loadWorkspaceMeetingTodos(input: {
+  actorUserId: string;
+  openOnly: boolean;
+  referenceNowMs: number;
+}): Promise<WorkspaceMeetingTodoSummary[]> {
+  return withActorRlsContext(input.actorUserId, async (db) => {
+    const projects = await db.project.findMany({
+      where: buildProjectPrincipalWhere(input.actorUserId),
+      orderBy: [{ name: "asc" }, { id: "asc" }],
+      select: {
+        id: true,
+        name: true,
+        ownerId: true,
+        memberships: {
+          where: { userId: input.actorUserId },
+          select: { role: true },
+          take: 1,
+        },
+        meetingNotes: {
+          where: {
+            actions: {
+              some: input.openOnly ? { completedAt: null } : {},
+            },
+          },
+          select: {
+            id: true,
+            title: true,
+            scheduledAt: true,
+            status: true,
+            createdAt: true,
+            actions: {
+              ...(input.openOnly ? { where: { completedAt: null } } : {}),
+              orderBy: [{ position: "asc" }, { createdAt: "asc" }],
+              select: {
+                id: true,
+                content: true,
+                completedAt: true,
+                updatedAt: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return projects.flatMap((project) => {
+      const role =
+        project.ownerId === input.actorUserId
+          ? ProjectMembershipRole.owner
+          : (project.memberships[0]?.role ?? ProjectMembershipRole.viewer);
+      const canEdit = hasRequiredRole(role, ProjectMembershipRole.editor);
+
+      return project.meetingNotes.flatMap((meeting) =>
+        meeting.actions.map((action) => {
+          const urgencyTimestamp = timestamp(
+            meeting.scheduledAt ?? meeting.createdAt
+          );
+
+          return {
+            id: action.id,
+            content: action.content,
+            completedAt: action.completedAt,
+            updatedAt: action.updatedAt,
+            isOverdue: isMeetingTodoOverdueAt({
+              scheduledAt: meeting.scheduledAt,
+              completedAt: action.completedAt,
+              meetingStatus: meeting.status,
+              referenceNowMs: input.referenceNowMs,
+            }),
+            urgencyTimestamp,
+            meeting: {
+              id: meeting.id,
+              title: meeting.title,
+              scheduledAt: meeting.scheduledAt,
+              status: meeting.status,
+            },
+            project: {
+              id: project.id,
+              name: project.name,
+              role,
+              canEdit,
+            },
+          };
+        })
+      );
+    });
+  }) as Promise<WorkspaceMeetingTodoSummary[]>;
+}
+
+export async function listWorkspaceMeetingTodos(input: {
+  actorUserId: string;
+  referenceNowMs?: number;
+}): Promise<{
+  open: WorkspaceMeetingTodoSummary[];
+  completed: WorkspaceMeetingTodoSummary[];
+}> {
+  const actorUserId = normalizeActorUserId(input.actorUserId);
+  if (!actorUserId) {
+    return { open: [], completed: [] };
+  }
+
+  const todos = await loadWorkspaceMeetingTodos({
+    actorUserId,
+    openOnly: false,
+    referenceNowMs: input.referenceNowMs ?? Date.now(),
+  });
+
+  const open = todos
+    .filter((todo) => todo.completedAt === null)
+    .sort((left, right) => {
+      if (left.isOverdue !== right.isOverdue) {
+        return left.isOverdue ? -1 : 1;
+      }
+
+      if (left.urgencyTimestamp !== right.urgencyTimestamp) {
+        return left.urgencyTimestamp - right.urgencyTimestamp;
+      }
+
+      return left.content.localeCompare(right.content);
+    });
+  const completed = todos
+    .filter((todo) => todo.completedAt !== null)
+    .sort((left, right) => {
+      const completedDifference =
+        timestamp(right.completedAt) - timestamp(left.completedAt);
+      return completedDifference || right.updatedAt.getTime() - left.updatedAt.getTime();
+    });
+
+  return { open, completed };
+}
+
+export async function getWorkspaceMeetingTodoNavigationSummary(
+  actorUserIdInput: string
+): Promise<WorkspaceMeetingTodoNavigationSummary> {
+  const actorUserId = normalizeActorUserId(actorUserIdInput);
+  if (!actorUserId) {
+    return { openCount: 0, overdueCount: 0 };
+  }
+
+  const open = await loadWorkspaceMeetingTodos({
+    actorUserId,
+    openOnly: true,
+    referenceNowMs: Date.now(),
+  });
+
+  return {
+    openCount: open.length,
+    overdueCount: open.filter((todo) => todo.isOverdue).length,
+  };
+}

--- a/lib/services/workspace-meeting-todo-service.ts
+++ b/lib/services/workspace-meeting-todo-service.ts
@@ -180,14 +180,52 @@ export async function getWorkspaceMeetingTodoNavigationSummary(
     return { openCount: 0, overdueCount: 0 };
   }
 
-  const open = await loadWorkspaceMeetingTodos({
-    actorUserId,
-    openOnly: true,
-    referenceNowMs: Date.now(),
-  });
+  return withActorRlsContext(actorUserId, async (db) => {
+    const projects = await db.project.findMany({
+      where: buildProjectPrincipalWhere(actorUserId),
+      select: {
+        meetingNotes: {
+          where: {
+            actions: {
+              some: { completedAt: null },
+            },
+          },
+          select: {
+            scheduledAt: true,
+            status: true,
+            _count: {
+              select: {
+                actions: {
+                  where: { completedAt: null },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const referenceNowMs = Date.now();
 
-  return {
-    openCount: open.length,
-    overdueCount: open.filter((todo) => todo.isOverdue).length,
-  };
+    return projects.reduce<WorkspaceMeetingTodoNavigationSummary>(
+      (summary, project) => {
+        for (const meeting of project.meetingNotes) {
+          const openInMeeting = meeting._count.actions;
+          summary.openCount += openInMeeting;
+          if (
+            isMeetingTodoOverdueAt({
+              scheduledAt: meeting.scheduledAt,
+              completedAt: null,
+              meetingStatus: meeting.status,
+              referenceNowMs,
+            })
+          ) {
+            summary.overdueCount += openInMeeting;
+          }
+        }
+
+        return summary;
+      },
+      { openCount: 0, overdueCount: 0 }
+    );
+  });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexusdash",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexusdash",
-      "version": "0.27.0",
+      "version": "0.28.0",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1079.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexusdash",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "private": true,
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0",

--- a/project.md
+++ b/project.md
@@ -1,6 +1,6 @@
 # NexusDash Project Blueprint (Current State)
 
-Last verified: 2026-07-26
+Last verified: 2026-07-05
 
 ## 1. Vision
 
@@ -10,8 +10,7 @@ NexusDash is a personal/team execution workspace that keeps project planning, de
 
 - Email/password sign-up and sign-in from `/`.
 - Email verification and password recovery lifecycle for credentials accounts.
-- DB-backed session authentication with protected app routes (`/projects/**`,
-  `/todos`, `/account/**`).
+- DB-backed session authentication with protected app routes (`/projects/**`, `/account/**`).
 - Multi-project workspace with project CRUD.
 - Project sharing v2 with owner-managed invites, role-based membership, email-bound invitation flows, and resumable invite acceptance.
 - Project dashboard with core panels:
@@ -27,15 +26,6 @@ NexusDash is a personal/team execution workspace that keeps project planning, de
     for task, task-comment, and context-card mutations; dashboards apply safe
     remote updates directly, keep adaptive polling and broad refresh as
     fallbacks, and acknowledge local mutations to avoid self-refresh prompts
-- Workspace meeting todos:
-  - dedicated `/todos` destination in the desktop sidebar and mobile bottom
-    navigation, with open and overdue counts
-  - actor-RLS-scoped aggregation across owned and shared projects, grouped by
-    source project with deep links back to the meeting note
-  - URL-backed Open/Completed views and project filters, plus authorized
-    completion/reopening and clear viewer read-only treatment
-  - desktop project dashboards retain the compact floating quick panel while
-    mobile uses the unobstructed full-screen workspace destination
 - Notification center:
   - durable per-user in-app inbox at `/account/notifications`
   - unread/read state and resolved lifecycle
@@ -136,9 +126,8 @@ Source of truth: [`prisma/schema.prisma`](./prisma/schema.prisma)
 
 From `tasks/current.md` + `tasks/backlog.md`:
 
-1. Continue the prioritized UX and collaboration backlog after TASK-332,
-   including meeting participant identities, todo assignees, granular
-   collaboration rights, and the queued shell refinements.
+1. The prioritized UI/UX remediation sequence is TASK-321, TASK-322, TASK-100,
+   TASK-133, TASK-129, TASK-108, then the TASK-323 verification gate.
 
 ## 8. Source-of-Truth Docs
 

--- a/project.md
+++ b/project.md
@@ -1,6 +1,6 @@
 # NexusDash Project Blueprint (Current State)
 
-Last verified: 2026-07-05
+Last verified: 2026-07-26
 
 ## 1. Vision
 
@@ -10,7 +10,8 @@ NexusDash is a personal/team execution workspace that keeps project planning, de
 
 - Email/password sign-up and sign-in from `/`.
 - Email verification and password recovery lifecycle for credentials accounts.
-- DB-backed session authentication with protected app routes (`/projects/**`, `/account/**`).
+- DB-backed session authentication with protected app routes (`/projects/**`,
+  `/todos`, `/account/**`).
 - Multi-project workspace with project CRUD.
 - Project sharing v2 with owner-managed invites, role-based membership, email-bound invitation flows, and resumable invite acceptance.
 - Project dashboard with core panels:
@@ -26,6 +27,15 @@ NexusDash is a personal/team execution workspace that keeps project planning, de
     for task, task-comment, and context-card mutations; dashboards apply safe
     remote updates directly, keep adaptive polling and broad refresh as
     fallbacks, and acknowledge local mutations to avoid self-refresh prompts
+- Workspace meeting todos:
+  - dedicated `/todos` destination in the desktop sidebar and mobile bottom
+    navigation, with open and overdue counts
+  - actor-RLS-scoped aggregation across owned and shared projects, grouped by
+    source project with deep links back to the meeting note
+  - URL-backed Open/Completed views and project filters, plus authorized
+    completion/reopening and clear viewer read-only treatment
+  - desktop project dashboards retain the compact floating quick panel while
+    mobile uses the unobstructed full-screen workspace destination
 - Notification center:
   - durable per-user in-app inbox at `/account/notifications`
   - unread/read state and resolved lifecycle
@@ -126,8 +136,9 @@ Source of truth: [`prisma/schema.prisma`](./prisma/schema.prisma)
 
 From `tasks/current.md` + `tasks/backlog.md`:
 
-1. The prioritized UI/UX remediation sequence is TASK-321, TASK-322, TASK-100,
-   TASK-133, TASK-129, TASK-108, then the TASK-323 verification gate.
+1. Continue the prioritized UX and collaboration backlog after TASK-332,
+   including meeting participant identities, todo assignees, granular
+   collaboration rights, and the queued shell refinements.
 
 ## 8. Source-of-Truth Docs
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -65,7 +65,7 @@ Last reviewed: 2026-07-26
   Dependencies: TASK-058, TASK-098, TASK-106, TASK-130
 - ID: TASK-332
   Title: Mobile meeting-todo popup refinement - audit and implement a discoverable entry pattern
-  Status: Ready for review - dedicated workspace Todos navigation implemented and validated
+  Status: In review - PR #390 adds the validated workspace Todos navigation
   Rationale: First audit the current mobile meeting-todo popup and its collisions, reachability, screen usage, focus behavior, and navigation context; then implement and validate the best mobile-only entry pattern, explicitly comparing a floating action button with a dedicated bottom-navigation destination before committing to the final interaction.
   Dependencies: TASK-100, TASK-316, TASK-321, TASK-322
 - ID: TASK-333

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -65,7 +65,7 @@ Last reviewed: 2026-07-26
   Dependencies: TASK-058, TASK-098, TASK-106, TASK-130
 - ID: TASK-332
   Title: Mobile meeting-todo popup refinement - audit and implement a discoverable entry pattern
-  Status: Next 12 - audit-gated mobile todo remediation
+  Status: Ready for review - dedicated workspace Todos navigation implemented and validated
   Rationale: First audit the current mobile meeting-todo popup and its collisions, reachability, screen usage, focus behavior, and navigation context; then implement and validate the best mobile-only entry pattern, explicitly comparing a floating action button with a dedicated bottom-navigation destination before committing to the final interaction.
   Dependencies: TASK-100, TASK-316, TASK-321, TASK-322
 - ID: TASK-333

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -2,116 +2,72 @@
 
 ## Task
 
-- ID: TASK-324
-- Title: Unified user hub and avatar-menu navigation rework
-- Status: Complete (2026-07-23)
-- Branch: `feature/task-324-unified-user-hub-navigation`
-- Pull request: [#380](https://github.com/dorianagaesse/nexus_dash/pull/380)
-- Brief: [`task-324-unified-user-hub-navigation.md`](./task-324-unified-user-hub-navigation.md)
+- ID: TASK-332
+- Title: Mobile meeting-todo navigation
+- Status: Ready for review
+- Branch: `feature/task-332-mobile-todo-navigation`
+- Brief: [`task-332-mobile-todo-navigation.md`](./task-332-mobile-todo-navigation.md)
 
 ## Objective
 
-Turn the current collection of account destinations into one coherent user
-space, while simplifying the retained avatar menu into a concise launcher
-rather than a second navigation system.
+Replace the obstructive mobile meeting-todo popup with a stable, route-backed
+Todos destination that can grow into project and assignee filtering.
 
 ## Scope
 
-- Build one responsive user-hub header and route-backed navigation treatment
-  across Account, Settings, and Notifications.
-- Preserve the existing account URLs, deep links, browser history, unread
-  state, safe contextual `returnTo` values, and authenticated shell.
-- Keep the avatar menu aligned to its desktop user-info card with explicit
-  Account, Settings, and Notifications destinations plus a spatially separated
-  logout action.
-- Keep appearance as a one-click shell control and place app version/repository
-  metadata in Settings rather than inside the avatar menu.
-- Cover active state, accessible naming, keyboard and focus behavior, light and
-  dark themes, loading/empty/error states, and 375 px containment.
-- Add focused component and Playwright coverage for hub and menu behavior.
+- Add protected workspace-level meeting todos at `/todos`.
+- Add Todos to adaptive primary navigation with an open-count badge.
+- Provide URL-backed status and project filtering, project grouping, source
+  meeting links, and completion/reopening.
+- Hide the project-scoped floating todo panel on mobile while retaining it on
+  desktop.
+- Cover authorization, read-only behavior, accessibility, safe areas, light
+  and dark themes, and 375 px containment.
 
 ## Runtime Assumptions
 
-- Docker Engine, the repository `.env`, installed dependencies, and Playwright
-  Chromium are available locally.
-- The repository PostgreSQL Compose service may be started when database-backed
-  rendering or browser validation requires it.
-- Preview validation, if required by acceptance or review, will run the deploy
-  workflow from `feature/task-324-unified-user-hub-navigation` with
-  `git_ref=feature/task-324-unified-user-hub-navigation`; workflow logs will be
-  checked for the requested checkout ref.
+- Docker Engine, the repository environment, installed dependencies, and
+  Playwright Chromium are available locally.
+- The local PostgreSQL Compose service may be started for browser validation.
+- Preview validation, if required, will use
+  `git_ref=feature/task-332-mobile-todo-navigation`.
 
 ## Acceptance Criteria
 
-1. Account, Settings, and Notifications are visibly available from one shared
-   user-hub navigation surface on desktop and mobile.
-2. Each hub view has a stable internal URL and supports refresh, deep linking,
-   browser Back/Forward, and contextual `returnTo` behavior.
-3. The active hub view is visually distinct and announced semantically without
-   relying on color alone.
-4. The avatar menu retains the user identity and provides explicit Account,
-   Settings, and Notifications destinations for casual-user discoverability.
-5. The desktop menu matches and aligns with the complete user-info card;
-   appearance remains a separate one-click control within that card,
-   version/repository metadata is available from Settings, and logout is
-   separated from navigation.
-6. Notification unread state remains discoverable from the avatar entry point
-   and the Notifications tab without creating competing primary actions.
-7. All interactive targets are at least 44 px, keyboard reachable, visibly
-   focused, and usable at 375 px without clipping or horizontal page overflow.
-8. Account routes retain the responsive authenticated shell and do not obscure
-   page content, feedback, dialogs, or fixed navigation.
+1. Mobile primary navigation consistently presents Projects, Todos, and Inbox
+   with labels, icons, 44 px targets, safe-area clearance, and active state.
+2. `/todos` is protected, refreshable, deep-linkable, and access-safe across
+   the signed-in user's projects.
+3. Open/Completed and project filters are URL-backed and work with browser
+   Back/Forward.
+4. Todos retain project and source-meeting context and sort overdue/recent work
+   predictably.
+5. Owners/editors can complete or reopen todos with clear feedback while
+   viewers receive a read-only treatment.
+6. The floating panel is absent on mobile and remains available on desktop.
+7. The touched UI passes 375 px, light/dark, keyboard, focus, and 44 px target
+   checks without overflow or fixed-navigation collisions.
+8. Existing meeting-note, notification-return, and desktop behavior remains
+   intact.
 
 ## Definition Of Done
 
-- The shared user hub and simplified avatar menu use reusable components and
-  established semantic design tokens.
-- Focused component tests cover tab semantics, active state, unread state, menu
-  composition, and safe contextual URLs.
-- Playwright covers desktop/mobile hub switching, direct entry, browser
-  history, notification deep links, and return-to-project continuity.
-- Light/dark and 375/768/1024/1440 px visual walkthroughs pass without
-  overflow, collision, or ambiguous current location; screenshots are captured
-  under `.tmp/`.
-- `npm run lint`, `npm run rls:check`, `npm test`, `npm run test:coverage`,
-  `npm run build`, and relevant Playwright checks pass.
-- Tracking documentation and product version are updated, the branch is
-  committed and pushed, and a ready-for-review PR is open with initial Copilot
-  review/check feedback handled before handoff.
+- Access-safe workspace reads live in `lib/services/**` under actor RLS.
+- Focused unit/component and Playwright coverage passes.
+- Required lint, RLS, test, coverage, build, and UI validation is green.
+- Tracking docs and product version are updated.
+- The branch is committed, pushed, and opened as a ready-for-review PR with
+  initial automated feedback handled.
 
-## Outcome
+## Progress
 
-- Introduced one shared responsive user hub for Account, Settings, and
-  Notifications while retaining each stable route and the authenticated shell.
-- Preserved safe project/task return context, notification deep links, browser
-  history, live unread state, and nested Settings routes.
-- Matched the desktop avatar menu to the full user-info card and restored
-  explicit Account, Settings, and Notifications actions with
-  Arrow/Home/End/Escape keyboard behavior and separated logout.
-- Restored the compact theme control to the desktop user-info card and retained
-  the mobile header control, while moving version plus the GitHub repository
-  link into Settings.
-- Added account-route loading/error recovery, 44 px controls on touched
-  surfaces, and reusable component/Playwright coverage.
-- Prepared product release `v0.27.0` with matching package and changelog data.
-
-## Validation
-
-- `npm run lint` passed.
-- `npm run rls:check` passed.
-- Release policy and `git diff --check` passed.
-- `npm test`: 948 passed, 2 skipped.
-- `npm run test:coverage`: 91.37% statements, 81.33% branches, 92.2%
-  functions, 91.88% lines.
-- `npm run test:e2e`: production build and all 23 Playwright tests passed.
-- Light/dark Playwright walkthroughs at 375, 768, 1024, and 1440 px passed;
-  latest theme-control screenshots are in
-  `.tmp/task324-theme-button-refinement/`.
-- Playwright verified the open desktop menu matches the complete user-info
-  card's width and left edge within one pixel, and all 23 E2E scenarios passed.
-- GitHub Quality Core, E2E Smoke, Tenant Isolation, Container Image, and branch
-  checks passed. Copilot's one actionable icon-sizing comment was applied and
-  resolved.
-- Stabilized the notification round-trip Playwright journey by closing the
-  intentionally open task dialog before using the shell return link; the
-  focused test passed three consecutive runs.
+- Completed the 393 x 852 mobile audit and selected a dedicated navigation
+  destination over a floating action button.
+- Created the dedicated task branch/worktree and implementation brief.
+- Implemented the protected workspace service/route, adaptive navigation,
+  URL-backed views and filters, source-meeting deep links, and access-aware
+  completion behavior.
+- Removed the floating panel from mobile layout while preserving its desktop
+  project workflow.
+- Passed the complete local validation baseline, including RLS isolation,
+  956 unit/API tests, coverage, production build, and all 24 Playwright flows.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,8 +4,9 @@
 
 - ID: TASK-332
 - Title: Mobile meeting-todo navigation
-- Status: Ready for review
+- Status: In review
 - Branch: `feature/task-332-mobile-todo-navigation`
+- Pull request: [#390](https://github.com/dorianagaesse/nexus_dash/pull/390)
 - Brief: [`task-332-mobile-todo-navigation.md`](./task-332-mobile-todo-navigation.md)
 
 ## Objective

--- a/tasks/task-332-mobile-todo-navigation.md
+++ b/tasks/task-332-mobile-todo-navigation.md
@@ -1,0 +1,131 @@
+# TASK-332 - Mobile meeting-todo navigation
+
+## Status
+
+Ready for review on `feature/task-332-mobile-todo-navigation`.
+
+## Objective
+
+Replace the obstructive mobile meeting-todo popup with a discoverable,
+route-backed workspace destination that remains useful as todo ownership and
+filtering capabilities expand.
+
+## Audit Decision
+
+The iPhone 14 Pro audit at a 393 x 852 CSS viewport found that the expanded
+popup occupied 352 x 371 px, covered roughly half of the usable content height,
+introduced a nested 320 px scroll region for 680 px of todo content, and used
+28 x 28 px completion and collapse controls. It hid the meeting context users
+needed to interpret the todos and competed with the fixed mobile navigation.
+
+A floating action button was rejected because it conventionally communicates
+creation rather than navigation, would add another floating collision near the
+safe area, and would not provide enough room for future project and assignee
+filters.
+
+The selected pattern is a stable `Todos` destination in adaptive primary
+navigation:
+
+- mobile uses a third labeled bottom-navigation item between Projects and
+  Inbox;
+- desktop exposes the same workspace destination in the sidebar;
+- `/todos` provides the full-screen list and stable deep link;
+- the existing project-scoped floating panel remains available on desktop but
+  is removed from the mobile layout.
+
+## Scope
+
+- Add a protected `/todos` workspace route for meeting todos across every
+  project the signed-in user can access.
+- Add Todos to adaptive primary navigation with an accessible active state and
+  open-count badge.
+- Present URL-backed Open/Completed views and project filtering.
+- Group todos by project and retain links to their source meeting notes.
+- Reuse the existing authorized completion endpoint and clearly distinguish
+  view-only projects.
+- Hide the floating project todo panel below the desktop breakpoint.
+- Preserve bottom safe-area spacing, browser history, contextual account return
+  paths, and project/meeting deep links.
+
+## Out Of Scope
+
+- Adding or changing todo assignee persistence.
+- Creating todos outside meeting notes.
+- Replacing the desktop project-scoped quick panel.
+- Redesigning meeting-note creation or editing.
+- Combining Kanban tasks and meeting todos into one work model.
+
+## Runtime Assumptions
+
+- Docker Engine, the repository environment, installed dependencies, and
+  Playwright Chromium are available locally.
+- The local PostgreSQL Compose service may be started for database-backed
+  browser validation.
+- Preview validation, if required by review, will run from
+  `feature/task-332-mobile-todo-navigation` with that explicit `git_ref`.
+
+## Acceptance Criteria
+
+1. Mobile primary navigation consistently presents Projects, Todos, and Inbox
+   in that order with labels, Lucide icons, at least 44 px targets, safe-area
+   clearance, and a semantically announced active state.
+2. `/todos` is protected, refreshable, deep-linkable, and lists meeting todos
+   from every project the signed-in user can access without exposing other
+   projects.
+3. Open and Completed views plus project filtering are reflected in the URL
+   and work with browser Back/Forward.
+4. Open todos prioritize overdue work, completed todos prioritize recent
+   completion, and both retain project and source-meeting context.
+5. Editors and owners can complete or reopen todos with pending, success, and
+   recoverable error feedback; viewers receive a clear read-only treatment.
+6. The project meeting-todo floating panel is absent from mobile layout and
+   accessibility navigation while remaining available on desktop.
+7. Todo rows and completion controls remain usable at 375 px, in light and dark
+   themes, without horizontal overflow or content hidden behind fixed
+   navigation.
+8. Existing project meeting-note deep links, completion behavior, notification
+   return paths, and desktop panel behavior remain intact.
+
+## Definition Of Done
+
+- Workspace todo reads live in `lib/services/**`, execute under actor RLS
+  context, and derive access from existing owner/membership rules.
+- Reusable route and list components use established semantic tokens and
+  Lucide icons.
+- Focused unit/component tests cover access-safe aggregation, sorting, shell
+  navigation, URL state, read-only behavior, and completion feedback.
+- Playwright covers mobile navigation, direct `/todos` entry, filters,
+  Back/Forward, completion/reopening, meeting deep links, and mobile popup
+  removal while retaining desktop behavior.
+- Light/dark walkthroughs at 375 and 393 px plus a desktop check pass, with
+  screenshots stored under `.tmp/`.
+- Required repository validation is green, tracking documentation and product
+  version are updated, and the branch ships through a ready-for-review PR with
+  initial automated feedback handled.
+
+## Outcome
+
+- Added the protected `/todos` route and actor-RLS-scoped workspace service.
+- Added Projects, Todos, and Inbox to adaptive primary navigation with open and
+  overdue badge context.
+- Added route-backed Open/Completed views, project filtering, project grouping,
+  viewer treatment, authorized completion/reopening, and deep links that open
+  and highlight the source meeting todo.
+- Removed the project floating panel from mobile layout and accessibility
+  navigation while retaining it at the desktop breakpoint.
+- Updated the product release to `v0.28.0`.
+
+## Validation
+
+- `npm run validate:local`
+  - RLS inventory and PostgreSQL tenant-isolation matrix passed.
+  - 134 Vitest files passed, 2 skipped; 956 tests passed, 2 skipped.
+  - Coverage: 91.37% statements, 81.33% branches, 92.2% functions, 91.88%
+    lines.
+  - Production build passed and generated `/todos`.
+  - All 24 Playwright scenarios passed.
+- TASK-332 browser checks passed at 393 x 852 light, 375 x 812 dark, and
+  1280 x 900 desktop. Screenshots are stored under `.tmp/` as
+  `task332-iphone-14-pro-light.png`, `task332-375-dark.png`, and
+  `task332-desktop-panel.png`.
+- `git diff --check` passed.

--- a/tasks/task-332-mobile-todo-navigation.md
+++ b/tasks/task-332-mobile-todo-navigation.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Ready for review on `feature/task-332-mobile-todo-navigation`.
+In review in [PR #390](https://github.com/dorianagaesse/nexus_dash/pull/390)
+from `feature/task-332-mobile-todo-navigation`.
 
 ## Objective
 

--- a/tests/components/authenticated-app-shell.test.tsx
+++ b/tests/components/authenticated-app-shell.test.tsx
@@ -41,6 +41,7 @@ describe("authenticated app shell", () => {
         usernameTag="dorian#1234"
         avatarSeed="seed"
         initialNotificationSnapshot={notificationSnapshot}
+        initialMeetingTodoSummary={{ openCount: 3, overdueCount: 1 }}
         notificationBanner={<div>Notification banner</div>}
       >
         <main>Settings content</main>
@@ -49,7 +50,9 @@ describe("authenticated app shell", () => {
 
     expect(result).toContain('aria-label="Primary navigation"');
     expect(result).toContain("Projects");
+    expect(result).toContain("Todos");
     expect(result).toContain("Inbox");
+    expect(result).toContain("3 open todos, 1 overdue");
     expect(result).toContain("Account menu");
     expect(result).toContain("data-account-identity-area");
     expect(result).toContain('aria-current="page"');
@@ -71,6 +74,7 @@ describe("authenticated app shell", () => {
         usernameTag="dorian#1234"
         avatarSeed="seed"
         initialNotificationSnapshot={notificationSnapshot}
+        initialMeetingTodoSummary={{ openCount: 3, overdueCount: 1 }}
         notificationBanner={<div>Notification banner</div>}
       >
         <main>Project content</main>

--- a/tests/components/meeting-todo-side-panel.test.tsx
+++ b/tests/components/meeting-todo-side-panel.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, test, vi } from "vitest";
+
+import { MeetingTodoSidePanel } from "@/components/meeting-todos/meeting-todo-side-panel";
+
+(globalThis as { React?: typeof React }).React = React;
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+describe("meeting todo side panel", () => {
+  test("stays out of mobile layout while remaining available on desktop", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <MeetingTodoSidePanel
+        notes={[
+          {
+            id: "meeting-1",
+            projectId: "project-1",
+            title: "Mobile review",
+            scheduledAt: "2026-07-10T09:00:00.000Z",
+            participants: [],
+            labels: [],
+            status: "actions_in_progress",
+            inputNotes: "",
+            outputNotes: "",
+            actions: [
+              {
+                id: "todo-1",
+                content: "Choose the mobile todo entry",
+                completedAt: null,
+                position: 0,
+              },
+            ],
+            createdAt: "2026-07-10T08:00:00.000Z",
+            updatedAt: "2026-07-10T10:00:00.000Z",
+          },
+        ]}
+        canEdit
+        referenceNowMs={new Date("2026-07-20T12:00:00.000Z").getTime()}
+        pendingActionId={null}
+        onOpenMeeting={vi.fn()}
+        onSetCompleted={vi.fn()}
+        />
+      );
+    });
+    const result = document.body.innerHTML;
+
+    expect(result).toContain('role="region"');
+    expect(result).toContain("hidden");
+    expect(result).toContain("lg:block");
+    expect(result).toContain("Meeting todos");
+
+    await act(async () => root.unmount());
+    container.remove();
+  });
+});

--- a/tests/components/workspace-meeting-todos.test.tsx
+++ b/tests/components/workspace-meeting-todos.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const navigationMock = vi.hoisted(() => ({
+  push: vi.fn(),
+  refresh: vi.fn(),
+}));
+
+let mockSearchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => navigationMock,
+  useSearchParams: () => mockSearchParams,
+}));
+
+import {
+  WorkspaceMeetingTodos,
+  type WorkspaceMeetingTodoItem,
+} from "@/components/meeting-todos/workspace-meeting-todos";
+
+(globalThis as { React?: typeof React }).React = React;
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const ownerTodo: WorkspaceMeetingTodoItem = {
+  id: "todo-owner",
+  content: "Confirm the mobile navigation pattern",
+  completedAt: null,
+  updatedAt: "2026-07-20T10:00:00.000Z",
+  isOverdue: true,
+  meeting: {
+    id: "meeting-1",
+    title: "Mobile launch readiness",
+    scheduledAt: "2026-07-10T09:00:00.000Z",
+    status: "actions_in_progress",
+  },
+  project: {
+    id: "project-1",
+    name: "Alpha",
+    role: "owner",
+    canEdit: true,
+  },
+};
+
+const viewerTodo: WorkspaceMeetingTodoItem = {
+  ...ownerTodo,
+  id: "todo-viewer",
+  content: "Review the shared launch notes",
+  isOverdue: false,
+  project: {
+    id: "project-2",
+    name: "Beta",
+    role: "viewer",
+    canEdit: false,
+  },
+};
+
+describe("workspace meeting todos", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+  });
+
+  test("renders route-backed views, source context, and touch-sized controls", () => {
+    const result = renderToStaticMarkup(
+      <WorkspaceMeetingTodos initialTodos={[ownerTodo, viewerTodo]} />
+    );
+
+    expect(result).toContain('aria-label="Todo views"');
+    expect(result).toContain('href="/todos"');
+    expect(result).toContain('href="/todos?view=completed"');
+    expect(result).toContain(
+      "/projects/project-1?meetingNoteId=meeting-1&amp;meetingTodoId=todo-owner"
+    );
+    expect(result).toContain("Complete todo: Confirm the mobile navigation pattern");
+    expect(result).toContain("h-11 w-11");
+    expect(result).toContain("Overdue");
+    expect(result).toContain("View only");
+  });
+
+  test("uses URL state for the completed project-filtered view", () => {
+    mockSearchParams = new URLSearchParams(
+      "view=completed&project=project-1"
+    );
+    const completedTodo = {
+      ...ownerTodo,
+      completedAt: "2026-07-20T11:00:00.000Z",
+      isOverdue: false,
+    };
+
+    const result = renderToStaticMarkup(
+      <WorkspaceMeetingTodos initialTodos={[completedTodo]} />
+    );
+
+    expect(result).toContain('aria-current="page"');
+    expect(result).toContain(
+      'href="/todos?project=project-1"'
+    );
+    expect(result).toContain("Reopen todo: Confirm the mobile navigation pattern");
+  });
+
+  test("completes editable todos with pending-safe feedback and refresh", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ note: { id: "meeting-1" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      );
+
+    await act(async () => {
+      root.render(<WorkspaceMeetingTodos initialTodos={[ownerTodo]} />);
+    });
+
+    const completeButton = container.querySelector(
+      'button[aria-label="Complete todo: Confirm the mobile navigation pattern"]'
+    ) as HTMLButtonElement;
+    await act(async () => {
+      completeButton.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/projects/project-1/meeting-notes/meeting-1/actions/todo-owner",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ completed: true }),
+      })
+    );
+    expect(container.textContent).toContain("Todo completed.");
+    expect(container.textContent).toContain("All caught up");
+    expect(navigationMock.refresh).toHaveBeenCalled();
+
+    await act(async () => root.unmount());
+    container.remove();
+    fetchMock.mockRestore();
+  });
+});

--- a/tests/e2e/authenticated-app-shell.spec.ts
+++ b/tests/e2e/authenticated-app-shell.spec.ts
@@ -213,7 +213,7 @@ test.describe("responsive authenticated app shell", () => {
       "nav[aria-label='Primary navigation']:visible"
     );
     await expect(mobileNavigation).toBeVisible();
-    await expect(mobileNavigation.getByRole("link")).toHaveCount(2);
+    await expect(mobileNavigation.getByRole("link")).toHaveCount(3);
     await expect(page.getByRole("button", { name: /Switch to .* mode/ })).toBeVisible();
     await page.getByRole("button", { name: "Account menu" }).click();
     await expect(

--- a/tests/e2e/workspace-meeting-todos.spec.ts
+++ b/tests/e2e/workspace-meeting-todos.spec.ts
@@ -1,0 +1,240 @@
+import { expect, test } from "@playwright/test";
+
+import { prisma } from "../../lib/prisma";
+import { signInAsVerifiedUser } from "./helpers/auth-helpers";
+import { uniqueProjectName } from "./helpers/project-helpers";
+
+async function createWorkspaceTodoFixture(userId: string) {
+  const ownerProjectName = uniqueProjectName("todo-owner-project");
+  const viewerProjectName = uniqueProjectName("todo-viewer-project");
+  const ownerMeetingTitle = uniqueProjectName("owner-planning");
+  const viewerMeetingTitle = uniqueProjectName("viewer-review");
+  const externalOwner = await prisma.user.create({
+    data: {
+      email: `${uniqueProjectName("todo-owner")}@nexusdash.local`,
+      name: "Todo Project Owner",
+      emailVerified: new Date(),
+    },
+    select: { id: true },
+  });
+  const ownerProject = await prisma.project.create({
+    data: {
+      ownerId: userId,
+      name: ownerProjectName,
+      description: "Editable meeting todos.",
+      memberships: {
+        create: {
+          userId,
+          role: "owner",
+        },
+      },
+      meetingNotes: {
+        create: {
+          title: ownerMeetingTitle,
+          scheduledAt: new Date(Date.now() - 9 * 24 * 60 * 60 * 1000),
+          participants: ["Dorian"],
+          status: "actions_in_progress",
+          inputNotes: "Validate the mobile todo destination.",
+          outputNotes: "",
+          createdByUserId: userId,
+          updatedByUserId: userId,
+          actions: {
+            create: [
+              {
+                content: "Complete the mobile navigation audit",
+                position: 0,
+              },
+              {
+                content: "Open the source meeting from Todos",
+                position: 1,
+              },
+              {
+                content: "Share the completed prototype",
+                position: 2,
+                completedAt: new Date(Date.now() - 60_000),
+              },
+            ],
+          },
+        },
+      },
+    },
+    select: {
+      id: true,
+      meetingNotes: {
+        select: {
+          id: true,
+          actions: {
+            select: { id: true, content: true },
+          },
+        },
+      },
+    },
+  });
+  const viewerProject = await prisma.project.create({
+    data: {
+      ownerId: externalOwner.id,
+      name: viewerProjectName,
+      description: "Read-only meeting todos.",
+      memberships: {
+        create: [
+          {
+            userId: externalOwner.id,
+            role: "owner",
+          },
+          {
+            userId,
+            role: "viewer",
+          },
+        ],
+      },
+      meetingNotes: {
+        create: {
+          title: viewerMeetingTitle,
+          scheduledAt: new Date(),
+          participants: ["Camille"],
+          status: "actions_in_progress",
+          inputNotes: "Viewer coverage.",
+          outputNotes: "",
+          createdByUserId: externalOwner.id,
+          updatedByUserId: externalOwner.id,
+          actions: {
+            create: {
+              content: "Review the shared read-only follow-up",
+              position: 0,
+            },
+          },
+        },
+      },
+    },
+    select: { id: true },
+  });
+
+  return {
+    ownerProjectId: ownerProject.id,
+    viewerProjectId: viewerProject.id,
+    ownerProjectName,
+    viewerProjectName,
+    ownerMeetingTitle,
+    ownerMeetingId: ownerProject.meetingNotes[0]!.id,
+    sourceTodoId: ownerProject.meetingNotes[0]!.actions.find(
+      (action) => action.content === "Open the source meeting from Todos"
+    )!.id,
+  };
+}
+
+test.describe("workspace meeting todos", () => {
+  test("replaces the mobile popup with a route-backed primary destination", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 393, height: 852 });
+    const userId = await signInAsVerifiedUser(page);
+    const fixture = await createWorkspaceTodoFixture(userId);
+
+    await page.goto("/todos");
+
+    const mobileNavigation = page.locator(
+      "nav[aria-label='Primary navigation']:visible"
+    );
+    await expect(mobileNavigation.getByRole("link")).toHaveCount(3);
+    await expect(
+      mobileNavigation.getByRole("link", { name: /Todos/ })
+    ).toHaveAttribute("aria-current", "page");
+    await expect(
+      page.getByRole("heading", { name: "Todos", exact: true })
+    ).toBeVisible();
+    await expect(page.getByText("Complete the mobile navigation audit")).toBeVisible();
+    await expect(page.getByText("Review the shared read-only follow-up")).toBeVisible();
+    await expect(page.getByText("View only", { exact: true })).toBeVisible();
+
+    const targetSizes = await mobileNavigation
+      .getByRole("link")
+      .evaluateAll((links) =>
+        links.map((link) => {
+          const rect = link.getBoundingClientRect();
+          return { width: rect.width, height: rect.height };
+        })
+      );
+    expect(targetSizes.every((target) => target.height >= 44)).toBe(true);
+    const completionBox = await page
+      .getByRole("button", {
+        name: "Complete todo: Complete the mobile navigation audit",
+      })
+      .boundingBox();
+    expect(completionBox?.width).toBeGreaterThanOrEqual(44);
+    expect(completionBox?.height).toBeGreaterThanOrEqual(44);
+    expect(
+      await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)
+    ).toBe(true);
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.getByRole("button", { name: "Switch to dark mode" }).click();
+    await expect(page.locator("html")).toHaveClass(/dark/);
+    expect(
+      await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)
+    ).toBe(true);
+    await page.getByRole("button", { name: "Switch to light mode" }).click();
+    await page.setViewportSize({ width: 393, height: 852 });
+
+    await page
+      .getByRole("combobox", { name: "Project", exact: true })
+      .selectOption(fixture.viewerProjectId);
+    await expect(page).toHaveURL(
+      new RegExp(`/todos\\?project=${fixture.viewerProjectId}$`)
+    );
+    await expect(page.getByText("Review the shared read-only follow-up")).toBeVisible();
+    await expect(
+      page.getByRole("button", {
+        name: "Complete todo: Review the shared read-only follow-up",
+      })
+    ).toHaveCount(0);
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/todos$/);
+    await page.getByRole("link", { name: /^completed/i }).click();
+    await expect(page).toHaveURL(/\/todos\?view=completed$/);
+    await expect(page.getByText("Share the completed prototype")).toBeVisible();
+    await page.goBack();
+    await expect(page).toHaveURL(/\/todos$/);
+
+    const completionResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "PATCH" &&
+        /\/meeting-notes\/[^/]+\/actions\/[^/]+$/.test(response.url()) &&
+        response.ok()
+    );
+    await page
+      .getByRole("button", {
+        name: "Complete todo: Complete the mobile navigation audit",
+      })
+      .click();
+    await completionResponse;
+    await expect(page.getByText("Todo completed.")).toBeVisible();
+    await expect(page.getByText("Complete the mobile navigation audit")).toBeHidden();
+
+    await page
+      .locator("li", { hasText: "Open the source meeting from Todos" })
+      .getByRole("link", { name: new RegExp(fixture.ownerMeetingTitle) })
+      .click();
+    await expect(page).toHaveURL(
+      new RegExp(
+        `/projects/${fixture.ownerProjectId}\\?meetingNoteId=${fixture.ownerMeetingId}&meetingTodoId=${fixture.sourceTodoId}`
+      )
+    );
+    const meetingDialog = page.getByRole("dialog");
+    await expect(
+      meetingDialog.getByRole("heading", {
+        name: fixture.ownerMeetingTitle,
+      })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("region", { name: "Meeting todos", exact: true })
+    ).toBeHidden();
+    await meetingDialog
+      .getByRole("button", { name: `Close ${fixture.ownerMeetingTitle}` })
+      .click();
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await expect(
+      page.getByRole("region", { name: "Meeting todos", exact: true })
+    ).toBeVisible();
+  });
+});

--- a/tests/lib/authenticated-shell-navigation.test.ts
+++ b/tests/lib/authenticated-shell-navigation.test.ts
@@ -28,6 +28,21 @@ describe("authenticated shell navigation", () => {
     );
   });
 
+  test("keeps Todos as a stable workspace destination and return origin", () => {
+    expect(buildAuthenticatedDestinationHref("/todos", "/projects/project-1")).toBe(
+      "/todos"
+    );
+    expect(
+      buildAuthenticatedDestinationHref("/account/settings", "/todos")
+    ).toBe("/account/settings?returnTo=%2Ftodos");
+    expect(
+      resolveContextualReturnDestination("/todos", {
+        href: "/projects",
+        label: "Projects",
+      })
+    ).toEqual({ href: "/todos", label: "Todos" });
+  });
+
   test("carries notification-list context into task targets", () => {
     expect(
       buildNotificationTargetHref(
@@ -89,6 +104,8 @@ describe("authenticated shell navigation", () => {
 
   test("marks only the matching primary destination current", () => {
     expect(isDestinationCurrent("/projects/project-1", "/projects")).toBe(true);
+    expect(isDestinationCurrent("/todos", "/todos")).toBe(true);
+    expect(isDestinationCurrent("/projects", "/todos")).toBe(false);
     expect(
       isDestinationCurrent("/account/settings/developers", "/account/settings")
     ).toBe(true);

--- a/tests/lib/workspace-meeting-todo-service.test.ts
+++ b/tests/lib/workspace-meeting-todo-service.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const projectAccessServiceMock = vi.hoisted(() => ({
+  buildProjectPrincipalWhere: vi.fn(),
+  hasRequiredRole: vi.fn(),
+}));
+
+const rlsContextMock = vi.hoisted(() => ({
+  withActorRlsContext: vi.fn(),
+}));
+
+const dbMock = vi.hoisted(() => ({
+  project: {
+    findMany: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/services/project-access-service", () => ({
+  buildProjectPrincipalWhere:
+    projectAccessServiceMock.buildProjectPrincipalWhere,
+  hasRequiredRole: projectAccessServiceMock.hasRequiredRole,
+}));
+
+vi.mock("@/lib/services/rls-context", () => ({
+  withActorRlsContext: rlsContextMock.withActorRlsContext,
+}));
+
+import {
+  getWorkspaceMeetingTodoNavigationSummary,
+  listWorkspaceMeetingTodos,
+} from "@/lib/services/workspace-meeting-todo-service";
+
+const referenceNowMs = new Date("2026-07-20T12:00:00.000Z").getTime();
+
+describe("workspace meeting todo service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    projectAccessServiceMock.buildProjectPrincipalWhere.mockReturnValue({
+      OR: [
+        { ownerId: "user-1" },
+        { memberships: { some: { userId: "user-1" } } },
+      ],
+    });
+    projectAccessServiceMock.hasRequiredRole.mockImplementation(
+      (role: string) => role === "owner" || role === "editor"
+    );
+    rlsContextMock.withActorRlsContext.mockImplementation(
+      async (_actorUserId: string, operation: (db: typeof dbMock) => unknown) =>
+        operation(dbMock)
+    );
+  });
+
+  test("aggregates only actor-visible projects and sorts overdue and recent work", async () => {
+    dbMock.project.findMany.mockResolvedValueOnce([
+      {
+        id: "project-owned",
+        name: "Alpha",
+        ownerId: "user-1",
+        memberships: [],
+        meetingNotes: [
+          {
+            id: "meeting-old",
+            title: "Launch review",
+            scheduledAt: new Date("2026-07-10T09:00:00.000Z"),
+            status: "actions_in_progress",
+            createdAt: new Date("2026-07-10T08:00:00.000Z"),
+            actions: [
+              {
+                id: "todo-overdue",
+                content: "Send the launch recap",
+                completedAt: null,
+                updatedAt: new Date("2026-07-10T10:00:00.000Z"),
+              },
+              {
+                id: "todo-completed",
+                content: "Confirm the launch window",
+                completedAt: new Date("2026-07-19T10:00:00.000Z"),
+                updatedAt: new Date("2026-07-19T10:00:00.000Z"),
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: "project-viewer",
+        name: "Beta",
+        ownerId: "user-2",
+        memberships: [{ role: "viewer" }],
+        meetingNotes: [
+          {
+            id: "meeting-new",
+            title: "Risk review",
+            scheduledAt: new Date("2026-07-18T09:00:00.000Z"),
+            status: "actions_in_progress",
+            createdAt: new Date("2026-07-18T08:00:00.000Z"),
+            actions: [
+              {
+                id: "todo-current",
+                content: "Review the open risks",
+                completedAt: null,
+                updatedAt: new Date("2026-07-18T10:00:00.000Z"),
+              },
+              {
+                id: "todo-completed-recent",
+                content: "Share the risk register",
+                completedAt: new Date("2026-07-20T10:00:00.000Z"),
+                updatedAt: new Date("2026-07-20T10:00:00.000Z"),
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    const result = await listWorkspaceMeetingTodos({
+      actorUserId: " user-1 ",
+      referenceNowMs,
+    });
+
+    expect(result.open.map((todo) => todo.id)).toEqual([
+      "todo-overdue",
+      "todo-current",
+    ]);
+    expect(result.open[0]).toMatchObject({
+      isOverdue: true,
+      project: {
+        id: "project-owned",
+        role: "owner",
+        canEdit: true,
+      },
+    });
+    expect(result.open[1]).toMatchObject({
+      isOverdue: false,
+      project: {
+        id: "project-viewer",
+        role: "viewer",
+        canEdit: false,
+      },
+    });
+    expect(result.completed.map((todo) => todo.id)).toEqual([
+      "todo-completed-recent",
+      "todo-completed",
+    ]);
+    expect(rlsContextMock.withActorRlsContext).toHaveBeenCalledWith(
+      "user-1",
+      expect.any(Function)
+    );
+    expect(projectAccessServiceMock.buildProjectPrincipalWhere).toHaveBeenCalledWith(
+      "user-1"
+    );
+  });
+
+  test("returns the navigation count from open accessible actions", async () => {
+    dbMock.project.findMany.mockResolvedValueOnce([
+      {
+        id: "project-1",
+        name: "Alpha",
+        ownerId: "user-1",
+        memberships: [],
+        meetingNotes: [
+          {
+            id: "meeting-1",
+            title: "Planning",
+            scheduledAt: new Date("2026-07-01T09:00:00.000Z"),
+            status: "actions_in_progress",
+            createdAt: new Date("2026-07-01T08:00:00.000Z"),
+            actions: [
+              {
+                id: "todo-1",
+                content: "Follow up",
+                completedAt: null,
+                updatedAt: new Date("2026-07-01T10:00:00.000Z"),
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    const result = await getWorkspaceMeetingTodoNavigationSummary("user-1");
+
+    expect(result.openCount).toBe(1);
+    expect(result.overdueCount).toBe(1);
+    expect(dbMock.project.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ OR: expect.any(Array) }),
+        select: expect.objectContaining({
+          meetingNotes: expect.objectContaining({
+            where: { actions: { some: { completedAt: null } } },
+          }),
+        }),
+      })
+    );
+  });
+
+  test("does not enter RLS context without an actor", async () => {
+    await expect(
+      listWorkspaceMeetingTodos({ actorUserId: " " })
+    ).resolves.toEqual({ open: [], completed: [] });
+    await expect(
+      getWorkspaceMeetingTodoNavigationSummary("")
+    ).resolves.toEqual({ openCount: 0, overdueCount: 0 });
+    expect(rlsContextMock.withActorRlsContext).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/workspace-meeting-todo-service.test.ts
+++ b/tests/lib/workspace-meeting-todo-service.test.ts
@@ -153,25 +153,16 @@ describe("workspace meeting todo service", () => {
   test("returns the navigation count from open accessible actions", async () => {
     dbMock.project.findMany.mockResolvedValueOnce([
       {
-        id: "project-1",
-        name: "Alpha",
-        ownerId: "user-1",
-        memberships: [],
         meetingNotes: [
           {
-            id: "meeting-1",
-            title: "Planning",
             scheduledAt: new Date("2026-07-01T09:00:00.000Z"),
             status: "actions_in_progress",
-            createdAt: new Date("2026-07-01T08:00:00.000Z"),
-            actions: [
-              {
-                id: "todo-1",
-                content: "Follow up",
-                completedAt: null,
-                updatedAt: new Date("2026-07-01T10:00:00.000Z"),
-              },
-            ],
+            _count: { actions: 2 },
+          },
+          {
+            scheduledAt: new Date("2026-07-01T09:00:00.000Z"),
+            status: "done",
+            _count: { actions: 1 },
           },
         ],
       },
@@ -179,16 +170,27 @@ describe("workspace meeting todo service", () => {
 
     const result = await getWorkspaceMeetingTodoNavigationSummary("user-1");
 
-    expect(result.openCount).toBe(1);
-    expect(result.overdueCount).toBe(1);
+    expect(result.openCount).toBe(3);
+    expect(result.overdueCount).toBe(2);
     expect(dbMock.project.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({ OR: expect.any(Array) }),
-        select: expect.objectContaining({
+        select: {
           meetingNotes: expect.objectContaining({
             where: { actions: { some: { completedAt: null } } },
+            select: expect.objectContaining({
+              scheduledAt: true,
+              status: true,
+              _count: {
+                select: {
+                  actions: {
+                    where: { completedAt: null },
+                  },
+                },
+              },
+            }),
           }),
-        }),
+        },
       })
     );
   });


### PR DESCRIPTION
## What changed

- added a protected `/todos` workspace destination backed by actor-RLS-scoped cross-project meeting-todo reads
- added Todos to the adaptive desktop sidebar and Projects / Todos / Inbox mobile bottom navigation, including open and overdue badge context
- added URL-backed Open/Completed views and project filtering, project grouping, viewer read-only treatment, authorized completion/reopening, and source-meeting deep links
- removed the floating project todo panel from mobile layout and accessibility navigation while retaining it on desktop
- bumped the product release to `v0.28.0` and updated task, architecture-decision, changelog, and journal documentation
- incorporated all initial Copilot feedback: simplified accessible tab names, replaced the shell badge's full-record load with a minimal count query, and kept `project.md` out of the feature PR

## Why

At 393 x 852, the expanded mobile popup occupied 352 x 371 px, nested a 320 px scroll area around 680 px of todo content, covered the project and meeting context needed to interpret follow-ups, and used 28 px controls. A stable route-backed navigation destination is clearer than a floating action button, avoids another safe-area collision, and leaves room for planned assignee and filtering capabilities.

## Validation

- `npm run validate:local`
  - RLS inventory and PostgreSQL tenant-isolation matrix passed
  - 134 Vitest files passed, 2 skipped; 956 tests passed, 2 skipped
  - coverage: 91.37% statements, 81.33% branches, 92.2% functions, 91.88% lines
  - production build passed and generated `/todos`
  - all 24 Playwright scenarios passed
- review follow-up: 14 focused tests, lint, production build, and six focused shell/todo Playwright scenarios passed
- responsive visual walkthroughs at 393 x 852 light, 375 x 812 dark, and 1280 x 900 desktop
- `git diff --check`