### PR TITLE
TASK-370: Isolate preview auth and database routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,8 @@ APP_REPOSITORY_URL=
 # Google OAuth / Calendar
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
-# Optional explicit callback override. When unset, callback URI is derived from TRUSTED_ORIGINS or NEXTAUTH_URL.
+# Optional explicit callback override. When unset, callback URI is derived from
+# TRUSTED_ORIGINS / NEXTAUTH_URL, or the immutable VERCEL_URL in Preview.
 # Keep this only if you intentionally pin a non-standard callback origin.
 # For Google OAuth, at least one of TRUSTED_ORIGINS or NEXTAUTH_URL must be set if GOOGLE_REDIRECT_URI is unset.
 GOOGLE_REDIRECT_URI=
@@ -20,7 +21,8 @@ GOOGLE_REDIRECT_URI=
 GOOGLE_TOKEN_ENCRYPTION_KEY=
 GOOGLE_CALENDAR_ID=primary
 
-# Optional, depending on auth strategy
+# Optional outside Preview. Vercel Preview derives its trusted auth origin from
+# the immutable VERCEL_URL and must not pin NEXTAUTH_URL to a mutable alias.
 NEXTAUTH_URL=
 NEXTAUTH_SECRET=
 # Required in production for agent bearer-token signing. Minimum 32 characters.
@@ -52,6 +54,9 @@ R2_SIGNED_URL_TTL_SECONDS=300
 # Remote/Supabase-style deployment values:
 # Vercel/serverless runtime must use Supabase transaction pooling on port 6543.
 DATABASE_URL=postgresql://<user>:<password>@<pooler-host>:6543/postgres?sslmode=require
+# Required for Supabase-backed Vercel Preview and Production. Configure a
+# different environment-scoped value matching that environment's project ref.
+EXPECTED_SUPABASE_PROJECT_REF=<project-ref>
 # Required in production. Must target the direct DB host (not pooler).
 # For Supabase production/preview:
 # - DATABASE_URL => transaction pooler host (*.pooler.supabase.com:6543)

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -385,8 +385,10 @@ jobs:
           if (deployment.projectId !== process.env.VERCEL_PROJECT_ID) {
             throw new Error("Preview deployment belongs to an unexpected Vercel project.");
           }
-          if (deployment.target !== "preview") {
-            throw new Error(`Expected Vercel preview target, received '${deployment.target ?? "unknown"}'.`);
+          // Vercel's REST API represents preview deployments with a null target,
+          // while some API/CLI versions normalize that value to "preview".
+          if (deployment.target != null && deployment.target !== "preview") {
+            throw new Error(`Expected Vercel preview target, received '${deployment.target}'.`);
           }
           if (deployment.readyState !== "READY") {
             throw new Error(`Expected ready preview deployment, received '${deployment.readyState ?? "unknown"}'.`);

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -51,6 +51,7 @@ jobs:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_CLI_VERSION: 50.18.0
       VERCEL_SCOPE: ${{ secrets.VERCEL_ORG_ID }}
+      EXPECTED_SUPABASE_PROJECT_REF: ${{ vars.EXPECTED_SUPABASE_PROJECT_REF }}
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
       GOOGLE_TOKEN_ENCRYPTION_KEY: ${{ secrets.GOOGLE_TOKEN_ENCRYPTION_KEY }}
@@ -70,12 +71,12 @@ jobs:
       AUTH_GITHUB_REDIRECT_URI: ${{ secrets.AUTH_GITHUB_REDIRECT_URI }}
 
     steps:
-      - name: Validate required Vercel secrets
+      - name: Validate required Vercel configuration
         run: |
           missing=0
-          for key in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID; do
+          for key in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID EXPECTED_SUPABASE_PROJECT_REF; do
             if [ -z "${!key}" ]; then
-              echo "::error::Missing required GitHub secret: $key"
+              echo "::error::Missing required GitHub configuration: $key"
               missing=1
             fi
           done
@@ -151,6 +152,7 @@ jobs:
               --meta "nexusDashGitCommitSha=$COMMIT_SHA" \
               -e "APP_VERSION=$APP_VERSION" \
               -e "APP_ENV=$APP_ENV" \
+              -e "EXPECTED_SUPABASE_PROJECT_REF=$EXPECTED_SUPABASE_PROJECT_REF" \
               -e "COMMIT_SHA=$COMMIT_SHA" \
               -e "APP_REPOSITORY_URL=$APP_REPOSITORY_URL"
           )
@@ -185,6 +187,7 @@ jobs:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_CLI_VERSION: 50.18.0
       VERCEL_SCOPE: ${{ secrets.VERCEL_ORG_ID }}
+      EXPECTED_SUPABASE_PROJECT_REF: ${{ vars.EXPECTED_SUPABASE_PROJECT_REF }}
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
       GOOGLE_TOKEN_ENCRYPTION_KEY: ${{ secrets.GOOGLE_TOKEN_ENCRYPTION_KEY }}
@@ -204,12 +207,12 @@ jobs:
       AUTH_GITHUB_REDIRECT_URI: ${{ secrets.AUTH_GITHUB_REDIRECT_URI }}
 
     steps:
-      - name: Validate required Vercel secrets
+      - name: Validate required Vercel configuration
         run: |
           missing=0
-          for key in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID; do
+          for key in VERCEL_TOKEN VERCEL_ORG_ID VERCEL_PROJECT_ID EXPECTED_SUPABASE_PROJECT_REF; do
             if [ -z "${!key}" ]; then
-              echo "::error::Missing required GitHub secret: $key"
+              echo "::error::Missing required GitHub configuration: $key"
               missing=1
             fi
           done
@@ -301,6 +304,8 @@ jobs:
             exit 1
           fi
 
+          DATABASE_URL="$MIGRATION_DATABASE_URL" node scripts/validate-supabase-project-ref.mjs
+
       - name: Apply Prisma migrations (preview)
         if: inputs.action == 'deploy-preview'
         env:
@@ -343,11 +348,87 @@ jobs:
               -e "AGENT_TOKEN_SIGNING_SECRET=$AGENT_TOKEN_SIGNING_SECRET" \
               -e "APP_VERSION=$APP_VERSION" \
               -e "APP_ENV=$APP_ENV" \
+              -e "EXPECTED_SUPABASE_PROJECT_REF=$EXPECTED_SUPABASE_PROJECT_REF" \
               -e "COMMIT_SHA=$COMMIT_SHA" \
               -e "APP_REPOSITORY_URL=$APP_REPOSITORY_URL"
           )
           echo "deployment_url=$deployment_url" >> "$GITHUB_OUTPUT"
           echo "$deployment_url" > preview-deployment.txt
+
+      - name: Validate preview deployment identity and readiness
+        if: inputs.action == 'deploy-preview'
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy_preview.outputs.deployment_url }}
+        run: |
+          deployment_host="${DEPLOYMENT_URL#https://}"
+          deployment_host="${deployment_host%%/*}"
+          curl \
+            --fail \
+            --silent \
+            --show-error \
+            --get "https://api.vercel.com/v13/deployments/${deployment_host}" \
+            --data-urlencode "teamId=$VERCEL_ORG_ID" \
+            --header "Authorization: Bearer $VERCEL_TOKEN" \
+            --output /tmp/preview-deployment.json
+
+          node <<'NODE'
+          const { readFileSync } = require("node:fs");
+          const deployment = JSON.parse(readFileSync("/tmp/preview-deployment.json", "utf8"));
+          const expectedHost = new URL(process.env.DEPLOYMENT_URL).hostname;
+          const actualHost = deployment.url ?? "";
+          const commitSha =
+            deployment.meta?.nexusDashGitCommitSha ??
+            deployment.meta?.githubCommitSha ??
+            deployment.gitSource?.sha ??
+            "";
+
+          if (deployment.projectId !== process.env.VERCEL_PROJECT_ID) {
+            throw new Error("Preview deployment belongs to an unexpected Vercel project.");
+          }
+          if (deployment.target !== "preview") {
+            throw new Error(`Expected Vercel preview target, received '${deployment.target ?? "unknown"}'.`);
+          }
+          if (deployment.readyState !== "READY") {
+            throw new Error(`Expected ready preview deployment, received '${deployment.readyState ?? "unknown"}'.`);
+          }
+          if (actualHost !== expectedHost) {
+            throw new Error("Preview deployment URL resolved to a different deployment host.");
+          }
+          if (commitSha.toLowerCase() !== process.env.COMMIT_SHA.toLowerCase()) {
+            throw new Error("Preview deployment revision does not match the checked-out git ref.");
+          }
+
+          console.log(`Verified immutable Vercel preview target for ${expectedHost}.`);
+          NODE
+
+          curl \
+            --fail \
+            --silent \
+            --show-error \
+            --retry 4 \
+            --retry-all-errors \
+            --retry-delay 5 \
+            "$DEPLOYMENT_URL/api/health/ready" \
+            --output /tmp/preview-readiness.json
+
+          node <<'NODE'
+          const { readFileSync } = require("node:fs");
+          const readiness = JSON.parse(readFileSync("/tmp/preview-readiness.json", "utf8"));
+          const expectedRevision = process.env.COMMIT_SHA.slice(0, 7).toLowerCase();
+          const actualRevision = readiness.deployment?.revision?.toLowerCase();
+
+          if (readiness.status !== "ready" || readiness.checks?.database !== "ok") {
+            throw new Error("Preview database readiness check did not pass.");
+          }
+          if (readiness.deployment?.environment !== "preview") {
+            throw new Error("Deployed application does not report the preview environment.");
+          }
+          if (actualRevision !== expectedRevision) {
+            throw new Error("Deployed application revision does not match the checked-out git ref.");
+          }
+
+          console.log(`Verified preview runtime ${actualRevision} and database readiness.`);
+          NODE
 
       - name: Deploy production (staged)
         if: inputs.action == 'deploy-production-staged'
@@ -369,6 +450,7 @@ jobs:
               --meta "nexusDashGitCommitSha=$COMMIT_SHA" \
               -e "APP_VERSION=$APP_VERSION" \
               -e "APP_ENV=$APP_ENV" \
+              -e "EXPECTED_SUPABASE_PROJECT_REF=$EXPECTED_SUPABASE_PROJECT_REF" \
               -e "COMMIT_SHA=$COMMIT_SHA" \
               -e "APP_REPOSITORY_URL=$APP_REPOSITORY_URL"
           )
@@ -527,6 +609,7 @@ jobs:
           if [ "${{ inputs.action }}" = "deploy-preview" ]; then
             if [ -n "${{ steps.deploy_preview.outputs.deployment_url }}" ]; then
               echo "- Preview URL: \`${{ steps.deploy_preview.outputs.deployment_url }}\`" >> "$GITHUB_STEP_SUMMARY"
+              echo "- Preview verification: immutable Vercel Preview target, matching revision/environment, database ready" >> "$GITHUB_STEP_SUMMARY"
             fi
           fi
           if [ "${{ inputs.action }}" = "deploy-production-staged" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ SHA, deployment URL, and workflow run belong in release evidence.
 
 - Define each release entry before the product-impacting PR is merged.
 
+## v0.37.1 - 2026-08-20
+
+- Fixed Vercel Preview authentication origins so callbacks and post-auth
+  redirects remain on the immutable deployment URL instead of a stale alias.
+- Pinned Preview and Production runtimes and migration connections to their
+  expected Supabase project refs, failing closed on cross-environment routing.
+- Added branch, deployment-target, revision, environment, and database
+  readiness verification before a preview URL artifact can be published.
+
 ## v0.37.0 - 2026-08-06
 
 - Added durable creator, optional human/agent assignee, and completion-actor

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Notes:
   - Supabase project-ref alignment between `DATABASE_URL`, `DIRECT_URL`, and
     `SUPABASE_URL` so production cannot silently boot against a preview or
     staging database
+  - environment pinning through `EXPECTED_SUPABASE_PROJECT_REF` for
+    Supabase-backed Vercel Preview and Production runtimes
 
 For Supabase production/preview:
 
@@ -140,6 +142,9 @@ For Supabase production/preview:
   session-pooler URL on `*.pooler.supabase.com:5432`.
 - `SUPABASE_URL`: the matching client API URL,
   `https://<project-ref>.supabase.co`.
+- `EXPECTED_SUPABASE_PROJECT_REF`: the same environment's non-secret project
+  ref. Configure distinct values in Vercel and GitHub `preview` / `production`
+  environments so a cross-environment connection fails closed.
 - Prisma runtime automatically adds the compatibility flags needed for the
   Supabase transaction pooler when constructing the `@prisma/adapter-pg`
   connection string.
@@ -479,6 +484,16 @@ Required GitHub secrets:
 - `MIGRATION_DATABASE_URL` (admin-capable migration connection; must not be the runtime `DATABASE_URL`)
 - `AGENT_TOKEN_SIGNING_SECRET` (required for production deploys; preview workflow falls back to a placeholder when intentionally unset)
 - Preview deployments still need `AGENT_TOKEN_SIGNING_SECRET` at runtime. GitHub Actions fallback values do not automatically populate Vercel's shared preview runtime unless the deployment explicitly passes them through.
+
+Required GitHub environment variable (not a secret):
+
+- `EXPECTED_SUPABASE_PROJECT_REF`, configured independently for `preview` and
+  `production`.
+
+The preview workflow validates the migration project ref, immutable Vercel
+deployment target, checked-out revision, deployed `APP_ENV`, and database
+readiness before uploading `preview-deployment`. Always use that artifact URL;
+historical or branch aliases may later point at a different target.
 
 ### Dependency Security Cadence
 

--- a/app/api/health/ready/route.ts
+++ b/app/api/health/ready/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { getAppMetadataSummary } from "@/lib/app-metadata";
 import { logServerError } from "@/lib/observability/logger";
 import { checkDatabaseReadiness } from "@/lib/services/health-service";
 
@@ -10,6 +11,7 @@ export async function GET(request: Request): Promise<Response> {
 
   try {
     await checkDatabaseReadiness();
+    const metadata = getAppMetadataSummary();
 
     return NextResponse.json(
       {
@@ -18,6 +20,10 @@ export async function GET(request: Request): Promise<Response> {
         timestamp: new Date().toISOString(),
         checks: {
           database: "ok",
+        },
+        deployment: {
+          environment: metadata.environment,
+          revision: metadata.revision,
         },
         requestId,
       },

--- a/docs/runbooks/database-connection-hardening.md
+++ b/docs/runbooks/database-connection-hardening.md
@@ -38,6 +38,10 @@ For Supabase production:
   `postgres.<project-ref>`). On direct/client URLs, it is encoded in the host
   (`db.<project-ref>.supabase.co` and
   `https://<project-ref>.supabase.co`).
+- `EXPECTED_SUPABASE_PROJECT_REF` must be configured separately in Vercel and
+  GitHub Preview/Production environments. It is non-secret metadata and pins
+  all three runtime endpoints plus the workflow migration connection to the
+  intended project.
 
 Do not use the Supabase session pooler (`*.pooler.supabase.com:5432`) for
 `DATABASE_URL` in Vercel/serverless runtime. Session mode is capped by the
@@ -115,7 +119,7 @@ recovery unless the operator explicitly authorizes a specific secret operation.
   Supabase.
 - `DIRECT_URL` / `MIGRATION_DATABASE_URL` do not use `app_runtime`.
 - Supabase project refs match across `DATABASE_URL`, `DIRECT_URL`, and
-  `SUPABASE_URL`.
+  `SUPABASE_URL`, and match `EXPECTED_SUPABASE_PROJECT_REF`.
 - Vercel logs do not show `EMAXCONNSESSION` during representative authenticated
   request bursts.
 - No credentials appear in logs, errors, or build artifacts.

--- a/docs/runbooks/github-actions-workflows.md
+++ b/docs/runbooks/github-actions-workflows.md
@@ -60,6 +60,10 @@ Run `.github/workflows/deploy-vercel.yml` manually:
 - `git_ref=<branch-or-sha>`
 
 Use the `preview-deployment` artifact or job summary URL for preview smoke.
+The artifact is uploaded only after the workflow verifies that the immutable
+URL belongs to the configured Vercel project, targets Preview, contains the
+requested revision, reports `APP_ENV=preview`, and can reach its database. Do
+not substitute a branch alias or a URL from an older deployment.
 
 ### Staged Production Deploy
 

--- a/docs/runbooks/vercel-env-contract-and-secrets.md
+++ b/docs/runbooks/vercel-env-contract-and-secrets.md
@@ -60,6 +60,7 @@ Required for Vercel runtime/deployments:
 
 - `DATABASE_URL`
 - `DIRECT_URL`
+- `EXPECTED_SUPABASE_PROJECT_REF` (environment-scoped, non-secret)
 
 For Supabase-backed Vercel deployments:
 
@@ -203,6 +204,7 @@ Can stay non-sensitive:
 - `R2_ACCOUNT_ID`
 - `SUPABASE_URL`
 - `SUPABASE_PUBLISHABLE_KEY`
+- `EXPECTED_SUPABASE_PROJECT_REF`
 
 Important:
 
@@ -213,10 +215,21 @@ Important:
 
 - Preview builds run with production-like checks (`NODE_ENV=production` during
   build), so missing production-only guards can break preview deploys.
+- Do not set `NEXTAUTH_URL` in Vercel Preview to a historical deployment or
+  branch alias. Preview auth origins resolve from the immutable system
+  `VERCEL_URL`; Production continues to use its trusted canonical origin.
+- For the same reason, do not pin `GOOGLE_REDIRECT_URI`,
+  `AUTH_GOOGLE_REDIRECT_URI`, or `AUTH_GITHUB_REDIRECT_URI` in Preview to a
+  historical deployment URL. When Preview provider credentials are enabled,
+  their provider-side callback allowlist must accept the immutable URL being
+  tested; otherwise leave that provider disabled for preview testing.
 - Production database secrets must come from the intended Supabase Production
   project, not local `.env` snapshots or preview/staging files. The app rejects
   production startup when Supabase project refs differ across `DATABASE_URL`,
   `DIRECT_URL`, and `SUPABASE_URL`.
+- `EXPECTED_SUPABASE_PROJECT_REF` must differ between Preview and Production.
+  Runtime startup and preview migrations fail closed when their Supabase ref
+  does not match this environment-scoped value.
 - When Supabase direct-host connectivity is unavailable, `DIRECT_URL` may use
   the admin session pooler on port `5432`. That is an admin/migration fallback,
   not permission to use session pooling or admin credentials for
@@ -326,7 +339,11 @@ Before merging deploy-affecting changes:
 1. Confirm required env vars exist for target environment.
 2. Confirm sensitive vars are marked sensitive where supported.
 3. Run manual preview deploy (`deploy-vercel.yml`, `action=deploy-preview`).
-4. Validate critical auth/integration path(s) on preview URL.
-5. If any preview path bypasses deployment-time `-e` injection, confirm
+4. Use only the immutable URL in the `preview-deployment` artifact. The
+   workflow verifies that it is a Vercel Preview target for the requested
+   revision, reports `APP_ENV=preview`, and passes database readiness before
+   uploading the artifact.
+5. Validate critical auth/integration path(s) on that preview URL.
+6. If any preview path bypasses deployment-time `-e` injection, confirm
    `AGENT_TOKEN_SIGNING_SECRET` exists in Vercel Preview before relying on that
    preview URL.

--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,24 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-08-20 - TASK-370 preview auth/database isolation diagnosis
+
+- The reported URL
+  `nexus-dash-dorianagaesse-3732-dorian-agaesses-projects.vercel.app` is a
+  mutable alias currently attached to a Vercel `production` deployment created
+  on 2026-08-09, so testing it exercised production data. The current manual
+  workflow runs for `main`, TASK-342, and TASK-356 emitted different immutable
+  URLs whose Vercel target is `preview` and whose logs show the requested refs
+  were checked out.
+- Vercel Preview and Production use distinct Supabase refs (`dikde…` and
+  `ixhy…` respectively), but Preview still had `NEXTAUTH_URL` pinned to the
+  stale alias. TASK-370 removes that static preview-origin dependency, adds an
+  expected-project-ref deployment pin, and makes preview artifact publication
+  contingent on target/revision/environment/database-readiness validation.
+- Focused regression validation passed: 4 files, 88 tests covering request
+  origin selection, environment validation, health metadata, and migration
+  project-ref validation.
+
 # 2026-08-08 - TASK-330 assignee control rebuilt as inline Participants-style chip
 
 - User feedback after the initial accountability ship called the previous

--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,32 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-08-20 - TASK-370 preview isolation validated
+
+- Removed stale Preview `NEXTAUTH_URL` and OAuth redirect overrides from
+  Vercel/GitHub configuration, left Production auth settings unchanged, and
+  pinned Preview and Production to their distinct expected Supabase refs.
+- Workflow run `32313383142` explicitly checked out
+  `fix/task-370-preview-auth-isolation`, validated staging migrations and the
+  immutable Vercel Preview identity, reported runtime revision `bf91a06`,
+  confirmed database readiness, and published
+  `https://nexus-dash-h1s18isxe-dorian-agaesses-projects.vercel.app`.
+- The deployed Chromium isolation case passed signup, logout, and subsequent
+  signin with a generated staging account while remaining on the immutable
+  preview origin. This also exercised the staging database so it remains
+  active.
+- Local validation passed lint, RLS inventory, 1,048 unit/API tests with 2
+  skipped, coverage (91.37% statements, 81.33% branches, 92.20% functions,
+  91.88% lines), production build, and focused deployment/auth suites. The
+  repository-wide local Playwright command built and passed its five
+  DB-independent cases but could not run 27 DB-backed cases because local
+  PostgreSQL was unavailable at `127.0.0.1:5432`; the same CI Playwright suite
+  passed with its PostgreSQL service.
+- Copilot completed its initial review with one actionable test-isolation
+  comment. Environment restoration now deletes originally absent variables
+  instead of writing the string `undefined`, and the focused seven-test suite
+  passes.
+
 # 2026-08-20 - TASK-370 preview auth/database isolation diagnosis
 
 - The reported URL

--- a/lib/app-metadata.ts
+++ b/lib/app-metadata.ts
@@ -52,9 +52,10 @@ function readVersion(): string {
 
 function readRevision(): string | null {
   const revision =
+    readOptionalEnv("COMMIT_SHA") ??
     readOptionalEnv("VERCEL_GIT_COMMIT_SHA") ??
     readOptionalEnv("GITHUB_SHA") ??
-    readOptionalEnv("COMMIT_SHA");
+    null;
   if (!revision) {
     return null;
   }

--- a/lib/env.server.ts
+++ b/lib/env.server.ts
@@ -522,6 +522,49 @@ function assertMatchingSupabaseProjectRefs(
   }
 }
 
+function assertExpectedSupabaseProjectRef(
+  databaseUrl: ParsedDatabaseConnectionString,
+  directUrl: ParsedDatabaseConnectionString,
+  supabaseClientProjectRef: string | null
+): void {
+  const vercelEnvironment = getVercelEnvironment();
+  if (vercelEnvironment !== "preview" && vercelEnvironment !== "production") {
+    return;
+  }
+
+  const configuredProjectRefs = [
+    databaseUrl.supabaseProjectRef,
+    directUrl.supabaseProjectRef,
+    supabaseClientProjectRef,
+  ].filter((value): value is string => Boolean(value));
+  if (configuredProjectRefs.length === 0) {
+    return;
+  }
+
+  const expectedProjectRef = getOptionalServerEnv(
+    "EXPECTED_SUPABASE_PROJECT_REF"
+  )?.toLowerCase();
+  if (!expectedProjectRef) {
+    throw new Error(
+      "EXPECTED_SUPABASE_PROJECT_REF is required for Vercel preview and production deployments."
+    );
+  }
+
+  if (!/^[a-z0-9-]+$/.test(expectedProjectRef)) {
+    throw new Error(
+      "EXPECTED_SUPABASE_PROJECT_REF must contain only lowercase letters, numbers, and hyphens."
+    );
+  }
+
+  if (
+    configuredProjectRefs.some((projectRef) => projectRef !== expectedProjectRef)
+  ) {
+    throw new Error(
+      `Supabase runtime configuration does not match EXPECTED_SUPABASE_PROJECT_REF for Vercel ${vercelEnvironment}.`
+    );
+  }
+}
+
 function assertProductionDatabaseConnectionHardening(
   databaseUrl: ParsedDatabaseConnectionString,
   directUrl: ParsedDatabaseConnectionString,
@@ -665,6 +708,11 @@ export function validateServerRuntimeConfig(
     runtimeEnvironment,
     supabaseClientProjectRef
   );
+  assertExpectedSupabaseProjectRef(
+    parsedDatabaseUrl,
+    parsedDirectUrl,
+    supabaseClientProjectRef
+  );
 
   assertOptionalEnvironmentGroup(
     ["NEXTAUTH_URL", "NEXTAUTH_SECRET"],
@@ -710,7 +758,11 @@ export function validateServerRuntimeConfig(
     throw new Error("TRUSTED_ORIGINS must contain at least one valid absolute URL.");
   }
 
-  const hasTrustedAppOrigin = trustedOriginsAreValid || Boolean(nextAuthUrl);
+  // Prebuilt Vercel previews do not have their immutable VERCEL_URL until the
+  // artifact is deployed. The runtime origin resolver still requires it.
+  const hasVercelPreviewOrigin = getVercelEnvironment() === "preview";
+  const hasTrustedAppOrigin =
+    trustedOriginsAreValid || Boolean(nextAuthUrl) || hasVercelPreviewOrigin;
   const hasGoogleRedirectResolution =
     Boolean(googleRedirectUri) ||
     hasTrustedAppOrigin;

--- a/lib/http/request-origin.ts
+++ b/lib/http/request-origin.ts
@@ -1,4 +1,9 @@
-import { getOptionalServerEnv, isProductionEnvironment } from "@/lib/env.server";
+import {
+  getOptionalServerEnv,
+  isLiveProductionDeployment,
+  isPreviewDeployment,
+  isProductionEnvironment,
+} from "@/lib/env.server";
 
 const DEFAULT_LOCAL_ORIGIN = "http://localhost:3000";
 
@@ -57,9 +62,26 @@ function resolveTrustedProductionOrigin(): string | null {
   }
 }
 
+function resolveVercelPreviewOrigin(): string | null {
+  const vercelUrl = getOptionalServerEnv("VERCEL_URL");
+  if (!vercelUrl) {
+    return null;
+  }
+
+  try {
+    return new URL(`https://${vercelUrl}`).origin;
+  } catch {
+    return null;
+  }
+}
+
 function isAllowedOrigin(origin: string): boolean {
   if (!isProductionEnvironment()) {
     return true;
+  }
+
+  if (isPreviewDeployment()) {
+    return origin === resolveVercelPreviewOrigin();
   }
 
   const trustedOrigin = resolveTrustedProductionOrigin();
@@ -89,13 +111,22 @@ function buildOrigin(protocol: string | null, host: string | null): string | nul
 
 export function resolveRequestOriginFromHeaders(headers: HeaderReader): string {
   const trustedOrigin = resolveTrustedProductionOrigin();
-  if (isProductionEnvironment()) {
+  if (isLiveProductionDeployment()) {
     if (trustedOrigin) {
       return trustedOrigin;
     }
 
     throw new Error(
       "Unable to resolve trusted request origin in production. Configure TRUSTED_ORIGINS or NEXTAUTH_URL."
+    );
+  }
+
+  const previewOrigin = isPreviewDeployment()
+    ? resolveVercelPreviewOrigin()
+    : null;
+  if (isPreviewDeployment() && !previewOrigin) {
+    throw new Error(
+      "Unable to resolve trusted request origin in Vercel preview. Configure VERCEL_URL."
     );
   }
 
@@ -117,7 +148,14 @@ export function resolveRequestOriginFromHeaders(headers: HeaderReader): string {
   }
 
   if (trustedOrigin) {
+    if (isPreviewDeployment()) {
+      return previewOrigin!;
+    }
     return trustedOrigin;
+  }
+
+  if (previewOrigin) {
+    return previewOrigin;
   }
 
   return DEFAULT_LOCAL_ORIGIN;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexusdash",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexusdash",
-      "version": "0.37.0",
+      "version": "0.37.1",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1079.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexusdash",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "private": true,
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0",

--- a/project.md
+++ b/project.md
@@ -104,6 +104,9 @@ Source of truth: [`prisma/schema.prisma`](./prisma/schema.prisma)
 
 - `npm run dev` and `npm run start` run `prisma migrate deploy` before app startup.
 - Runtime config is validated at server startup via `validateServerRuntimeConfig()`.
+- Supabase-backed Vercel Preview and Production runtimes are pinned to an
+  environment-scoped expected project ref; preview auth origins use the
+  immutable Vercel deployment host rather than a static alias.
 - CI quality gates:
   - `Quality Core`
   - `E2E Smoke`
@@ -113,6 +116,8 @@ Source of truth: [`prisma/schema.prisma`](./prisma/schema.prisma)
 - CD workflow supports:
   - staged production deploy
   - manual preview deploy
+    - verifies immutable Preview target, revision/environment metadata, and
+      database readiness before publishing its URL artifact
   - promote
   - rollback
 

--- a/scripts/validate-supabase-project-ref.mjs
+++ b/scripts/validate-supabase-project-ref.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+function readRequiredEnv(name) {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+export function extractSupabaseProjectRef(connectionString) {
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(connectionString);
+  } catch {
+    throw new Error("Database connection must be a valid absolute URL.");
+  }
+
+  const host = parsedUrl.hostname.toLowerCase();
+  if (host.endsWith(".pooler.supabase.com")) {
+    const username = decodeURIComponent(parsedUrl.username);
+    const separatorIndex = username.lastIndexOf(".");
+    return separatorIndex > 0 ? username.slice(separatorIndex + 1).toLowerCase() : null;
+  }
+
+  const directMatch = /^db\.([a-z0-9-]+)\.supabase\.co$/i.exec(host);
+  return directMatch?.[1]?.toLowerCase() ?? null;
+}
+
+export function validateSupabaseProjectRef(connectionString, expectedProjectRef) {
+  const normalizedExpectedRef = expectedProjectRef.trim().toLowerCase();
+  if (!/^[a-z0-9-]+$/.test(normalizedExpectedRef)) {
+    throw new Error(
+      "EXPECTED_SUPABASE_PROJECT_REF must contain only lowercase letters, numbers, and hyphens."
+    );
+  }
+
+  const actualProjectRef = extractSupabaseProjectRef(connectionString);
+  if (!actualProjectRef || actualProjectRef !== normalizedExpectedRef) {
+    throw new Error(
+      "Database connection does not match EXPECTED_SUPABASE_PROJECT_REF."
+    );
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  try {
+    validateSupabaseProjectRef(
+      readRequiredEnv("DATABASE_URL"),
+      readRequiredEnv("EXPECTED_SUPABASE_PROJECT_REF")
+    );
+    process.stdout.write("Supabase project-ref validation passed.\n");
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -8,7 +8,7 @@ Last reviewed: 2026-08-08
 ### Active Runtime Remediation
 - ID: TASK-370
   Title: Preview authentication and database isolation guardrails
-  Status: In Progress
+  Status: Complete (2026-08-20; PR #432)
   Rationale: Prevent stale or mutable Vercel aliases from being mistaken for previews, keep preview auth callbacks on the immutable deployment origin, pin Preview and Production to their intended Supabase project refs, and make the preview workflow verify target, revision, environment metadata, and database readiness before publishing its artifact.
   Dependencies: TASK-048, TASK-068, TASK-259, TASK-315
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -5,6 +5,13 @@ Use this file to capture tasks discovered during development. Each entry should 
 Last reviewed: 2026-08-08
 
 ## Pending
+### Active Runtime Remediation
+- ID: TASK-370
+  Title: Preview authentication and database isolation guardrails
+  Status: In Progress
+  Rationale: Prevent stale or mutable Vercel aliases from being mistaken for previews, keep preview auth callbacks on the immutable deployment origin, pin Preview and Production to their intended Supabase project refs, and make the preview workflow verify target, revision, environment metadata, and database readiness before publishing its artifact.
+  Dependencies: TASK-048, TASK-068, TASK-259, TASK-315
+
 ### Execution Queue (Now / Next)
 - ID: TASK-100
   Title: Mobile UI/UX refinement - touch ergonomics, compact layouts, and small-screen polish

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,7 +4,8 @@
 
 ## Status
 
-In progress on `fix/task-370-preview-auth-isolation`.
+Complete on `fix/task-370-preview-auth-isolation`; validated on the immutable
+Vercel Preview deployment and delivered through PR #432.
 
 ## Context
 
@@ -69,3 +70,15 @@ ref or verify the deployed target before publishing the preview URL.
   environments are available to configure `EXPECTED_SUPABASE_PROJECT_REF`.
 - Preview validation uses the immutable URL emitted by `deploy-vercel.yml`, not
   a branch alias or a historical Vercel URL.
+
+## Validation Evidence
+
+- Workflow run `32313383142` checked out the explicit fix branch, applied
+  staging migrations, verified Preview target/revision/environment/database
+  readiness, and published
+  `https://nexus-dash-h1s18isxe-dorian-agaesses-projects.vercel.app`.
+- The deployed opt-in Playwright case created a staging account, signed out,
+  signed back in, and remained on that immutable origin.
+- Lint, RLS inventory, unit/API, coverage, build, and CI Playwright validation
+  passed. Copilot's initial review completed; its environment-restoration
+  comment was applied and covered by the focused request-origin test.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,98 +1,71 @@
 # Current Task
 
-## TASK-330: Meeting Todo Assignees and Completion Accountability
+## TASK-370: Preview Authentication and Database Isolation Guardrails
 
 ## Status
 
-Implementation and validation complete on
-`feature/task-330-meeting-todo-assignees`; ready for review.
+In progress on `fix/task-370-preview-auth-isolation`.
 
 ## Context
 
-Meeting todos currently preserve only content and completion time. They do not
-show who created the follow-up, who owns it, or who completed it. Overdue
-reminders therefore fall back to the meeting-note creator even when another
-project collaborator is actually accountable.
-
-TASK-337's universal project-actor model is not implemented yet. This task will
-introduce a deliberately narrow, reusable meeting-todo actor contract for human
-project members and active project agent credentials without expanding into
-cross-artifact ownership.
+Authentication from a URL believed to be a preview reached production and a
+signup reported an email already present in the production user database.
+Investigation confirmed that the tested Vercel alias currently targets a
+production deployment. The Vercel Preview environment also retained that alias
+as `NEXTAUTH_URL`, so preview auth callbacks and generated links could select a
+stale production origin even when the immutable deployment itself was a real
+preview. Preview and production currently use distinct Supabase project refs,
+but the deployment contract does not pin either environment to its intended
+ref or verify the deployed target before publishing the preview URL.
 
 ## Scope
 
-- Persist durable creator, optional assignee, and completion-actor identity for
-  every meeting todo, including safe display snapshots.
-- Backfill existing todo creators from their meeting-note creator.
-- Preserve existing todo identity and provenance when a meeting note is edited.
-- Allow assignment only to current project members or active, unexpired project
-  agent credentials. Meeting guests are not assignment candidates.
-- Display inactive/revoked assignees as needing reassignment instead of silently
-  converting them to unassigned.
-- Add accessible assignment controls in meeting detail and the project Todos
-  page, plus `All`, `Assigned to me`, and `Unassigned` responsibility views.
-- Record the authenticated human or agent credential that completes a todo.
-- Send overdue reminders only to an active human assignee. Do not redirect an
-  agent assignment to its credential owner, and do not treat the note creator
-  as an implicit assignee.
-
-## Out Of Scope
-
-- A universal actor table or cross-artifact actor migration (TASK-337).
-- Cross-project responsibility queues (TASK-346).
-- New agent capability vocabulary or granular meeting scopes (TASK-331).
-- Assignment notifications or preference controls beyond the existing overdue
-  reminder pipeline (TASK-347).
+- Resolve request origins from the current immutable Vercel deployment host in
+  preview instead of using a static `NEXTAUTH_URL`.
+- Pin production-like runtimes to an explicitly configured expected Supabase
+  project ref and reject cross-environment database routing at startup.
+- Validate the preview migration target, Vercel deployment target, deployed
+  environment/revision metadata, and database readiness before uploading the
+  preview URL artifact.
+- Remove stale Vercel Preview origin/redirect overrides (`NEXTAUTH_URL` and
+  OAuth callback URLs) and configure expected project-ref metadata for Preview
+  and Production.
+- Exercise signup/signin on the fixed preview without touching production.
 
 ## Acceptance Criteria
 
-1. Each meeting todo exposes creator, optional assignee, and (when completed)
-   completion actor with actor kind, stable identifier, display label, avatar
-   treatment, and current access state.
-2. New todos record their creator. Existing todos are backfilled from the
-   meeting-note creator, and editing a note does not replace unchanged todo IDs
-   or erase creator/assignee/completion provenance.
-3. Editors can assign or clear a todo from meeting detail and the project Todos
-   page using a labeled, keyboard-operable control with pending and error
-   feedback; viewers see the same identity information without mutation affordances.
-4. Assignment validation is enforced in the service boundary. Human candidates
-   must currently own or belong to the project; agent candidates must be active,
-   unexpired credentials for that project. Assignment never grants access.
-5. External meeting participants are never offered or accepted as assignees.
-6. Removed human members and revoked/expired agents remain visibly attached to
-   their todo as inactive and are labeled `Needs reassignment` until cleared or
-   reassigned.
-7. The project Todos page supports stable URL-backed `All`, `Assigned to me`,
-   and `Unassigned` filters for both open and completed views, with accurate
-   counts and useful filtered empty states.
-8. Completing a todo records the authenticated human or agent credential as the
-   completion actor; reopening clears the current completion actor together
-   with the completion timestamp.
-9. Overdue reminder reconciliation targets only active human assignees with
-   current project access. Unassigned, inactive-human, and agent-assigned todos
-   do not generate a reminder for another person.
-10. UI remains usable at 375px and desktop widths, in light and dark themes,
-    with visible focus, semantic status text, at least 44px primary touch
-    targets, and no color-only responsibility state.
+1. A preview request resolves auth callback/link origins to that preview's
+   immutable `VERCEL_URL`, never the production domain or a stale alias.
+2. Preview and production fail closed when their runtime Supabase project ref
+   does not match `EXPECTED_SUPABASE_PROJECT_REF`.
+3. The preview deploy workflow rejects a non-preview Vercel target, a revision
+   mismatch, an environment mismatch, an unreachable database, or a migration
+   connection aimed at the wrong Supabase project.
+4. The workflow artifact contains the immutable URL of the exact requested
+   branch deployment only after all preview checks pass.
+5. A new account can sign up and sign back in on the fixed preview while the
+   browser remains on the preview origin.
+6. Existing production routing and trusted-origin behavior remain unchanged.
 
 ## Definition Of Done
 
-- Prisma schema, migration, RLS inventory, services, routes, UI projections,
-  reminder reconciliation, and relevant documentation are updated together.
-- Focused unit, service, route, component, and Playwright coverage exercises
-  human/agent assignment, invalid actors, inactive states, responsibility
-  filters, creator/completer provenance, role restrictions, and reminder targeting.
+- Focused origin, runtime-environment, health-route, and deploy-validation
+  coverage passes.
 - `npm run lint`, `npm run rls:check`, `npm test`, `npm run test:coverage`,
-  `npm run build`, and relevant meeting-todo E2E coverage pass.
-- `tasks/current.md`, `tasks/backlog.md`, `tasks/task-330-meeting-todo-assignees.md`,
-  `project.md`, and `journal.md` reflect the delivered behavior.
-- The branch is pushed, a ready-for-review PR is open, required checks are
-  green, and initial Copilot review feedback is resolved or documented.
+  `npm run build`, and relevant deployed-preview Playwright checks pass.
+- Vercel/GitHub environment metadata is configured without exposing secrets.
+- The branch preview workflow completes for the explicit branch ref and its
+  logs prove the checked-out ref and validated Preview target.
+- A ready-for-review PR is open; required checks and initial Copilot review are
+  complete; actionable threads are resolved before merge.
+- `tasks/current.md`, `tasks/backlog.md`, relevant runbooks, and `journal.md`
+  record the diagnosis and validation outcome.
 
 ## Runtime Assumptions
 
-- Local database-backed validation uses the repository `.env` contract and a
-  reachable PostgreSQL instance when migration or E2E execution requires it.
-- No new secrets or external provider configuration are introduced.
-- Preview deployment is not an acceptance requirement; local browser coverage
-  is sufficient unless review feedback exposes a preview-only concern.
+- Preview and production remain separate Supabase projects; their project refs
+  are safe non-secret deployment metadata while connection strings stay secret.
+- GitHub `preview` and `production` environments and the corresponding Vercel
+  environments are available to configure `EXPECTED_SUPABASE_PROJECT_REF`.
+- Preview validation uses the immutable URL emitted by `deploy-vercel.yml`, not
+  a branch alias or a historical Vercel URL.

--- a/tasks/task-370-preview-auth-isolation.md
+++ b/tasks/task-370-preview-auth-isolation.md
@@ -1,0 +1,22 @@
+# TASK-370: Preview Authentication and Database Isolation Guardrails
+
+## Problem
+
+The URL used for preview testing was a mutable Vercel alias that currently
+targets production. Vercel Preview also used that alias for `NEXTAUTH_URL` and
+OAuth callback overrides, so origin-dependent auth flows could leave a valid preview. Although Preview and
+Production use distinct Supabase projects today, neither runtime was pinned to
+an expected project ref and preview artifacts were published without checking
+the Vercel target or application readiness metadata.
+
+## Delivery Contract
+
+- Preview auth origins come from the immutable Vercel deployment URL.
+- Runtime and migration connections match the environment's expected Supabase
+  project ref.
+- Preview deployment artifacts are emitted only after target, revision,
+  environment, and database-readiness validation.
+- Deployed signup/signin remains on the preview origin.
+
+See `tasks/current.md` for acceptance criteria, definition of done, and runtime
+assumptions.

--- a/tests/api/health-ready.route.test.ts
+++ b/tests/api/health-ready.route.test.ts
@@ -28,6 +28,7 @@ describe("GET /api/health/ready", () => {
     const payload = (await response.json()) as {
       status: string;
       checks: { database: string };
+      deployment: { environment: string; revision: string | null };
       service: string;
       timestamp: string;
       requestId: string | null;
@@ -37,6 +38,7 @@ describe("GET /api/health/ready", () => {
     expect(response.headers.get("cache-control")).toBe("no-store");
     expect(payload.status).toBe("ready");
     expect(payload.checks.database).toBe("ok");
+    expect(payload.deployment.environment).toBe("test");
     expect(payload.service).toBe("nexusdash");
     expect(typeof payload.timestamp).toBe("string");
     expect(payload.requestId).toBe("req-ready-1");

--- a/tests/app/home-auth-actions.test.ts
+++ b/tests/app/home-auth-actions.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const sessionUserMock = vi.hoisted(() => ({
   getSessionUserIdFromServer: vi.fn(),
@@ -71,6 +71,7 @@ import { signInAction, signUpAction } from "@/app/home-auth-actions";
 describe("home auth actions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubEnv("NEXTAUTH_URL", "https://nexus-dash.app");
     isLiveProductionDeploymentMock.mockReturnValue(true);
     sessionUserMock.getSessionUserIdFromServer.mockResolvedValue(null);
     emailVerificationMock.isEmailVerifiedForUser.mockResolvedValue(true);
@@ -91,6 +92,10 @@ describe("home auth actions", () => {
     redirectMock.mockImplementation((path: string) => {
       throw new Error(`NEXT_REDIRECT:${path}`);
     });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   test("signInAction redirects to home with form error when credentials are invalid", async () => {

--- a/tests/e2e/preview-auth-isolation.spec.ts
+++ b/tests/e2e/preview-auth-isolation.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+
+const previewBaseUrl = process.env.PLAYWRIGHT_BASE_URL?.trim();
+const shouldRunPreviewAuth = process.env.TASK370_PREVIEW_AUTH === "1";
+
+test.describe("preview authentication isolation", () => {
+  test.skip(
+    !previewBaseUrl || !shouldRunPreviewAuth,
+    "Set PLAYWRIGHT_BASE_URL and TASK370_PREVIEW_AUTH=1 for deployed-preview validation."
+  );
+
+  test("signup and subsequent signin remain on the immutable preview origin", async ({
+    page,
+  }) => {
+    const previewOrigin = new URL(previewBaseUrl!).origin;
+    const suffix = Date.now().toString(36);
+    const username = `task370.${suffix}`.slice(0, 20);
+    const email = `task370-preview-${suffix}@nexusdash.local`;
+    const password = `Task370!Preview${suffix}`;
+
+    await page.goto("/?form=signup");
+    await page.getByLabel("Username").fill(username);
+    await page.getByLabel("Email address").fill(email);
+    await page.getByLabel("Password", { exact: true }).fill(password);
+    await page.getByLabel("Confirm password").fill(password);
+    await page.getByRole("button", { name: "Create your account" }).click();
+
+    await expect(page).toHaveURL(/\/projects(?:\?.*)?$/);
+    expect(new URL(page.url()).origin).toBe(previewOrigin);
+
+    await page.getByRole("button", { name: /^Account menu/ }).click();
+    await page.getByRole("menuitem", { name: "Log out" }).click();
+    await expect(page).toHaveURL(/\/(?:\?.*)?$/);
+    expect(new URL(page.url()).origin).toBe(previewOrigin);
+
+    await page.getByLabel("Email address").fill(email);
+    await page.getByLabel("Password").fill(password);
+    await page.getByRole("button", { name: "Sign in to NexusDash" }).click();
+
+    await expect(page).toHaveURL(/\/projects(?:\?.*)?$/);
+    expect(new URL(page.url()).origin).toBe(previewOrigin);
+  });
+});

--- a/tests/lib/app-metadata.test.ts
+++ b/tests/lib/app-metadata.test.ts
@@ -81,6 +81,16 @@ describe("app-metadata", () => {
     expect(summary.revision).toBe("1234567");
   });
 
+  test("prefers the workflow-injected revision over provider metadata", () => {
+    process.env.COMMIT_SHA = "abcdef0123456789";
+    process.env.VERCEL_GIT_COMMIT_SHA = "9999999999999999";
+    process.env.GITHUB_SHA = "8888888888888888";
+
+    const summary = getAppMetadataSummary();
+
+    expect(summary.revision).toBe("abcdef0");
+  });
+
   test("falls back to package version when configured version is invalid", () => {
     process.env.APP_VERSION = "release-candidate";
 

--- a/tests/lib/env.server.test.ts
+++ b/tests/lib/env.server.test.ts
@@ -22,11 +22,13 @@ import {
 const ENV_KEYS_TO_RESET = [
   "NODE_ENV",
   "VERCEL_ENV",
+  "VERCEL_URL",
   "DATABASE_URL",
   "DIRECT_URL",
   "SUPABASE_URL",
   "SUPABASE_PUBLISHABLE_KEY",
   "SUPABASE_API_KEY",
+  "EXPECTED_SUPABASE_PROJECT_REF",
   "NEXTAUTH_URL",
   "NEXTAUTH_SECRET",
   "TRUSTED_ORIGINS",
@@ -871,6 +873,78 @@ describe("env.server", () => {
 
     expect(() => validateServerRuntimeConfig()).toThrow(
       "SUPABASE_URL must target the same Supabase project as DATABASE_URL and DIRECT_URL in production."
+    );
+  });
+
+  test("allows runtime-derived OAuth redirects in Vercel preview", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("VERCEL_ENV", "preview");
+    vi.stubEnv("VERCEL_URL", "nexus-dash-immutable.example.vercel.app");
+    vi.stubEnv("DATABASE_URL", "postgresql://localhost:5432/postgres");
+    vi.stubEnv("DIRECT_URL", "postgresql://localhost:5433/postgres");
+    vi.stubEnv("AUTH_GOOGLE_CLIENT_ID", "client-id");
+    vi.stubEnv("AUTH_GOOGLE_CLIENT_SECRET", "client-secret");
+    vi.stubEnv("AUTH_GOOGLE_REDIRECT_URI", "");
+    vi.stubEnv("NEXTAUTH_URL", "");
+    vi.stubEnv("NEXTAUTH_SECRET", "");
+    vi.stubEnv("TRUSTED_ORIGINS", "");
+
+    expect(() => validateServerRuntimeConfig()).not.toThrow();
+  });
+
+  test("passes Vercel preview validation for the expected Supabase project", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("VERCEL_ENV", "preview");
+    vi.stubEnv("EXPECTED_SUPABASE_PROJECT_REF", "preview-ref");
+    vi.stubEnv(
+      "DATABASE_URL",
+      "postgresql://app_runtime.preview-ref:pwd@aws-1-eu-west-1.pooler.supabase.com:6543/postgres?sslmode=require"
+    );
+    vi.stubEnv(
+      "DIRECT_URL",
+      "postgresql://postgres:pwd@db.preview-ref.supabase.co:5432/postgres?sslmode=require"
+    );
+    vi.stubEnv("SUPABASE_URL", "https://preview-ref.supabase.co");
+    vi.stubEnv("SUPABASE_PUBLISHABLE_KEY", "pk_test_123");
+
+    expect(() => validateServerRuntimeConfig()).not.toThrow();
+  });
+
+  test("requires an expected Supabase project ref in Vercel preview", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("VERCEL_ENV", "preview");
+    vi.stubEnv("EXPECTED_SUPABASE_PROJECT_REF", "");
+    vi.stubEnv(
+      "DATABASE_URL",
+      "postgresql://app_runtime.preview-ref:pwd@aws-1-eu-west-1.pooler.supabase.com:6543/postgres?sslmode=require"
+    );
+    vi.stubEnv(
+      "DIRECT_URL",
+      "postgresql://postgres:pwd@db.preview-ref.supabase.co:5432/postgres?sslmode=require"
+    );
+
+    expect(() => validateServerRuntimeConfig()).toThrow(
+      "EXPECTED_SUPABASE_PROJECT_REF is required for Vercel preview and production deployments."
+    );
+  });
+
+  test("rejects a Vercel preview runtime aimed at another Supabase project", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("VERCEL_ENV", "preview");
+    vi.stubEnv("EXPECTED_SUPABASE_PROJECT_REF", "preview-ref");
+    vi.stubEnv(
+      "DATABASE_URL",
+      "postgresql://app_runtime.production-ref:pwd@aws-1-eu-west-1.pooler.supabase.com:6543/postgres?sslmode=require"
+    );
+    vi.stubEnv(
+      "DIRECT_URL",
+      "postgresql://postgres:pwd@db.production-ref.supabase.co:5432/postgres?sslmode=require"
+    );
+    vi.stubEnv("SUPABASE_URL", "https://production-ref.supabase.co");
+    vi.stubEnv("SUPABASE_PUBLISHABLE_KEY", "pk_test_123");
+
+    expect(() => validateServerRuntimeConfig()).toThrow(
+      "Supabase runtime configuration does not match EXPECTED_SUPABASE_PROJECT_REF for Vercel preview."
     );
   });
 

--- a/tests/lib/request-origin.test.ts
+++ b/tests/lib/request-origin.test.ts
@@ -13,17 +13,23 @@ class TestHeaders {
 
 describe("request-origin", () => {
   const originalNodeEnv = process.env.NODE_ENV;
+  const originalVercelEnv = process.env.VERCEL_ENV;
+  const originalVercelUrl = process.env.VERCEL_URL;
   const originalNextAuthUrl = process.env.NEXTAUTH_URL;
   const originalTrustedOrigins = process.env.TRUSTED_ORIGINS;
 
   beforeEach(() => {
     process.env.NODE_ENV = "test";
+    delete process.env.VERCEL_ENV;
+    delete process.env.VERCEL_URL;
     delete process.env.NEXTAUTH_URL;
     delete process.env.TRUSTED_ORIGINS;
   });
 
   afterEach(() => {
     process.env.NODE_ENV = originalNodeEnv;
+    process.env.VERCEL_ENV = originalVercelEnv;
+    process.env.VERCEL_URL = originalVercelUrl;
     process.env.NEXTAUTH_URL = originalNextAuthUrl;
     process.env.TRUSTED_ORIGINS = originalTrustedOrigins;
   });
@@ -63,6 +69,64 @@ describe("request-origin", () => {
     );
 
     expect(origin).toBe("https://nexus-dash.app");
+  });
+
+  test("uses the immutable deployment origin in Vercel preview", () => {
+    process.env.NODE_ENV = "production";
+    process.env.VERCEL_ENV = "preview";
+    process.env.VERCEL_URL =
+      "nexus-dash-immutable-dorian-agaesses-projects.vercel.app";
+    process.env.NEXTAUTH_URL = "https://nexus-dash.app";
+
+    const origin = resolveRequestOriginFromHeaders(
+      new TestHeaders({
+        "x-forwarded-proto": "https",
+        "x-forwarded-host":
+          "nexus-dash-immutable-dorian-agaesses-projects.vercel.app",
+      })
+    );
+
+    expect(origin).toBe(
+      "https://nexus-dash-immutable-dorian-agaesses-projects.vercel.app"
+    );
+  });
+
+  test("falls back to the immutable deployment origin for a stale preview alias", () => {
+    process.env.NODE_ENV = "production";
+    process.env.VERCEL_ENV = "preview";
+    process.env.VERCEL_URL =
+      "nexus-dash-immutable-dorian-agaesses-projects.vercel.app";
+    process.env.NEXTAUTH_URL =
+      "https://nexus-dash-stale-dorian-agaesses-projects.vercel.app";
+
+    const origin = resolveRequestOriginFromHeaders(
+      new TestHeaders({
+        "x-forwarded-proto": "https",
+        "x-forwarded-host":
+          "nexus-dash-stale-dorian-agaesses-projects.vercel.app",
+      })
+    );
+
+    expect(origin).toBe(
+      "https://nexus-dash-immutable-dorian-agaesses-projects.vercel.app"
+    );
+  });
+
+  test("fails closed when Vercel preview has no immutable deployment URL", () => {
+    process.env.NODE_ENV = "production";
+    process.env.VERCEL_ENV = "preview";
+    delete process.env.VERCEL_URL;
+
+    expect(() =>
+      resolveRequestOriginFromHeaders(
+        new TestHeaders({
+          "x-forwarded-proto": "https",
+          "x-forwarded-host": "preview.example.com",
+        })
+      )
+    ).toThrow(
+      "Unable to resolve trusted request origin in Vercel preview. Configure VERCEL_URL."
+    );
   });
 
   test("throws in production when no trusted origin is configured", () => {

--- a/tests/lib/request-origin.test.ts
+++ b/tests/lib/request-origin.test.ts
@@ -11,6 +11,15 @@ class TestHeaders {
   }
 }
 
+function restoreEnvironmentVariable(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}
+
 describe("request-origin", () => {
   const originalNodeEnv = process.env.NODE_ENV;
   const originalVercelEnv = process.env.VERCEL_ENV;
@@ -27,11 +36,11 @@ describe("request-origin", () => {
   });
 
   afterEach(() => {
-    process.env.NODE_ENV = originalNodeEnv;
-    process.env.VERCEL_ENV = originalVercelEnv;
-    process.env.VERCEL_URL = originalVercelUrl;
-    process.env.NEXTAUTH_URL = originalNextAuthUrl;
-    process.env.TRUSTED_ORIGINS = originalTrustedOrigins;
+    restoreEnvironmentVariable("NODE_ENV", originalNodeEnv);
+    restoreEnvironmentVariable("VERCEL_ENV", originalVercelEnv);
+    restoreEnvironmentVariable("VERCEL_URL", originalVercelUrl);
+    restoreEnvironmentVariable("NEXTAUTH_URL", originalNextAuthUrl);
+    restoreEnvironmentVariable("TRUSTED_ORIGINS", originalTrustedOrigins);
   });
 
   test("uses forwarded origin when available", () => {

--- a/tests/scripts/validate-supabase-project-ref.test.ts
+++ b/tests/scripts/validate-supabase-project-ref.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  extractSupabaseProjectRef,
+  validateSupabaseProjectRef,
+} from "../../scripts/validate-supabase-project-ref.mjs";
+
+describe("validate-supabase-project-ref", () => {
+  test("extracts project refs from transaction and session pooler usernames", () => {
+    expect(
+      extractSupabaseProjectRef(
+        "postgresql://app_runtime.preview-ref:secret@aws-1-eu-west-1.pooler.supabase.com:6543/postgres"
+      )
+    ).toBe("preview-ref");
+    expect(
+      extractSupabaseProjectRef(
+        "postgresql://postgres.preview-ref:secret@aws-1-eu-west-1.pooler.supabase.com:5432/postgres"
+      )
+    ).toBe("preview-ref");
+  });
+
+  test("extracts project refs from direct Supabase hosts", () => {
+    expect(
+      extractSupabaseProjectRef(
+        "postgresql://postgres:secret@db.preview-ref.supabase.co:5432/postgres"
+      )
+    ).toBe("preview-ref");
+  });
+
+  test("accepts the expected project and rejects cross-environment targets", () => {
+    const connection =
+      "postgresql://postgres.preview-ref:secret@aws-1-eu-west-1.pooler.supabase.com:5432/postgres";
+
+    expect(() => validateSupabaseProjectRef(connection, "preview-ref")).not.toThrow();
+    expect(() => validateSupabaseProjectRef(connection, "production-ref")).toThrow(
+      "Database connection does not match EXPECTED_SUPABASE_PROJECT_REF."
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- derive Preview auth origins from the immutable Vercel deployment URL
- pin Preview and Production to environment-specific Supabase project refs
- validate preview target, revision, runtime environment, and database readiness before publishing the artifact
- remove stale Preview auth/callback overrides that pointed at a production alias

## Validation
- npm run lint
- npm run rls:check
- npm test (1048 passed, 2 skipped)
- npm run test:coverage
- npm run build
- deployed-preview auth isolation smoke pending on this PR