### PR TITLE
TASK-351: Add stable user-facing task IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ SHA, deployment URL, and workflow run belong in release evidence.
 
 - Define each release entry before the product-impacting PR is merged.
 
+## v0.32.0 - 2026-07-30
+
+- Added immutable, globally unique task references rendered as `ND-<number>`,
+  with sequence-backed allocation for concurrent creates and migration
+  backfill for existing tasks.
+- Exposed task references in read/edit task-detail headers and beside every
+  related-task suggestion without revealing internal database IDs.
+- Added create/edit related-task search by friendly reference plus focused
+  formatter, API, component, migration, responsive browser, and stability
+  coverage.
+
 ## v0.31.2 - 2026-07-30
 
 - Removed the eight-result cap from create-task and task-detail related-task

--- a/app/api/projects/[projectId]/tasks/route.ts
+++ b/app/api/projects/[projectId]/tasks/route.ts
@@ -15,6 +15,7 @@ import { requireAgentProjectScopes } from "@/lib/services/project-access-service
 import { mapTaskEpicSummary } from "@/lib/epic";
 import { mapTaskPersonSummary } from "@/lib/task-person";
 import { formatTaskDeadlineDate } from "@/lib/task-deadline";
+import { formatTaskReference } from "@/lib/task-reference";
 import { mergeRelatedTaskSummaries } from "@/lib/task-related";
 
 const ATTACHMENT_FILES_FIELD = "attachmentFiles";
@@ -92,6 +93,7 @@ export async function GET(request: NextRequest, props: { params: Promise<{ proje
     {
       tasks: tasks.map((task) => ({
         id: task.id,
+        reference: formatTaskReference(task.referenceNumber),
         title: task.title,
         description: task.description,
         blockedNote: task.blockedNote,

--- a/app/projects/[projectId]/kanban-board-section.tsx
+++ b/app/projects/[projectId]/kanban-board-section.tsx
@@ -20,6 +20,7 @@ import { mapTaskPersonSummary } from "@/lib/task-person";
 import { mergeRelatedTaskSummaries } from "@/lib/task-related";
 import { ATTACHMENT_KIND_FILE } from "@/lib/task-attachment";
 import { formatTaskDeadlineDate } from "@/lib/task-deadline";
+import { formatTaskReference } from "@/lib/task-reference";
 import { getTaskLabelsFromStorage } from "@/lib/task-label";
 import { isTaskStatus } from "@/lib/task-status";
 
@@ -66,6 +67,7 @@ export async function KanbanBoardSection({
 
     const normalizedTask: KanbanTask = {
       id: task.id,
+      reference: formatTaskReference(task.referenceNumber) ?? null,
       title: task.title,
       description: task.description,
       deadlineDate: formatTaskDeadlineDate(task.deadlineAt),

--- a/components/kanban-board-types.ts
+++ b/components/kanban-board-types.ts
@@ -74,6 +74,7 @@ export interface TaskAttachment {
 
 export interface KanbanTask {
   id: string;
+  reference: string | null;
   title: string;
   description: string | null;
   deadlineDate: string | null;
@@ -95,6 +96,7 @@ export interface KanbanTask {
 
 export interface TaskMutationResponseTask {
   id: string;
+  reference: string;
   title: string;
   label: string | null;
   labelsJson: string | null;

--- a/components/kanban-board-types.ts
+++ b/components/kanban-board-types.ts
@@ -96,7 +96,8 @@ export interface KanbanTask {
 
 export interface TaskMutationResponseTask {
   id: string;
-  reference: string;
+  // Persisted activity events created before TASK-351 do not include a reference.
+  reference?: string;
   title: string;
   label: string | null;
   labelsJson: string | null;

--- a/components/kanban-board.tsx
+++ b/components/kanban-board.tsx
@@ -117,6 +117,7 @@ function getTaskMutationErrorMessage(errorCode?: string): string {
 function mapTaskMutationResponseTask(task: TaskMutationResponseTask): KanbanTask {
   return {
     id: task.id,
+    reference: task.reference ?? null,
     title: task.title,
     labels: getTaskLabelsFromStorage(task.labelsJson, task.label),
     description: task.description,
@@ -577,6 +578,7 @@ export function KanbanBoard({
       .filter((task) => task.id !== selectedTask.id)
       .map((task) => ({
         id: task.id,
+        reference: task.reference ?? "",
         title: task.title,
         status: task.status,
       }))
@@ -588,6 +590,7 @@ export function KanbanBoard({
       TASK_STATUSES.flatMap((status) => columns[status])
         .map((task) => ({
           id: task.id,
+          reference: task.reference ?? "",
           title: task.title,
           status: task.status,
         }))
@@ -1286,6 +1289,7 @@ export function KanbanBoard({
 
       insertCreatedTask({
         id: optimisticTaskId,
+        reference: null,
         title: draft.title,
         labels: draft.labels,
         description: draft.description,

--- a/components/kanban/related-task-field.tsx
+++ b/components/kanban/related-task-field.tsx
@@ -11,6 +11,7 @@ import { cn } from "@/lib/utils";
 
 export interface RelatedTaskOption {
   id: string;
+  reference: string;
   title: string;
   status: string;
 }
@@ -63,7 +64,8 @@ export function RelatedTaskSelector({
     }
 
     return unselectedTasks.filter((task) => {
-      const haystack = `${task.title} ${task.status}`.toLowerCase();
+      const haystack =
+        `${task.reference} ${task.title} ${task.status}`.toLowerCase();
       return haystack.includes(normalizedQuery);
     });
   }, [availableTasks, normalizedQuery, selectedTasks]);
@@ -300,12 +302,20 @@ export function RelatedTaskSelector({
                         }
                         data-task-status={task.status}
                         tabIndex={-1}
-                        className="flex min-h-11 w-full items-center rounded-md px-3 py-2 text-left text-sm transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[active=true]:bg-muted"
+                        aria-label={task.title}
+                        aria-describedby={`${listboxId}-option-${index}-reference`}
+                        className="flex min-h-11 w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[active=true]:bg-muted"
                         onMouseDown={(event) => event.preventDefault()}
                         onMouseMove={() => setActiveSuggestionIndex(index)}
                         onClick={() => selectTask(task.id)}
                         disabled={disabled}
                       >
+                        <span
+                          id={`${listboxId}-option-${index}-reference`}
+                          className="shrink-0 select-all font-mono text-xs font-semibold tabular-nums text-muted-foreground"
+                        >
+                          {task.reference}
+                        </span>
                         <span className="min-w-0 flex-1 truncate">
                           {task.title}
                         </span>

--- a/components/kanban/related-task-field.tsx
+++ b/components/kanban/related-task-field.tsx
@@ -301,19 +301,16 @@ export function RelatedTaskSelector({
                           index === activeSuggestionIndex ? "true" : undefined
                         }
                         data-task-status={task.status}
+                        data-task-title={task.title}
                         tabIndex={-1}
-                        aria-label={task.title}
-                        aria-describedby={`${listboxId}-option-${index}-reference`}
+                        aria-label={`${task.reference}, ${task.title}`}
                         className="flex min-h-11 w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[active=true]:bg-muted"
                         onMouseDown={(event) => event.preventDefault()}
                         onMouseMove={() => setActiveSuggestionIndex(index)}
                         onClick={() => selectTask(task.id)}
                         disabled={disabled}
                       >
-                        <span
-                          id={`${listboxId}-option-${index}-reference`}
-                          className="shrink-0 select-all font-mono text-xs font-semibold tabular-nums text-muted-foreground"
-                        >
+                        <span className="shrink-0 select-all font-mono text-xs font-semibold tabular-nums text-muted-foreground">
                           {task.reference}
                         </span>
                         <span className="min-w-0 flex-1 truncate">

--- a/components/kanban/task-detail-modal.tsx
+++ b/components/kanban/task-detail-modal.tsx
@@ -357,16 +357,27 @@ export function TaskDetailModal({
               )}
             >
               <div className={cn("min-w-0 flex-1 space-y-2", isEditing && "w-full pr-1")}>
-                <Badge
-                  variant="outline"
-                  className={
-                    isArchivedTask
-                      ? "border-emerald-500/60 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
-                      : undefined
-                  }
-                >
-                  {isArchivedTask ? "Archived" : selectedTask.status}
-                </Badge>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge
+                    variant="outline"
+                    className={
+                      isArchivedTask
+                        ? "border-emerald-500/60 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+                        : undefined
+                    }
+                  >
+                    {isArchivedTask ? "Archived" : selectedTask.status}
+                  </Badge>
+                  {selectedTask.reference ? (
+                    <Badge
+                      variant="outline"
+                      aria-label={`Task reference ${selectedTask.reference}`}
+                      className="select-all font-mono font-semibold tabular-nums text-muted-foreground"
+                    >
+                      {selectedTask.reference}
+                    </Badge>
+                  ) : null}
+                </div>
                 {!isEditing ? (
                   <div className="space-y-3 sm:flex sm:items-end sm:justify-between sm:gap-4 sm:space-y-0">
                     <CardTitle

--- a/journal.md
+++ b/journal.md
@@ -35,6 +35,8 @@ Use it for important implementation milestones, blockers, validation runs, and r
   91.37% statements / 81.33% branches / 92.2% functions / 91.88% lines,
   production build, focused browser coverage, and all 30 Chromium scenarios.
 - Prepared feature release `v0.32.0`.
+- Published implementation commit `a3704dd` and opened ready-for-review
+  [PR #402](https://github.com/dorianagaesse/nexus_dash/pull/402).
 
 # 2026-07-30 - TASK-350 related-task picker completeness
 

--- a/journal.md
+++ b/journal.md
@@ -37,6 +37,13 @@ Use it for important implementation milestones, blockers, validation runs, and r
 - Prepared feature release `v0.32.0`.
 - Published implementation commit `a3704dd` and opened ready-for-review
   [PR #402](https://github.com/dorianagaesse/nexus_dash/pull/402).
+- Copilot completed its initial review with two actionable comments. Updated
+  option accessible names to include the friendly reference and made
+  `TaskMutationResponseTask.reference` optional for persisted pre-TASK-351
+  activity events while keeping fresh API/OpenAPI responses required.
+- Post-review validation passed: lint, 16 focused component/helper tests,
+  production build, and the bilateral, TASK-350, and TASK-351 Playwright
+  regressions.
 
 # 2026-07-30 - TASK-350 related-task picker completeness
 

--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,39 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-07-30 - TASK-351 user-facing task IDs
+
+- Started from merged TASK-350 on the dedicated
+  `feature/task-351-user-facing-task-ids` worktree and replaced the stale
+  current-task brief with explicit acceptance criteria and definition of done.
+- Applied UI/UX Pro Max guidance for a data-dense Next.js/Shadcn dashboard:
+  preserve title hierarchy, use compact monospaced/tabular reference metadata,
+  retain 44 px listbox options and keyboard semantics, and verify 375 px
+  containment.
+- Added immutable globally unique `Task.referenceNumber` values, rendered
+  through the shared formatter as `ND-<number>`. PostgreSQL sequence allocation
+  backfills existing rows, prevents concurrent-create collisions, never reuses
+  deleted values, and grants sequence access to `app_runtime` when that role is
+  present.
+- Kept CUIDs as the private routing/relation/authorization identity. Added the
+  friendly reference to server-rendered task data, list/mutation/activity
+  payloads, and the agent OpenAPI schema without accepting it as a mutation
+  input.
+- Added references to read/edit task-detail headers and related-task options;
+  create/edit search now matches complete or partial friendly references while
+  internal CUIDs remain absent from the search index.
+- Added formatter, route, component, modal, and Playwright regressions. The
+  browser flow proves create allocation, detail visibility, create/edit
+  reference search, update stability, reload stability, and narrow viewport
+  containment; visual inspection confirmed the reference remains subordinate
+  to task titles in light mode.
+- Complete validation passed: Prisma schema and all 49 migrations, lint, RLS
+  inventory, release policy, real PostgreSQL tenant isolation, 143 passing
+  Vitest files with 2 skipped, 995 passing tests with 2 skipped, coverage at
+  91.37% statements / 81.33% branches / 92.2% functions / 91.88% lines,
+  production build, focused browser coverage, and all 30 Chromium scenarios.
+- Prepared feature release `v0.32.0`.
+
 # 2026-07-30 - TASK-350 related-task picker completeness
 
 - Mapped GitHub issue #396 to TASK-350 and isolated the work on

--- a/lib/agent-onboarding.ts
+++ b/lib/agent-onboarding.ts
@@ -1401,6 +1401,7 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
           type: "object",
           required: [
             "id",
+            "reference",
             "title",
             "description",
             "blockedNote",
@@ -1424,6 +1425,10 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
           ],
           properties: {
             id: { type: "string" },
+            reference: {
+              type: "string",
+              pattern: "^ND-[1-9][0-9]*$",
+            },
             title: { type: "string" },
             description: { type: ["string", "null"] },
             blockedNote: { type: ["string", "null"] },
@@ -1558,6 +1563,7 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
               type: "object",
               required: [
                 "id",
+                "reference",
                 "title",
                 "label",
                 "labelsJson",
@@ -1579,6 +1585,10 @@ export function buildAgentOpenApiDocument(appOrigin?: string | null) {
               ],
               properties: {
                 id: { type: "string" },
+                reference: {
+                  type: "string",
+                  pattern: "^ND-[1-9][0-9]*$",
+                },
                 title: { type: "string" },
                 label: { type: ["string", "null"] },
                 labelsJson: { type: ["string", "null"] },

--- a/lib/services/project-task-service.ts
+++ b/lib/services/project-task-service.ts
@@ -25,6 +25,7 @@ import {
   formatTaskDeadlineDate,
   parseTaskDeadlineDate,
 } from "@/lib/task-deadline";
+import { formatTaskReference } from "@/lib/task-reference";
 import {
   requireAgentProjectScopes,
   requireProjectRole,
@@ -96,6 +97,7 @@ interface CreateTaskForProjectInput {
 
 interface UpdatedTaskPayload {
   id: string;
+  reference: string;
   title: string;
   label: string | null;
   labelsJson: string | null;
@@ -240,6 +242,7 @@ async function loadTaskMutationPayload(
     where: { id: taskId },
     select: {
       id: true,
+      referenceNumber: true,
       title: true,
       label: true,
       labelsJson: true,
@@ -313,6 +316,7 @@ async function loadTaskMutationPayload(
 
   return {
     id: task.id,
+    reference: formatTaskReference(task.referenceNumber),
     title: task.title,
     label: task.label,
     labelsJson: task.labelsJson,

--- a/lib/task-reference.ts
+++ b/lib/task-reference.ts
@@ -1,0 +1,19 @@
+const TASK_REFERENCE_PREFIX = "ND";
+
+export function formatTaskReference(referenceNumber: number): string;
+export function formatTaskReference(
+  referenceNumber: null | undefined
+): undefined;
+export function formatTaskReference(
+  referenceNumber: number | null | undefined
+): string | undefined {
+  if (referenceNumber == null) {
+    return undefined;
+  }
+
+  if (!Number.isSafeInteger(referenceNumber) || referenceNumber < 1) {
+    throw new Error("task-reference-number-invalid");
+  }
+
+  return `${TASK_REFERENCE_PREFIX}-${referenceNumber}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexusdash",
-  "version": "0.31.2",
+  "version": "0.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexusdash",
-      "version": "0.31.2",
+      "version": "0.32.0",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1079.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexusdash",
-  "version": "0.31.2",
+  "version": "0.32.0",
   "private": true,
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0",

--- a/prisma/migrations/20260730120000_task351_user_facing_task_ids/migration.sql
+++ b/prisma/migrations/20260730120000_task351_user_facing_task_ids/migration.sql
@@ -1,0 +1,22 @@
+-- TASK-351 gives every existing and future task a stable, user-facing number.
+-- PostgreSQL owns allocation so concurrent task creates cannot collide, while
+-- the existing CUID remains the internal primary key and relation target.
+CREATE SEQUENCE "Task_referenceNumber_seq";
+
+ALTER TABLE "Task"
+ADD COLUMN "referenceNumber" INTEGER NOT NULL
+DEFAULT nextval('"Task_referenceNumber_seq"');
+
+ALTER SEQUENCE "Task_referenceNumber_seq"
+OWNED BY "Task"."referenceNumber";
+
+CREATE UNIQUE INDEX "Task_referenceNumber_key"
+ON "Task"("referenceNumber");
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_runtime') THEN
+    GRANT USAGE, SELECT ON SEQUENCE "Task_referenceNumber_seq" TO app_runtime;
+  END IF;
+END
+$$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -470,6 +470,7 @@ model RoadmapEvent {
 
 model Task {
   id                String                @id @default(cuid())
+  referenceNumber   Int                   @unique @default(autoincrement())
   title             String
   description       String?
   blockedNote       String?

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -77,7 +77,7 @@ Last reviewed: 2026-07-30
   Brief: `tasks/task-350-related-task-picker.md`
 - ID: TASK-351
   Title: User-facing task IDs - stable references in task details and relationship search
-  Status: Next 14 - task follow-up identifiers
+  Status: Ready for review (2026-07-30)
   Rationale: Introduce or expose concise, stable user-facing task identifiers so users can refer to tasks unambiguously; show the identifier when a task detail modal is open and beside each candidate while searching for a task to relate, without exposing opaque internal database IDs.
   Dependencies: TASK-076, TASK-133
 - ID: TASK-352

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -77,7 +77,7 @@ Last reviewed: 2026-07-30
   Brief: `tasks/task-350-related-task-picker.md`
 - ID: TASK-351
   Title: User-facing task IDs - stable references in task details and relationship search
-  Status: Ready for review (2026-07-30)
+  Status: In review (2026-07-30, PR #402)
   Rationale: Introduce or expose concise, stable user-facing task identifiers so users can refer to tasks unambiguously; show the identifier when a task detail modal is open and beside each candidate while searching for a task to relate, without exposing opaque internal database IDs.
   Dependencies: TASK-076, TASK-133
 - ID: TASK-352

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -2,104 +2,117 @@
 
 ## Task
 
-- ID: TASK-350
-- Title: Complete related-task candidate list
-- Status: In review
-- Branch: `fix/task-350-related-task-picker`
-- GitHub issue: [#396](https://github.com/dorianagaesse/nexus_dash/issues/396)
-- Pull request: [#400](https://github.com/dorianagaesse/nexus_dash/pull/400)
-- Brief: [`task-350-related-task-picker.md`](./task-350-related-task-picker.md)
+- ID: TASK-351
+- Title: User-facing task IDs
+- Status: Ready for review (2026-07-30)
+- Branch: `feature/task-351-user-facing-task-ids`
+- Brief: [`task-351-user-facing-task-ids.md`](./task-351-user-facing-task-ids.md)
 
 ## Objective
 
-Ensure the create-task and task-detail `Related to` pickers expose every
-eligible active task in the authorized current project, including Blocked
-tasks, with complete search and accessible scrolling through long result sets.
+Give every task a concise, stable reference that users can read, search, and
+share without exposing the opaque database ID.
 
 ## Scope
 
-- Trace candidate construction in create and task-detail flows across every
-  Kanban status.
-- Preserve project authorization, archived-task rules, current-task exclusion,
-  and intentional selected/already-related behavior.
-- Provide bounded result-list scrolling without moving the underlying modal or
-  page.
-- Keep keyboard focus and the active option visible through the complete
-  filtered result set.
-- Cover clear empty and no-search-results states.
-- Add focused component and Playwright regression coverage with enough tasks to
-  overflow the picker.
-- Record before/after candidate counts by status and visual evidence.
+- Add an immutable database-generated numeric reference to every existing and
+  future task.
+- Format references consistently as `ND-<number>` at the application boundary.
+- Show the reference in the task-detail header in read and edit modes.
+- Show the reference beside every related-task search candidate.
+- Match related-task searches by formatted reference as well as title and
+  status.
+- Preserve internal task IDs for routing, mutations, relations, and
+  authorization.
+- Add focused migration, mapping, component, API, and browser coverage.
 
 ## Runtime Assumptions
 
-- Installed dependencies and Playwright Chromium are available locally.
-- The local PostgreSQL Compose service may be started for browser validation.
-- Preview validation will use
-  `git_ref=fix/task-350-related-task-picker` if the local UI evidence cannot
-  cover the complete authenticated flow.
+- The PostgreSQL migration must backfill existing tasks and allocate future
+  references atomically through a database sequence.
+- References are globally unique, immutable, and never reused after task
+  deletion.
+- Existing local PostgreSQL and `.env` prerequisites are unchanged.
+- Browser validation uses the existing Playwright project/task fixture and may
+  run locally or against a branch preview.
+- Any preview validation must pass
+  `git_ref=feature/task-351-user-facing-task-ids` explicitly.
 
 ## Acceptance Criteria
 
-1. All eligible active tasks from Backlog, In Progress, Blocked, and Done are
-   present in or discoverable through both related-task pickers.
-2. The current task is excluded; selected and already-related tasks retain
-   intentional behavior; archived tasks remain unavailable.
-3. Search filters the complete eligible candidate set rather than a visible or
-   status-limited subset.
-4. Long results scroll inside the picker without clipping rows or scrolling
-   the underlying modal/page.
-5. Keyboard navigation reaches every filtered result and keeps the active
-   option visible.
-6. Empty and no-search-results states are distinct and clear.
-7. Cross-project and unauthorized tasks remain unavailable.
-8. Focused component and Playwright regression coverage passes at desktop and
-   narrow viewports.
-9. Before/after candidate counts by status and overflowing-list screenshots or
-   recordings are recorded.
-10. Repository task tracking and journal context are updated in the same PR.
+1. Every existing and newly created task has one globally unique numeric
+   reference rendered as `ND-<number>`.
+2. A task keeps the same reference after title, status, relation, archive, and
+   restore mutations and after a full reload.
+3. The task-detail modal exposes the reference in both read and edit modes
+   without displaying the internal database ID.
+4. Every related-task candidate exposes its reference beside its title.
+5. Searching the related-task picker by a complete or partial formatted
+   reference returns the authorized matching task in create and edit flows.
+6. Reference display and search remain keyboard accessible, readable at a
+   375 px viewport, and compatible with light and dark themes.
+7. Project authorization, active/archived candidate rules, bilateral
+   relations, and internal task routing remain unchanged.
+8. Focused migration/mapping, service/API, component, and Playwright coverage
+   passes.
+9. Release metadata, task tracking, root-cause notes, and validation evidence
+   are updated in the same pull request.
 
 ## Definition Of Done
 
-- Root cause is documented as data filtering, visual clipping, interaction
-  handling, or a combination.
-- Candidate logic is shared or aligned between create and detail flows.
-- Focused unit/component and Playwright coverage passes.
-- Lint, RLS inventory, unit tests, coverage, production build, and relevant E2E
-  validation are green.
-- Product version and tracking docs are updated consistently.
-- The branch is committed, pushed, and opened as a ready-for-review PR with
-  initial automated feedback handled.
+- The migration safely backfills existing rows and uses a database sequence for
+  concurrency-safe future allocation.
+- Reference formatting is centralized and reused by server/client presentation
+  paths.
+- The modal and related-task picker meet the UI/UX accessibility and responsive
+  checks from the UI/UX Pro Max review.
+- `npm run lint`, `npm run rls:check`, `npm test`, `npm run test:coverage`,
+  `npm run build`, release validation, and relevant Playwright coverage pass.
+- The feature release advances to `v0.32.0` with matching changelog and lockfile
+  metadata.
+- The branch is committed and pushed, a ready-for-review PR is open, and
+  initial Copilot review/check feedback is handled without merging the PR.
 
 ## Progress
 
-- Confirmed GitHub issue #396 maps to TASK-350 in the execution backlog.
-- Created a dedicated worktree and fix branch from `origin/main` because the
-  root checkout is concurrently occupied by issue #395.
-- Confirmed create and detail callers already aggregate every active status and
-  exclude archived tasks; the shared selector truncated both default and
-  searched suggestions to eight and lacked keyboard option navigation.
-- Replaced the cap with a viewport-aware, overscroll-contained listbox and
-  combobox keyboard behavior that keeps the active option visible.
-- Recorded detail candidate counts before/after with four tasks per status:
-  source 4/4/4/4 in both cases, rendered 8 total before and 4/4/4/4 after.
-- Added passing component coverage and a passing Chromium regression spanning
-  detail/create selection, final-row scrolling, Blocked-task search,
-  authorization boundaries, archived exclusion, persistence, and 375 px
-  containment.
-- Added before, final-row, and narrow-create screenshots to `docs/reports/`
-  and embedded them in the TASK-350 brief for PR review.
-- Passed lint, RLS inventory, version policy, all 140 runnable Vitest files
-  (981 tests; 2 files/tests skipped), coverage at 91.37% statements / 81.33%
-  branches / 92.2% functions / 91.88% lines, the standard Turbopack production
-  build, and all 28 Chromium scenarios.
-- Published the reviewable implementation and visual evidence in PR #400.
-- Rebased PR #400 onto `origin/main` after TASK-349 merged, preserving both
-  related-task behaviors and updating the bilateral Playwright selector to the
-  picker's accessible `option` role.
-- Advanced the release from `v0.31.1` to `v0.31.2` because merged PR #399 now
-  owns `v0.31.1`.
-- Rebase validation passed: lint, RLS inventory, release policy, 988 unit/API
-  tests with 2 skipped, coverage at 91.37% statements / 81.33% branches /
-  92.2% functions / 91.88% lines, production build, both focused related-task
-  browser scenarios, and the complete 29-scenario Playwright suite.
+- Confirmed TASK-351 is the next backlog item after the merged TASK-350 work.
+- Created the dedicated worktree and feature branch from `origin/main`.
+- Chose a globally unique `ND-<number>` reference so users can cite a task
+  unambiguously while opaque CUIDs remain internal.
+- Completed the UI/UX Pro Max design-system, accessibility/search, and Next.js
+  implementation reviews for the modal and related-task picker surfaces.
+- Added `Task.referenceNumber` with sequence-backed backfill, uniqueness, and
+  conditional least-privilege `app_runtime` sequence access.
+- Centralized `ND-<number>` formatting, added the reference to task list and
+  mutation contracts, and documented it in the agent OpenAPI schema.
+- Added the reference to read/edit modal headers and related-task candidates;
+  create and edit pickers now match complete or partial references without
+  indexing internal CUIDs.
+- Visually reviewed the desktop edit/search state and verified narrow create
+  containment at 375 px.
+
+## Outcome
+
+- Existing and new tasks receive stable, globally unique references while CUIDs
+  remain the internal route, mutation, authorization, and relation identity.
+- Reference allocation is concurrency-safe and deleted values are not reused.
+- Reference values survive task update, relation, and reload flows.
+- The task-detail and related-task surfaces preserve the established
+  information hierarchy, theme tokens, 44 px options, and keyboard behavior.
+- Prepared feature release `v0.32.0`.
+
+## Validation
+
+- `npx prisma validate` and local `prisma migrate deploy` passed; all 49
+  migrations are applied.
+- `npm run lint`, `npm run rls:check`, `git diff --check`, and
+  `npm run release:check -- --base origin/main --branch feature/task-351-user-facing-task-ids`
+  passed.
+- `npm run test:rls:setup` and `npm run test:rls` passed with the
+  least-privilege `NOBYPASSRLS` runtime role.
+- `npm test`: 995 passed, 2 skipped.
+- `npm run test:coverage`: 91.37% statements, 81.33% branches, 92.2%
+  functions, 91.88% lines.
+- `npm run build` passed with documented local-safe runtime placeholders.
+- Focused TASK-351 Playwright coverage passed, followed by the complete
+  30-scenario Chromium suite.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,8 +4,9 @@
 
 - ID: TASK-351
 - Title: User-facing task IDs
-- Status: Ready for review (2026-07-30)
+- Status: In review (2026-07-30)
 - Branch: `feature/task-351-user-facing-task-ids`
+- Pull request: [#402](https://github.com/dorianagaesse/nexus_dash/pull/402)
 - Brief: [`task-351-user-facing-task-ids.md`](./task-351-user-facing-task-ids.md)
 
 ## Objective
@@ -116,3 +117,5 @@ share without exposing the opaque database ID.
 - `npm run build` passed with documented local-safe runtime placeholders.
 - Focused TASK-351 Playwright coverage passed, followed by the complete
   30-scenario Chromium suite.
+- Implementation commit `a3704dd` is pushed and ready-for-review PR #402 is
+  open.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -119,3 +119,8 @@ share without exposing the opaque database ID.
   30-scenario Chromium suite.
 - Implementation commit `a3704dd` is pushed and ready-for-review PR #402 is
   open.
+- Addressed both initial Copilot review comments: related-task references now
+  participate directly in option accessible names, and legacy activity payloads
+  may omit `reference` explicitly in the client mutation type.
+- Post-review lint, 16 focused component/helper tests, production build, and
+  the three related-task Playwright regressions passed.

--- a/tasks/task-351-user-facing-task-ids.md
+++ b/tasks/task-351-user-facing-task-ids.md
@@ -1,0 +1,75 @@
+# TASK-351 User-Facing Task IDs
+
+## Summary
+
+NexusDash tasks currently expose only titles in the product UI. The stable task
+identity is a CUID used for database relations and URLs, but that value is
+opaque, unsuitable for conversation, and intentionally absent from the task
+interface. Duplicate or similar titles therefore leave users without a concise
+way to identify a task in discussion or related-task search.
+
+TASK-351 adds a separate immutable numeric reference. The application renders
+that number as `ND-<number>`, keeps the CUID as the internal primary key, and
+surfaces the friendly reference only where users need to identify or find a
+task.
+
+## Product Decisions
+
+- References are globally unique rather than project-local, so `ND-42` points
+  to at most one task even outside the immediate project conversation.
+- PostgreSQL owns allocation through an auto-incrementing sequence. Concurrent
+  creates cannot choose the same reference.
+- Deleted task references are not reused.
+- The database stores the numeric value; a shared formatter owns the `ND-`
+  presentation prefix.
+- The task-detail header and related-task suggestions show the reference in
+  compact, tabular/monospaced text that stays subordinate to the title.
+- Related-task search indexes the formatted reference in addition to title and
+  status. Internal CUIDs are not added to the search haystack.
+- TASK-352 remains responsible for the broader status-color and candidate-row
+  visual redesign.
+
+## Data and Architecture
+
+- Add `Task.referenceNumber Int @unique @default(autoincrement())`.
+- Add a PostgreSQL migration that backfills every existing task and creates the
+  unique index and sequence-backed default.
+- Include `referenceNumber` in task list and mutation payloads.
+- Keep persistence access in `lib/services/**`; API routes continue to map
+  service results without allocating references themselves.
+- Use the existing internal `Task.id` for route paths, relation rows,
+  optimistic reconciliation, and service authorization.
+
+## UI/UX Guidance
+
+The UI/UX Pro Max review classifies NexusDash as a data-dense project dashboard.
+For this focused task:
+
+- Preserve the current information hierarchy: status, reference, title.
+- Use semantic theme tokens and existing badges instead of new ad-hoc colors.
+- Use `font-mono` and tabular numerals for a stable, scannable identifier.
+- Keep every suggestion row at least 44 px high and retain existing keyboard
+  listbox behavior and visible focus states.
+- Include the reference in the option's accessible name through visible text.
+- Verify 375 px containment and both color schemes.
+
+## Acceptance Criteria
+
+1. Existing and new tasks receive unique stable references rendered as
+   `ND-<number>`.
+2. Task mutations and reloads never change the reference.
+3. The task-detail modal shows the reference in read and edit modes.
+4. Related-task suggestions show and can be filtered by reference.
+5. No internal task CUID is displayed or searchable.
+6. Authorization and candidate eligibility behavior is unchanged.
+7. Focused automated coverage proves migration/backfill, payload mapping,
+   reference search, and responsive UI behavior.
+
+## Validation Plan
+
+- Prisma schema validation and migration SQL inspection/test.
+- Focused formatter, API/service, and related-task component tests.
+- Focused Playwright coverage for create, detail display, reference search,
+  mutation stability, reload stability, and narrow viewport containment.
+- Repository baseline: lint, RLS inventory, unit tests, coverage, build, release
+  policy, and relevant E2E.

--- a/tests/api/task-create.route.test.ts
+++ b/tests/api/task-create.route.test.ts
@@ -74,6 +74,7 @@ describe("GET /api/projects/:projectId/tasks", () => {
     projectServiceMock.listProjectKanbanTasks.mockResolvedValueOnce([
       {
         id: "task-a",
+        referenceNumber: 42,
         title: "Task A",
         description: null,
         blockedNote: null,
@@ -103,10 +104,11 @@ describe("GET /api/projects/:projectId/tasks", () => {
       taskRouteParams("p1")
     );
     const payload = (await response.json()) as {
-      tasks: Array<{ relatedTasks: unknown[] }>;
+      tasks: Array<{ reference: string; relatedTasks: unknown[] }>;
     };
 
     expect(response.status).toBe(200);
+    expect(payload.tasks[0]?.reference).toBe("ND-42");
     expect(payload.tasks[0]?.relatedTasks).toEqual([
       {
         id: "task-b",

--- a/tests/components/kanban-board-related.test.ts
+++ b/tests/components/kanban-board-related.test.ts
@@ -17,6 +17,7 @@ function createTask(
 ): KanbanTask {
   return {
     id,
+    reference: "ND-1",
     title,
     description: null,
     deadlineDate: null,

--- a/tests/components/related-task-field.test.tsx
+++ b/tests/components/related-task-field.test.tsx
@@ -20,6 +20,7 @@ const STATUSES = ["Backlog", "In Progress", "Blocked", "Done"] as const;
 const AVAILABLE_TASKS: RelatedTaskOption[] = STATUSES.flatMap((status) =>
   Array.from({ length: 3 }, (_, index) => ({
     id: `${status.toLowerCase().replaceAll(" ", "-")}-${index + 1}`,
+    reference: `ND-${STATUSES.indexOf(status) * 3 + index + 1}`,
     title: `${status} candidate ${index + 1}`,
     status,
   }))
@@ -149,6 +150,15 @@ describe("RelatedTaskSelector", () => {
 
     expect(getOptions()).toHaveLength(1);
     expect(getOptions()[0]?.textContent).toContain("Blocked candidate 3");
+
+    await act(async () => {
+      setInputValue(input, "ND-10");
+    });
+
+    expect(getOptions()).toHaveLength(1);
+    expect(getOptions()[0]?.textContent).toContain("ND-10");
+    expect(getOptions()[0]?.textContent).toContain("Done candidate 1");
+    expect(getOptions()[0]?.getAttribute("aria-describedby")).toBeTruthy();
   });
 
   test("keeps keyboard navigation on the input while reaching and selecting the last task", async () => {
@@ -186,7 +196,9 @@ describe("RelatedTaskSelector", () => {
       );
     });
 
-    expect(container.textContent).toContain(lastOption?.textContent);
+    expect(container.textContent).toContain(
+      lastOption?.getAttribute("aria-label")
+    );
     expect(getOptions()).toHaveLength(11);
   });
 

--- a/tests/components/related-task-field.test.tsx
+++ b/tests/components/related-task-field.test.tsx
@@ -158,7 +158,9 @@ describe("RelatedTaskSelector", () => {
     expect(getOptions()).toHaveLength(1);
     expect(getOptions()[0]?.textContent).toContain("ND-10");
     expect(getOptions()[0]?.textContent).toContain("Done candidate 1");
-    expect(getOptions()[0]?.getAttribute("aria-describedby")).toBeTruthy();
+    expect(getOptions()[0]?.getAttribute("aria-label")).toBe(
+      "ND-10, Done candidate 1"
+    );
   });
 
   test("keeps keyboard navigation on the input while reaching and selecting the last task", async () => {
@@ -196,9 +198,7 @@ describe("RelatedTaskSelector", () => {
       );
     });
 
-    expect(container.textContent).toContain(
-      lastOption?.getAttribute("aria-label")
-    );
+    expect(container.textContent).toContain(lastOption?.dataset.taskTitle);
     expect(getOptions()).toHaveLength(11);
   });
 

--- a/tests/components/task-detail-modal-comments.test.tsx
+++ b/tests/components/task-detail-modal-comments.test.tsx
@@ -35,6 +35,7 @@ const ownerSummary = {
 
 const baseTask: KanbanTask = {
   id: "task-1",
+  reference: "ND-42",
   title: "Comment identity",
   description: null,
   deadlineDate: null,
@@ -183,6 +184,9 @@ describe("TaskDetailModal comments", () => {
 
     expect(document.body.textContent).toContain("Build bot (agent)");
     expect(document.body.textContent).toContain("via owner#0001");
+    expect(
+      document.body.querySelector("[aria-label='Task reference ND-42']")
+    ).not.toBeNull();
     expect(document.body.querySelectorAll("[data-agent-avatar='true']")).toHaveLength(1);
 
     await act(async () => {

--- a/tests/e2e/related-task-bilateral.spec.ts
+++ b/tests/e2e/related-task-bilateral.spec.ts
@@ -45,7 +45,9 @@ test.describe("bilateral related tasks", () => {
     await taskDialog.getByRole("button", { name: "Task options" }).click();
     await page.getByRole("button", { name: /^Edit$/ }).click();
     await page.getByPlaceholder("Search active tasks").fill(taskBTitle);
-    await page.getByRole("option", { name: taskBTitle, exact: true }).click();
+    await page
+      .getByRole("option", { name: new RegExp(`${taskBTitle}$`) })
+      .click();
     await page.getByRole("button", { name: "Save changes" }).click();
     await expect(page.getByText("Task saved.")).toBeVisible();
     await taskDialog.getByRole("button", { name: "Close task" }).click();

--- a/tests/e2e/task-350-related-task-picker.spec.ts
+++ b/tests/e2e/task-350-related-task-picker.spec.ts
@@ -205,7 +205,7 @@ test("related-task pickers expose and navigate every eligible mixed-status task"
   const activeOption = detailListbox.locator("[data-active='true']");
   await expect(activeOption).toHaveCount(1);
   await expect(activeOption).toBeInViewport();
-  const finalTaskTitle = await activeOption.textContent();
+  const finalTaskTitle = await activeOption.getAttribute("aria-label");
   expect(finalTaskTitle).toBeTruthy();
   await detailSearch.press("Enter");
   await expect(

--- a/tests/e2e/task-350-related-task-picker.spec.ts
+++ b/tests/e2e/task-350-related-task-picker.spec.ts
@@ -139,8 +139,7 @@ test("related-task pickers expose and navigate every eligible mixed-status task"
   for (const status of TASK_STATUSES) {
     await expect(
       detailListbox.getByRole("option", {
-        name: candidateTitle(status, 4),
-        exact: true,
+        name: new RegExp(`${candidateTitle(status, 4)}$`),
       })
     ).toBeAttached();
   }
@@ -205,7 +204,7 @@ test("related-task pickers expose and navigate every eligible mixed-status task"
   const activeOption = detailListbox.locator("[data-active='true']");
   await expect(activeOption).toHaveCount(1);
   await expect(activeOption).toBeInViewport();
-  const finalTaskTitle = await activeOption.getAttribute("aria-label");
+  const finalTaskTitle = await activeOption.getAttribute("data-task-title");
   expect(finalTaskTitle).toBeTruthy();
   await detailSearch.press("Enter");
   await expect(
@@ -218,7 +217,7 @@ test("related-task pickers expose and navigate every eligible mixed-status task"
   await detailSearch.fill(blockedTaskTitle);
   await expect(detailListbox.getByRole("option")).toHaveCount(1);
   await detailListbox
-    .getByRole("option", { name: blockedTaskTitle, exact: true })
+    .getByRole("option", { name: new RegExp(`${blockedTaskTitle}$`) })
     .click();
   const saveRequest = page.waitForResponse(
     (response) =>
@@ -262,8 +261,7 @@ test("related-task pickers expose and navigate every eligible mixed-status task"
   await createSearch.fill(blockedTaskTitle);
   await expect(createListbox.getByRole("option")).toHaveCount(1);
   const createBlockedOption = createListbox.getByRole("option", {
-    name: blockedTaskTitle,
-    exact: true,
+    name: new RegExp(`${blockedTaskTitle}$`),
   });
   const createBlockedOptionBounds = await createBlockedOption.boundingBox();
   expect(createBlockedOptionBounds).not.toBeNull();

--- a/tests/e2e/task-351-user-facing-task-ids.spec.ts
+++ b/tests/e2e/task-351-user-facing-task-ids.spec.ts
@@ -1,0 +1,151 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+
+import { expect, test } from "@playwright/test";
+
+import { prisma } from "../../lib/prisma";
+import { formatTaskReference } from "../../lib/task-reference";
+import { signInAsVerifiedUser } from "./helpers/auth-helpers";
+import { uniqueProjectName } from "./helpers/project-helpers";
+
+const screenshotDirectory = process.env.TASK351_SCREENSHOT_DIR?.trim();
+
+test("task references stay stable and identify related-task candidates", async ({
+  page,
+}) => {
+  const userId = await signInAsVerifiedUser(page);
+  const project = await prisma.project.create({
+    data: {
+      name: uniqueProjectName("task-reference"),
+      description: "Stable task reference coverage",
+      ownerId: userId,
+      memberships: {
+        create: {
+          userId,
+          role: "owner",
+        },
+      },
+    },
+    select: {
+      id: true,
+    },
+  });
+  const currentTask = await prisma.task.create({
+    data: {
+      title: "Reference stability task",
+      projectId: project.id,
+      createdByUserId: userId,
+      updatedByUserId: userId,
+    },
+    select: {
+      id: true,
+      referenceNumber: true,
+    },
+  });
+  const candidateTask = await prisma.task.create({
+    data: {
+      title: "Reference search candidate",
+      status: "Blocked",
+      projectId: project.id,
+      createdByUserId: userId,
+      updatedByUserId: userId,
+    },
+    select: {
+      id: true,
+      referenceNumber: true,
+    },
+  });
+  const currentReference = formatTaskReference(currentTask.referenceNumber)!;
+  const candidateReference = formatTaskReference(candidateTask.referenceNumber)!;
+
+  await page.goto(`/projects/${project.id}?taskId=${currentTask.id}`);
+  await expect(
+    page.getByLabel(`Task reference ${currentReference}`)
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "Task options" }).click();
+  await page.getByRole("button", { name: /^Edit$/ }).click();
+
+  const titleInput = page.getByRole("textbox", { name: "Task title" });
+  await titleInput.fill("Reference stability task updated");
+  const detailSearch = page.getByRole("combobox", {
+    name: "Search related tasks",
+  });
+  await detailSearch.fill(candidateReference);
+  const detailCandidate = page.getByRole("option", {
+    name: "Reference search candidate",
+  });
+  await expect(detailCandidate).toBeVisible();
+  await expect(detailCandidate).toContainText(candidateReference);
+
+  if (screenshotDirectory) {
+    await mkdir(screenshotDirectory, { recursive: true });
+    await page.screenshot({
+      path: path.join(screenshotDirectory, "task-reference-detail-search.png"),
+      fullPage: true,
+    });
+  }
+
+  await detailCandidate.click();
+  const updateResponsePromise = page.waitForResponse(
+    (response) =>
+      response.request().method() === "PATCH" &&
+      response.url().endsWith(`/tasks/${currentTask.id}`) &&
+      response.ok()
+  );
+  await page.getByRole("button", { name: "Save changes" }).click();
+  const updateResponse = await updateResponsePromise;
+  const updatePayload = (await updateResponse.json()) as {
+    task: { reference: string };
+  };
+  expect(updatePayload.task.reference).toBe(currentReference);
+  await expect(
+    page.getByLabel(`Task reference ${currentReference}`)
+  ).toBeVisible();
+
+  await page.reload();
+  await expect(
+    page.getByLabel(`Task reference ${currentReference}`)
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "Close task" }).click();
+  await page.setViewportSize({ width: 375, height: 812 });
+  await page.getByRole("button", { name: "New task" }).click();
+  const createSearch = page.getByRole("combobox", {
+    name: "Search related tasks",
+  });
+  await createSearch.scrollIntoViewIfNeeded();
+  await createSearch.fill(candidateReference);
+  const createCandidate = page.getByRole("option", {
+    name: "Reference search candidate",
+  });
+  await expect(createCandidate).toBeVisible();
+  await expect(createCandidate).toContainText(candidateReference);
+
+  const candidateBounds = await createCandidate.boundingBox();
+  expect(candidateBounds).not.toBeNull();
+  expect(candidateBounds!.x).toBeGreaterThanOrEqual(0);
+  expect(candidateBounds!.x + candidateBounds!.width).toBeLessThanOrEqual(375);
+
+  await createCandidate.click();
+  await page.locator("#task-title").fill("Created with stable reference");
+  const createResponsePromise = page.waitForResponse(
+    (response) =>
+      response.request().method() === "POST" &&
+      response.url().endsWith(`/projects/${project.id}/tasks`) &&
+      response.ok()
+  );
+  await page.getByRole("button", { name: "Create task" }).click();
+  const createResponse = await createResponsePromise;
+  const createPayload = (await createResponse.json()) as {
+    task: { id: string; reference: string };
+  };
+  expect(createPayload.task.reference).toMatch(/^ND-[1-9][0-9]*$/);
+  expect(createPayload.task.reference).not.toBe(currentReference);
+  expect(createPayload.task.reference).not.toBe(candidateReference);
+
+  await page.getByRole("button", { name: /Created with stable reference/ }).click();
+  await expect(
+    page.getByLabel(`Task reference ${createPayload.task.reference}`)
+  ).toBeVisible();
+});

--- a/tests/lib/task-reference.test.ts
+++ b/tests/lib/task-reference.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest";
+
+import { formatTaskReference } from "@/lib/task-reference";
+
+describe("formatTaskReference", () => {
+  test("formats a stable user-facing task reference", () => {
+    expect(formatTaskReference(1)).toBe("ND-1");
+    expect(formatTaskReference(4821)).toBe("ND-4821");
+  });
+
+  test("allows missing values at compatibility boundaries", () => {
+    expect(formatTaskReference(undefined)).toBeUndefined();
+    expect(formatTaskReference(null)).toBeUndefined();
+  });
+
+  test.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    "rejects invalid reference number %s",
+    (referenceNumber) => {
+      expect(() => formatTaskReference(referenceNumber)).toThrow(
+        "task-reference-number-invalid"
+      );
+    }
+  );
+});


### PR DESCRIPTION
## What changed

- add an immutable, globally unique `Task.referenceNumber` with PostgreSQL sequence-backed backfill and allocation
- render friendly references as `ND-<number>` in task-detail headers and related-task candidates
- search related-task candidates by complete or partial friendly reference while keeping CUIDs internal
- expose the reference through list/mutation/activity payloads and the agent OpenAPI contract
- add focused formatter, API, component, migration, responsive Playwright, and stability coverage
- advance the feature release to `v0.32.0`

## Why

Tasks previously had only titles in the product UI. Similar or duplicate titles were ambiguous, while the only stable identity was an opaque CUID intended for database relations and URLs. TASK-351 adds a concise reference users can cite and search without exposing that internal ID.

## User and developer impact

Users can identify a task unambiguously from its detail modal and find it in either related-task picker by reference. References stay stable across edits, relations, archive/restore flows, and reloads. Existing routing, authorization, bilateral relations, and candidate eligibility continue to use the internal task ID.

The migration allocates references atomically, backfills existing rows, never reuses deleted values, and conditionally grants sequence access to the production `app_runtime` role.

## Validation

- `npx prisma validate`
- local `prisma migrate deploy` (49 migrations applied)
- `npm run lint`
- `npm run rls:check`
- `npm run test:rls:setup`
- `npm run test:rls`
- `npm test` (995 passed, 2 skipped)
- `npm run test:coverage` (91.37% statements, 81.33% branches, 92.2% functions, 91.88% lines)
- `npm run build`
- focused TASK-351 Playwright scenario
- complete Playwright suite (30 passed)
- `npm run release:check -- --base origin/main --branch feature/task-351-user-facing-task-ids`
- `git diff --check`