### PR TITLE
TASK-352: Refine related-task picker presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ SHA, deployment URL, and workflow run belong in release evidence.
 
 - Define each release entry before the product-impacting PR is merged.
 
+## v0.33.0 - 2026-07-31
+
+- Redesigned related-task suggestions into scannable reference, bounded title,
+  and visible status columns that remain contained at a 375 px viewport.
+- Reused one shared light/dark Kanban badge palette for Backlog, In Progress,
+  Blocked, and Done so picker and board status treatments stay consistent.
+- Preserved full titles and status in accessible option names, retained
+  keyboard/listbox behavior, and added focused component and responsive
+  light/dark browser coverage.
+
 ## v0.32.0 - 2026-07-30
 
 - Added immutable, globally unique task references rendered as `ND-<number>`,

--- a/components/kanban/kanban-columns-grid.tsx
+++ b/components/kanban/kanban-columns-grid.tsx
@@ -34,6 +34,7 @@ import {
   getDescriptionPreview,
   type TaskColumns,
 } from "@/components/kanban-board-utils";
+import { TASK_STATUS_BADGE_CLASS_NAMES } from "@/components/kanban/task-status-presentation";
 import {
   formatTaskDeadlineForDisplay,
   getTaskDeadlineUrgency,
@@ -47,7 +48,6 @@ const COLUMN_CHROME: Record<
   TaskStatus,
   {
     accent: string;
-    badge: string;
     column: string;
     dragState: string;
     emptyCopy: string;
@@ -55,8 +55,6 @@ const COLUMN_CHROME: Record<
 > = {
   Backlog: {
     accent: "bg-slate-400/80 dark:bg-slate-300/70",
-    badge:
-      "border-slate-300/70 bg-slate-100/80 text-slate-700 dark:border-slate-700/70 dark:bg-slate-900/60 dark:text-slate-200",
     column:
       "border-slate-200/70 bg-gradient-to-b from-slate-100/30 via-card to-card dark:border-slate-800/80 dark:from-slate-900/35",
     dragState: "bg-slate-100/50 dark:bg-slate-900/35",
@@ -64,8 +62,6 @@ const COLUMN_CHROME: Record<
   },
   "In Progress": {
     accent: "bg-sky-500/80 dark:bg-sky-400/80",
-    badge:
-      "border-sky-200/80 bg-sky-100/80 text-sky-700 dark:border-sky-900/70 dark:bg-sky-950/55 dark:text-sky-200",
     column:
       "border-sky-200/70 bg-gradient-to-b from-sky-100/35 via-card to-card dark:border-sky-950/80 dark:from-sky-950/30",
     dragState: "bg-sky-100/45 dark:bg-sky-950/30",
@@ -73,8 +69,6 @@ const COLUMN_CHROME: Record<
   },
   Blocked: {
     accent: "bg-amber-500/85 dark:bg-amber-400/85",
-    badge:
-      "border-amber-200/80 bg-amber-100/80 text-amber-700 dark:border-amber-900/70 dark:bg-amber-950/55 dark:text-amber-200",
     column:
       "border-amber-200/70 bg-gradient-to-b from-amber-100/35 via-card to-card dark:border-amber-950/80 dark:from-amber-950/30",
     dragState: "bg-amber-100/45 dark:bg-amber-950/30",
@@ -82,8 +76,6 @@ const COLUMN_CHROME: Record<
   },
   Done: {
     accent: "bg-emerald-500/80 dark:bg-emerald-400/80",
-    badge:
-      "border-emerald-200/80 bg-emerald-100/80 text-emerald-700 dark:border-emerald-900/70 dark:bg-emerald-950/55 dark:text-emerald-200",
     column:
       "border-emerald-200/70 bg-gradient-to-b from-emerald-100/35 via-card to-card dark:border-emerald-950/80 dark:from-emerald-950/28",
     dragState: "bg-emerald-100/45 dark:bg-emerald-950/28",
@@ -230,7 +222,10 @@ function KanbanColumn({
       <CardHeader className="pb-3">
         <CardTitle className="flex items-center justify-between text-base">
           <span>{status}</span>
-          <Badge variant="outline" className={chrome.badge}>
+          <Badge
+            variant="outline"
+            className={TASK_STATUS_BADGE_CLASS_NAMES[status]}
+          >
             {tasks.length}
           </Badge>
         </CardTitle>

--- a/components/kanban/related-task-field.tsx
+++ b/components/kanban/related-task-field.tsx
@@ -6,14 +6,16 @@ import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 import { Archive, Link2, Search, X } from "lucide-react";
 
 import type { TaskRelatedSummary } from "@/components/kanban-board-types";
+import { TASK_STATUS_BADGE_CLASS_NAMES } from "@/components/kanban/task-status-presentation";
 import { Button } from "@/components/ui/button";
+import type { TaskStatus } from "@/lib/task-status";
 import { cn } from "@/lib/utils";
 
 export interface RelatedTaskOption {
   id: string;
   reference: string;
   title: string;
-  status: string;
+  status: TaskStatus;
 }
 
 interface RelatedTaskSelectorProps {
@@ -303,18 +305,30 @@ export function RelatedTaskSelector({
                         data-task-status={task.status}
                         data-task-title={task.title}
                         tabIndex={-1}
-                        aria-label={`${task.reference}, ${task.title}`}
-                        className="flex min-h-11 w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[active=true]:bg-muted"
+                        aria-label={`${task.reference}, ${task.title}, ${task.status}`}
+                        className="grid min-h-11 w-full grid-cols-[minmax(4rem,auto)_minmax(0,1fr)_auto] items-center gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors duration-200 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[active=true]:bg-muted"
                         onMouseDown={(event) => event.preventDefault()}
                         onMouseMove={() => setActiveSuggestionIndex(index)}
                         onClick={() => selectTask(task.id)}
                         disabled={disabled}
                       >
-                        <span className="shrink-0 select-all font-mono text-xs font-semibold tabular-nums text-muted-foreground">
+                        <span className="select-all font-mono text-xs font-semibold tabular-nums text-muted-foreground">
                           {task.reference}
                         </span>
-                        <span className="min-w-0 flex-1 truncate">
+                        <span
+                          className="min-w-0 truncate"
+                          title={task.title}
+                        >
                           {task.title}
+                        </span>
+                        <span
+                          data-task-status-badge="true"
+                          className={cn(
+                            "shrink-0 rounded-full border px-2 py-0.5 text-[11px] font-medium leading-4",
+                            TASK_STATUS_BADGE_CLASS_NAMES[task.status]
+                          )}
+                        >
+                          {task.status}
                         </span>
                       </button>
                     ))}

--- a/components/kanban/task-status-presentation.ts
+++ b/components/kanban/task-status-presentation.ts
@@ -1,0 +1,12 @@
+import type { TaskStatus } from "@/lib/task-status";
+
+export const TASK_STATUS_BADGE_CLASS_NAMES: Record<TaskStatus, string> = {
+  Backlog:
+    "border-slate-300/70 bg-slate-100/80 text-slate-700 dark:border-slate-700/70 dark:bg-slate-900/60 dark:text-slate-200",
+  "In Progress":
+    "border-sky-200/80 bg-sky-100/80 text-sky-700 dark:border-sky-900/70 dark:bg-sky-950/55 dark:text-sky-200",
+  Blocked:
+    "border-amber-200/80 bg-amber-100/80 text-amber-700 dark:border-amber-900/70 dark:bg-amber-950/55 dark:text-amber-200",
+  Done:
+    "border-emerald-200/80 bg-emerald-100/80 text-emerald-700 dark:border-emerald-900/70 dark:bg-emerald-950/55 dark:text-emerald-200",
+};

--- a/journal.md
+++ b/journal.md
@@ -41,6 +41,9 @@ Use it for important implementation milestones, blockers, validation runs, and r
 - Published planning commit `0bffdc8` and implementation commit `8c66ec7`, then
   opened ready-for-review
   [PR #404](https://github.com/dorianagaesse/nexus_dash/pull/404).
+- Copilot completed its initial review with one actionable tracking comment;
+  aligned TASK-352's backlog status with the current-task `In review` state and
+  PR #404.
 
 # 2026-07-30 - TASK-351 user-facing task IDs
 

--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,42 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-07-31 - TASK-352 related-task picker presentation
+
+- Started from merged TASK-351 on the dedicated
+  `feature/task-352-related-task-picker-presentation` worktree and committed the
+  current-task acceptance criteria and detailed design brief before
+  implementation.
+- Applied UI/UX Pro Max guidance for a dense productivity dashboard: maintain a
+  44 px row target, preserve combobox/listbox keyboard ownership, keep the full
+  title available when ellipsized, use status text in addition to color, and
+  validate 375 px containment in light and dark themes.
+- Extracted the established Kanban status badge classes into a shared
+  presentation map and reused the exact Backlog, In Progress, Blocked, and Done
+  palette in both Kanban headers and related-task candidates.
+- Redesigned each candidate as a reference/title/status grid. Friendly IDs use
+  monospaced tabular text, titles flex and truncate with hover text, and status
+  remains visible and participates in the full accessible option name.
+- Preserved candidate eligibility, sorting, reference/title/status filtering,
+  viewport-aware scrolling, keyboard navigation, bilateral relation behavior,
+  and internal task identities.
+- Added focused component coverage plus TASK-352 browser coverage for all four
+  statuses, exact accessible names, long-title truncation, 44 px rows, mobile
+  containment, keyboard selection, and distinct light/dark rendering.
+- Visually inspected the generated 375 px light and dark screenshots; IDs,
+  ellipsized titles, status labels, modal boundaries, and popover containment
+  are clear in both themes.
+- Prepared feature release `v0.33.0`.
+- Complete validation passed: lint, RLS inventory, release policy, 143 passing
+  Vitest files with 2 skipped, 996 passing tests with 2 skipped, coverage at
+  91.37% statements / 81.33% branches / 92.2% functions / 91.88% lines,
+  production build, focused related-task regressions, and all 31 Chromium
+  scenarios.
+- Fresh-worktree validation initially lacked database and trusted-origin
+  configuration. Final test/build runs used the documented local PostgreSQL URL
+  and paired local-only `NEXTAUTH_URL`/`NEXTAUTH_SECRET` placeholders; no
+  repository environment file or secret was created.
+
 # 2026-07-30 - TASK-351 user-facing task IDs
 
 - Started from merged TASK-350 on the dedicated

--- a/journal.md
+++ b/journal.md
@@ -38,6 +38,9 @@ Use it for important implementation milestones, blockers, validation runs, and r
   configuration. Final test/build runs used the documented local PostgreSQL URL
   and paired local-only `NEXTAUTH_URL`/`NEXTAUTH_SECRET` placeholders; no
   repository environment file or secret was created.
+- Published planning commit `0bffdc8` and implementation commit `8c66ec7`, then
+  opened ready-for-review
+  [PR #404](https://github.com/dorianagaesse/nexus_dash/pull/404).
 
 # 2026-07-30 - TASK-351 user-facing task IDs
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexusdash",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexusdash",
-      "version": "0.32.0",
+      "version": "0.33.0",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1079.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexusdash",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "private": true,
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0",

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -82,7 +82,7 @@ Last reviewed: 2026-07-30
   Dependencies: TASK-076, TASK-133
 - ID: TASK-352
   Title: Related-task picker presentation - readable IDs, titles, and status colors
-  Status: In progress (2026-07-31)
+  Status: In review (2026-07-31, PR #404)
   Rationale: Redesign the current `Related to` candidate list so each row clearly presents the user-facing task ID, a bounded/truncated title, and status using the established Kanban column color, with accessible text that does not rely on color alone.
   Dependencies: TASK-133, TASK-350, TASK-351
 - ID: TASK-353

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -71,18 +71,18 @@ Last reviewed: 2026-07-30
   Brief: `tasks/task-349-bilateral-related-task-relationships.md`
 - ID: TASK-350
   Title: Complete related-task candidate list - investigate missing and non-scrollable tasks
-  Status: In review - PR #400 fixes issue #396
+  Status: Complete (2026-07-30, PR #400)
   Rationale: Investigate and fix GitHub issue #396 by determining whether eligible tasks are missing because of status filtering, Blocked-task exclusion, clipped overflow, or a combination; ensure the full authorized candidate set is searchable, keyboard reachable, and scrollable.
   Dependencies: TASK-076, TASK-133, TASK-321
   Brief: `tasks/task-350-related-task-picker.md`
 - ID: TASK-351
   Title: User-facing task IDs - stable references in task details and relationship search
-  Status: In review (2026-07-30, PR #402)
+  Status: Complete (2026-07-31, PR #402)
   Rationale: Introduce or expose concise, stable user-facing task identifiers so users can refer to tasks unambiguously; show the identifier when a task detail modal is open and beside each candidate while searching for a task to relate, without exposing opaque internal database IDs.
   Dependencies: TASK-076, TASK-133
 - ID: TASK-352
   Title: Related-task picker presentation - readable IDs, titles, and status colors
-  Status: Next 15 - related-task list visual refinement
+  Status: In progress (2026-07-31)
   Rationale: Redesign the current `Related to` candidate list so each row clearly presents the user-facing task ID, a bounded/truncated title, and status using the established Kanban column color, with accessible text that does not rely on color alone.
   Dependencies: TASK-133, TASK-350, TASK-351
 - ID: TASK-353

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,8 +4,9 @@
 
 - ID: TASK-352
 - Title: Related-task picker presentation
-- Status: In progress (2026-07-31)
+- Status: In review (2026-07-31)
 - Branch: `feature/task-352-related-task-picker-presentation`
+- Pull request: [#404](https://github.com/dorianagaesse/nexus_dash/pull/404)
 - Brief:
   [`task-352-related-task-picker-presentation.md`](./task-352-related-task-picker-presentation.md)
 
@@ -119,3 +120,5 @@ responsive, accessible row.
 - The complete 31-scenario Chromium suite passed with the documented local
   database and paired trusted-origin placeholders.
 - Generated 375 px light and dark screenshots were visually inspected.
+- Planning commit `0bffdc8` and implementation commit `8c66ec7` are pushed;
+  ready-for-review PR #404 is open.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -85,7 +85,37 @@ responsive, accessible row.
   responsive-layout, dark-theme, and Next.js guidance review.
 - Located the established status badge palette in the Kanban column component
   and defined the shared-presentation boundary for implementation.
+- Extracted the exact status badge palette into a shared presentation map used
+  by both Kanban headers and related-task candidates.
+- Redesigned candidate rows as a reference/title/status grid with visible
+  status text, full accessible names, hover-accessible full titles, and
+  ellipsis containment.
+- Added component and browser coverage for all four statuses, keyboard
+  selection, long titles, 44 px targets, 375 px containment, and light/dark
+  themes.
+- Visually reviewed the generated 375 px light and dark picker states.
+- Prepared feature release `v0.33.0`.
+
+## Outcome
+
+- Related-task candidates now scan consistently as friendly reference, bounded
+  title, and workflow status without changing which tasks users can relate.
+- Status colors match the Kanban columns through one shared source and remain
+  understandable through visible and announced text.
+- Long titles retain their full value while the visible row stays contained on
+  narrow screens.
 
 ## Validation
 
-- Pending implementation.
+- `npm run lint`, `npm run rls:check`, `git diff --check`, and
+  `npm run release:check -- --base origin/main --branch feature/task-352-related-task-picker-presentation`
+  passed.
+- `npm test`: 996 passed, 2 skipped.
+- `npm run test:coverage`: 91.37% statements, 81.33% branches, 92.2%
+  functions, 91.88% lines.
+- `npm run build` passed with documented local-safe environment placeholders.
+- Focused TASK-352 component/browser coverage and the bilateral, TASK-350, and
+  TASK-351 related-task regressions passed.
+- The complete 31-scenario Chromium suite passed with the documented local
+  database and paired trusted-origin placeholders.
+- Generated 375 px light and dark screenshots were visually inspected.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -2,125 +2,90 @@
 
 ## Task
 
-- ID: TASK-351
-- Title: User-facing task IDs
-- Status: In review (2026-07-30)
-- Branch: `feature/task-351-user-facing-task-ids`
-- Pull request: [#402](https://github.com/dorianagaesse/nexus_dash/pull/402)
-- Brief: [`task-351-user-facing-task-ids.md`](./task-351-user-facing-task-ids.md)
+- ID: TASK-352
+- Title: Related-task picker presentation
+- Status: In progress (2026-07-31)
+- Branch: `feature/task-352-related-task-picker-presentation`
+- Brief:
+  [`task-352-related-task-picker-presentation.md`](./task-352-related-task-picker-presentation.md)
 
 ## Objective
 
-Give every task a concise, stable reference that users can read, search, and
-share without exposing the opaque database ID.
+Make every related-task candidate easy to scan and distinguish by presenting
+its friendly task reference, bounded title, and Kanban-colored status in one
+responsive, accessible row.
 
 ## Scope
 
-- Add an immutable database-generated numeric reference to every existing and
-  future task.
-- Format references consistently as `ND-<number>` at the application boundary.
-- Show the reference in the task-detail header in read and edit modes.
-- Show the reference beside every related-task search candidate.
-- Match related-task searches by formatted reference as well as title and
-  status.
-- Preserve internal task IDs for routing, mutations, relations, and
-  authorization.
-- Add focused migration, mapping, component, API, and browser coverage.
+- Present each candidate as a stable reference column, a flexible truncated
+  title, and a compact status badge.
+- Reuse the established Backlog, In Progress, Blocked, and Done Kanban badge
+  colors in both light and dark themes.
+- Centralize the shared status presentation classes so the picker cannot drift
+  from the Kanban columns.
+- Keep status text visible and include reference, full title, and status in the
+  option's accessible name so meaning never depends on color.
+- Preserve the complete candidate set, reference/title/status filtering,
+  viewport-aware scrolling, keyboard navigation, and selection behavior from
+  TASK-350 and TASK-351.
+- Add focused component and browser coverage for presentation, accessibility,
+  long-title containment, mobile sizing, and both themes.
 
 ## Runtime Assumptions
 
-- The PostgreSQL migration must backfill existing tasks and allocate future
-  references atomically through a database sequence.
-- References are globally unique, immutable, and never reused after task
-  deletion.
+- TASK-350 and TASK-351 are present on `origin/main`; candidate eligibility and
+  stable `ND-<number>` references need no data or API changes.
+- Task statuses remain limited to the four values in `lib/task-status.ts`.
 - Existing local PostgreSQL and `.env` prerequisites are unchanged.
-- Browser validation uses the existing Playwright project/task fixture and may
-  run locally or against a branch preview.
-- Any preview validation must pass
-  `git_ref=feature/task-351-user-facing-task-ids` explicitly.
+- Browser validation uses the existing Playwright project/task fixture.
+- If a branch preview is required during review, it must pass
+  `git_ref=feature/task-352-related-task-picker-presentation` explicitly.
 
 ## Acceptance Criteria
 
-1. Every existing and newly created task has one globally unique numeric
-   reference rendered as `ND-<number>`.
-2. A task keeps the same reference after title, status, relation, archive, and
-   restore mutations and after a full reload.
-3. The task-detail modal exposes the reference in both read and edit modes
-   without displaying the internal database ID.
-4. Every related-task candidate exposes its reference beside its title.
-5. Searching the related-task picker by a complete or partial formatted
-   reference returns the authorized matching task in create and edit flows.
-6. Reference display and search remain keyboard accessible, readable at a
-   375 px viewport, and compatible with light and dark themes.
-7. Project authorization, active/archived candidate rules, bilateral
-   relations, and internal task routing remain unchanged.
-8. Focused migration/mapping, service/API, component, and Playwright coverage
-   passes.
-9. Release metadata, task tracking, root-cause notes, and validation evidence
-   are updated in the same pull request.
+1. Every related-task suggestion shows the friendly `ND-<number>` reference,
+   task title, and human-readable status in a consistent scan order.
+2. Backlog, In Progress, Blocked, and Done use the same semantic badge colors
+   as their Kanban columns in light and dark themes.
+3. Status remains understandable without color: visible status text is
+   present, and the option accessible name includes reference, full title, and
+   status.
+4. Long titles truncate with an ellipsis in the row, expose the full title to
+   pointer and assistive-technology users, and do not create horizontal
+   overflow at a 375 px viewport.
+5. Candidate rows remain at least 44 px high with existing hover, active,
+   focus, keyboard navigation, list scrolling, and selection behavior intact.
+6. Candidate eligibility, sorting, filtering by reference/title/status,
+   bilateral relationship behavior, and internal task identity remain
+   unchanged.
+7. Focused component and Playwright coverage proves all four status
+   presentations, accessible names, truncation, narrow containment, and theme
+   compatibility.
+8. Release metadata, task tracking, and validation evidence are updated in the
+   same pull request.
 
 ## Definition Of Done
 
-- The migration safely backfills existing rows and uses a database sequence for
-  concurrency-safe future allocation.
-- Reference formatting is centralized and reused by server/client presentation
-  paths.
-- The modal and related-task picker meet the UI/UX accessibility and responsive
-  checks from the UI/UX Pro Max review.
+- The picker and Kanban columns consume one shared status badge palette.
+- The row layout follows the UI/UX Pro Max accessibility, 44 px target,
+  truncation, responsive, and dark-mode guidance.
 - `npm run lint`, `npm run rls:check`, `npm test`, `npm run test:coverage`,
   `npm run build`, release validation, and relevant Playwright coverage pass.
-- The feature release advances to `v0.32.0` with matching changelog and lockfile
-  metadata.
-- The branch is committed and pushed, a ready-for-review PR is open, and
-  initial Copilot review/check feedback is handled without merging the PR.
+- The feature release advances to `v0.33.0` with matching changelog and
+  lockfile metadata.
+- The branch is committed and pushed, a ready-for-review PR is open, and the
+  initial Copilot review/check outcome is handled without merging the PR.
 
 ## Progress
 
-- Confirmed TASK-351 is the next backlog item after the merged TASK-350 work.
-- Created the dedicated worktree and feature branch from `origin/main`.
-- Chose a globally unique `ND-<number>` reference so users can cite a task
-  unambiguously while opaque CUIDs remain internal.
-- Completed the UI/UX Pro Max design-system, accessibility/search, and Next.js
-  implementation reviews for the modal and related-task picker surfaces.
-- Added `Task.referenceNumber` with sequence-backed backfill, uniqueness, and
-  conditional least-privilege `app_runtime` sequence access.
-- Centralized `ND-<number>` formatting, added the reference to task list and
-  mutation contracts, and documented it in the agent OpenAPI schema.
-- Added the reference to read/edit modal headers and related-task candidates;
-  create and edit pickers now match complete or partial references without
-  indexing internal CUIDs.
-- Visually reviewed the desktop edit/search state and verified narrow create
-  containment at 375 px.
-
-## Outcome
-
-- Existing and new tasks receive stable, globally unique references while CUIDs
-  remain the internal route, mutation, authorization, and relation identity.
-- Reference allocation is concurrency-safe and deleted values are not reused.
-- Reference values survive task update, relation, and reload flows.
-- The task-detail and related-task surfaces preserve the established
-  information hierarchy, theme tokens, 44 px options, and keyboard behavior.
-- Prepared feature release `v0.32.0`.
+- Confirmed TASK-352 is the next presentation refinement after merged
+  TASK-350 and TASK-351.
+- Created the dedicated worktree and feature branch from merged `origin/main`.
+- Completed the UI/UX Pro Max design-system, accessibility, truncation,
+  responsive-layout, dark-theme, and Next.js guidance review.
+- Located the established status badge palette in the Kanban column component
+  and defined the shared-presentation boundary for implementation.
 
 ## Validation
 
-- `npx prisma validate` and local `prisma migrate deploy` passed; all 49
-  migrations are applied.
-- `npm run lint`, `npm run rls:check`, `git diff --check`, and
-  `npm run release:check -- --base origin/main --branch feature/task-351-user-facing-task-ids`
-  passed.
-- `npm run test:rls:setup` and `npm run test:rls` passed with the
-  least-privilege `NOBYPASSRLS` runtime role.
-- `npm test`: 995 passed, 2 skipped.
-- `npm run test:coverage`: 91.37% statements, 81.33% branches, 92.2%
-  functions, 91.88% lines.
-- `npm run build` passed with documented local-safe runtime placeholders.
-- Focused TASK-351 Playwright coverage passed, followed by the complete
-  30-scenario Chromium suite.
-- Implementation commit `a3704dd` is pushed and ready-for-review PR #402 is
-  open.
-- Addressed both initial Copilot review comments: related-task references now
-  participate directly in option accessible names, and legacy activity payloads
-  may omit `reference` explicitly in the client mutation type.
-- Post-review lint, 16 focused component/helper tests, production build, and
-  the three related-task Playwright regressions passed.
+- Pending implementation.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -122,3 +122,5 @@ responsive, accessible row.
 - Generated 375 px light and dark screenshots were visually inspected.
 - Planning commit `0bffdc8` and implementation commit `8c66ec7` are pushed;
   ready-for-review PR #404 is open.
+- Copilot's initial review completed with one actionable tracking comment;
+  TASK-352's backlog status now matches this brief's review state and PR.

--- a/tasks/task-352-related-task-picker-presentation.md
+++ b/tasks/task-352-related-task-picker-presentation.md
@@ -1,0 +1,74 @@
+# TASK-352 Related-Task Picker Presentation
+
+## Summary
+
+TASK-350 made the full authorized related-task candidate set reachable and
+TASK-351 added stable user-facing references. The picker now contains the right
+information, but each suggestion still reads as an undifferentiated reference
+and title pair. Status participates in search without being visible, and the
+picker does not reuse the status colors that users already learn from the
+Kanban board.
+
+TASK-352 refines only this presentation. It gives the reference, title, and
+status predictable visual roles while preserving candidate eligibility,
+search, keyboard navigation, scrolling, and relation mutations.
+
+## Product Decisions
+
+- Candidate information order is reference, title, status: stable identity
+  first, distinguishing content second, workflow state last.
+- The reference stays monospaced with tabular numerals and a bounded width so
+  IDs align while titles receive the flexible space.
+- Titles remain one line and truncate with an ellipsis. Their full value is
+  preserved in the option's accessible name and exposed as hover text.
+- Status uses a compact outlined badge with the exact light/dark palette
+  established by the matching Kanban column.
+- Visible status text is mandatory. Color reinforces the state but never
+  carries it alone.
+- The complete row remains the selection target and stays at least 44 px high.
+- No new animation is needed; the established hover, active, and focus
+  treatments remain the interaction feedback.
+
+## Shared Presentation Boundary
+
+The Kanban column currently owns its status badge classes locally. Move that
+badge palette into a client-safe presentation module keyed by `TaskStatus`, and
+consume it from both the column header and related-task candidates. Column
+backgrounds, drag states, accent bars, empty-state copy, and icons remain local
+to the Kanban grid because they are not shared by this task.
+
+## UI/UX Guidance
+
+The UI/UX Pro Max review classifies NexusDash as a dense productivity
+dashboard. For this component:
+
+- Keep the existing semantic theme tokens and subdued flat presentation.
+- Use a three-track grid with a fixed reference, `minmax(0, 1fr)` title, and
+  content-sized status so long text cannot force horizontal overflow.
+- Retain the 44 px row target, keyboard-owned combobox focus, listbox
+  semantics, visible focus ring, and viewport-aware vertical scrolling.
+- Provide text in addition to status color and include the full task identity
+  in the accessible name.
+- Check 375 px containment, long text, light mode, and dark mode independently.
+- Avoid decorative motion, raw color values, hidden status meaning, and title
+  overflow.
+
+## Acceptance Criteria
+
+1. Each candidate visibly exposes its friendly reference, title, and status.
+2. Status badges reuse the Kanban column palette through a shared module.
+3. Option names announce reference, full title, and status.
+4. Long titles visibly truncate without clipping the reference or status and
+   without creating mobile horizontal overflow.
+5. The existing search, navigation, scrolling, and selection interaction
+   contract is unchanged.
+6. Focused component and browser tests cover all four statuses, accessible
+   naming, long-title containment, 375 px layout, and both themes.
+
+## Validation Plan
+
+- Focused status-presentation and related-task component tests.
+- Focused Playwright coverage for create/edit candidate rows, long titles,
+  keyboard selection, narrow viewport containment, and light/dark themes.
+- Repository baseline: lint, RLS inventory, unit tests, coverage, build,
+  release-policy validation, and relevant E2E.

--- a/tests/components/related-task-field.test.tsx
+++ b/tests/components/related-task-field.test.tsx
@@ -10,6 +10,7 @@ import {
   type RelatedTaskOption,
 } from "@/components/kanban/related-task-field";
 import type { TaskRelatedSummary } from "@/components/kanban-board-types";
+import { TASK_STATUS_BADGE_CLASS_NAMES } from "@/components/kanban/task-status-presentation";
 
 (globalThis as { React?: typeof React }).React = React;
 (
@@ -159,8 +160,52 @@ describe("RelatedTaskSelector", () => {
     expect(getOptions()[0]?.textContent).toContain("ND-10");
     expect(getOptions()[0]?.textContent).toContain("Done candidate 1");
     expect(getOptions()[0]?.getAttribute("aria-label")).toBe(
-      "ND-10, Done candidate 1"
+      "ND-10, Done candidate 1, Done"
     );
+  });
+
+  test("presents references, bounded titles, and shared Kanban status badges", async () => {
+    const longTitle =
+      "A deliberately long related-task title that must remain available while the visible row truncates";
+    const input = await renderHarness({
+      availableTasks: STATUSES.map((status, index) => ({
+        id: `presentation-${index}`,
+        reference: `ND-${index + 101}`,
+        title: index === 0 ? longTitle : `${status} presentation candidate`,
+        status,
+      })),
+    });
+
+    await act(async () => {
+      input.focus();
+    });
+    await act(async () => {});
+
+    const options = getOptions();
+    expect(options).toHaveLength(4);
+    expect(options[0]?.className).toContain(
+      "grid-cols-[minmax(4rem,auto)_minmax(0,1fr)_auto]"
+    );
+    expect(options[0]?.className).toContain("min-h-11");
+
+    for (const [index, status] of STATUSES.entries()) {
+      const option = options[index]!;
+      const title = index === 0 ? longTitle : `${status} presentation candidate`;
+      const titleElement = option.querySelector<HTMLElement>("[title]");
+      const statusBadge = option.querySelector<HTMLElement>(
+        "[data-task-status-badge='true']"
+      );
+
+      expect(option.getAttribute("aria-label")).toBe(
+        `ND-${index + 101}, ${title}, ${status}`
+      );
+      expect(titleElement?.title).toBe(title);
+      expect(titleElement?.className).toContain("truncate");
+      expect(statusBadge?.textContent).toBe(status);
+      for (const className of TASK_STATUS_BADGE_CLASS_NAMES[status].split(" ")) {
+        expect(statusBadge?.className).toContain(className);
+      }
+    }
   });
 
   test("keeps keyboard navigation on the input while reaching and selecting the last task", async () => {

--- a/tests/e2e/related-task-bilateral.spec.ts
+++ b/tests/e2e/related-task-bilateral.spec.ts
@@ -46,7 +46,9 @@ test.describe("bilateral related tasks", () => {
     await page.getByRole("button", { name: /^Edit$/ }).click();
     await page.getByPlaceholder("Search active tasks").fill(taskBTitle);
     await page
-      .getByRole("option", { name: new RegExp(`${taskBTitle}$`) })
+      .getByRole("option", {
+        name: new RegExp(`${taskBTitle}, Backlog$`),
+      })
       .click();
     await page.getByRole("button", { name: "Save changes" }).click();
     await expect(page.getByText("Task saved.")).toBeVisible();

--- a/tests/e2e/task-350-related-task-picker.spec.ts
+++ b/tests/e2e/task-350-related-task-picker.spec.ts
@@ -139,7 +139,7 @@ test("related-task pickers expose and navigate every eligible mixed-status task"
   for (const status of TASK_STATUSES) {
     await expect(
       detailListbox.getByRole("option", {
-        name: new RegExp(`${candidateTitle(status, 4)}$`),
+        name: new RegExp(`${candidateTitle(status, 4)}, ${status}$`),
       })
     ).toBeAttached();
   }
@@ -217,7 +217,9 @@ test("related-task pickers expose and navigate every eligible mixed-status task"
   await detailSearch.fill(blockedTaskTitle);
   await expect(detailListbox.getByRole("option")).toHaveCount(1);
   await detailListbox
-    .getByRole("option", { name: new RegExp(`${blockedTaskTitle}$`) })
+    .getByRole("option", {
+      name: new RegExp(`${blockedTaskTitle}, Blocked$`),
+    })
     .click();
   const saveRequest = page.waitForResponse(
     (response) =>
@@ -261,7 +263,7 @@ test("related-task pickers expose and navigate every eligible mixed-status task"
   await createSearch.fill(blockedTaskTitle);
   await expect(createListbox.getByRole("option")).toHaveCount(1);
   const createBlockedOption = createListbox.getByRole("option", {
-    name: new RegExp(`${blockedTaskTitle}$`),
+    name: new RegExp(`${blockedTaskTitle}, Blocked$`),
   });
   const createBlockedOptionBounds = await createBlockedOption.boundingBox();
   expect(createBlockedOptionBounds).not.toBeNull();

--- a/tests/e2e/task-352-related-task-picker-presentation.spec.ts
+++ b/tests/e2e/task-352-related-task-picker-presentation.spec.ts
@@ -1,0 +1,179 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+
+import { expect, test } from "@playwright/test";
+
+import { prisma } from "../../lib/prisma";
+import { formatTaskReference } from "../../lib/task-reference";
+import { TASK_STATUSES, type TaskStatus } from "../../lib/task-status";
+import { signInAsVerifiedUser } from "./helpers/auth-helpers";
+import { uniqueProjectName } from "./helpers/project-helpers";
+
+const screenshotDirectory = process.env.TASK352_SCREENSHOT_DIR?.trim();
+const LONG_TITLE =
+  "A deliberately long related-task title that stays identifiable while its visible candidate row truncates cleanly";
+
+function candidateTitle(status: TaskStatus): string {
+  return status === "Backlog"
+    ? LONG_TITLE
+    : `${status} presentation candidate`;
+}
+
+test("related-task candidates present accessible IDs, bounded titles, and themed statuses", async ({
+  page,
+}) => {
+  const userId = await signInAsVerifiedUser(page);
+  const project = await prisma.project.create({
+    data: {
+      name: uniqueProjectName("related-task-presentation"),
+      description: "Related-task picker presentation coverage",
+      ownerId: userId,
+      memberships: {
+        create: {
+          userId,
+          role: "owner",
+        },
+      },
+    },
+    select: {
+      id: true,
+    },
+  });
+  const currentTask = await prisma.task.create({
+    data: {
+      title: "Current presentation task",
+      projectId: project.id,
+      createdByUserId: userId,
+      updatedByUserId: userId,
+    },
+    select: {
+      id: true,
+    },
+  });
+  const candidates = await Promise.all(
+    TASK_STATUSES.map((status, position) =>
+      prisma.task.create({
+        data: {
+          title: candidateTitle(status),
+          status,
+          position,
+          projectId: project.id,
+          createdByUserId: userId,
+          updatedByUserId: userId,
+        },
+        select: {
+          referenceNumber: true,
+          status: true,
+          title: true,
+        },
+      })
+    )
+  );
+
+  await page.setViewportSize({ width: 375, height: 812 });
+  await page.goto(`/projects/${project.id}?taskId=${currentTask.id}`);
+  await page.getByRole("button", { name: "Task options" }).click();
+  await page.getByRole("button", { name: /^Edit$/ }).click();
+
+  const search = page.getByRole("combobox", {
+    name: "Search related tasks",
+  });
+  await search.scrollIntoViewIfNeeded();
+  await search.focus();
+  const listbox = page.getByRole("listbox", {
+    name: "Related task suggestions",
+  });
+  await expect(listbox.getByRole("option")).toHaveCount(TASK_STATUSES.length);
+
+  const themeColors = new Map<string, string[]>();
+  for (const theme of ["light", "dark"] as const) {
+    await page.evaluate((nextTheme) => {
+      window.localStorage.setItem("nexusdash-theme", nextTheme);
+      document.documentElement.classList.toggle("dark", nextTheme === "dark");
+    }, theme);
+    await expect(page.locator("html")).toHaveClass(
+      theme === "dark" ? /dark/ : /^(?!.*\bdark\b)/
+    );
+
+    const statusColors: string[] = [];
+    for (const candidate of candidates) {
+      const reference = formatTaskReference(candidate.referenceNumber)!;
+      const option = listbox.getByRole("option", {
+        name: `${reference}, ${candidate.title}, ${candidate.status}`,
+        exact: true,
+      });
+      const title = option.locator(`[title="${candidate.title}"]`);
+      const statusBadge = option.locator(
+        "[data-task-status-badge='true']"
+      );
+
+      await expect(option).toBeVisible();
+      await expect(option).toHaveAttribute(
+        "aria-label",
+        `${reference}, ${candidate.title}, ${candidate.status}`
+      );
+      await expect(title).toHaveAttribute("title", candidate.title);
+      await expect(statusBadge).toHaveText(candidate.status);
+
+      const optionBounds = await option.boundingBox();
+      expect(optionBounds).not.toBeNull();
+      expect(optionBounds!.height).toBeGreaterThanOrEqual(44);
+      expect(optionBounds!.x).toBeGreaterThanOrEqual(0);
+      expect(optionBounds!.x + optionBounds!.width).toBeLessThanOrEqual(375);
+      expect(
+        await option.evaluate(
+          (element) => element.scrollWidth <= element.clientWidth
+        )
+      ).toBe(true);
+
+      statusColors.push(
+        await statusBadge.evaluate(
+          (element) => window.getComputedStyle(element).backgroundColor
+        )
+      );
+    }
+
+    expect(new Set(statusColors).size).toBe(TASK_STATUSES.length);
+    themeColors.set(theme, statusColors);
+
+    if (screenshotDirectory) {
+      await mkdir(screenshotDirectory, { recursive: true });
+      await page.screenshot({
+        path: path.join(
+          screenshotDirectory,
+          `related-task-picker-${theme}-375.png`
+        ),
+      });
+    }
+  }
+
+  expect(themeColors.get("light")).not.toEqual(themeColors.get("dark"));
+
+  const longTitle = listbox.locator(`[title="${LONG_TITLE}"]`);
+  expect(
+    await longTitle.evaluate(
+      (element) => element.scrollWidth > element.clientWidth
+    )
+  ).toBe(true);
+
+  await search.fill("Blocked");
+  const blockedCandidate = candidates.find(
+    (candidate) => candidate.status === "Blocked"
+  )!;
+  const blockedReference = formatTaskReference(
+    blockedCandidate.referenceNumber
+  )!;
+  const blockedOption = listbox.getByRole("option", {
+    name: `${blockedReference}, ${blockedCandidate.title}, Blocked`,
+    exact: true,
+  });
+  await expect(blockedOption).toBeVisible();
+  await search.press("End");
+  await expect(blockedOption).toHaveAttribute("data-active", "true");
+  await search.press("Enter");
+  await expect(
+    page.getByRole("button", {
+      name: `Remove related task ${blockedCandidate.title}`,
+    })
+  ).toBeVisible();
+});


### PR DESCRIPTION
## Summary

- redesign related-task candidates as a scannable reference, bounded title, and visible status row
- reuse one shared light/dark Kanban badge palette for Backlog, In Progress, Blocked, and Done
- preserve full titles and status in accessible option names while retaining the existing search, keyboard, scrolling, and relation behavior
- add focused component and responsive light/dark Playwright coverage
- prepare feature release `v0.33.0`

## Why

TASK-350 made the complete authorized candidate set reachable and TASK-351 added stable user-facing references, but status was still search-only and candidate rows did not reuse the Kanban state language. TASK-352 gives reference, title, and status predictable visual roles without changing eligibility or mutations.

## Validation

- `npm run lint`
- `npm run rls:check`
- `npm test` — 996 passed, 2 skipped
- `npm run test:coverage` — 91.37% statements, 81.33% branches, 92.2% functions, 91.88% lines
- `npm run build`
- `npm run release:check -- --base origin/main --branch feature/task-352-related-task-picker-presentation`
- focused bilateral/TASK-350/TASK-351/TASK-352 Playwright regressions
- complete Playwright Chromium suite — 31 passed
- visual inspection at 375 px in light and dark themes

Local production-mode build/browser validation used the documented PostgreSQL URL plus local-only disabled-email, signing, and paired trusted-origin placeholders. No environment file or secret was committed.