### PR TITLE
Harden production promotion and extend execution backlog

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -124,9 +124,9 @@ jobs:
       - name: Generate Prisma client
         run: npx prisma generate
 
-      # Keep staging read-only against the production database. Applying a
-      # migration here can make the live deployment incompatible before the
-      # staged build has been reviewed and promoted.
+      # Keep staging from mutating the production database. Applying a migration
+      # here can make the live deployment incompatible before the staged build
+      # has been reviewed and promoted.
       - name: Pull Vercel environment (production)
         run: npx vercel@${VERCEL_CLI_VERSION} pull --yes --environment=production --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN"
 
@@ -148,6 +148,7 @@ jobs:
               --skip-domain \
               --scope="$VERCEL_SCOPE" \
               --token="$VERCEL_TOKEN" \
+              --meta "nexusDashGitCommitSha=$COMMIT_SHA" \
               -e "APP_VERSION=$APP_VERSION" \
               -e "APP_ENV=$APP_ENV" \
               -e "COMMIT_SHA=$COMMIT_SHA" \
@@ -170,7 +171,7 @@ jobs:
           echo "- App version: \`$APP_VERSION\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- App revision: \`${COMMIT_SHA:0:7}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- URL: \`${{ steps.deploy_staged.outputs.deployment_url }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Next step: run workflow dispatch with \`action=promote\` to promote this deployment." >> "$GITHUB_STEP_SUMMARY"
+          echo "- Next step: run workflow dispatch with \`action=promote\`, this URL, and \`git_ref=$COMMIT_SHA\`." >> "$GITHUB_STEP_SUMMARY"
 
   manual-operation:
     name: Manual Deploy/Promote/Rollback
@@ -186,7 +187,6 @@ jobs:
       VERCEL_SCOPE: ${{ secrets.VERCEL_ORG_ID }}
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
-      MIGRATION_DATABASE_URL: ${{ secrets.MIGRATION_DATABASE_URL }}
       GOOGLE_TOKEN_ENCRYPTION_KEY: ${{ secrets.GOOGLE_TOKEN_ENCRYPTION_KEY }}
       GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
       GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
@@ -286,6 +286,8 @@ jobs:
 
       - name: Validate migration connection secret
         if: ${{ inputs.action == 'deploy-preview' || inputs.action == 'promote' }}
+        env:
+          MIGRATION_DATABASE_URL: ${{ secrets.MIGRATION_DATABASE_URL }}
         run: |
           if [ -z "$MIGRATION_DATABASE_URL" ]; then
             echo "::error::Missing required GitHub secret: MIGRATION_DATABASE_URL"
@@ -301,6 +303,8 @@ jobs:
 
       - name: Apply Prisma migrations (preview)
         if: inputs.action == 'deploy-preview'
+        env:
+          MIGRATION_DATABASE_URL: ${{ secrets.MIGRATION_DATABASE_URL }}
         run: |
           for attempt in 1 2 3; do
             echo "Running preview Prisma migrations (attempt ${attempt}/3)..."
@@ -333,6 +337,7 @@ jobs:
               --prebuilt \
               --scope="$VERCEL_SCOPE" \
               --token="$VERCEL_TOKEN" \
+              --meta "nexusDashGitCommitSha=$COMMIT_SHA" \
               -e "RESEND_API_KEY=$RESEND_API_KEY" \
               -e "NOTIFICATION_EMAIL_DISPATCH_SECRET=$NOTIFICATION_EMAIL_DISPATCH_SECRET" \
               -e "AGENT_TOKEN_SIGNING_SECRET=$AGENT_TOKEN_SIGNING_SECRET" \
@@ -361,6 +366,7 @@ jobs:
               --skip-domain \
               --scope="$VERCEL_SCOPE" \
               --token="$VERCEL_TOKEN" \
+              --meta "nexusDashGitCommitSha=$COMMIT_SHA" \
               -e "APP_VERSION=$APP_VERSION" \
               -e "APP_ENV=$APP_ENV" \
               -e "COMMIT_SHA=$COMMIT_SHA" \
@@ -406,10 +412,63 @@ jobs:
             exit 1
           fi
 
+      - name: Validate promotion target revision
+        if: inputs.action == 'promote'
+        run: |
+          deployment_lookup="${DEPLOYMENT_TARGET#https://}"
+          deployment_lookup="${deployment_lookup%%/*}"
+
+          curl \
+            --fail \
+            --silent \
+            --show-error \
+            --get "https://api.vercel.com/v13/deployments/${deployment_lookup}" \
+            --data-urlencode "teamId=$VERCEL_ORG_ID" \
+            --header "Authorization: Bearer $VERCEL_TOKEN" \
+            --output /tmp/vercel-deployment.json
+
+          node <<'NODE' > /tmp/vercel-deployment-metadata.txt
+          const { readFileSync } = require("node:fs");
+          const deployment = JSON.parse(
+            readFileSync("/tmp/vercel-deployment.json", "utf8")
+          );
+          const projectId = deployment.projectId ?? deployment.project?.id ?? "";
+          const commitSha =
+            deployment.meta?.nexusDashGitCommitSha ??
+            deployment.meta?.githubCommitSha ??
+            deployment.gitSource?.sha ??
+            "";
+          process.stdout.write(`${projectId}\t${commitSha}\n`);
+          NODE
+
+          IFS=$'\t' read -r deployment_project_id deployment_commit_sha < /tmp/vercel-deployment-metadata.txt
+
+          if [ "$deployment_project_id" != "$VERCEL_PROJECT_ID" ]; then
+            echo "::error::Deployment '$DEPLOYMENT_TARGET' belongs to project '$deployment_project_id', not '$VERCEL_PROJECT_ID'."
+            exit 1
+          fi
+
+          if [ -z "$deployment_commit_sha" ]; then
+            echo "::error::Deployment '$DEPLOYMENT_TARGET' has no source revision metadata."
+            echo "::error::Create a new staged deployment with this workflow before promoting."
+            exit 1
+          fi
+
+          expected_commit_sha=$(printf '%s' "$COMMIT_SHA" | tr '[:upper:]' '[:lower:]')
+          actual_commit_sha=$(printf '%s' "$deployment_commit_sha" | tr '[:upper:]' '[:lower:]')
+          if [ "$actual_commit_sha" != "$expected_commit_sha" ]; then
+            echo "::error::Promotion revision mismatch."
+            echo "::error::Checked out '$expected_commit_sha' for migrations, but '$DEPLOYMENT_TARGET' contains '$actual_commit_sha'."
+            echo "::error::Set git_ref to the staged deployment revision."
+            exit 1
+          fi
+
       # Promotion is the release boundary: update the schema only after the
       # target deployment is validated and immediately before switching aliases.
       - name: Apply Prisma migrations (production promotion)
         if: inputs.action == 'promote'
+        env:
+          MIGRATION_DATABASE_URL: ${{ secrets.MIGRATION_DATABASE_URL }}
         run: |
           for attempt in 1 2 3; do
             echo "Running production Prisma migrations before promotion (attempt ${attempt}/3)..."
@@ -474,7 +533,7 @@ jobs:
             if [ -n "${{ steps.deploy_prod_staged.outputs.deployment_url }}" ]; then
               echo "- Staged production URL: \`${{ steps.deploy_prod_staged.outputs.deployment_url }}\`" >> "$GITHUB_STEP_SUMMARY"
             fi
-            echo "- Next step: run with \`action=promote\`." >> "$GITHUB_STEP_SUMMARY"
+            echo "- Next step: run with \`action=promote\`, this URL, and \`git_ref=$COMMIT_SHA\`." >> "$GITHUB_STEP_SUMMARY"
           fi
           if [ "${{ inputs.action }}" = "promote" ] || [ "${{ inputs.action }}" = "rollback" ]; then
             target="${DEPLOYMENT_TARGET:-<not-normalized>}"

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -23,7 +23,7 @@ on:
         required: false
         type: string
       git_ref:
-        description: "Git ref for deploy actions (branch/tag/SHA)"
+        description: "Git ref for deploy/promote actions; promote must match the staged deployment revision"
         required: false
         default: "main"
         type: string
@@ -53,7 +53,6 @@ jobs:
       VERCEL_SCOPE: ${{ secrets.VERCEL_ORG_ID }}
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
-      MIGRATION_DATABASE_URL: ${{ secrets.MIGRATION_DATABASE_URL }}
       GOOGLE_TOKEN_ENCRYPTION_KEY: ${{ secrets.GOOGLE_TOKEN_ENCRYPTION_KEY }}
       GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
       GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
@@ -97,20 +96,6 @@ jobs:
             exit 1
           fi
 
-      - name: Validate migration connection secret
-        run: |
-          if [ -z "$MIGRATION_DATABASE_URL" ]; then
-            echo "::error::Missing required GitHub secret: MIGRATION_DATABASE_URL"
-            echo "::error::Migrations must never fall back to runtime DATABASE_URL."
-            exit 1
-          fi
-
-          if [ -n "$DATABASE_URL" ] && [ "$MIGRATION_DATABASE_URL" = "$DATABASE_URL" ]; then
-            echo "::error::MIGRATION_DATABASE_URL must not be equal to DATABASE_URL."
-            echo "::error::Use a dedicated migration connection, separate from runtime app traffic."
-            exit 1
-          fi
-
       - name: Checkout
         uses: actions/checkout@v7
         with:
@@ -139,24 +124,9 @@ jobs:
       - name: Generate Prisma client
         run: npx prisma generate
 
-      - name: Apply Prisma migrations
-        run: |
-          for attempt in 1 2 3; do
-            echo "Running Prisma migrations (attempt ${attempt}/3)..."
-            if DATABASE_URL="$MIGRATION_DATABASE_URL" DIRECT_URL="$MIGRATION_DATABASE_URL" npx prisma migrate deploy; then
-              exit 0
-            fi
-
-            if [ "$attempt" -lt 3 ]; then
-              delay=$((attempt * 15))
-              echo "::warning::Prisma migrations failed; retrying in ${delay}s."
-              sleep "$delay"
-            fi
-          done
-
-          echo "::error::Prisma migrations failed after 3 attempts."
-          exit 1
-
+      # Keep staging read-only against the production database. Applying a
+      # migration here can make the live deployment incompatible before the
+      # staged build has been reviewed and promoted.
       - name: Pull Vercel environment (production)
         run: npx vercel@${VERCEL_CLI_VERSION} pull --yes --environment=production --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN"
 
@@ -278,20 +248,20 @@ jobs:
           fi
 
       - name: Checkout
-        if: ${{ inputs.action == 'deploy-preview' || inputs.action == 'deploy-production-staged' }}
+        if: ${{ inputs.action == 'deploy-preview' || inputs.action == 'deploy-production-staged' || inputs.action == 'promote' }}
         uses: actions/checkout@v7
         with:
           ref: ${{ inputs.git_ref }}
 
       - name: Setup Node.js
-        if: ${{ inputs.action == 'deploy-preview' || inputs.action == 'deploy-production-staged' }}
+        if: ${{ inputs.action == 'deploy-preview' || inputs.action == 'deploy-production-staged' || inputs.action == 'promote' }}
         uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: npm
 
       - name: Resolve app metadata
-        if: ${{ inputs.action == 'deploy-preview' || inputs.action == 'deploy-production-staged' }}
+        if: ${{ inputs.action == 'deploy-preview' || inputs.action == 'deploy-production-staged' || inputs.action == 'promote' }}
         run: |
           app_version="$(node -p "require('./package.json').version")"
           commit_sha="$(git rev-parse HEAD)"
@@ -307,15 +277,15 @@ jobs:
           echo "APP_REPOSITORY_URL=$repository_url" >> "$GITHUB_ENV"
 
       - name: Install dependencies
-        if: ${{ inputs.action == 'deploy-preview' || inputs.action == 'deploy-production-staged' }}
+        if: ${{ inputs.action == 'deploy-preview' || inputs.action == 'deploy-production-staged' || inputs.action == 'promote' }}
         run: npm ci
 
       - name: Generate Prisma client
-        if: ${{ inputs.action == 'deploy-preview' || inputs.action == 'deploy-production-staged' }}
+        if: ${{ inputs.action == 'deploy-preview' || inputs.action == 'deploy-production-staged' || inputs.action == 'promote' }}
         run: npx prisma generate
 
       - name: Validate migration connection secret
-        if: ${{ inputs.action == 'deploy-preview' || inputs.action == 'deploy-production-staged' }}
+        if: ${{ inputs.action == 'deploy-preview' || inputs.action == 'promote' }}
         run: |
           if [ -z "$MIGRATION_DATABASE_URL" ]; then
             echo "::error::Missing required GitHub secret: MIGRATION_DATABASE_URL"
@@ -329,11 +299,11 @@ jobs:
             exit 1
           fi
 
-      - name: Apply Prisma migrations
-        if: ${{ inputs.action == 'deploy-preview' || inputs.action == 'deploy-production-staged' }}
+      - name: Apply Prisma migrations (preview)
+        if: inputs.action == 'deploy-preview'
         run: |
           for attempt in 1 2 3; do
-            echo "Running Prisma migrations (attempt ${attempt}/3)..."
+            echo "Running preview Prisma migrations (attempt ${attempt}/3)..."
             if DATABASE_URL="$MIGRATION_DATABASE_URL" DIRECT_URL="$MIGRATION_DATABASE_URL" npx prisma migrate deploy; then
               exit 0
             fi
@@ -435,6 +405,27 @@ jobs:
             cat /tmp/vercel-inspect.txt
             exit 1
           fi
+
+      # Promotion is the release boundary: update the schema only after the
+      # target deployment is validated and immediately before switching aliases.
+      - name: Apply Prisma migrations (production promotion)
+        if: inputs.action == 'promote'
+        run: |
+          for attempt in 1 2 3; do
+            echo "Running production Prisma migrations before promotion (attempt ${attempt}/3)..."
+            if DATABASE_URL="$MIGRATION_DATABASE_URL" DIRECT_URL="$MIGRATION_DATABASE_URL" npx prisma migrate deploy; then
+              exit 0
+            fi
+
+            if [ "$attempt" -lt 3 ]; then
+              delay=$((attempt * 15))
+              echo "::warning::Prisma migrations failed; retrying in ${delay}s."
+              sleep "$delay"
+            fi
+          done
+
+          echo "::error::Prisma migrations failed after 3 attempts; production was not promoted."
+          exit 1
 
       - name: Promote deployment to production
         if: inputs.action == 'promote'

--- a/docs/runbooks/github-actions-workflows.md
+++ b/docs/runbooks/github-actions-workflows.md
@@ -68,12 +68,26 @@ Automatic path:
 1. Merge to `main`.
 2. Wait for `Quality Gates` on `main`.
 3. `Deploy Vercel (CD + Rollback)` creates a staged production deployment.
-4. Promote the staged URL manually with `action=promote`.
+4. Promote the staged URL manually with `action=promote` and
+   `git_ref=<staged-commit-sha>` from the staged deployment summary.
 
 Manual path:
 
 - `action=deploy-production-staged`
 - optional `git_ref=<branch-or-sha>`
+
+Production-staged deploys record the checked-out commit SHA in Vercel
+deployment metadata and do not run Prisma migrations. Promotion fails closed
+unless the deployment belongs to the configured Vercel project and its recorded
+SHA exactly matches the checked-out `git_ref`. Only then does the workflow
+expose the migration-only GitHub secret, apply production migrations, and
+promote the staged deployment.
+
+This sequencing limits the migration-to-alias window but does not make
+destructive schema changes atomic with Vercel promotion. Production migrations
+must remain backward-compatible with the currently live release; use
+expand/contract migrations when removing or renaming data that live code still
+reads.
 
 Rollback path:
 

--- a/journal.md
+++ b/journal.md
@@ -2873,6 +2873,28 @@ Low-value entries to avoid going forward:
   record, and Resend path. The fixed owner recipient and reporter identity will
   be server-controlled; diagnostics will be explicit and privacy-bounded.
 
+# 2026-07-30 - PR #397 deployment-promotion review hardening
+
+- Validated both unresolved Copilot comments on
+  `.github/workflows/deploy-vercel.yml`: promotion could migrate a different
+  revision than the selected Vercel deployment, and the migration-only
+  production secret was exposed to every manual operation.
+- Added commit metadata to workflow-created deployments and a fail-closed
+  promotion guard that verifies both the Vercel project ID and exact checked-out
+  commit SHA before production migrations can run.
+- Scoped `MIGRATION_DATABASE_URL` to the migration validation/execution steps,
+  retained preview migrations, and kept production-staged deploys free of
+  migration commands.
+- Documented the required promotion `git_ref` and the remaining expand/contract
+  requirement because database migration and Vercel alias promotion are not an
+  atomic transaction.
+- Validation passed: workflow YAML parse, Bash syntax for all 27 `run` steps,
+  deployment sequencing/secret-scope assertions, `git diff --check`,
+  `npm run lint`, `npm run rls:check`, 969 unit/API tests, coverage at 91.37%
+  statements / 81.33% branches / 92.2% functions / 91.88% lines, and the
+  production build with documented local database plus build-only preview
+  placeholders.
+
 # 2026-07-26 - TASK-333 implementation and local validation
 
 - Added the persistent desktop and mobile entries, responsive report form,

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -2,7 +2,7 @@
 
 Use this file to capture tasks discovered during development. Each entry should include: ID, title, rationale, dependencies.
 
-Last reviewed: 2026-07-26
+Last reviewed: 2026-07-28
 
 ## Pending
 ### Execution Queue (Now / Next)
@@ -84,6 +84,31 @@ Last reviewed: 2026-07-26
   Status: Next 15 - epic scanning and content readability
   Rationale: Expand epic content by default on mobile so users can read meaningful context without repeated disclosure interactions, then test a comparable expanded desktop treatment and retain the version that improves comprehension without making dense project views harder to scan.
   Dependencies: TASK-100, TASK-108, TASK-133, TASK-270
+- ID: TASK-336
+  Title: Bilateral related-task relationships - keep both task directions consistent
+  Status: Next 16 - related-task correctness
+  Rationale: Fix GitHub issue #395 so relating task A to task B makes the same canonical relationship visible when either task is opened, including immediately after optimistic updates and after reload, while keeping add/remove behavior duplicate-free and project-scoped.
+  Dependencies: TASK-076, TASK-118
+- ID: TASK-337
+  Title: Complete related-task candidate list - investigate missing and non-scrollable tasks
+  Status: Next 17 - related-task picker completeness
+  Rationale: Investigate and fix GitHub issue #396 by determining whether eligible tasks are missing because of status filtering, Blocked-task exclusion, clipped overflow, or a combination; ensure the full authorized candidate set is searchable, keyboard reachable, and scrollable.
+  Dependencies: TASK-076, TASK-133, TASK-321
+- ID: TASK-338
+  Title: User-facing task IDs - stable references in task details and relationship search
+  Status: Next 18 - task follow-up identifiers
+  Rationale: Introduce or expose concise, stable user-facing task identifiers so users can refer to tasks unambiguously; show the identifier when a task detail modal is open and beside each candidate while searching for a task to relate, without exposing opaque internal database IDs.
+  Dependencies: TASK-076, TASK-133
+- ID: TASK-339
+  Title: Related-task picker presentation - readable IDs, titles, and status colors
+  Status: Next 19 - related-task list visual refinement
+  Rationale: Redesign the current `Related to` candidate list so each row clearly presents the user-facing task ID, a bounded/truncated title, and status using the established Kanban column color, with accessible text that does not rely on color alone.
+  Dependencies: TASK-133, TASK-337, TASK-338
+- ID: TASK-340
+  Title: Movable meeting-todos modal - compact bottom-right project entry
+  Status: Next 20 - project todo popup refinement
+  Rationale: Replace the current meeting-todo popup treatment with a compact bottom-right floating `Todos` button using the todo icon and label; open the aggregated todos in an accessible modal that can be moved within the project-page area while preserving containment, focus, responsive behavior, and existing todo actions.
+  Dependencies: TASK-098, TASK-316, TASK-321, TASK-322, TASK-330, TASK-332
 ### Deferred (Intentional)
 - ID: TASK-102
   Title: Collaboration service modularization - split invite, membership, and recipient flows into smaller service units


### PR DESCRIPTION
## Summary

- keep automatic and manual production-staged deployments from running production Prisma migrations
- expose the GitHub migration-only connection only to preview/promotion migration steps
- record the checked-out commit SHA in Vercel deployment metadata and require an exact project/revision match before promotion migrations
- run production Prisma migrations only during explicit promotion, after validating the target and immediately before switching the production alias
- retain preview migrations in the preview environment
- add TASK-349 through TASK-353 to the execution queue, including dependencies for task IDs, related-task picker improvements, and the meeting-todos modal
- reference bug issues #395 and #396 from the corresponding backlog tasks

## Why

A staged deployment applied a destructive production migration before the staged application was promoted. The live domain remained on older code that queried the removed `ProjectMeetingNote.participants` column, causing project pages to fail while the public homepage stayed healthy.

The workflow change makes explicit promotion the production migration boundary and binds the migration checkout to the selected Vercel deployment revision. This prevents an unpromoted staged build from applying migrations and fails closed when an operator supplies a mismatched deployment URL or `git_ref`.

## Impact

Production staging no longer runs migration commands or receives the GitHub `MIGRATION_DATABASE_URL` secret at job scope. Explicit promotion checks out the requested revision, validates the Vercel target/project, verifies the deployment's recorded commit SHA, applies pending migrations, and aborts without switching aliases if validation or migration fails.

Database migration and Vercel alias promotion are not atomic, so production migrations must still be backward-compatible with the currently live release; destructive changes require expand/contract sequencing.

The backlog now captures the five requested follow-ups in dependency order. They were renumbered from the branch's original TASK-336..340 allocation to TASK-349..353 after `main` assigned TASK-336..348 to the multi-user collaboration audit and refinement program.

## Validation

- workflow YAML parse
- Bash syntax validation for all 27 workflow `run` steps
- deployment sequencing and migration-secret scope assertions
- unique backlog ID assertion after reconciling `origin/main`
- `git diff --check`
- `npm run lint`
- `npm run rls:check`
- `npm test` (136 files passed, 2 skipped; 969 tests passed, 2 skipped)
- `npm run test:coverage` (91.37% statements, 81.33% branches, 92.2% functions, 91.88% lines)
- `npm run build` with documented local-safe database and preview placeholders
- `VERSION_POLICY_BRANCH_NAME=chore/deployment-promotion-and-backlog npm run release:check`
- production recovery independently completed and verified on `v0.30.0` / `c1ebb17`
## Preview validation

- Workflow run `30534612705` dispatched from `--ref chore/deployment-promotion-and-backlog` with `action=deploy-preview` and `git_ref=chore/deployment-promotion-and-backlog`
- Checkout logs confirm the branch ref and commit `8e41286bf88a4d0a010da96e27cd3a91925a0c52`
- Preview deployment: `https://nexus-dash-8lsms6ugu-dorian-agaesses-projects.vercel.app`
- `/api/health/live` returned HTTP 200
