### PR TITLE
TASK-349: Make related-task relationships bilateral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ SHA, deployment URL, and workflow run belong in release evidence.
 
 - Define each release entry before the product-impacting PR is merged.
 
+## v0.31.1 - 2026-07-30
+
+- Made canonical related-task links reconcile bilaterally after local saves and
+  live project updates, so adding or removing a relationship is immediately
+  visible from either task without a broad refresh.
+- Consolidated incoming/outgoing relation serialization into one sorted,
+  duplicate-safe mapping while preserving the existing canonical database row,
+  archived-task visibility, and project authorization boundaries.
+- Added service/API, client reconciliation, and Playwright regressions for
+  bilateral add/remove behavior, repeated updates, and full reloads.
+
 ## v0.31.0 - 2026-07-27
 
 - Replaced the obstructive mobile meeting-todo popup with a dedicated,

--- a/app/api/projects/[projectId]/tasks/route.ts
+++ b/app/api/projects/[projectId]/tasks/route.ts
@@ -15,6 +15,7 @@ import { requireAgentProjectScopes } from "@/lib/services/project-access-service
 import { mapTaskEpicSummary } from "@/lib/epic";
 import { mapTaskPersonSummary } from "@/lib/task-person";
 import { formatTaskDeadlineDate } from "@/lib/task-deadline";
+import { mergeRelatedTaskSummaries } from "@/lib/task-related";
 
 const ATTACHMENT_FILES_FIELD = "attachmentFiles";
 type TaskAttachment = Awaited<ReturnType<typeof listProjectKanbanTasks>>[number]["attachments"][number];
@@ -58,30 +59,6 @@ function serializeJsonField(value: unknown): string {
   }
 
   return JSON.stringify(value);
-}
-
-function mapRelatedTasks(task: {
-  outgoingRelations: Array<{
-    rightTask: {
-      id: string;
-      title: string;
-      status: string;
-      archivedAt: Date | null;
-    };
-  }>;
-  incomingRelations: Array<{
-    leftTask: {
-      id: string;
-      title: string;
-      status: string;
-      archivedAt: Date | null;
-    };
-  }>;
-}) {
-  return [
-    ...task.outgoingRelations.map((relation) => relation.rightTask),
-    ...task.incomingRelations.map((relation) => relation.leftTask),
-  ].sort((left, right) => left.title.localeCompare(right.title));
 }
 
 export async function GET(request: NextRequest, props: { params: Promise<{ projectId: string }> }) {
@@ -135,7 +112,7 @@ export async function GET(request: NextRequest, props: { params: Promise<{ proje
         attachments: task.attachments.map((attachment: TaskAttachment) =>
           mapTaskAttachmentResponse(params.projectId, task.id, attachment)
         ),
-        relatedTasks: mapRelatedTasks(task),
+        relatedTasks: mergeRelatedTaskSummaries(task),
         blockedFollowUps: task.blockedFollowUps,
       })),
     },

--- a/app/projects/[projectId]/kanban-board-section.tsx
+++ b/app/projects/[projectId]/kanban-board-section.tsx
@@ -17,7 +17,7 @@ import {
 import { listProjectEpics } from "@/lib/services/project-epic-service";
 import { mapTaskEpicSummary } from "@/lib/epic";
 import { mapTaskPersonSummary } from "@/lib/task-person";
-import { mapRelatedTaskSummary } from "@/lib/task-related";
+import { mergeRelatedTaskSummaries } from "@/lib/task-related";
 import { ATTACHMENT_KIND_FILE } from "@/lib/task-attachment";
 import { formatTaskDeadlineDate } from "@/lib/task-deadline";
 import { getTaskLabelsFromStorage } from "@/lib/task-label";
@@ -27,8 +27,6 @@ type ProjectKanbanTask = Awaited<ReturnType<typeof listProjectKanbanTasks>>[numb
 type TaskAttachment = ProjectKanbanTask["attachments"][number];
 type TaskBlockedFollowUp =
   ProjectKanbanTask["blockedFollowUps"][number];
-type OutgoingRelation = ProjectKanbanTask["outgoingRelations"][number];
-type IncomingRelation = ProjectKanbanTask["incomingRelations"][number];
 
 interface KanbanBoardSectionProps {
   projectId: string;
@@ -85,14 +83,7 @@ export async function KanbanBoardSection({
       createdAt: task.createdAt.toISOString(),
       updatedAt: task.updatedAt.toISOString(),
       archivedAt: task.archivedAt ? task.archivedAt.toISOString() : null,
-      relatedTasks: [
-        ...task.outgoingRelations.map((entry: OutgoingRelation) =>
-          mapRelatedTaskSummary(entry.rightTask)
-        ),
-        ...task.incomingRelations.map((entry: IncomingRelation) =>
-          mapRelatedTaskSummary(entry.leftTask)
-        ),
-      ].sort((left, right) => left.title.localeCompare(right.title)),
+      relatedTasks: mergeRelatedTaskSummaries(task),
       status: task.status,
       position: task.position,
       attachments: task.attachments.map((attachment: TaskAttachment) => ({

--- a/components/kanban-board-related.ts
+++ b/components/kanban-board-related.ts
@@ -1,0 +1,74 @@
+import type {
+  KanbanTask,
+  TaskRelatedSummary,
+} from "@/components/kanban-board-types";
+import { normalizeRelatedTaskSummaries } from "@/lib/task-related";
+
+function summariesMatch(
+  left: TaskRelatedSummary[],
+  right: TaskRelatedSummary[]
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((summary, index) => {
+      const other = right[index];
+      return (
+        summary.id === other?.id &&
+        summary.title === other.title &&
+        summary.status === other.status &&
+        summary.archivedAt === other.archivedAt
+      );
+    })
+  );
+}
+
+/**
+ * Reconciles one authoritative task mutation against any loaded task.
+ *
+ * TaskRelation is stored as one canonical, undirected row. Mutation responses
+ * contain the authoritative related-task set for the changed task, so every
+ * other loaded task must add or remove the inverse summary locally.
+ */
+export function reconcileBilateralTaskRelations(
+  task: KanbanTask,
+  authoritativeTask: KanbanTask
+): KanbanTask {
+  const authoritativeRelatedTasks = normalizeRelatedTaskSummaries(
+    authoritativeTask.relatedTasks.filter(
+      (relatedTask) => relatedTask.id !== authoritativeTask.id
+    )
+  );
+
+  if (task.id === authoritativeTask.id) {
+    return {
+      ...task,
+      ...authoritativeTask,
+      relatedTasks: authoritativeRelatedTasks,
+    };
+  }
+
+  const authoritativeRelatedTaskIds = new Set(
+    authoritativeRelatedTasks.map((relatedTask) => relatedTask.id)
+  );
+  const inverseSummary: TaskRelatedSummary = {
+    id: authoritativeTask.id,
+    title: authoritativeTask.title,
+    status: authoritativeTask.status,
+    archivedAt: authoritativeTask.archivedAt,
+  };
+  const nextRelatedTasks = normalizeRelatedTaskSummaries([
+    ...task.relatedTasks.filter(
+      (relatedTask) => relatedTask.id !== authoritativeTask.id
+    ),
+    ...(authoritativeRelatedTaskIds.has(task.id) ? [inverseSummary] : []),
+  ]);
+
+  if (summariesMatch(task.relatedTasks, nextRelatedTasks)) {
+    return task;
+  }
+
+  return {
+    ...task,
+    relatedTasks: nextRelatedTasks,
+  };
+}

--- a/components/kanban-board.tsx
+++ b/components/kanban-board.tsx
@@ -38,6 +38,7 @@ import {
   readApiError,
   type TaskColumns,
 } from "@/components/kanban-board-utils";
+import { reconcileBilateralTaskRelations } from "@/components/kanban-board-related";
 import { useProjectSectionExpanded } from "@/lib/hooks/use-project-section-expanded";
 import {
   ATTACHMENT_KIND_FILE,
@@ -955,55 +956,30 @@ export function KanbanBoard({
     (updatedTask: KanbanTask) => {
       setColumns((previousColumns) => {
         const nextColumns = cloneColumns(previousColumns);
-        const taskColumn = nextColumns[updatedTask.status];
-        const taskIndex = taskColumn.findIndex((task) => task.id === updatedTask.id);
-
-        if (taskIndex === -1) {
-          return previousColumns;
-        }
-
-        taskColumn[taskIndex] = {
-          ...taskColumn[taskIndex],
-          ...updatedTask,
-        };
+        TASK_STATUSES.forEach((status) => {
+          nextColumns[status] = nextColumns[status].map((task) =>
+            reconcileBilateralTaskRelations(task, updatedTask)
+          );
+        });
 
         return nextColumns;
       });
 
-      setArchivedDoneTasks((previousArchivedTasks) => {
-        const taskIndex = previousArchivedTasks.findIndex((task) => task.id === updatedTask.id);
-
-        if (taskIndex === -1) {
-          return previousArchivedTasks;
-        }
-
-        if (updatedTask.status !== "Done") {
-          return previousArchivedTasks.filter((task) => task.id !== updatedTask.id);
-        }
-
-        const nextArchivedTasks = [...previousArchivedTasks];
-        nextArchivedTasks[taskIndex] = {
-          ...nextArchivedTasks[taskIndex],
-          ...updatedTask,
-        };
-        return nextArchivedTasks;
-      });
+      setArchivedDoneTasks((previousArchivedTasks) =>
+        previousArchivedTasks.map((task) =>
+          reconcileBilateralTaskRelations(task, updatedTask)
+        )
+      );
 
       setSelectedTask((previousTask) => {
-        if (!previousTask || previousTask.id !== updatedTask.id) {
-          return previousTask;
-        }
-        return updatedTask;
+        return previousTask
+          ? reconcileBilateralTaskRelations(previousTask, updatedTask)
+          : previousTask;
       });
       setEditEpicId(updatedTask.epic?.id ?? "");
       setEditAssigneeUserId(updatedTask.assignee?.id ?? "");
-      syncRelatedTaskSummary(updatedTask.id, {
-        title: updatedTask.title,
-        status: updatedTask.status,
-        archivedAt: updatedTask.archivedAt,
-      });
     },
-    [syncRelatedTaskSummary]
+    []
   );
 
   const insertCreatedTask = useCallback(
@@ -1073,9 +1049,11 @@ export function KanbanBoard({
       setColumns((previousColumns) => {
         const nextColumns = createEmptyColumns<KanbanTask>();
         TASK_STATUSES.forEach((status) => {
-          nextColumns[status] = previousColumns[status].filter(
-            (task) => task.id !== remoteTask.id
-          );
+          nextColumns[status] = previousColumns[status]
+            .filter((task) => task.id !== remoteTask.id)
+            .map((task) =>
+              reconcileBilateralTaskRelations(task, remoteTask)
+            );
         });
 
         if (!remoteTask.archivedAt && isTaskStatus(remoteTask.status)) {
@@ -1089,9 +1067,11 @@ export function KanbanBoard({
       });
 
       setArchivedDoneTasks((previousTasks) => {
-        const withoutRemoteTask = previousTasks.filter(
-          (task) => task.id !== remoteTask.id
-        );
+        const withoutRemoteTask = previousTasks
+          .filter((task) => task.id !== remoteTask.id)
+          .map((task) =>
+            reconcileBilateralTaskRelations(task, remoteTask)
+          );
         if (remoteTask.status === "Done" && remoteTask.archivedAt) {
           return [...withoutRemoteTask, remoteTask].sort(
             (left, right) =>
@@ -1103,21 +1083,15 @@ export function KanbanBoard({
       });
 
       setSelectedTask((previousTask) => {
-        if (!previousTask || previousTask.id !== remoteTask.id) {
-          return previousTask;
-        }
-        return remoteTask;
+        return previousTask
+          ? reconcileBilateralTaskRelations(previousTask, remoteTask)
+          : previousTask;
       });
 
-      syncRelatedTaskSummary(remoteTask.id, {
-        title: remoteTask.title,
-        status: remoteTask.status,
-        archivedAt: remoteTask.archivedAt,
-      });
       setIsExpanded(true);
       setPersistError(null);
     },
-    [setIsExpanded, syncRelatedTaskSummary]
+    [setIsExpanded]
   );
 
   const applyRemoteReorder = useCallback(

--- a/journal.md
+++ b/journal.md
@@ -3119,3 +3119,25 @@ Low-value entries to avoid going forward:
   shell badge query to select only meeting status/date plus open-action counts.
   Four focused test files (14 tests), lint, production build, and six focused
   Playwright shell/todo scenarios passed after the review fixes.
+
+# 2026-07-30 - TASK-349 bilateral related-task relationships started
+
+- Took ownership of GitHub issue #395 on
+  `fix/395-bilateral-task-relations`, created from the latest `origin/main`,
+  and aligned it with the existing TASK-349 backlog entry.
+- Reproduced the defect as client reconciliation rather than persistence:
+  `replaceTaskRelations` already deletes both pair directions and creates one
+  canonical row, and reload/list payloads already select incoming plus outgoing
+  relations. Local saves and remote task activity only replaced the mutated
+  task, leaving the inverse summary on the other loaded task stale.
+- Centralized bilateral server mapping in a duplicate-safe helper and added an
+  authoritative client reconciler across active, archived, selected, and live
+  remote task state without changing the schema, RLS, authorization, or
+  archived-task rules.
+- Prepared patch release `v0.31.1` and added focused mapping, API, client, and
+  Playwright regression coverage.
+- Validation passed: 42 focused Vitest tests; full lint, RLS inventory, and
+  release-policy gates; 985 unit/API tests with 2 skipped; coverage at 91.37%
+  statements / 81.33% branches / 92.2% functions / 91.88% lines; production
+  build; the focused bilateral add/remove/reload Playwright scenario; and the
+  complete 28-scenario Playwright suite against local PostgreSQL.

--- a/journal.md
+++ b/journal.md
@@ -3141,3 +3141,6 @@ Low-value entries to avoid going forward:
   statements / 81.33% branches / 92.2% functions / 91.88% lines; production
   build; the focused bilateral add/remove/reload Playwright scenario; and the
   complete 28-scenario Playwright suite against local PostgreSQL.
+- Committed the reviewable implementation as `5c1b820`, pushed
+  `fix/395-bilateral-task-relations`, and opened ready-for-review PR
+  [#399](https://github.com/dorianagaesse/nexus_dash/pull/399).

--- a/lib/services/project-task-service.ts
+++ b/lib/services/project-task-service.ts
@@ -2,7 +2,7 @@ import { deleteAttachmentFile } from "@/lib/attachment-storage";
 import { sanitizeRichText } from "@/lib/rich-text";
 import {
   buildCanonicalTaskRelation,
-  mapRelatedTaskSummary,
+  mergeRelatedTaskSummaries,
   normalizeRelatedTaskIds,
   type RelatedTaskSummary,
 } from "@/lib/task-related";
@@ -231,18 +231,6 @@ const relatedTaskSummarySelect = {
   status: true,
   archivedAt: true,
 } as const;
-
-function mergeRelatedTaskSummaries(task: {
-  outgoingRelations: { rightTask: { id: string; title: string; status: string; archivedAt: Date | null } }[];
-  incomingRelations: { leftTask: { id: string; title: string; status: string; archivedAt: Date | null } }[];
-}): RelatedTaskSummary[] {
-  const relatedTasks = [
-    ...task.outgoingRelations.map((entry) => mapRelatedTaskSummary(entry.rightTask)),
-    ...task.incomingRelations.map((entry) => mapRelatedTaskSummary(entry.leftTask)),
-  ];
-
-  return relatedTasks.sort((left, right) => left.title.localeCompare(right.title));
-}
 
 async function loadTaskMutationPayload(
   db: DbClient,

--- a/lib/task-related.ts
+++ b/lib/task-related.ts
@@ -5,6 +5,25 @@ export interface RelatedTaskSummary {
   archivedAt: string | null;
 }
 
+interface TaskRelationSummarySource {
+  outgoingRelations: {
+    rightTask: {
+      id: string;
+      title: string;
+      status: string;
+      archivedAt: Date | string | null;
+    };
+  }[];
+  incomingRelations: {
+    leftTask: {
+      id: string;
+      title: string;
+      status: string;
+      archivedAt: Date | string | null;
+    };
+  }[];
+}
+
 function normalizeTaskId(value: unknown): string {
   if (typeof value !== "string") {
     return "";
@@ -59,6 +78,37 @@ export function mapRelatedTaskSummary(task: {
         ? task.archivedAt.toISOString()
         : task.archivedAt ?? null,
   };
+}
+
+export function normalizeRelatedTaskSummaries(
+  relatedTasks: Iterable<RelatedTaskSummary>
+): RelatedTaskSummary[] {
+  const summariesById = new Map<string, RelatedTaskSummary>();
+
+  for (const relatedTask of relatedTasks) {
+    if (!relatedTask.id || summariesById.has(relatedTask.id)) {
+      continue;
+    }
+
+    summariesById.set(relatedTask.id, relatedTask);
+  }
+
+  return Array.from(summariesById.values()).sort((left, right) =>
+    left.title.localeCompare(right.title)
+  );
+}
+
+export function mergeRelatedTaskSummaries(
+  task: TaskRelationSummarySource
+): RelatedTaskSummary[] {
+  return normalizeRelatedTaskSummaries([
+    ...task.outgoingRelations.map((entry) =>
+      mapRelatedTaskSummary(entry.rightTask)
+    ),
+    ...task.incomingRelations.map((entry) =>
+      mapRelatedTaskSummary(entry.leftTask)
+    ),
+  ]);
 }
 
 export function createRelatedTaskMap<T extends { id: string; relatedTasks: RelatedTaskSummary[] }>(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexusdash",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexusdash",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1079.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexusdash",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "private": true,
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0",

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -92,9 +92,10 @@ Last reviewed: 2026-07-30
   Dependencies: TASK-100, TASK-108, TASK-133, TASK-270
 - ID: TASK-349
   Title: Bilateral related-task relationships - keep both task directions consistent
-  Status: Next 16 - related-task correctness
+  Status: In progress (2026-07-30, GitHub issue #395)
   Rationale: Fix GitHub issue #395 so relating task A to task B makes the same canonical relationship visible when either task is opened, including immediately after optimistic updates and after reload, while keeping add/remove behavior duplicate-free and project-scoped.
   Dependencies: TASK-076, TASK-118
+  Brief: `tasks/task-349-bilateral-related-task-relationships.md`
 - ID: TASK-350
   Title: Complete related-task candidate list - investigate missing and non-scrollable tasks
   Status: Next 17 - related-task picker completeness

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -92,7 +92,7 @@ Last reviewed: 2026-07-30
   Dependencies: TASK-100, TASK-108, TASK-133, TASK-270
 - ID: TASK-349
   Title: Bilateral related-task relationships - keep both task directions consistent
-  Status: In progress (2026-07-30, GitHub issue #395)
+  Status: In review (2026-07-30, PR #399)
   Rationale: Fix GitHub issue #395 so relating task A to task B makes the same canonical relationship visible when either task is opened, including immediately after optimistic updates and after reload, while keeping add/remove behavior duplicate-free and project-scoped.
   Dependencies: TASK-076, TASK-118
   Brief: `tasks/task-349-bilateral-related-task-relationships.md`

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -2,90 +2,88 @@
 
 ## Task
 
-- ID: TASK-332
-- Title: Mobile meeting-todo navigation
-- Status: In review
-- Branch: `feature/task-332-mobile-todo-navigation-rebased`
-- Pull request: [#394](https://github.com/dorianagaesse/nexus_dash/pull/394)
-- Brief: [`task-332-mobile-todo-navigation.md`](./task-332-mobile-todo-navigation.md)
+- ID: TASK-349
+- Title: Bilateral related-task relationships
+- Status: In progress (2026-07-30)
+- Branch: `fix/395-bilateral-task-relations`
+- GitHub issue: [#395](https://github.com/dorianagaesse/nexus_dash/issues/395)
+- Brief: [`task-349-bilateral-related-task-relationships.md`](./task-349-bilateral-related-task-relationships.md)
 
 ## Objective
 
-Replace the obstructive mobile meeting-todo popup with a project-scoped,
-route-backed Todos destination and an extensible mobile navigation dock that
-clearly separates workspace destinations from current-project destinations.
+Make the existing canonical task relationship visible and consistent from both
+task directions after local mutations, live project updates, and full reloads.
 
 ## Scope
 
-- Add protected project meeting todos at `/projects/[projectId]/todos`.
-- Add Todos to the current-project group in the adaptive sidebar and mobile
-  navigation dock.
-- Keep workspace navigation separate from project navigation on mobile through
-  a contained, horizontally scrollable two-group rail.
-- Provide URL-backed status views, source meeting links, and
-  completion/reopening without cross-project aggregation.
-- Hide the project-scoped floating todo panel on mobile while retaining it on
-  desktop.
-- Cover authorization, read-only behavior, accessibility, safe areas, light
-  and dark themes, and 375 px containment.
+- Preserve the single canonical `leftTaskId`/`rightTaskId` database row.
+- Verify task mutation and project-list responses merge incoming and outgoing
+  relationships.
+- Reconcile add, replace, and remove operations across every loaded active and
+  archived task, including the currently selected task.
+- Apply the same bilateral reconciliation to remote project activity updates.
+- Add focused service/API, client reconciliation, and browser regression
+  coverage without redesigning the related-task picker.
 
 ## Runtime Assumptions
 
-- Docker Engine, the repository environment, installed dependencies, and
-  Playwright Chromium are available locally.
-- The local PostgreSQL Compose service may be started for browser validation.
-- Preview validation, if required, will use
-  `git_ref=feature/task-332-mobile-todo-navigation-rebased`.
+- Existing local PostgreSQL and `.env` prerequisites are unchanged.
+- No Prisma model or migration change is expected because `TaskRelation`
+  already stores one canonical undirected pair.
+- Browser validation uses the existing Playwright project/task fixture and may
+  run locally or against a branch preview.
+- A preview deployment, if used, must pass
+  `git_ref=fix/395-bilateral-task-relations` explicitly.
 
 ## Acceptance Criteria
 
-1. Mobile primary navigation exposes distinct Workspace and Project groups in
-   a contained horizontal rail with labels, Lucide icons, 44 px targets,
-   safe-area clearance, keyboard access, and active state.
-2. `/projects/[projectId]/todos` is protected, refreshable, deep-linkable, and
-   strictly limited to the authorized current project.
-3. Open/Completed views are URL-backed and work with browser Back/Forward.
-4. Todos retain source-meeting context and sort overdue/recent work
-   predictably without exposing another project's work.
-5. Owners/editors can complete or reopen todos with clear feedback while
-   viewers receive a read-only treatment.
-6. Desktop and mobile project navigation both expose Overview and Todos while
-   the floating panel remains desktop-only.
-7. The touched UI passes 375 px, light/dark, keyboard, focus, and 44 px target
-   checks without overflow or fixed-navigation collisions.
-8. Existing meeting-note, notification-return, and desktop behavior remains
-   intact.
+1. Relating task A to task B makes B visible from A and A visible from B
+   immediately after save and after a full reload.
+2. Removing the relation from either task removes it from both loaded task
+   views immediately and remains removed after reload.
+3. Repeated saves and duplicate input IDs keep one logical relation and one UI
+   entry.
+4. Local mutation and remote project-activity reconciliation update every
+   affected active or archived task without requiring a broad refresh.
+5. Existing archived-task visibility, project authorization, and cross-project
+   validation rules remain unchanged.
+6. Focused service/API, client reconciliation, and Playwright regression
+   coverage passes.
+7. Task tracking, root-cause notes, validation evidence, and release metadata
+   are updated in the same pull request.
 
 ## Definition Of Done
 
-- Access-safe project reads live in `lib/services/**` under actor RLS.
-- Focused unit/component and Playwright coverage passes.
-- Required lint, RLS, test, coverage, build, and UI validation is green.
-- Tracking docs and product version are updated.
-- The branch is committed, pushed, and opened as a ready-for-review PR with
-  initial automated feedback handled.
+- The root cause is documented with immediate-state and reload behavior.
+- The fix uses the established service boundary and canonical relation model.
+- `npm run lint`, `npm run rls:check`, `npm test`, `npm run test:coverage`,
+  `npm run build`, and the relevant Playwright coverage pass.
+- The patch version, changelog, task/backlog tracking, and journal are updated.
+- The branch is committed and pushed, a ready-for-review PR is open, and
+  initial automated review/check feedback is handled before handoff.
 
-## Progress
+## Outcome
 
-- Completed the 393 x 852 mobile audit and selected a dedicated navigation
-  destination over a floating action button.
-- Reconciled the branch with `origin/main` at `f220331` and preserved the
-  merged TASK-329, TASK-333, TASK-334, and TASK-336 behavior.
-- Traced the stale preview error to code/schema skew: the successful TASK-329
-  migration removed the legacy meeting-note participant column while the old
-  TASK-332 preview bundle still queried it. Updated the Playwright fixture to
-  exercise structured participant rows and prepared a fresh preview deployment.
-- Reframed Todos as a protected project destination at
-  `/projects/[projectId]/todos`; removed the workspace aggregate route, badge
-  query, cross-project filter, and cross-project service.
-- Added distinct Workspace and Project groups to the desktop sidebar and a
-  contained horizontal mobile dock while retaining the project quick panel
-  only at the desktop breakpoint.
-- Preserved URL-backed Open/Completed views, browser history, source-meeting
-  deep links, authorized completion/reopening, and viewer treatment.
-- Visually reviewed the project Todos workflow at the iPhone 14 Pro
-  393 x 852 viewport in light and dark themes, plus 375 px containment and
-  1280 px desktop behavior.
-- Passed the complete local gate: all 48 migrations, RLS inventory and tenant
-  isolation, lint, 978 unit/API tests with 2 skipped, unchanged coverage,
-  production build, and all 27 Playwright scenarios.
+- Preserved the canonical undirected database row and existing tenant
+  boundaries.
+- Centralized incoming/outgoing serialization into one sorted, duplicate-safe
+  mapper used by server-rendered, list API, and mutation response paths.
+- Reconciled authoritative local and remote mutations across both task
+  directions in active, archived, and selected client state.
+- Added focused mapping, API, reconciliation, and browser coverage for add,
+  remove, repeat-save, immediate-state, and reload behavior.
+- Prepared patch release `v0.31.1`.
+
+## Validation
+
+- `npm run lint` passed.
+- `npm run rls:check` passed.
+- `npm run release:check -- --base origin/main --branch fix/395-bilateral-task-relations`
+  and `git diff --check` passed.
+- `npm test`: 985 passed, 2 skipped.
+- `npm run test:coverage`: 91.37% statements, 81.33% branches, 92.2%
+  functions, 91.88% lines.
+- `npm run build` passed with local PostgreSQL and documented preview-safe
+  environment overrides.
+- Focused Playwright regression passed, followed by the complete 28-scenario
+  Playwright suite.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,9 +4,10 @@
 
 - ID: TASK-349
 - Title: Bilateral related-task relationships
-- Status: In progress (2026-07-30)
+- Status: In review (2026-07-30)
 - Branch: `fix/395-bilateral-task-relations`
 - GitHub issue: [#395](https://github.com/dorianagaesse/nexus_dash/issues/395)
+- Pull request: [#399](https://github.com/dorianagaesse/nexus_dash/pull/399)
 - Brief: [`task-349-bilateral-related-task-relationships.md`](./task-349-bilateral-related-task-relationships.md)
 
 ## Objective
@@ -87,3 +88,5 @@ task directions after local mutations, live project updates, and full reloads.
   environment overrides.
 - Focused Playwright regression passed, followed by the complete 28-scenario
   Playwright suite.
+- Implementation commit `5c1b820` is pushed and ready-for-review PR #399 is
+  open.

--- a/tasks/task-349-bilateral-related-task-relationships.md
+++ b/tasks/task-349-bilateral-related-task-relationships.md
@@ -1,0 +1,85 @@
+# TASK-349 - Bilateral related-task relationships
+
+## Status
+
+Implementation and local validation complete (2026-07-30)
+
+## Objective
+
+Fix GitHub issue #395 so one canonical task relationship behaves as an
+undirected relationship everywhere it is read or reconciled.
+
+## Root-Cause Investigation
+
+- Persistence already deletes both pair directions and recreates one canonical
+  `leftTaskId`/`rightTaskId` row with duplicate skipping.
+- Server project-list and mutation payloads already select both
+  `incomingRelations` and `outgoingRelations`, so a full reload reconstructs
+  both directions.
+- The local task-update path replaces only the task that was saved. It does not
+  add or remove the inverse summary on the other loaded task.
+- Remote task activity similarly upserts only the changed task, leaving inverse
+  references stale for collaborators until a broad project refresh.
+
+## Scope
+
+- Add a focused, reusable client reconciliation primitive for authoritative
+  related-task updates.
+- Apply it to local saves and remote activity upserts across active, archived,
+  and selected task state.
+- Strengthen bilateral response and duplicate-regression coverage.
+- Add a browser regression for immediate and reload behavior.
+
+## Out Of Scope
+
+- Picker layout or candidate-list redesign.
+- User-facing task identifiers.
+- Cross-project relationships.
+- Blocked follow-up behavior.
+- Prisma schema or migration changes.
+
+## Acceptance Criteria
+
+1. Adding B from A immediately exposes A from B and survives reload.
+2. Removing the relation from either task immediately removes both directions
+   and survives reload.
+3. Repeated saves do not create duplicate rows or summaries.
+4. Active and archived related-task summaries preserve current visibility
+   rules.
+5. Authorization and same-project validation remain unchanged.
+6. Focused service/API, reconciliation, and browser tests pass.
+
+## Definition Of Done
+
+- Root cause and delivered behavior are recorded in this brief and
+  `journal.md`.
+- Required validation is green.
+- Release metadata and `CHANGELOG.md` reflect the user-visible fix.
+- The dedicated branch is pushed and a ready-for-review PR is open.
+
+## Outcome
+
+- Kept the existing canonical `TaskRelation` persistence and same-project
+  validation unchanged.
+- Centralized incoming/outgoing relation serialization into one sorted,
+  duplicate-safe mapper used by task list, server-rendered board, and mutation
+  payload paths.
+- Added a focused client reconciliation primitive that updates the changed
+  task plus every inverse reference across active, archived, selected, and
+  remote-live state.
+- Added API, mapping, reconciliation, and browser regression coverage for
+  bilateral add/remove behavior, duplicate prevention, and reload persistence.
+
+## Validation
+
+- Focused Vitest: 42 tests passed across task mapping, create/update API, and
+  client reconciliation.
+- Focused ESLint passed.
+- Production build passed with documented local PostgreSQL and preview-safe
+  environment overrides.
+- Focused Playwright bilateral add/remove/reload scenario passed against the
+  local production build.
+- Full repository validation passed: lint, RLS inventory, release policy, 985
+  unit/API tests with 2 skipped, coverage at 91.37% statements / 81.33%
+  branches / 92.2% functions / 91.88% lines, production build, and all 28
+  Playwright scenarios.

--- a/tasks/task-349-bilateral-related-task-relationships.md
+++ b/tasks/task-349-bilateral-related-task-relationships.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implementation and local validation complete (2026-07-30)
+In review (2026-07-30, PR #399)
 
 ## Objective
 
@@ -83,3 +83,5 @@ undirected relationship everywhere it is read or reconciled.
   unit/API tests with 2 skipped, coverage at 91.37% statements / 81.33%
   branches / 92.2% functions / 91.88% lines, production build, and all 28
   Playwright scenarios.
+- Published implementation commit `5c1b820` and opened ready-for-review PR
+  [#399](https://github.com/dorianagaesse/nexus_dash/pull/399).

--- a/tests/api/task-create.route.test.ts
+++ b/tests/api/task-create.route.test.ts
@@ -9,6 +9,10 @@ const projectTaskServiceMock = vi.hoisted(() => ({
   createTaskForProject: vi.fn(),
 }));
 
+const projectServiceMock = vi.hoisted(() => ({
+  listProjectKanbanTasks: vi.fn(),
+}));
+
 vi.mock("@/lib/auth/api-guard", () => ({
   getAgentProjectAccessContext: apiGuardMock.getAgentProjectAccessContext,
   requireApiPrincipal: apiGuardMock.requireApiPrincipal,
@@ -29,14 +33,14 @@ vi.mock("@/lib/services/project-attachment-service", () => ({
 }));
 
 vi.mock("@/lib/services/project-service", () => ({
-  listProjectKanbanTasks: vi.fn(),
+  listProjectKanbanTasks: projectServiceMock.listProjectKanbanTasks,
 }));
 
 vi.mock("@/lib/services/project-access-service", () => ({
   requireAgentProjectScopes: vi.fn(() => ({ ok: true })),
 }));
 
-import { POST } from "@/app/api/projects/[projectId]/tasks/route";
+import { GET, POST } from "@/app/api/projects/[projectId]/tasks/route";
 
 async function readJson(response: Response): Promise<Record<string, unknown>> {
   return (await response.json()) as Record<string, unknown>;
@@ -45,6 +49,74 @@ async function readJson(response: Response): Promise<Record<string, unknown>> {
 function taskRouteParams(projectId: string) {
   return { params: Promise.resolve({ projectId }) };
 }
+
+describe("GET /api/projects/:projectId/tasks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiGuardMock.requireApiPrincipal.mockResolvedValue({
+      ok: true,
+      principal: {
+        kind: "human",
+        actorUserId: "test-user",
+        requestId: "request-1",
+      },
+    });
+    apiGuardMock.getAgentProjectAccessContext.mockReturnValue(undefined);
+  });
+
+  test("serializes incoming and outgoing relations once in both task directions", async () => {
+    const relatedTask = {
+      id: "task-b",
+      title: "Task B",
+      status: "Done",
+      archivedAt: new Date("2026-07-29T08:00:00.000Z"),
+    };
+    projectServiceMock.listProjectKanbanTasks.mockResolvedValueOnce([
+      {
+        id: "task-a",
+        title: "Task A",
+        description: null,
+        blockedNote: null,
+        deadlineAt: null,
+        _count: { comments: 0 },
+        completedAt: null,
+        archivedAt: null,
+        status: "Backlog",
+        position: 0,
+        label: null,
+        labelsJson: null,
+        createdAt: new Date("2026-07-30T08:00:00.000Z"),
+        updatedAt: new Date("2026-07-30T08:00:00.000Z"),
+        epic: null,
+        assigneeUser: null,
+        createdByUser: null,
+        updatedByUser: null,
+        attachments: [],
+        outgoingRelations: [{ rightTask: relatedTask }],
+        incomingRelations: [{ leftTask: relatedTask }],
+        blockedFollowUps: [],
+      },
+    ]);
+
+    const response = await GET(
+      new Request("http://localhost/api/projects/p1/tasks") as never,
+      taskRouteParams("p1")
+    );
+    const payload = (await response.json()) as {
+      tasks: Array<{ relatedTasks: unknown[] }>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(payload.tasks[0]?.relatedTasks).toEqual([
+      {
+        id: "task-b",
+        title: "Task B",
+        status: "Done",
+        archivedAt: "2026-07-29T08:00:00.000Z",
+      },
+    ]);
+  });
+});
 
 describe("POST /api/projects/:projectId/tasks", () => {
   beforeEach(() => {

--- a/tests/components/kanban-board-related.test.ts
+++ b/tests/components/kanban-board-related.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "vitest";
+
+import { reconcileBilateralTaskRelations } from "@/components/kanban-board-related";
+import type { KanbanTask } from "@/components/kanban-board-types";
+
+const person = {
+  id: "user-1",
+  displayName: "Test User",
+  usernameTag: null,
+  avatarSeed: "user-1",
+};
+
+function createTask(
+  id: string,
+  title: string,
+  relatedTasks: KanbanTask["relatedTasks"] = []
+): KanbanTask {
+  return {
+    id,
+    title,
+    description: null,
+    deadlineDate: null,
+    commentCount: 0,
+    labels: [],
+    blockedFollowUps: [],
+    status: "Backlog",
+    position: 0,
+    archivedAt: null,
+    attachments: [],
+    relatedTasks,
+    epic: null,
+    assignee: null,
+    createdBy: person,
+    updatedBy: person,
+    createdAt: "2026-07-30T08:00:00.000Z",
+    updatedAt: "2026-07-30T08:00:00.000Z",
+  };
+}
+
+describe("reconcileBilateralTaskRelations", () => {
+  test("adds the inverse relation to the other loaded task", () => {
+    const taskB = createTask("task-b", "Task B");
+    const updatedTaskA = createTask("task-a", "Task A", [
+      {
+        id: taskB.id,
+        title: taskB.title,
+        status: taskB.status,
+        archivedAt: taskB.archivedAt,
+      },
+    ]);
+
+    expect(reconcileBilateralTaskRelations(taskB, updatedTaskA).relatedTasks).toEqual([
+      {
+        id: "task-a",
+        title: "Task A",
+        status: "Backlog",
+        archivedAt: null,
+      },
+    ]);
+  });
+
+  test("removes the inverse relation when the authoritative task unlinks it", () => {
+    const taskB = createTask("task-b", "Task B", [
+      {
+        id: "task-a",
+        title: "Task A",
+        status: "Backlog",
+        archivedAt: null,
+      },
+    ]);
+    const updatedTaskA = createTask("task-a", "Task A");
+
+    expect(reconcileBilateralTaskRelations(taskB, updatedTaskA).relatedTasks).toEqual([]);
+  });
+
+  test("deduplicates repeated updates and refreshes the inverse summary", () => {
+    const taskB = createTask("task-b", "Task B", [
+      {
+        id: "task-a",
+        title: "Old title",
+        status: "Backlog",
+        archivedAt: null,
+      },
+      {
+        id: "task-a",
+        title: "Old title",
+        status: "Backlog",
+        archivedAt: null,
+      },
+    ]);
+    const updatedTaskA = {
+      ...createTask("task-a", "Updated task A", [
+        {
+          id: "task-b",
+          title: "Task B",
+          status: "Backlog",
+          archivedAt: null,
+        },
+      ]),
+      status: "Done" as const,
+      archivedAt: "2026-07-30T09:00:00.000Z",
+    };
+
+    const firstResult = reconcileBilateralTaskRelations(taskB, updatedTaskA);
+    const repeatedResult = reconcileBilateralTaskRelations(firstResult, updatedTaskA);
+
+    expect(repeatedResult.relatedTasks).toEqual([
+      {
+        id: "task-a",
+        title: "Updated task A",
+        status: "Done",
+        archivedAt: "2026-07-30T09:00:00.000Z",
+      },
+    ]);
+  });
+
+  test("normalizes duplicate summaries on the authoritative task itself", () => {
+    const updatedTaskA = createTask("task-a", "Task A", [
+      {
+        id: "task-b",
+        title: "Task B",
+        status: "Backlog",
+        archivedAt: null,
+      },
+      {
+        id: "task-b",
+        title: "Task B",
+        status: "Backlog",
+        archivedAt: null,
+      },
+      {
+        id: "task-a",
+        title: "Task A",
+        status: "Backlog",
+        archivedAt: null,
+      },
+    ]);
+
+    expect(
+      reconcileBilateralTaskRelations(createTask("task-a", "Old Task A"), updatedTaskA)
+        .relatedTasks
+    ).toEqual([
+      {
+        id: "task-b",
+        title: "Task B",
+        status: "Backlog",
+        archivedAt: null,
+      },
+    ]);
+  });
+});
+

--- a/tests/e2e/related-task-bilateral.spec.ts
+++ b/tests/e2e/related-task-bilateral.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "@playwright/test";
+
+import { signInAsVerifiedUser } from "./helpers/auth-helpers";
+import {
+  createProjectFromProjectsPage,
+  openNewestProjectDashboard,
+  uniqueProjectName,
+} from "./helpers/project-helpers";
+
+test.describe("bilateral related tasks", () => {
+  test("adds and removes a relation from both task directions immediately and after reload", async ({
+    page,
+  }) => {
+    await signInAsVerifiedUser(page);
+
+    const projectName = uniqueProjectName("related-tasks");
+    const taskATitle = uniqueProjectName("relation-a");
+    const taskBTitle = uniqueProjectName("relation-b");
+
+    await createProjectFromProjectsPage(page, projectName);
+    await openNewestProjectDashboard(page, projectName);
+
+    const projectId = page.url().match(/\/projects\/([^/?#]+)/)?.[1];
+    expect(projectId).toBeTruthy();
+
+    for (const title of [taskATitle, taskBTitle]) {
+      const response = await page.request.post(`/api/projects/${projectId}/tasks`, {
+        data: { title },
+      });
+      expect(response.ok()).toBeTruthy();
+    }
+
+    await page.reload();
+    await expect(page.getByRole("heading", { name: "Kanban board" })).toBeVisible();
+
+    const openTask = async (title: string) => {
+      await page
+        .getByRole("button", { name: new RegExp(title) })
+        .first()
+        .click();
+      return page.getByRole("dialog", { name: title });
+    };
+
+    let taskDialog = await openTask(taskATitle);
+    await taskDialog.getByRole("button", { name: "Task options" }).click();
+    await page.getByRole("button", { name: /^Edit$/ }).click();
+    await page.getByPlaceholder("Search active tasks").fill(taskBTitle);
+    await page.getByRole("button", { name: taskBTitle, exact: true }).click();
+    await page.getByRole("button", { name: "Save changes" }).click();
+    await expect(page.getByText("Task saved.")).toBeVisible();
+    await taskDialog.getByRole("button", { name: "Close task" }).click();
+
+    taskDialog = await openTask(taskBTitle);
+    await expect(
+      taskDialog.getByRole("button", { name: taskATitle, exact: true })
+    ).toBeVisible();
+    await taskDialog.getByRole("button", { name: "Close task" }).click();
+
+    await page.reload();
+    taskDialog = await openTask(taskBTitle);
+    await expect(
+      taskDialog.getByRole("button", { name: taskATitle, exact: true })
+    ).toBeVisible();
+
+    await taskDialog.getByRole("button", { name: "Task options" }).click();
+    await page.getByRole("button", { name: /^Edit$/ }).click();
+    await page
+      .getByRole("button", { name: `Remove related task ${taskATitle}` })
+      .click();
+    await page.getByRole("button", { name: "Save changes" }).click();
+    await expect(page.getByText("Task saved.")).toBeVisible();
+    await taskDialog.getByRole("button", { name: "Close task" }).click();
+
+    taskDialog = await openTask(taskATitle);
+    await expect(
+      taskDialog.getByRole("button", { name: taskBTitle, exact: true })
+    ).toHaveCount(0);
+    await taskDialog.getByRole("button", { name: "Close task" }).click();
+
+    await page.reload();
+    taskDialog = await openTask(taskATitle);
+    await expect(
+      taskDialog.getByRole("button", { name: taskBTitle, exact: true })
+    ).toHaveCount(0);
+  });
+});

--- a/tests/lib/task-related.test.ts
+++ b/tests/lib/task-related.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  buildCanonicalTaskRelation,
+  mergeRelatedTaskSummaries,
+  normalizeRelatedTaskIds,
+} from "@/lib/task-related";
+
+describe("task-related", () => {
+  test("normalizes IDs and builds one canonical pair", () => {
+    expect(normalizeRelatedTaskIds([" task-b ", "task-b", "", "task-a"])).toEqual([
+      "task-b",
+      "task-a",
+    ]);
+    expect(buildCanonicalTaskRelation("task-z", "task-a")).toEqual({
+      leftTaskId: "task-a",
+      rightTaskId: "task-z",
+    });
+  });
+
+  test("merges incoming and outgoing relations into one sorted summary list", () => {
+    expect(
+      mergeRelatedTaskSummaries({
+        outgoingRelations: [
+          {
+            rightTask: {
+              id: "task-c",
+              title: "Charlie",
+              status: "Done",
+              archivedAt: new Date("2026-07-29T08:00:00.000Z"),
+            },
+          },
+        ],
+        incomingRelations: [
+          {
+            leftTask: {
+              id: "task-a",
+              title: "Alpha",
+              status: "Backlog",
+              archivedAt: null,
+            },
+          },
+          {
+            leftTask: {
+              id: "task-c",
+              title: "Charlie duplicate",
+              status: "Done",
+              archivedAt: new Date("2026-07-29T08:00:00.000Z"),
+            },
+          },
+        ],
+      })
+    ).toEqual([
+      {
+        id: "task-a",
+        title: "Alpha",
+        status: "Backlog",
+        archivedAt: null,
+      },
+      {
+        id: "task-c",
+        title: "Charlie",
+        status: "Done",
+        archivedAt: "2026-07-29T08:00:00.000Z",
+      },
+    ]);
+  });
+});
+


### PR DESCRIPTION
## Summary

- reconcile canonical related-task relationships in both loaded task directions after local saves
- apply the same inverse add/remove reconciliation to remote project activity updates and archived/selected task state
- centralize incoming/outgoing serialization in one sorted, duplicate-safe mapper
- add mapping, API, client reconciliation, and Playwright regression coverage
- prepare patch release `v0.31.1`

## Root cause

`TaskRelation` persistence was already canonical and undirected, and reload payloads already selected both incoming and outgoing relations. The immediate client mutation path only replaced the task that was saved, while the remote activity path only upserted the task carried by the event. The inverse summary on the other loaded task therefore stayed stale until a broad reload.

## Impact

Adding or removing a relationship from either task is now visible immediately from both task detail views, remains correct after reload, and stays consistent for live collaborators without creating duplicate rows or UI entries. Existing project authorization, cross-project validation, and archived-task rules are unchanged.

## Validation

- `npm run lint`
- `npm run rls:check`
- `npm run release:check -- --base origin/main --branch fix/395-bilateral-task-relations`
- `npm test` — 985 passed, 2 skipped
- `npm run test:coverage` — 91.37% statements, 81.33% branches, 92.2% functions, 91.88% lines
- `npm run build`
- `npx playwright test tests/e2e/related-task-bilateral.spec.ts`
- `npx playwright test` — 28 passed

Fixes #395