### PR TITLE
TASK-325: Audit Google Calendar architecture and risks

### DIFF
--- a/docs/audits/task-325-google-calendar-integration-audit.md
+++ b/docs/audits/task-325-google-calendar-integration-audit.md
@@ -1,0 +1,211 @@
+# TASK-325 Google Calendar Integration Audit
+
+- Audit date: 2026-08-06
+- Baseline: `a632a19` (`origin/main`)
+- Scope: Google Calendar OAuth, credentials, settings, project surfaces, event
+  operations, tests, RLS, and deployment configuration
+
+## Executive assessment
+
+The current integration has a sound **user-ownership boundary** but an
+incomplete **connection lifecycle and product model**.
+
+Every stored Google credential belongs to one NexusDash user. OAuth initiation
+requires a signed-in session, the callback binds the random state and initiating
+user to that same session, service reads use the authenticated user ID, and
+PostgreSQL RLS independently restricts the credential row to that user. Project
+members therefore cannot select or use another member's token through the
+implemented routes.
+
+The weaknesses begin after that boundary. NexusDash cannot genuinely disconnect
+Google, does not enforce its stored revocation state, never identifies the
+connected Google account, and represents only one connection plus one manually
+entered calendar ID per user. The project Calendar looks collaborative while it
+is a private overlay, and its summary request currently omits the project ID
+required by the service. Automated coverage is broad at the mocked unit/API
+layer but does not prove a live OAuth round trip or the calendar credential RLS
+policy with two real database principals.
+
+TASK-326 should close the ownership-lifecycle gaps without redesigning the
+connection model. TASK-327 should then migrate to user-owned connections and
+selectable calendar sources. TASK-348 remains responsible for separating the
+private "My calendar" overlay from a future shared project schedule.
+
+## Effective architecture and data flow
+
+1. `GET /api/auth/google` resolves the session user, normalizes `returnTo`,
+   generates random state, and stores state, return path, and actor ID in
+   HttpOnly, secure-in-production, SameSite=Lax cookies.
+2. The callback distinguishes Calendar authorization from Google social sign-in,
+   compares state, requires the current session user to equal the initiating
+   actor, exchanges the code server-side, and upserts only that user's row.
+3. `GoogleCalendarCredential.userId` is unique and cascades from `User`; its RLS
+   select/insert/update/delete policies require `userId = app.current_user_id()`
+   and the table is forced through RLS.
+4. Access and refresh tokens are encrypted with AES-256-GCM when
+   `GOOGLE_TOKEN_ENCRYPTION_KEY` is configured. Production validation requires
+   that key when Calendar OAuth is enabled; development currently permits
+   plaintext storage.
+5. Calendar service operations require a signed-in user and project access.
+   Reads require viewer access; mutations require editor access. Google tokens
+   and the stored calendar target are always resolved using the signed-in user.
+6. Event data is fetched live from Google. NexusDash stores no event copies,
+   sync cursor, or background event synchronization state.
+
+## Verified strengths
+
+| Area | Current safeguard | Evidence |
+| --- | --- | --- |
+| OAuth ownership | Callback state is random and bound to both the initiating actor cookie and current session | Calendar auth start/callback routes and route tests |
+| Credential ownership | One credential row is keyed by `userId`; callers cannot submit a subject user through Calendar event routes | Prisma schema, credential service, API guards |
+| Database isolation | Forced direct-user RLS covers select, insert, update, and delete | TASK-085 migrations and RLS inventory |
+| Layering | Prisma access remains in services; routes parse, authenticate, call services, and map responses | Credential, account-settings, project, and calendar services |
+| Token confidentiality | Tokens are never returned to clients and are encrypted in production | Token crypto service and runtime env validation |
+| Refresh handling | Expired access tokens refresh server-side and retain the previous refresh token when Google omits a new one | Calendar access and credential services |
+| Project isolation | Event operations prove project membership/role before contacting Google | Calendar service and API tests |
+| Upstream errors | Known authentication, scope, not-found, and generic provider failures are mapped to bounded app errors; provider payloads are not returned | Calendar service |
+
+## Findings
+
+### P0 — disconnect is not implemented
+
+`DELETE /api/account/settings/google-calendar` resets `calendarId` to `primary`;
+it does not revoke Google consent, mark the credential revoked, or remove local
+tokens. Settings exposes no disconnect control. This contradicts the route's
+destructive verb and leaves users without an app-owned way to terminate access.
+
+**Owner:** TASK-326. Mark the connection unusable first, attempt provider
+revocation, then permanently delete local tokens even if upstream revocation
+cannot be confirmed. Return a safe warning with a Google Account recovery path.
+
+### P0 — stored revocation state is not enforced
+
+The model has `revokedAt`, and project summary treats a revoked row as
+disconnected, but credential lookup, refresh, token update, and target update do
+not filter it. A revoked row could therefore still authorize event operations.
+
+**Owner:** TASK-326. Make every operational read/update active-only and keep a
+revoked row fail-closed if cleanup fails.
+
+### P1 — the dashboard summary request is structurally invalid
+
+The Calendar service requires `projectId` for viewer authorization.
+`ProjectCalendarPanel` supplies it, but `CalendarSummaryStatCard` requests
+`/api/calendar/events?range=current-week` without it. Connected users therefore
+receive `project-id-required` and the summary cannot produce a count.
+
+**Owner:** TASK-326. Pass the containing project ID through the summary card.
+
+### P1 — development can persist real tokens as plaintext
+
+Encryption is mandatory in production-like runtime validation, but the crypto
+helper intentionally returns plaintext when no key is configured and local
+Calendar OAuth is allowed in that state. A developer using a real Google account
+can therefore leave bearer and refresh tokens readable in local PostgreSQL.
+
+**Owner:** TASK-326. Require the key whenever Calendar OAuth is configured
+outside tests and lazily encrypt legacy plaintext rows after authenticated
+access.
+
+### P1 — connection identity and cardinality are insufficient
+
+`providerAccountId` exists but the OAuth flow never obtains or writes it. The
+unique `userId` constraint permits only one connection, and a single
+`calendarId` mixes connection identity, calendar discovery, read selection, and
+write target into one row.
+
+**Owner:** TASK-327. Introduce user-owned provider connections, discovered
+calendar sources, and account-level preferences with a data-preserving legacy
+migration.
+
+### P1 — calendar selection is unverified manual input
+
+Settings accepts any string up to 255 characters. It does not confirm that the
+calendar exists, belongs to the connected account, is readable, or is writable.
+Invalid IDs fail later in the project panel, and read-only calendars are not
+distinguished before mutation.
+
+The OAuth request currently asks only for `calendar.events`; Google's
+CalendarList endpoint requires a CalendarList or broader Calendar scope, so the
+current grant cannot power discovery.
+
+**Owner:** TASK-327. Request the narrow read-only CalendarList scope, discover
+the account's list, persist safe metadata/access roles, and validate selection
+and write-target ownership in services.
+
+### P1 — private data is presented as a project module
+
+Members in the same project see different events because each request uses the
+current member's Google token. Project role controls whether a member may mutate
+their own calendar: editors can, viewers cannot. This does not leak another
+member's calendar, but it can be mistaken for a shared project schedule.
+
+**Owner:** TASK-348. Preserve the current role rule through TASK-326/327, then
+label the personal overlay explicitly and design shared scheduling as a separate
+NexusDash-owned domain.
+
+### P2 — event reads are capped without pagination or partial-source semantics
+
+The current list request asks for 250 events once. There is no page traversal,
+retry/backoff contract, truncation signal, or concept of one source succeeding
+while another fails. These become material as soon as multiple calendars are
+selected.
+
+**Owner:** TASK-327. Add bounded pagination/concurrency, one safe retry for
+read-only throttling/transient failures, deterministic aggregation, and
+per-source warnings. Never automatically retry event mutations.
+
+### P2 — validation does not exercise provider or credential RLS end to end
+
+Focused unit/API coverage is substantial and passes 76 tests on the audit
+baseline. The Playwright smoke accepts either disconnected or connected state
+but does not complete OAuth or CRUD against Google. The RLS inventory includes
+the credential model, but the real isolation script does not seed two calendar
+credentials and prove cross-user CRUD denial.
+
+**Owners:** TASK-326 adds the two-user RLS matrix; TASK-327 adds provider-contract
+coverage and a two-account live smoke.
+
+### P2 — operational recovery is coarse
+
+Refresh failure maps to `reauthorization-required`, but connection health is not
+stored and Settings cannot identify which account needs attention. Encryption
+key rotation requires blanket reauthorization. Ephemeral preview OAuth also
+depends on a callback URI registered with Google, while the deployment workflow
+injects only one configured redirect URI.
+
+**Owner:** TASK-327 for per-connection health/reconnect UX and runbook updates.
+Versioned key rotation and broader provider operations remain future hardening.
+
+## Coverage baseline
+
+- Focused Calendar suite: 9 files, 76 tests passed with the documented local
+  validation environment.
+- RLS inventory: covers every Prisma model and matches committed migrations.
+- Existing E2E: verifies the panel can render a disconnected or already
+  connected state and refresh; it does not authorize Google.
+- Deployment: Vercel workflow forwards Calendar client ID, secret, redirect URI,
+  and token-encryption key to preview/production jobs; the env/runbook contract
+  treats the secret and encryption key as sensitive.
+
+## Remediation sequence
+
+1. **TASK-326 — ownership lifecycle hardening.** Active-only reads, true
+   disconnect, upstream revocation, mandatory encryption for configured OAuth,
+   summary request repair, and real RLS isolation.
+2. **TASK-327 — connection expansion.** Provider-ready user-owned connection
+   model, multiple Google accounts, discovered/selectable calendars, explicit
+   write target, aggregated live events, and connection management UX.
+3. **TASK-348 — personal versus shared scheduling.** Make private-overlay
+   semantics explicit and design a NexusDash-owned collaborative schedule.
+
+## Explicit non-findings
+
+- No route or service path reviewed returns stored tokens to the browser.
+- No implemented Calendar path selects credentials by project owner/member ID.
+- No agent credential grants Calendar access.
+- No evidence was found that one project member can read another member's
+  Google connection through the current service contracts.
+
+This was a repository and automated-contract audit, not a penetration test or a
+completed live-provider certification.

--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,20 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-08-06 - TASK-325 Google Calendar integration audit completed
+
+- Audited Google Calendar OAuth, credential storage and RLS, token lifecycle,
+  account settings, project surfaces, event CRUD, tests, and deployment at
+  baseline `a632a19`.
+- Confirmed the current-user ownership boundary is sound, while identifying
+  missing disconnect/revocation enforcement, a broken summary request,
+  optional local token encryption, unverified calendar IDs, singular connection
+  constraints, private-project UX ambiguity, and provider/RLS test gaps.
+- Published the audit and decision-complete TASK-326/TASK-327 briefs. TASK-348
+  remains the owner of personal-calendar versus shared-project scheduling.
+- Validation: focused Calendar suite passed 9 files / 76 tests; `npm run
+  rls:check` passed; documentation diff checks passed.
+
 # 2026-08-06 - Execution backlog reconciled after recent merges
 
 - Audited the execution queue against first-parent Git history and GitHub merge

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -35,19 +35,22 @@ Last reviewed: 2026-08-06
   Brief: `tasks/task-323-production-readiness-ux-verification.md`
 - ID: TASK-325
   Title: Google Calendar integration audit - current-state architecture, behavior, and risk assessment
-  Status: Next 6 - calendar integration discovery
+  Status: Complete (2026-08-06; ready for review)
   Rationale: Audit the current Google Calendar implementation across authentication, credential storage, account settings, project surfaces, event operations, tests, and deployment configuration; document the effective ownership model, known gaps, security risks, and a prioritized remediation path before extending the integration.
   Dependencies: TASK-005, TASK-032, TASK-076, TASK-083
+  Brief: `tasks/task-325-google-calendar-integration-audit.md`
 - ID: TASK-326
   Title: Google Calendar connection ownership - enforce user-scoped rather than project-scoped integration
   Status: Next 7 - calendar ownership verification and remediation
   Rationale: Verify and enforce that each Google Calendar authorization, credential, target-calendar preference, refresh lifecycle, and disconnect action belongs to the authenticated user rather than an individual project, while ensuring project calendar views use only the current user's connection and cannot expose another member's credentials or settings.
   Dependencies: TASK-076, TASK-083, TASK-325
+  Brief: `tasks/task-326-google-calendar-connection-ownership.md`
 - ID: TASK-327
   Title: Additional calendar connections - provider and multi-calendar expansion
   Status: Next 8 - calendar connection expansion
   Rationale: Define and implement a scalable connection model beyond the current Google Calendar path, including additional Google accounts, selectable calendars, and future calendar providers, with clear per-user ownership, connection management, synchronization behavior, and consistent project-calendar UX.
   Dependencies: TASK-325, TASK-326
+  Brief: `tasks/task-327-additional-calendar-connections.md`
 - ID: TASK-330
   Title: Meeting todo assignees and completion accountability - human/agent ownership across notes and the project-wide panel
   Status: Next 9 - meeting follow-up ownership

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,11 +1,49 @@
-# Current Task
+# TASK-325: Google Calendar Integration Audit
 
 ## Status
 
-No active implementation task selected.
+Complete on `docs/task-325-google-calendar-audit`; ready for review.
 
-## Next Step
+## Objective
 
-Start with TASK-100, the first item in the prioritized execution queue in
-`tasks/backlog.md`. Replace this placeholder with its active task brief before
-implementation begins.
+Audit the implemented Google Calendar integration from OAuth initiation through
+event operations and deployment, establish the effective user/project ownership
+model, and turn every material gap into decision-complete follow-up work.
+
+## Scope
+
+- OAuth initiation, callback state and actor binding, scopes, and redirect
+  configuration.
+- Credential schema, RLS, encryption, refresh, revocation, and recovery.
+- Account settings and project dashboard Calendar behavior.
+- Event list/create/update/delete contracts and upstream failure handling.
+- Unit, API, RLS, E2E, deployment, and live-provider validation coverage.
+
+## Acceptance Criteria
+
+1. A dated, commit-pinned audit documents current architecture and behavior.
+2. Security and product strengths are distinguished from verified gaps and
+   residual risks.
+3. Findings cover ownership, token lifecycle, UI semantics, event operations,
+   tests, environment configuration, and operational recovery.
+4. Each material remediation is assigned to TASK-326, TASK-327, TASK-348, or a
+   clearly identified future concern without duplicating existing work.
+5. TASK-326 and TASK-327 have decision-complete briefs derived from the audit.
+
+## Definition Of Done
+
+- The audit is committed under `docs/audits/`.
+- TASK-326 and TASK-327 briefs are committed under `tasks/`.
+- Backlog status, `tasks/current.md`, and `journal.md` are consistent.
+- Documentation checks, focused calendar tests, and the RLS inventory check
+  pass.
+- The branch is pushed, a ready-for-review PR is open, and initial automated
+  review/check feedback is handled.
+
+## Outcome
+
+- Audit: `docs/audits/task-325-google-calendar-integration-audit.md`
+- Ownership hardening brief:
+  `tasks/task-326-google-calendar-connection-ownership.md`
+- Connection expansion brief:
+  `tasks/task-327-additional-calendar-connections.md`

--- a/tasks/task-325-google-calendar-integration-audit.md
+++ b/tasks/task-325-google-calendar-integration-audit.md
@@ -1,0 +1,36 @@
+# TASK-325: Google Calendar Integration Audit
+
+## Status
+
+Complete; ready for review.
+
+## Objective
+
+Establish a repository-grounded baseline for Google Calendar architecture,
+security, product behavior, testing, and operations before changing connection
+ownership or expanding beyond one Google account and one target calendar.
+
+## Deliverables
+
+- A dated audit under `docs/audits/` pinned to the reviewed commit.
+- Prioritized findings mapped to TASK-326, TASK-327, and TASK-348.
+- Decision-complete implementation briefs for TASK-326 and TASK-327.
+
+## Acceptance Criteria
+
+1. The audit covers OAuth, credential storage, encryption, refresh/revocation,
+   account settings, project surfaces, event CRUD, RLS, tests, and deployment.
+2. The effective user-scoped ownership model and remaining project-role coupling
+   are explained accurately.
+3. Verified gaps include impact, evidence, priority, and owning follow-up task.
+4. Existing safeguards and passing regression coverage are recorded rather than
+   presenting every area as deficient.
+5. No runtime behavior is changed by this task.
+
+## Definition Of Done
+
+- Audit and successor briefs are committed.
+- Tracking documents agree on task status and sequencing.
+- Focused calendar tests, RLS inventory validation, and documentation checks
+  pass.
+- A ready-for-review PR is open and automated feedback is handled.

--- a/tasks/task-326-google-calendar-connection-ownership.md
+++ b/tasks/task-326-google-calendar-connection-ownership.md
@@ -1,0 +1,51 @@
+# TASK-326: Google Calendar Connection Ownership Hardening
+
+## Status
+
+Pending after TASK-325.
+
+## Objective
+
+Close the remaining lifecycle and enforcement gaps in the existing one-Google-
+connection-per-user model without beginning the multi-account migration.
+
+## Implementation Contract
+
+- Treat only `revokedAt = null` credentials as operational for lookup, refresh,
+  target update, and project connection status.
+- Disconnect is authenticated-user-only, idempotent, and fail-closed: mark the
+  row revoked, attempt Google refresh-token revocation, then delete local tokens
+  even when upstream revocation cannot be confirmed.
+- `DELETE /api/account/settings/google-calendar` means disconnect. Calendar
+  target reset remains `PATCH` with an empty value.
+- Require `GOOGLE_TOKEN_ENCRYPTION_KEY` whenever Calendar OAuth is configured
+  outside tests and lazily encrypt legacy plaintext tokens on authenticated
+  read.
+- Settings provides accessible confirmation, pending, success, warning, and
+  recovery states for disconnect.
+- The project summary Calendar request includes its required `projectId`.
+- Preserve current project viewer/editor behavior; TASK-348 owns private versus
+  shared schedule semantics.
+
+## Acceptance Criteria
+
+1. Revoked credentials cannot authorize reads, writes, refresh, or target
+   updates.
+2. Disconnect removes only the signed-in user's credential and never exposes a
+   token or provider error payload.
+3. Local tokens are deleted even when Google revocation fails, and the response
+   reports whether upstream revocation was confirmed.
+4. Calendar OAuth cannot run outside tests without an encryption key; legacy
+   plaintext tokens are rewritten encrypted when safely read.
+5. The connected dashboard summary successfully supplies project authorization
+   context.
+6. Unit/API/UI and real PostgreSQL RLS tests cover ownership and failure paths.
+
+## Definition Of Done
+
+- Runtime, tests, docs, ADR index, changelog, version, backlog, current task, and
+  journal are consistent.
+- Lint, RLS inventory/matrix, tests, coverage, build, and E2E pass.
+- Branch preview is deployed from the explicit git ref and Calendar recovery
+  states are validated.
+- A ready-for-review PR is open and automated feedback is resolved.

--- a/tasks/task-327-additional-calendar-connections.md
+++ b/tasks/task-327-additional-calendar-connections.md
@@ -1,0 +1,60 @@
+# TASK-327: Additional Calendar Connections
+
+## Status
+
+Pending after TASK-326.
+
+## Objective
+
+Support multiple Google accounts and selectable calendars through a provider-
+ready, strictly user-owned model while continuing to fetch event data live.
+
+## Implementation Contract
+
+- Migrate the singular credential without data loss into `CalendarConnection`,
+  `CalendarSource`, and `CalendarPreference` models with direct user ownership,
+  composite ownership foreign keys, forced RLS, and inventory coverage.
+- Use provider strings plus a TypeScript adapter contract; Google is the only
+  live provider in this task.
+- Request `openid`, `email`, Calendar events, and read-only CalendarList scopes;
+  use Google `sub` as stable account identity.
+- Support add and reconnect OAuth intents. A reconnect must return the same
+  non-legacy provider account.
+- Discover/persist calendar metadata and access role. Calendar selection and the
+  one write target are account-wide, not project-owned.
+- Preserve existing users through a selected legacy source and upgrade the
+  placeholder connection identity on reauthorization.
+- Aggregate live events across selected sources with bounded concurrency,
+  pagination, deterministic sorting, truncation signals, and partial-source
+  warnings. Retry reads once for transient failures; never retry mutations.
+- Keep the singular Google settings API as a compatibility facade and add
+  connection, sync, disconnect, and preference APIs.
+- Build accessible responsive connection cards, selection controls, write-target
+  choice, and recovery states. Project Calendar events identify their source and
+  creation can choose a selected writable calendar.
+
+## Acceptance Criteria
+
+1. A user can connect two Google accounts without one overwriting the other.
+2. A user can select readable calendars across connections and choose exactly
+   one selected writable target for new events.
+3. Another NexusDash user cannot see or mutate any connection, source,
+   preference, token, or event from the first user.
+4. Existing single-connection users retain their active calendar and can adopt
+   the legacy row during reauthorization.
+5. Disconnecting one account leaves other accounts intact and clears an affected
+   write target rather than choosing one silently.
+6. Event responses and UI expose safe source metadata, never credentials.
+7. Partial provider failures remain recoverable and do not hide successful
+   sources.
+8. Automated coverage and a two-Google-account live smoke validate the complete
+   connection lifecycle.
+
+## Definition Of Done
+
+- Migration, RLS, adapters, APIs, Settings, project UI, tests, ADR, runbook,
+  changelog, version, and tracking documents are complete.
+- Full validation and explicit-ref preview deployment pass.
+- Two authorized Google test accounts complete connect, select, event CRUD,
+  reconnect, and single-account disconnect smoke coverage.
+- A ready-for-review PR is open and automated feedback is resolved.


### PR DESCRIPTION
## Summary
- audit the current Google Calendar OAuth, credential, RLS, UI, API, test, and deployment paths
- document verified strengths and prioritized lifecycle/model gaps
- add decision-complete TASK-326 and TASK-327 implementation briefs

## Validation
- focused Calendar suite: 9 files / 76 tests
- npm run rls:check
- git diff --check

## Stack
This is the first PR in the TASK-325 -> TASK-326 -> TASK-327 dependency stack.