### PR TITLE
Capture product feedback as TASK-371 through TASK-405

### DIFF
--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,21 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-08-24 - ChatGPT and Codex connector Epic added to backlog
+
+- Integrated the attached ND-MCP plan as non-executable TASK-385 with a
+  dedicated Epic brief and twenty focused delivery tasks, TASK-386 through
+  TASK-405.
+- Preserved the proposed remote Streamable HTTP MCP, OAuth 2.1, shared-service,
+  read/write tool, no-delete v1, private-plugin, test/evaluation, preview,
+  production, and operations workstreams.
+- Verified the cited official OpenAI documentation for stable HTTPS MCP
+  endpoints, Streamable HTTP, OAuth 2.1/PKCE metadata requirements, Developer
+  mode testing, confirmations, and current plugin surfaces. Kept account,
+  workspace, mobile, and Codex availability behind TASK-386 rather than
+  assuming universal access.
+- Docs-only planning change; no connector or runtime behavior was implemented.
+
 # 2026-08-24 - Codex session feedback added to backlog
 
 - Captured thirteen submitted feedback points as fourteen focused follow-ups,

--- a/journal.md
+++ b/journal.md
@@ -37,6 +37,10 @@ Use it for important implementation milestones, blockers, validation runs, and r
   discovery-to-project-bound grant exchange and multi-project consent model,
   required immediate invalidation of issued access tokens, and added pre-auth
   abuse limits for public OAuth and metadata endpoints.
+- Final thread triage made Epic completion conditional on TASK-386-supported
+  surfaces, added signed discovery/project token-use claims with cross-project
+  replay rejection, and independently gated sensitive write tools until the
+  server-enforced confirmation flow is active.
 - Docs-only planning change; no connector or runtime behavior was implemented.
 
 # 2026-08-24 - Codex session feedback added to backlog

--- a/journal.md
+++ b/journal.md
@@ -26,6 +26,10 @@ Use it for important implementation milestones, blockers, validation runs, and r
 - The final safety pass defined relation add/remove preservation, sanitized and
   bounded evaluation evidence, server-enforced confirmation intents for
   sensitive writes, and least-privilege v1 scopes limited to exposed tools.
+- Dependency review added a membership-filtered project-discovery capability,
+  made scope mapping precede plugin packaging, placed evaluation retention
+  policy before artifact collection, and kept connector quotas in TASK-397
+  without reactivating the broader deferred TASK-064 baseline.
 - Docs-only planning change; no connector or runtime behavior was implemented.
 
 # 2026-08-24 - Codex session feedback added to backlog

--- a/journal.md
+++ b/journal.md
@@ -30,6 +30,9 @@ Use it for important implementation milestones, blockers, validation runs, and r
   made scope mapping precede plugin packaging, placed evaluation retention
   policy before artifact collection, and kept connector quotas in TASK-397
   without reactivating the broader deferred TASK-064 baseline.
+- Release-safety review made `/mcp` disabled by default and fail closed until
+  OAuth enforcement is active, and added `tasks/current.md` to the Epic's
+  explicit completion tracking.
 - Docs-only planning change; no connector or runtime behavior was implemented.
 
 # 2026-08-24 - Codex session feedback added to backlog

--- a/journal.md
+++ b/journal.md
@@ -5,14 +5,18 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 # 2026-08-24 - Codex session feedback added to backlog
 
-- Captured nine submitted follow-ups as TASK-371 through TASK-379 under a new
-  `Codex Session Feedback Refinement Program` section in `tasks/backlog.md`.
-- Added screenshot attachments for task descriptions/comments and preserved
-  the submitted `dd` item verbatim with an explicit clarification gate.
+- Captured nine submitted feedback points as ten focused follow-ups, TASK-371
+  through TASK-380, under a new `Codex Session Feedback Refinement Program`
+  section in `tasks/backlog.md`.
+- Added a backlog task for screenshot attachments in task descriptions/comments
+  and preserved the submitted `dd` item verbatim with an explicit clarification
+  gate.
 - Converted the agent-session feedback into focused API tasks covering a
   canonical labels array, single-task status transitions, true partial PATCH,
   complete create responses, server-side epic/label filters, bounded bulk
-  operations, non-delete credential presets, and Epic-driven task labels.
+  operations, non-delete credential presets, and Epic-driven task labels. The
+  filters and bulk operations are separate tasks because their API contracts
+  and acceptance concerns are independent.
 - Docs-only backlog grooming; no runtime behavior changed.
 
 # 2026-08-20 - TASK-370 preview isolation validated

--- a/journal.md
+++ b/journal.md
@@ -5,8 +5,8 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 # 2026-08-24 - Codex session feedback added to backlog
 
-- Captured nine submitted feedback points as ten focused follow-ups, TASK-371
-  through TASK-380, under a new `Codex Session Feedback Refinement Program`
+- Captured eleven submitted feedback points as twelve focused follow-ups,
+  TASK-371 through TASK-382, under a new `Codex Session Feedback Refinement Program`
   section in `tasks/backlog.md`.
 - Added a backlog task for screenshot attachments in task descriptions/comments
   and preserved the submitted `dd` item verbatim with an explicit clarification
@@ -17,6 +17,9 @@ Use it for important implementation milestones, blockers, validation runs, and r
   operations, non-delete credential presets, and Epic-driven task labels. The
   filters and bulk operations are separate tasks because their API contracts
   and acceptance concerns are independent.
+- Added two Kanban refinement tasks: a responsive bounded-height board with
+  independently scrollable lanes, and a search/filter surface spanning task
+  titles, descriptions, comments, labels, and clickable label chips.
 - Docs-only backlog grooming; no runtime behavior changed.
 
 # 2026-08-20 - TASK-370 preview isolation validated

--- a/journal.md
+++ b/journal.md
@@ -19,6 +19,10 @@ Use it for important implementation milestones, blockers, validation runs, and r
 - Copilot review made project discovery and paginated comment reads explicit,
   added the Epic Definition of Done, and moved the exercised operations runbook
   ahead of production rollout so revocation and rollback are real gates.
+- A follow-up review made TASK-386's availability evidence dated and
+  reproducible with explicit revalidation triggers, and added runtime
+  assumptions plus a branch/preview/runbook-backed validation contract to the
+  Epic brief.
 - Docs-only planning change; no connector or runtime behavior was implemented.
 
 # 2026-08-24 - Codex session feedback added to backlog

--- a/journal.md
+++ b/journal.md
@@ -5,8 +5,8 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 # 2026-08-24 - Codex session feedback added to backlog
 
-- Captured twelve submitted feedback points as thirteen focused follow-ups,
-  TASK-371 through TASK-383, under a new `Codex Session Feedback Refinement Program`
+- Captured thirteen submitted feedback points as fourteen focused follow-ups,
+  TASK-371 through TASK-384, under a new `Codex Session Feedback Refinement Program`
   section in `tasks/backlog.md`.
 - Added a backlog task for screenshot attachments in task descriptions/comments
   and preserved the submitted `dd` item verbatim with an explicit clarification
@@ -23,6 +23,9 @@ Use it for important implementation milestones, blockers, validation runs, and r
 - Added a focused bug task to diagnose and fix stale Epic task counts after
   task creation, linking, unlinking, or reassignment without requiring a no-op
   Epic edit/save; sequenced the broader cross-client realtime work after it.
+- Added an independently executable Kanban Epic filter covering one or more
+  Epics, unassigned tasks, clear state, result counts, filtered drag-and-drop,
+  and future composition with search and label filters.
 - Copilot review aligned the partial PATCH and create-response entries with
   behavior that already exists at runtime, replaced an undefined Kanban
   dependency, and kept Kanban search independently executable from lane

--- a/journal.md
+++ b/journal.md
@@ -23,6 +23,9 @@ Use it for important implementation milestones, blockers, validation runs, and r
   reproducible with explicit revalidation triggers, and added runtime
   assumptions plus a branch/preview/runbook-backed validation contract to the
   Epic brief.
+- The final safety pass defined relation add/remove preservation, sanitized and
+  bounded evaluation evidence, server-enforced confirmation intents for
+  sensitive writes, and least-privilege v1 scopes limited to exposed tools.
 - Docs-only planning change; no connector or runtime behavior was implemented.
 
 # 2026-08-24 - Codex session feedback added to backlog

--- a/journal.md
+++ b/journal.md
@@ -16,6 +16,9 @@ Use it for important implementation milestones, blockers, validation runs, and r
   mode testing, confirmations, and current plugin surfaces. Kept account,
   workspace, mobile, and Codex availability behind TASK-386 rather than
   assuming universal access.
+- Copilot review made project discovery and paginated comment reads explicit,
+  added the Epic Definition of Done, and moved the exercised operations runbook
+  ahead of production rollout so revocation and rollback are real gates.
 - Docs-only planning change; no connector or runtime behavior was implemented.
 
 # 2026-08-24 - Codex session feedback added to backlog

--- a/journal.md
+++ b/journal.md
@@ -20,6 +20,10 @@ Use it for important implementation milestones, blockers, validation runs, and r
 - Added two Kanban refinement tasks: a responsive bounded-height board with
   independently scrollable lanes, and a search/filter surface spanning task
   titles, descriptions, comments, labels, and clickable label chips.
+- Copilot review aligned the partial PATCH and create-response entries with
+  behavior that already exists at runtime, replaced an undefined Kanban
+  dependency, and kept Kanban search independently executable from lane
+  scrolling.
 - Docs-only backlog grooming; no runtime behavior changed.
 
 # 2026-08-20 - TASK-370 preview isolation validated

--- a/journal.md
+++ b/journal.md
@@ -5,8 +5,8 @@ Use it for important implementation milestones, blockers, validation runs, and r
 
 # 2026-08-24 - Codex session feedback added to backlog
 
-- Captured eleven submitted feedback points as twelve focused follow-ups,
-  TASK-371 through TASK-382, under a new `Codex Session Feedback Refinement Program`
+- Captured twelve submitted feedback points as thirteen focused follow-ups,
+  TASK-371 through TASK-383, under a new `Codex Session Feedback Refinement Program`
   section in `tasks/backlog.md`.
 - Added a backlog task for screenshot attachments in task descriptions/comments
   and preserved the submitted `dd` item verbatim with an explicit clarification
@@ -20,6 +20,9 @@ Use it for important implementation milestones, blockers, validation runs, and r
 - Added two Kanban refinement tasks: a responsive bounded-height board with
   independently scrollable lanes, and a search/filter surface spanning task
   titles, descriptions, comments, labels, and clickable label chips.
+- Added a focused bug task to diagnose and fix stale Epic task counts after
+  task creation, linking, unlinking, or reassignment without requiring a no-op
+  Epic edit/save; sequenced the broader cross-client realtime work after it.
 - Copilot review aligned the partial PATCH and create-response entries with
   behavior that already exists at runtime, replaced an undefined Kanban
   dependency, and kept Kanban search independently executable from lane

--- a/journal.md
+++ b/journal.md
@@ -33,6 +33,10 @@ Use it for important implementation milestones, blockers, validation runs, and r
 - Release-safety review made `/mcp` disabled by default and fail closed until
   OAuth enforcement is active, and added `tasks/current.md` to the Epic's
   explicit completion tracking.
+- Authorization review made TASK-402 the sole activation gate, defined the
+  discovery-to-project-bound grant exchange and multi-project consent model,
+  required immediate invalidation of issued access tokens, and added pre-auth
+  abuse limits for public OAuth and metadata endpoints.
 - Docs-only planning change; no connector or runtime behavior was implemented.
 
 # 2026-08-24 - Codex session feedback added to backlog

--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,18 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-08-24 - Codex session feedback added to backlog
+
+- Captured nine submitted follow-ups as TASK-371 through TASK-379 under a new
+  `Codex Session Feedback Refinement Program` section in `tasks/backlog.md`.
+- Added screenshot attachments for task descriptions/comments and preserved
+  the submitted `dd` item verbatim with an explicit clarification gate.
+- Converted the agent-session feedback into focused API tasks covering a
+  canonical labels array, single-task status transitions, true partial PATCH,
+  complete create responses, server-side epic/label filters, bounded bulk
+  operations, non-delete credential presets, and Epic-driven task labels.
+- Docs-only backlog grooming; no runtime behavior changed.
+
 # 2026-08-20 - TASK-370 preview isolation validated
 
 - Removed stale Preview `NEXTAUTH_URL` and OAuth redirect overrides from

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -245,12 +245,12 @@ Last reviewed: 2026-08-24
 - ID: TASK-393
   Title: NexusDash MCP write tools
   Status: Pending
-  Rationale: Implement and test task creation, true partial updates, status moves, comments, labels, Epic assignment, and authorized task relations through the shared services. Each mutation must return the complete final resource plus a concise change summary, and v1 must expose no permanent-delete operation.
+  Rationale: Implement and test task creation, true partial updates, status moves, comments, labels, Epic assignment, and authorized task relations through the shared services. Relation mutations must expose explicit add/remove sets that preserve unmentioned links; any separately named full-replacement operation must preview removed links and require confirmation. Each mutation must return the complete final resource plus a concise change summary, and v1 must expose no permanent-delete operation.
   Dependencies: TASK-099, TASK-349, TASK-373, TASK-374, TASK-375, TASK-376, TASK-388, TASK-389, TASK-390, TASK-391
 - ID: TASK-394
   Title: MCP tool annotations and sensitive-write confirmations
   Status: Pending
-  Rationale: Add accurate MCP annotations for read-only, write, idempotent, and potentially destructive behavior, then verify client confirmations identify the exact NexusDash resource and requested action in understandable language. Ensure annotations and confirmations remain consistent with the enforced tool policy rather than acting as the authorization boundary.
+  Rationale: Add accurate MCP annotations for read-only, write, idempotent, and potentially destructive behavior, then verify client confirmations identify the exact NexusDash resource and requested action in understandable language. For every write classified as confirmation-required, implement a server-enforced two-step intent flow (preparation tool or equivalent exchange) that issues a short-lived, single-use token bound to the user, tool, resource, proposed payload hash, and authorization state; reject direct, expired, replayed, or changed-payload execution. Client prompts remain UX signals rather than the enforcement boundary.
   Dependencies: TASK-389, TASK-392, TASK-393
 - ID: TASK-395
   Title: OAuth 2.1 authorization for the NexusDash MCP server
@@ -260,7 +260,7 @@ Last reviewed: 2026-08-24
 - ID: TASK-396
   Title: OAuth scope mapping to NexusDash project capabilities
   Status: Pending
-  Rationale: Define and enforce MCP OAuth scopes for project, task, context, and roadmap reads/writes, map them to the canonical NexusDash capability vocabulary, and check both scope and current project authorization on every tool call. Prevent assignments or responsibility metadata from granting access and block all cross-user or cross-project traversal.
+  Rationale: Define and enforce only the OAuth scopes required by the v1 catalog: project read, task read/write, context read, and roadmap read. Map them to the canonical NexusDash capability vocabulary and check both scope and current project authorization on every tool call. Do not request or issue context-write or roadmap-write scopes until explicit write tools, acceptance criteria, and authorization tests are approved; prevent responsibility metadata from granting access and block cross-user or cross-project traversal.
   Dependencies: TASK-331, TASK-389, TASK-395
 - ID: TASK-397
   Title: MCP security controls, quotas, audit, and observability
@@ -285,7 +285,7 @@ Last reviewed: 2026-08-24
 - ID: TASK-401
   Title: NexusDash connector agent evaluation suite
   Status: Pending
-  Rationale: Build repeatable evaluations for direct and indirect tool requests, search-first behavior, prior-identifier reuse, duplicate-risk creation, confirmation-required writes, insufficient permission, unsupported deletion, empty results, and ambiguous matches. Record chosen tools, arguments, results, confirmation behavior, and pass criteria so releases can be compared.
+  Rationale: Build repeatable evaluations for direct and indirect tool requests, search-first behavior, prior-identifier reuse, duplicate-risk creation, confirmation-required writes, insufficient permission, unsupported deletion, empty results, and ambiguous matches. Use synthetic or sanitized fixtures; record chosen tools, redacted arguments/results/identifiers, confirmation behavior, and pass criteria under an explicit bounded-retention policy so releases can be compared without retaining raw task, comment, context, roadmap, or user content.
   Dependencies: TASK-392, TASK-393, TASK-394, TASK-398, TASK-399
 - ID: TASK-402
   Title: Preview deployment and end-to-end MCP connector validation

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -235,7 +235,7 @@ Last reviewed: 2026-08-24
 - ID: TASK-391
   Title: Remote NexusDash MCP server over Streamable HTTP
   Status: Pending
-  Rationale: Expose a stable public HTTPS MCP endpoint, preferably `/mcp`, with protocol initialization, tool discovery, concise server instructions, schema validation, structured errors, serverless-compatible lifecycle behavior, safe diagnostics, and redacted logging. Keep transport concerns thin over the shared application services.
+  Rationale: Implement a stable HTTPS MCP endpoint, preferably `/mcp`, with protocol initialization, tool discovery, concise server instructions, schema validation, structured errors, serverless-compatible lifecycle behavior, safe diagnostics, and redacted logging. Keep the tool endpoint disabled by default and fail closed when OAuth enforcement or required metadata/config is absent or invalid; do not expose unauthenticated tool discovery or calls while TASK-395 is incomplete. Keep transport concerns thin over the shared application services.
   Dependencies: TASK-315, TASK-387, TASK-389, TASK-390
 - ID: TASK-392
   Title: NexusDash MCP read tools

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -2,7 +2,7 @@
 
 Use this file to capture tasks discovered during development. Each entry should include: ID, title, rationale, dependencies.
 
-Last reviewed: 2026-08-08
+Last reviewed: 2026-08-24
 
 ## Pending
 ### Active Runtime Remediation
@@ -135,6 +135,52 @@ Last reviewed: 2026-08-08
   Status: Pending
   Rationale: The Roadmap section's milestone/grouped-event model only "clicked" for the reviewer after creating two or three items. Add an opt-in help affordance (reusing the upcoming TASK-134 pattern) plus a clearer empty-state explanation of what a milestone is, how phases and events relate, and what good inputs look like, so the first interaction is self-explanatory.
   Dependencies: TASK-106, TASK-130, TASK-134
+### Codex Session Feedback Refinement Program
+- ID: TASK-371
+  Title: Screenshot attachments in task descriptions and comments
+  Status: Pending
+  Rationale: Let collaborators paste or upload screenshots directly in task descriptions and task comments so visual evidence, reproduction context, and design feedback stay with the work instead of requiring an external link. Reuse the existing attachment storage and authorization boundaries, provide inline previews, and keep upload behavior accessible on desktop and mobile.
+  Dependencies: TASK-019, TASK-029, TASK-099, TASK-133
+- ID: TASK-372
+  Title: dd
+  Status: Pending - scope clarification required
+  Rationale: Preserve the submitted backlog item exactly as provided so it is not lost. Clarify the intended outcome, affected product surface, acceptance criteria, and dependencies before moving it into the execution queue or beginning implementation.
+  Dependencies: None identified pending clarification
+- ID: TASK-373
+  Title: Agent task API labels contract - expose a canonical string array
+  Status: Pending
+  Rationale: Return task labels to agent clients as a first-class `labels: string[]` field instead of requiring callers to reconcile the legacy singular `label` value with the JSON-encoded `labelsJson` string. Keep the write and read contracts consistent, document any compatibility window, and cover empty, single-label, and multi-label responses.
+  Dependencies: TASK-031, TASK-115, TASK-127
+- ID: TASK-374
+  Title: Agent task API single-task status transition
+  Status: Pending
+  Rationale: Allow an agent to change one task's status without submitting the ordering of every Kanban column. Define a focused project-scoped mutation that preserves deterministic ordering in both the source and destination columns, returns the updated task, and leaves full-board reorder available for explicit bulk reordering.
+  Dependencies: TASK-059, TASK-115, TASK-127, TASK-276
+- ID: TASK-375
+  Title: Agent task API true partial PATCH semantics
+  Status: Pending
+  Rationale: Make `PATCH /api/projects/{projectId}/tasks/{taskId}` accept only the fields being changed instead of requiring `title` when an agent updates another property such as the description. Distinguish omitted fields from explicit null or clear operations, retain validation for supplied values, and document the partial-update contract.
+  Dependencies: TASK-055, TASK-115, TASK-127
+- ID: TASK-376
+  Title: Agent task creation API complete response representation
+  Status: Pending
+  Rationale: Return the complete created task representation from the task creation endpoint rather than only its identifier so agents can immediately use canonical labels, status, ordering, epic, assignment, timestamps, and other server-derived fields without a follow-up read.
+  Dependencies: TASK-055, TASK-115, TASK-127, TASK-373
+- ID: TASK-377
+  Title: Agent task API server filters and bulk operations
+  Status: Pending
+  Rationale: Add server-side `epicId` and `label` filters to task listing and define bounded bulk operations for common agent workflows. Specify pagination, filter composition, per-item authorization and validation, maximum batch size, atomicity or partial-failure behavior, and response details so callers do not need to download and rewrite an entire board.
+  Dependencies: TASK-059, TASK-107, TASK-115, TASK-127, TASK-331, TASK-373
+- ID: TASK-378
+  Title: Agent credential presets for read/write access without delete
+  Status: Pending
+  Rationale: Make it straightforward to issue a project-scoped agent token that can read and update tasks without deletion permission. The underlying write/delete scope split already exists, so align credential setup guidance, presets, and task-oriented onboarding examples to avoid granting `task:delete` for missions that do not require destructive access.
+  Dependencies: TASK-059, TASK-115, TASK-331
+- ID: TASK-379
+  Title: Epic default or suggested task label
+  Status: Pending
+  Rationale: Let an Epic define a label that is automatically applied or clearly suggested when tasks are created in or linked to that Epic. Define precedence when a task already has labels, behavior when tasks move between Epics, and whether the Epic policy is required or advisory so related work cannot silently remain inconsistently labeled.
+  Dependencies: TASK-031, TASK-107, TASK-343
 ### Collaboration Refinement Program (TASK-336 Audit)
 - ID: TASK-337
   Title: First-class project actor identity - human and agent assignment/provenance foundation

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -220,7 +220,7 @@ Last reviewed: 2026-08-24
 - ID: TASK-388
   Title: Initial NexusDash MCP tool catalog and contracts
   Status: Pending
-  Rationale: Define model-readable names, descriptions, input schemas, structured outputs, pagination, filters, project/Epic/label name resolution, ambiguity handling, and explicit errors for the initial project summary, Epic, task search/read/write/move/comment, context-card, and roadmap tools. Keep permanent deletion outside v1 and align task contracts with TASK-373 through TASK-377.
+  Rationale: Define model-readable names, descriptions, input schemas, structured outputs, pagination, filters, project/Epic/label name resolution, ambiguity handling, and explicit errors for project discovery/summary, Epic, task search/read/write/move/comment, paginated comment history, context-card, and roadmap tools. Keep permanent deletion outside v1 and align task contracts with TASK-373 through TASK-377.
   Dependencies: TASK-127, TASK-373, TASK-374, TASK-375, TASK-376, TASK-377, TASK-386, TASK-387
 - ID: TASK-389
   Title: MCP tool security, effects, and confirmation policy
@@ -240,7 +240,7 @@ Last reviewed: 2026-08-24
 - ID: TASK-392
   Title: NexusDash MCP read tools
   Status: Pending
-  Rationale: Implement and test authorized, concise, paginated tools for project summaries, Epic lists/details, task search/filter/list/detail with comments, context cards, and roadmap data. Cover empty and ambiguous results, stable identifiers, bounded payloads, and project isolation.
+  Rationale: Implement and test authorized, concise, paginated tools for project discovery and summaries, Epic lists/details, task search/filter/list/detail, bounded paginated task-comment history, context cards, and roadmap data. Cover empty and ambiguous results, stable identifiers, bounded payloads, and project isolation.
   Dependencies: TASK-377, TASK-388, TASK-389, TASK-390, TASK-391
 - ID: TASK-393
   Title: NexusDash MCP write tools
@@ -301,12 +301,12 @@ Last reviewed: 2026-08-24
   Title: NexusDash private connector production rollout
   Status: Pending
   Rationale: Complete security review, production MCP/OAuth URL verification, preview/production credential isolation, migration/env/secret checks, alert thresholds, rollback rehearsal, private plugin release, and a full post-deploy smoke test. Production rollout must remain reversible and must not broaden the confirmed v1 tool or permission scope.
-  Dependencies: TASK-042, TASK-315, TASK-370, TASK-396, TASK-397, TASK-400, TASK-401, TASK-402, TASK-403
+  Dependencies: TASK-042, TASK-315, TASK-370, TASK-396, TASK-397, TASK-400, TASK-401, TASK-402, TASK-403, TASK-405
 - ID: TASK-405
-  Title: NexusDash connector operations and maintenance runbook
+  Title: NexusDash connector production-readiness and operations runbook
   Status: Pending
-  Rationale: Document plugin installation and connection, environment ownership, secret rotation and revocation, tool/schema changes, MCP metadata updates, OAuth and discovery diagnosis, automated tests and evaluations, server/plugin rollback, and emergency disablement. Include safe evidence collection that never records access tokens, refresh tokens, client secrets, or unnecessary user content.
-  Dependencies: TASK-395, TASK-397, TASK-399, TASK-402, TASK-404
+  Rationale: Before production rollout, document and exercise plugin installation and connection, environment ownership, secret rotation and revocation, connector disconnect, tool/schema changes, MCP metadata updates, OAuth and discovery diagnosis, automated tests and evaluations, server/plugin rollback, and emergency disablement. Include safe evidence collection that never records access tokens, refresh tokens, client secrets, or unnecessary user content, then retain the same runbook for ongoing maintenance.
+  Dependencies: TASK-395, TASK-397, TASK-399, TASK-402
 ### Collaboration Refinement Program (TASK-336 Audit)
 - ID: TASK-337
   Title: First-class project actor identity - human and agent assignment/provenance foundation

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -189,7 +189,7 @@ Last reviewed: 2026-08-24
 - ID: TASK-381
   Title: Bounded Kanban height with independently scrollable lanes
   Status: Pending
-  Rationale: Prevent the Kanban board from growing indefinitely with the number of task cards. Give the board a responsive fixed or viewport-bounded vertical size and make each lane's task area scroll independently while keeping the lane header, task count, filters, and create affordances visible. Preserve drag-and-drop behavior, keyboard access, scroll position, and usable mobile layouts when tasks move within or between long lanes.
+  Rationale: Prevent the Kanban board from growing indefinitely with the number of task cards. Give the board a responsive fixed or viewport-bounded vertical size and make each lane's task area scroll independently while keeping the lane header, task count, and create affordances visible. Preserve drag-and-drop behavior, keyboard access, scroll position, and usable mobile layouts when tasks move within or between long lanes.
   Dependencies: TASK-096, TASK-100, TASK-133, TASK-322
 - ID: TASK-382
   Title: Kanban task search and clickable label filters

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -210,7 +210,7 @@ Last reviewed: 2026-08-24
 - ID: TASK-386
   Title: ChatGPT and Codex plugin availability gate for the target account
   Status: Pending - discovery gate
-  Rationale: Before implementation, verify Developer mode, custom remote MCP connection, private plugin installation, ChatGPT web/desktop/mobile access, and supported Codex surfaces for the owner's actual account and workspace. Record rollout, policy, authentication, and client differences so the program does not promise an unavailable surface; keep the result current enough to inform preview acceptance.
+  Rationale: Before implementation, verify Developer mode, custom remote MCP connection, private plugin installation, ChatGPT web/desktop/mobile access, and supported Codex surfaces for the owner's actual account and workspace. Produce a dated evidence report naming the tested account/workspace type, client and platform versions, official documentation sources, observed rollout/policy/authentication limits, and results per surface. Revalidate before TASK-402 and TASK-403 whenever the report is older than 30 days, official availability guidance changes, the workspace policy changes, or a target client/plugin version materially changes.
   Dependencies: TASK-115
 - ID: TASK-387
   Title: ChatGPT and Codex connector architecture ADR

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -260,13 +260,13 @@ Last reviewed: 2026-08-24
 - ID: TASK-396
   Title: OAuth scope mapping to NexusDash project capabilities
   Status: Pending
-  Rationale: Define and enforce only the OAuth scopes required by the v1 catalog: project read, task read/write, context read, and roadmap read. Map them to the canonical NexusDash capability vocabulary and check both scope and current project authorization on every tool call. Do not request or issue context-write or roadmap-write scopes until explicit write tools, acceptance criteria, and authorization tests are approved; prevent responsibility metadata from granting access and block cross-user or cross-project traversal.
+  Rationale: Define and enforce only the OAuth scopes required by the v1 catalog: a distinct project-discovery scope for membership-filtered `list_projects`, plus project-bound project read, task read/write, context read, and roadmap read scopes. The discovery scope may return only projects currently visible to the authenticated user and never authorizes a project-specific operation by itself; every subsequent tool must check its project-bound scope and current membership/capability. Do not request or issue context-write or roadmap-write scopes until explicit write tools, acceptance criteria, and authorization tests are approved; prevent responsibility metadata from granting access and block cross-user or cross-project traversal.
   Dependencies: TASK-331, TASK-389, TASK-395
 - ID: TASK-397
   Title: MCP security controls, quotas, audit, and observability
   Status: Pending
-  Rationale: Add per-user and per-tool rate limits, payload and pagination bounds, forged-identifier defenses, write audit events, OAuth refusal/error logging, token and sensitive-data redaction, immediate compromised-session revocation, and latency/error/usage metrics. Define actionable alerts without logging model prompts or resource content unnecessarily.
-  Dependencies: TASK-043, TASK-064, TASK-307, TASK-389, TASK-395, TASK-396
+  Rationale: Deliver the connector's public-endpoint rate-limiting baseline with per-user and per-tool quotas, payload and pagination bounds, forged-identifier defenses, write audit events, OAuth refusal/error logging, token and sensitive-data redaction, immediate compromised-session revocation, and latency/error/usage metrics. Before TASK-401 begins, approve a bounded retention and redaction policy for evaluation and preview artifacts. Define actionable alerts without logging model prompts or resource content unnecessarily; broader non-connector API rate limiting remains tracked separately by TASK-064.
+  Dependencies: TASK-043, TASK-307, TASK-389, TASK-395, TASK-396
 - ID: TASK-398
   Title: NexusDash plugin skill and model operating instructions
   Status: Pending
@@ -276,7 +276,7 @@ Last reviewed: 2026-08-24
   Title: Private NexusDash plugin packaging
   Status: Pending
   Rationale: Package the remote MCP server and NexusDash skill in a valid private plugin with stable identity, description, icon, permission metadata, connection instructions, privacy/support information, and separate preview/production versioning. Do not add a custom UI in v1 or embed static NexusDash API credentials.
-  Dependencies: TASK-386, TASK-391, TASK-394, TASK-395, TASK-398
+  Dependencies: TASK-386, TASK-391, TASK-394, TASK-395, TASK-396, TASK-398
 - ID: TASK-400
   Title: MCP, OAuth, plugin, and Agent REST automated test matrix
   Status: Pending
@@ -286,7 +286,7 @@ Last reviewed: 2026-08-24
   Title: NexusDash connector agent evaluation suite
   Status: Pending
   Rationale: Build repeatable evaluations for direct and indirect tool requests, search-first behavior, prior-identifier reuse, duplicate-risk creation, confirmation-required writes, insufficient permission, unsupported deletion, empty results, and ambiguous matches. Use synthetic or sanitized fixtures; record chosen tools, redacted arguments/results/identifiers, confirmation behavior, and pass criteria under an explicit bounded-retention policy so releases can be compared without retaining raw task, comment, context, roadmap, or user content.
-  Dependencies: TASK-392, TASK-393, TASK-394, TASK-398, TASK-399
+  Dependencies: TASK-389, TASK-392, TASK-393, TASK-394, TASK-397, TASK-398, TASK-399
 - ID: TASK-402
   Title: Preview deployment and end-to-end MCP connector validation
   Status: Pending
@@ -397,8 +397,8 @@ Last reviewed: 2026-08-24
   Dependencies: TASK-039, TASK-043
 - ID: TASK-064
   Title: Security hardening - API rate limiting baseline (deferred)
-  Status: Pending
-  Rationale: Add rate limiting and abuse controls when endpoints are exposed publicly; defer now until deployment/auth topology is finalized so policy matches real traffic boundaries.
+  Status: Pending (Deferred - connector-specific public endpoint covered by TASK-397)
+  Rationale: Add a broader rate-limiting and abuse-control baseline for public NexusDash API surfaces when their deployment/auth topology is finalized. TASK-397 owns the remote connector's MCP/OAuth-specific per-user and per-tool quotas so the connector program is not blocked by this intentionally deferred cross-API task.
   Dependencies: TASK-039, TASK-040, TASK-046
 
 ### Epic Tracking (Non-Executable)

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -206,6 +206,107 @@ Last reviewed: 2026-08-24
   Status: Pending
   Rationale: Add an Epic filter to the Kanban board so users can focus every lane on tasks linked to one or more selected Epics, explicitly include or isolate tasks with no Epic, and clear the selection in one action. Show active Epic filters and filtered result counts, preserve authorized project boundaries, keep drag-and-drop behavior predictable while a filter is active, and compose cleanly with task search and label filters when those controls are available without making this task depend on their delivery.
   Dependencies: TASK-107, TASK-108, TASK-133
+### ChatGPT and Codex Connector Program (TASK-385 Epic)
+- ID: TASK-386
+  Title: ChatGPT and Codex plugin availability gate for the target account
+  Status: Pending - discovery gate
+  Rationale: Before implementation, verify Developer mode, custom remote MCP connection, private plugin installation, ChatGPT web/desktop/mobile access, and supported Codex surfaces for the owner's actual account and workspace. Record rollout, policy, authentication, and client differences so the program does not promise an unavailable surface; keep the result current enough to inform preview acceptance.
+  Dependencies: TASK-115
+- ID: TASK-387
+  Title: ChatGPT and Codex connector architecture ADR
+  Status: Pending
+  Rationale: Record the ChatGPT/Codex to OAuth to MCP to NexusDash service/data path, coexistence with the Agent REST API, identity and authorization model, Vercel/serverless constraints, MCP session strategy, security boundaries, observability, risks, metrics, and rollback decisions before transport implementation begins.
+  Dependencies: TASK-059, TASK-127, TASK-315, TASK-386
+- ID: TASK-388
+  Title: Initial NexusDash MCP tool catalog and contracts
+  Status: Pending
+  Rationale: Define model-readable names, descriptions, input schemas, structured outputs, pagination, filters, project/Epic/label name resolution, ambiguity handling, and explicit errors for the initial project summary, Epic, task search/read/write/move/comment, context-card, and roadmap tools. Keep permanent deletion outside v1 and align task contracts with TASK-373 through TASK-377.
+  Dependencies: TASK-127, TASK-373, TASK-374, TASK-375, TASK-376, TASK-377, TASK-386, TASK-387
+- ID: TASK-389
+  Title: MCP tool security, effects, and confirmation policy
+  Status: Pending
+  Rationale: Classify every planned tool by required OAuth scope, read/write behavior, idempotence, exact side effects, sensitivity, confirmation requirement, project-membership validation, and bounded pagination or payload limits. Prohibit permanent-delete tools in v1 and make the policy testable by the server and plugin clients.
+  Dependencies: TASK-331, TASK-387, TASK-388
+- ID: TASK-390
+  Title: Shared application-service foundation for Agent REST and MCP transports
+  Status: Pending
+  Rationale: Audit and consolidate the internal project, Epic, task, status, label, relation, comment, context-card, roadmap, authorization, and audit services so REST routes and MCP tools use the same application behavior directly. Keep persistence inside `lib/services/**` and avoid implementing MCP as a client of the public REST API when an internal service boundary exists.
+  Dependencies: TASK-060, TASK-127, TASK-387, TASK-388, TASK-389
+- ID: TASK-391
+  Title: Remote NexusDash MCP server over Streamable HTTP
+  Status: Pending
+  Rationale: Expose a stable public HTTPS MCP endpoint, preferably `/mcp`, with protocol initialization, tool discovery, concise server instructions, schema validation, structured errors, serverless-compatible lifecycle behavior, safe diagnostics, and redacted logging. Keep transport concerns thin over the shared application services.
+  Dependencies: TASK-315, TASK-387, TASK-389, TASK-390
+- ID: TASK-392
+  Title: NexusDash MCP read tools
+  Status: Pending
+  Rationale: Implement and test authorized, concise, paginated tools for project summaries, Epic lists/details, task search/filter/list/detail with comments, context cards, and roadmap data. Cover empty and ambiguous results, stable identifiers, bounded payloads, and project isolation.
+  Dependencies: TASK-377, TASK-388, TASK-389, TASK-390, TASK-391
+- ID: TASK-393
+  Title: NexusDash MCP write tools
+  Status: Pending
+  Rationale: Implement and test task creation, true partial updates, status moves, comments, labels, Epic assignment, and authorized task relations through the shared services. Each mutation must return the complete final resource plus a concise change summary, and v1 must expose no permanent-delete operation.
+  Dependencies: TASK-099, TASK-349, TASK-373, TASK-374, TASK-375, TASK-376, TASK-388, TASK-389, TASK-390, TASK-391
+- ID: TASK-394
+  Title: MCP tool annotations and sensitive-write confirmations
+  Status: Pending
+  Rationale: Add accurate MCP annotations for read-only, write, idempotent, and potentially destructive behavior, then verify client confirmations identify the exact NexusDash resource and requested action in understandable language. Ensure annotations and confirmations remain consistent with the enforced tool policy rather than acting as the authorization boundary.
+  Dependencies: TASK-389, TASK-392, TASK-393
+- ID: TASK-395
+  Title: OAuth 2.1 authorization for the NexusDash MCP server
+  Status: Pending
+  Rationale: Implement Authorization Code with PKCE, short-lived access tokens, revocable rotating refresh tokens, protected-resource metadata, authorization-server or OpenID Connect metadata, correct `resource` propagation, and the selected CIMD, DCR, or predefined-client strategy. Reuse NexusDash identity where safe and support connector disconnect, consent revocation, and token-family invalidation.
+  Dependencies: TASK-048, TASK-059, TASK-083, TASK-386, TASK-387, TASK-391
+- ID: TASK-396
+  Title: OAuth scope mapping to NexusDash project capabilities
+  Status: Pending
+  Rationale: Define and enforce MCP OAuth scopes for project, task, context, and roadmap reads/writes, map them to the canonical NexusDash capability vocabulary, and check both scope and current project authorization on every tool call. Prevent assignments or responsibility metadata from granting access and block all cross-user or cross-project traversal.
+  Dependencies: TASK-331, TASK-389, TASK-395
+- ID: TASK-397
+  Title: MCP security controls, quotas, audit, and observability
+  Status: Pending
+  Rationale: Add per-user and per-tool rate limits, payload and pagination bounds, forged-identifier defenses, write audit events, OAuth refusal/error logging, token and sensitive-data redaction, immediate compromised-session revocation, and latency/error/usage metrics. Define actionable alerts without logging model prompts or resource content unnecessarily.
+  Dependencies: TASK-043, TASK-064, TASK-307, TASK-389, TASK-395, TASK-396
+- ID: TASK-398
+  Title: NexusDash plugin skill and model operating instructions
+  Status: Pending
+  Rationale: Author short, robust plugin instructions that make the model search before creating, resolve projects/Epics/labels safely, avoid duplicates, request confirmation when required, reject unsupported deletion, present completed changes clearly, and stay within the user's permissions and stated scope. Put the highest-impact safety and workflow constraints in the earliest server-loaded instructions.
+  Dependencies: TASK-388, TASK-389, TASK-392, TASK-393, TASK-394
+- ID: TASK-399
+  Title: Private NexusDash plugin packaging
+  Status: Pending
+  Rationale: Package the remote MCP server and NexusDash skill in a valid private plugin with stable identity, description, icon, permission metadata, connection instructions, privacy/support information, and separate preview/production versioning. Do not add a custom UI in v1 or embed static NexusDash API credentials.
+  Dependencies: TASK-386, TASK-391, TASK-394, TASK-395, TASK-398
+- ID: TASK-400
+  Title: MCP, OAuth, plugin, and Agent REST automated test matrix
+  Status: Pending
+  Rationale: Cover MCP initialization/discovery, schemas, read/write tools, pagination, empty results, OAuth authorization/expiry/refresh/revocation, insufficient scopes, unauthorized projects, annotations, confirmations, redaction, and Agent REST non-regression. Include realistic transport and authorization boundaries rather than only isolated tool handlers.
+  Dependencies: TASK-391, TASK-392, TASK-393, TASK-394, TASK-395, TASK-396, TASK-397, TASK-399
+- ID: TASK-401
+  Title: NexusDash connector agent evaluation suite
+  Status: Pending
+  Rationale: Build repeatable evaluations for direct and indirect tool requests, search-first behavior, prior-identifier reuse, duplicate-risk creation, confirmation-required writes, insufficient permission, unsupported deletion, empty results, and ambiguous matches. Record chosen tools, arguments, results, confirmation behavior, and pass criteria so releases can be compared.
+  Dependencies: TASK-392, TASK-393, TASK-394, TASK-398, TASK-399
+- ID: TASK-402
+  Title: Preview deployment and end-to-end MCP connector validation
+  Status: Pending
+  Rationale: Deploy MCP, OAuth, and the private plugin against the explicit preview branch; verify the endpoint with MCP Inspector and supported ChatGPT Developer mode; exercise reads, writes, confirmations, logs, metrics, schemas, tool selection, token lifecycle, and Agent REST regression; and retain preview URL, workflow, revision, and environment evidence.
+  Dependencies: TASK-315, TASK-370, TASK-399, TASK-400, TASK-401
+- ID: TASK-403
+  Title: ChatGPT and Codex web, desktop, and mobile connector experience validation
+  Status: Pending
+  Rationale: On every surface confirmed by TASK-386, connect the same NexusDash account from a new conversation, read projects, search tasks, create/update/move work, verify confirmations and token expiry, disconnect/reconnect, and prove the flow works with the local computer turned off. Document account rollout, workspace-policy, client, and Codex limitations rather than treating unsupported surfaces as failures.
+  Dependencies: TASK-386, TASK-402
+- ID: TASK-404
+  Title: NexusDash private connector production rollout
+  Status: Pending
+  Rationale: Complete security review, production MCP/OAuth URL verification, preview/production credential isolation, migration/env/secret checks, alert thresholds, rollback rehearsal, private plugin release, and a full post-deploy smoke test. Production rollout must remain reversible and must not broaden the confirmed v1 tool or permission scope.
+  Dependencies: TASK-042, TASK-315, TASK-370, TASK-396, TASK-397, TASK-400, TASK-401, TASK-402, TASK-403
+- ID: TASK-405
+  Title: NexusDash connector operations and maintenance runbook
+  Status: Pending
+  Rationale: Document plugin installation and connection, environment ownership, secret rotation and revocation, tool/schema changes, MCP metadata updates, OAuth and discovery diagnosis, automated tests and evaluations, server/plugin rollback, and emergency disablement. Include safe evidence collection that never records access tokens, refresh tokens, client secrets, or unnecessary user content.
+  Dependencies: TASK-395, TASK-397, TASK-399, TASK-402, TASK-404
 ### Collaboration Refinement Program (TASK-336 Audit)
 - ID: TASK-337
   Title: First-class project actor identity - human and agent assignment/provenance foundation
@@ -301,6 +402,12 @@ Last reviewed: 2026-08-24
   Dependencies: TASK-039, TASK-040, TASK-046
 
 ### Epic Tracking (Non-Executable)
+- ID: TASK-385
+  Title: Remote NexusDash connector for ChatGPT and Codex
+  Status: Pending (Epic - split into TASK-386 through TASK-405)
+  Rationale: Let an authenticated user discover and operate authorized NexusDash projects from supported ChatGPT and Codex surfaces through a remotely hosted Streamable HTTP MCP server, OAuth 2.1, and a private plugin, without a local computer or manually supplied `.env`. Preserve the Agent REST API, reuse NexusDash services and permissions, separate reads from confirmed writes, expose no permanent deletion in v1, and gate promised surfaces on current account/workspace availability.
+  Dependencies: TASK-386, TASK-387, TASK-388, TASK-389, TASK-390, TASK-391, TASK-392, TASK-393, TASK-394, TASK-395, TASK-396, TASK-397, TASK-398, TASK-399, TASK-400, TASK-401, TASK-402, TASK-403, TASK-404, TASK-405
+  Brief: `tasks/task-385-chatgpt-codex-connector-epic.md`
 - ID: TASK-110
   Title: Modular dashboard personalization - user-configurable project workspace composition and arrangement
   Status: Pending (Epic - likely split into dashboard-layout foundation, module registry/adapters, arrangement UX, and mobile-specific follow-ups)

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -167,16 +167,21 @@ Last reviewed: 2026-08-24
   Rationale: Return the complete created task representation from the task creation endpoint rather than only its identifier so agents can immediately use canonical labels, status, ordering, epic, assignment, timestamps, and other server-derived fields without a follow-up read.
   Dependencies: TASK-055, TASK-115, TASK-127, TASK-373
 - ID: TASK-377
-  Title: Agent task API server filters and bulk operations
+  Title: Agent task API server-side epic and label filters
   Status: Pending
-  Rationale: Add server-side `epicId` and `label` filters to task listing and define bounded bulk operations for common agent workflows. Specify pagination, filter composition, per-item authorization and validation, maximum batch size, atomicity or partial-failure behavior, and response details so callers do not need to download and rewrite an entire board.
+  Rationale: Add server-side `epicId` and `label` filters to task listing so agent clients can retrieve focused work without downloading and filtering an entire board. Define filter composition, empty and unknown-filter behavior, pagination interaction, and response metadata while preserving project authorization boundaries.
   Dependencies: TASK-059, TASK-107, TASK-115, TASK-127, TASK-331, TASK-373
 - ID: TASK-378
+  Title: Agent task API bounded bulk operations
+  Status: Pending
+  Rationale: Define bounded bulk task operations for common agent workflows without requiring repeated single-item calls or full-board rewrites. Specify supported mutations, maximum batch size, per-item authorization and validation, atomicity or partial-failure behavior, idempotency expectations, and detailed result reporting.
+  Dependencies: TASK-059, TASK-115, TASK-127, TASK-331, TASK-374, TASK-375
+- ID: TASK-379
   Title: Agent credential presets for read/write access without delete
   Status: Pending
   Rationale: Make it straightforward to issue a project-scoped agent token that can read and update tasks without deletion permission. The underlying write/delete scope split already exists, so align credential setup guidance, presets, and task-oriented onboarding examples to avoid granting `task:delete` for missions that do not require destructive access.
   Dependencies: TASK-059, TASK-115, TASK-331
-- ID: TASK-379
+- ID: TASK-380
   Title: Epic default or suggested task label
   Status: Pending
   Rationale: Let an Epic define a label that is automatically applied or clearly suggested when tasks are created in or linked to that Epic. Define precedence when a task already has labels, behavior when tasks move between Epics, and whether the Epic policy is required or advisory so related work cannot silently remain inconsistently labeled.

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -186,6 +186,16 @@ Last reviewed: 2026-08-24
   Status: Pending
   Rationale: Let an Epic define a label that is automatically applied or clearly suggested when tasks are created in or linked to that Epic. Define precedence when a task already has labels, behavior when tasks move between Epics, and whether the Epic policy is required or advisory so related work cannot silently remain inconsistently labeled.
   Dependencies: TASK-031, TASK-107, TASK-343
+- ID: TASK-381
+  Title: Bounded Kanban height with independently scrollable lanes
+  Status: Pending
+  Rationale: Prevent the Kanban board from growing indefinitely with the number of task cards. Give the board a responsive fixed or viewport-bounded vertical size and make each lane's task area scroll independently while keeping the lane header, task count, filters, and create affordances visible. Preserve drag-and-drop behavior, keyboard access, scroll position, and usable mobile layouts when tasks move within or between long lanes.
+  Dependencies: TASK-003, TASK-100, TASK-133, TASK-322
+- ID: TASK-382
+  Title: Kanban task search and clickable label filters
+  Status: Pending
+  Rationale: Add a search and filter surface above the Kanban board that finds authorized tasks by title, description, comments, labels, and other useful task text without exposing hidden or cross-project content. Let users click a label on a task card or in the filter controls to toggle that label filter, clearly show active search/filter state and result counts, support combining or clearing criteria, and keep matching behavior responsive for large boards.
+  Dependencies: TASK-031, TASK-099, TASK-108, TASK-133, TASK-381
 ### Collaboration Refinement Program (TASK-336 Audit)
 - ID: TASK-337
   Title: First-class project actor identity - human and agent assignment/provenance foundation

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -235,7 +235,7 @@ Last reviewed: 2026-08-24
 - ID: TASK-391
   Title: Remote NexusDash MCP server over Streamable HTTP
   Status: Pending
-  Rationale: Implement a stable HTTPS MCP endpoint, preferably `/mcp`, with protocol initialization, tool discovery, concise server instructions, schema validation, structured errors, serverless-compatible lifecycle behavior, safe diagnostics, and redacted logging. Keep the tool endpoint disabled by default and fail closed when OAuth enforcement or required metadata/config is absent or invalid; do not expose unauthenticated tool discovery or calls while TASK-395 is incomplete. Keep transport concerns thin over the shared application services.
+  Rationale: Implement a stable HTTPS MCP endpoint, preferably `/mcp`, with protocol initialization, tool discovery, concise server instructions, schema validation, structured errors, serverless-compatible lifecycle behavior, safe diagnostics, and redacted logging. Keep the endpoint and each tool disabled by default and fail closed when OAuth enforcement, required metadata/config, scope/project binding, or a tool's security prerequisite is absent or invalid. In particular, expose no unauthenticated tool discovery/calls while TASK-395 is incomplete and no confirmation-required write until TASK-394's server-enforced intent path is active. Keep transport concerns thin over shared services.
   Dependencies: TASK-315, TASK-387, TASK-389, TASK-390
 - ID: TASK-392
   Title: NexusDash MCP read tools
@@ -245,7 +245,7 @@ Last reviewed: 2026-08-24
 - ID: TASK-393
   Title: NexusDash MCP write tools
   Status: Pending
-  Rationale: Implement and test task creation, true partial updates, status moves, comments, labels, Epic assignment, and authorized task relations through the shared services. Relation mutations must expose explicit add/remove sets that preserve unmentioned links; any separately named full-replacement operation must preview removed links and require confirmation. Each mutation must return the complete final resource plus a concise change summary, and v1 must expose no permanent-delete operation.
+  Rationale: Implement and test task creation, true partial updates, status moves, comments, labels, Epic assignment, and authorized task relations through the shared services. Keep every confirmation-required handler independently disabled and fail closed until TASK-394's server-enforced intent validation is active, even if OAuth or other MCP tools are already enabled. Relation mutations must expose explicit add/remove sets that preserve unmentioned links; any separately named full-replacement operation must preview removed links and require confirmation. Each mutation returns the complete final resource plus a concise change summary, and v1 exposes no permanent-delete operation.
   Dependencies: TASK-099, TASK-349, TASK-373, TASK-374, TASK-375, TASK-376, TASK-388, TASK-389, TASK-390, TASK-391
 - ID: TASK-394
   Title: MCP tool annotations and sensitive-write confirmations
@@ -255,12 +255,12 @@ Last reviewed: 2026-08-24
 - ID: TASK-395
   Title: OAuth 2.1 authorization for the NexusDash MCP server
   Status: Pending
-  Rationale: Implement Authorization Code with PKCE, short-lived access tokens, revocable rotating refresh tokens, protected-resource metadata, authorization-server or OpenID Connect metadata, correct `resource` propagation, and the selected CIMD, DCR, or predefined-client strategy. Support a discovery-only bootstrap grant followed by a client-compatible incremental authorization or token exchange for a selected project. Reuse NexusDash identity where safe and support connector disconnect and consent revocation; enforce immediate failure of already-issued access tokens through introspection, a session/token version, or a bounded denylist in addition to refresh-token-family invalidation.
+  Rationale: Implement Authorization Code with PKCE, short-lived access tokens, revocable rotating refresh tokens, protected-resource metadata, authorization-server or OpenID Connect metadata, correct `resource` propagation, and the selected CIMD, DCR, or predefined-client strategy. Support a discovery-only bootstrap grant followed by a client-compatible incremental authorization or token exchange for one selected project. Sign explicit token-use and immutable `project_id` (or ADR-approved equivalent), subject, audience/resource, scope, token/session-version, and expiry claims so adapters can reject cross-project replay before service execution. Reuse NexusDash identity where safe and support disconnect and consent revocation; immediately reject already-issued revoked access tokens through introspection, session/token version, or a bounded denylist in addition to refresh-family invalidation.
   Dependencies: TASK-048, TASK-059, TASK-083, TASK-386, TASK-387, TASK-391
 - ID: TASK-396
   Title: OAuth scope mapping to NexusDash project capabilities
   Status: Pending
-  Rationale: Define and enforce only the OAuth scopes required by the v1 catalog: a discovery-only bootstrap scope for membership-filtered `list_projects`, plus short-lived grants bound to one selected project with project read, task read/write, context read, and roadmap read scopes. Define the post-discovery incremental authorization/token exchange, project identifier binding, consent representation, and separate-grant behavior for multi-project use. The discovery scope never authorizes a project-specific operation; every subsequent tool verifies the token's project binding, approved scope, current membership, and capability. Do not request or issue context-write or roadmap-write scopes until explicit write tools and tests are approved; block cross-user or cross-project traversal.
+  Rationale: Define and enforce only the OAuth scopes required by the v1 catalog: a discovery-only bootstrap scope for membership-filtered `list_projects`, plus short-lived grants bound to one selected project with project read, task read/write, context read, and roadmap read scopes. Define the post-discovery incremental authorization/token exchange, consent representation, separate-grant behavior for multi-project use, and verified `project_id` claim comparison against every project argument/resource before service calls. Discovery-only tokens carry no project claim and never authorize project data; project tokens verify claim, scope, current membership, and capability. Do not issue context-write or roadmap-write scopes until tools and tests are approved; explicitly test that a token for project A cannot be replayed against project B.
   Dependencies: TASK-331, TASK-389, TASK-395
 - ID: TASK-397
   Title: MCP security controls, quotas, audit, and observability
@@ -280,7 +280,7 @@ Last reviewed: 2026-08-24
 - ID: TASK-400
   Title: MCP, OAuth, plugin, and Agent REST automated test matrix
   Status: Pending
-  Rationale: Cover MCP initialization/discovery, schemas, read/write tools, pagination, empty results, discovery-only and project-bound grant exchange, multi-project isolation, OAuth authorization/expiry/refresh/revocation, immediate rejection of an already-issued revoked access token, pre-auth endpoint abuse limits, insufficient scopes, unauthorized projects, annotations, confirmations, redaction, and Agent REST non-regression. Include realistic transport and authorization boundaries rather than only isolated tool handlers.
+  Rationale: Cover MCP initialization/discovery, schemas, read/write tools, pagination, empty results, discovery-only and project-bound grant exchange, signed project-claim validation, cross-project token replay rejection, multi-project isolation, OAuth authorization/expiry/refresh/revocation, immediate rejection of an already-issued revoked access token, pre-auth endpoint abuse limits, insufficient scopes, unauthorized projects, annotations, confirmations, and redaction. Prove confirmation-required writes remain disabled between OAuth delivery and TASK-394 intent enforcement, and retain Agent REST non-regression across realistic transport boundaries.
   Dependencies: TASK-391, TASK-392, TASK-393, TASK-394, TASK-395, TASK-396, TASK-397, TASK-399
 - ID: TASK-401
   Title: NexusDash connector agent evaluation suite

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -157,14 +157,14 @@ Last reviewed: 2026-08-24
   Rationale: Allow an agent to change one task's status without submitting the ordering of every Kanban column. Define a focused project-scoped mutation that preserves deterministic ordering in both the source and destination columns, returns the updated task, and leaves full-board reorder available for explicit bulk reordering.
   Dependencies: TASK-059, TASK-115, TASK-127, TASK-276
 - ID: TASK-375
-  Title: Agent task API true partial PATCH semantics
+  Title: Agent task OpenAPI contract for true partial PATCH semantics
   Status: Pending
-  Rationale: Make `PATCH /api/projects/{projectId}/tasks/{taskId}` accept only the fields being changed instead of requiring `title` when an agent updates another property such as the description. Distinguish omitted fields from explicit null or clear operations, retain validation for supplied values, and document the partial-update contract.
+  Rationale: Align the published agent OpenAPI contract with the runtime's existing partial-update behavior so `PATCH /api/projects/{projectId}/tasks/{taskId}` does not document `title` as required when only another field changes. Document omitted fields versus explicit null or clear operations, retain validation for supplied values, and add contract coverage that prevents the schema from drifting from the tested route behavior.
   Dependencies: TASK-055, TASK-115, TASK-127
 - ID: TASK-376
-  Title: Agent task creation API complete response representation
+  Title: Agent task creation OpenAPI complete response contract
   Status: Pending
-  Rationale: Return the complete created task representation from the task creation endpoint rather than only its identifier so agents can immediately use canonical labels, status, ordering, epic, assignment, timestamps, and other server-derived fields without a follow-up read.
+  Rationale: Align the published `TaskCreateResponse` schema and agent documentation with the runtime response, which already includes both `taskId` and the complete created `task`. Describe the canonical labels, status, ordering, epic, assignment, timestamps, and other server-derived fields, and add contract coverage so generated clients can use the full task without a follow-up read.
   Dependencies: TASK-055, TASK-115, TASK-127, TASK-373
 - ID: TASK-377
   Title: Agent task API server-side epic and label filters
@@ -190,12 +190,12 @@ Last reviewed: 2026-08-24
   Title: Bounded Kanban height with independently scrollable lanes
   Status: Pending
   Rationale: Prevent the Kanban board from growing indefinitely with the number of task cards. Give the board a responsive fixed or viewport-bounded vertical size and make each lane's task area scroll independently while keeping the lane header, task count, filters, and create affordances visible. Preserve drag-and-drop behavior, keyboard access, scroll position, and usable mobile layouts when tasks move within or between long lanes.
-  Dependencies: TASK-003, TASK-100, TASK-133, TASK-322
+  Dependencies: TASK-096, TASK-100, TASK-133, TASK-322
 - ID: TASK-382
   Title: Kanban task search and clickable label filters
   Status: Pending
   Rationale: Add a search and filter surface above the Kanban board that finds authorized tasks by title, description, comments, labels, and other useful task text without exposing hidden or cross-project content. Let users click a label on a task card or in the filter controls to toggle that label filter, clearly show active search/filter state and result counts, support combining or clearing criteria, and keep matching behavior responsive for large boards.
-  Dependencies: TASK-031, TASK-099, TASK-108, TASK-133, TASK-381
+  Dependencies: TASK-031, TASK-099, TASK-108, TASK-133
 ### Collaboration Refinement Program (TASK-336 Audit)
 - ID: TASK-337
   Title: First-class project actor identity - human and agent assignment/provenance foundation

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -201,6 +201,11 @@ Last reviewed: 2026-08-24
   Status: Pending - bug remediation
   Rationale: Reproduce and identify why an Epic's linked-task count and derived progress remain stale after creating a task in that Epic, then refresh only after the Epic edit form is opened and saved. Trace the task create/link/unlink/reassignment mutation path through server-derived Epic data and client state reconciliation, fix the root cause without relying on a no-op Epic save or full page reload, and add regression coverage proving the Epic area updates immediately after each relevant task mutation. This focused same-session correctness fix should land before TASK-367 expands cross-client realtime Epic refresh behavior.
   Dependencies: TASK-107, TASK-118, TASK-276, TASK-311
+- ID: TASK-384
+  Title: Kanban task filtering by Epic
+  Status: Pending
+  Rationale: Add an Epic filter to the Kanban board so users can focus every lane on tasks linked to one or more selected Epics, explicitly include or isolate tasks with no Epic, and clear the selection in one action. Show active Epic filters and filtered result counts, preserve authorized project boundaries, keep drag-and-drop behavior predictable while a filter is active, and compose cleanly with task search and label filters when those controls are available without making this task depend on their delivery.
+  Dependencies: TASK-107, TASK-108, TASK-133
 ### Collaboration Refinement Program (TASK-336 Audit)
 - ID: TASK-337
   Title: First-class project actor identity - human and agent assignment/provenance foundation

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -210,7 +210,7 @@ Last reviewed: 2026-08-24
 - ID: TASK-386
   Title: ChatGPT and Codex plugin availability gate for the target account
   Status: Pending - discovery gate
-  Rationale: Before implementation, verify Developer mode, custom remote MCP connection, private plugin installation, ChatGPT web/desktop/mobile access, and supported Codex surfaces for the owner's actual account and workspace. Produce a dated evidence report naming the tested account/workspace type, client and platform versions, official documentation sources, observed rollout/policy/authentication limits, and results per surface. Revalidate before TASK-402 and TASK-403 whenever the report is older than 30 days, official availability guidance changes, the workspace policy changes, or a target client/plugin version materially changes.
+  Rationale: Before implementation, verify Developer mode, custom remote MCP connection, private plugin installation, ChatGPT web/desktop/mobile access, supported Codex surfaces, and support for the selected incremental project-authorization flow on the owner's actual account and workspace. Produce a dated evidence report naming the tested account/workspace type, client and platform versions, official documentation sources, observed rollout/policy/authentication limits, and results per surface. Revalidate before TASK-402 and TASK-403 whenever the report is older than 30 days, official availability guidance changes, the workspace policy changes, or a target client/plugin version materially changes.
   Dependencies: TASK-115
 - ID: TASK-387
   Title: ChatGPT and Codex connector architecture ADR
@@ -255,17 +255,17 @@ Last reviewed: 2026-08-24
 - ID: TASK-395
   Title: OAuth 2.1 authorization for the NexusDash MCP server
   Status: Pending
-  Rationale: Implement Authorization Code with PKCE, short-lived access tokens, revocable rotating refresh tokens, protected-resource metadata, authorization-server or OpenID Connect metadata, correct `resource` propagation, and the selected CIMD, DCR, or predefined-client strategy. Reuse NexusDash identity where safe and support connector disconnect, consent revocation, and token-family invalidation.
+  Rationale: Implement Authorization Code with PKCE, short-lived access tokens, revocable rotating refresh tokens, protected-resource metadata, authorization-server or OpenID Connect metadata, correct `resource` propagation, and the selected CIMD, DCR, or predefined-client strategy. Support a discovery-only bootstrap grant followed by a client-compatible incremental authorization or token exchange for a selected project. Reuse NexusDash identity where safe and support connector disconnect and consent revocation; enforce immediate failure of already-issued access tokens through introspection, a session/token version, or a bounded denylist in addition to refresh-token-family invalidation.
   Dependencies: TASK-048, TASK-059, TASK-083, TASK-386, TASK-387, TASK-391
 - ID: TASK-396
   Title: OAuth scope mapping to NexusDash project capabilities
   Status: Pending
-  Rationale: Define and enforce only the OAuth scopes required by the v1 catalog: a distinct project-discovery scope for membership-filtered `list_projects`, plus project-bound project read, task read/write, context read, and roadmap read scopes. The discovery scope may return only projects currently visible to the authenticated user and never authorizes a project-specific operation by itself; every subsequent tool must check its project-bound scope and current membership/capability. Do not request or issue context-write or roadmap-write scopes until explicit write tools, acceptance criteria, and authorization tests are approved; prevent responsibility metadata from granting access and block cross-user or cross-project traversal.
+  Rationale: Define and enforce only the OAuth scopes required by the v1 catalog: a discovery-only bootstrap scope for membership-filtered `list_projects`, plus short-lived grants bound to one selected project with project read, task read/write, context read, and roadmap read scopes. Define the post-discovery incremental authorization/token exchange, project identifier binding, consent representation, and separate-grant behavior for multi-project use. The discovery scope never authorizes a project-specific operation; every subsequent tool verifies the token's project binding, approved scope, current membership, and capability. Do not request or issue context-write or roadmap-write scopes until explicit write tools and tests are approved; block cross-user or cross-project traversal.
   Dependencies: TASK-331, TASK-389, TASK-395
 - ID: TASK-397
   Title: MCP security controls, quotas, audit, and observability
   Status: Pending
-  Rationale: Deliver the connector's public-endpoint rate-limiting baseline with per-user and per-tool quotas, payload and pagination bounds, forged-identifier defenses, write audit events, OAuth refusal/error logging, token and sensitive-data redaction, immediate compromised-session revocation, and latency/error/usage metrics. Before TASK-401 begins, approve a bounded retention and redaction policy for evaluation and preview artifacts. Define actionable alerts without logging model prompts or resource content unnecessarily; broader non-connector API rate limiting remains tracked separately by TASK-064.
+  Rationale: Deliver the connector's public-endpoint rate-limiting baseline with pre-authentication IP/client/endpoint limits for metadata, authorization, registration, and token paths plus post-authentication per-user and per-tool quotas. Add payload and pagination bounds, forged-identifier defenses, write audit events, OAuth refusal/error logging, token and sensitive-data redaction, immediate compromised-session/access-token revocation, and latency/error/usage metrics. Before TASK-401 begins, approve a bounded retention and redaction policy for evaluation and preview artifacts. Validate abuse paths that never authenticate or create many sessions/clients; broader non-connector API rate limiting remains tracked by TASK-064.
   Dependencies: TASK-043, TASK-307, TASK-389, TASK-395, TASK-396
 - ID: TASK-398
   Title: NexusDash plugin skill and model operating instructions
@@ -280,7 +280,7 @@ Last reviewed: 2026-08-24
 - ID: TASK-400
   Title: MCP, OAuth, plugin, and Agent REST automated test matrix
   Status: Pending
-  Rationale: Cover MCP initialization/discovery, schemas, read/write tools, pagination, empty results, OAuth authorization/expiry/refresh/revocation, insufficient scopes, unauthorized projects, annotations, confirmations, redaction, and Agent REST non-regression. Include realistic transport and authorization boundaries rather than only isolated tool handlers.
+  Rationale: Cover MCP initialization/discovery, schemas, read/write tools, pagination, empty results, discovery-only and project-bound grant exchange, multi-project isolation, OAuth authorization/expiry/refresh/revocation, immediate rejection of an already-issued revoked access token, pre-auth endpoint abuse limits, insufficient scopes, unauthorized projects, annotations, confirmations, redaction, and Agent REST non-regression. Include realistic transport and authorization boundaries rather than only isolated tool handlers.
   Dependencies: TASK-391, TASK-392, TASK-393, TASK-394, TASK-395, TASK-396, TASK-397, TASK-399
 - ID: TASK-401
   Title: NexusDash connector agent evaluation suite
@@ -290,7 +290,7 @@ Last reviewed: 2026-08-24
 - ID: TASK-402
   Title: Preview deployment and end-to-end MCP connector validation
   Status: Pending
-  Rationale: Deploy MCP, OAuth, and the private plugin against the explicit preview branch; verify the endpoint with MCP Inspector and supported ChatGPT Developer mode; exercise reads, writes, confirmations, logs, metrics, schemas, tool selection, token lifecycle, and Agent REST regression; and retain preview URL, workflow, revision, and environment evidence.
+  Rationale: Deploy MCP, OAuth, and the private plugin against the explicit preview branch. Keep `/mcp` disabled until a fail-closed activation preflight proves the expected branch/revision/environment, OAuth metadata and enforcement, project-bound grant exchange, scope checks, immediate revocation, security controls, schemas, and required secrets/config are valid; TASK-402 is the first task permitted to activate the endpoint. Then verify it with MCP Inspector and supported ChatGPT Developer mode; exercise reads, writes, confirmations, logs, metrics, tool selection, token lifecycle, and Agent REST regression; and retain preview URL, workflow, revision, activation, and environment evidence.
   Dependencies: TASK-315, TASK-370, TASK-399, TASK-400, TASK-401
 - ID: TASK-403
   Title: ChatGPT and Codex web, desktop, and mobile connector experience validation

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -124,7 +124,7 @@ Last reviewed: 2026-08-24
   Title: Epic live refresh on task and epic mutations
   Status: Pending
   Rationale: Creating or linking a task does not update the Epics panel in real time, so users have to manually refresh to see their epic's progress and linked-tasks count update. Extend the typed realtime/refresh path so epic rollups, progress, and linked-task counts reconcile after relevant task mutations, and add focused dashboard activity events for epic mutations themselves; preserve the safe remote-update semantics already shipped for tasks, comments, and context cards.
-  Dependencies: TASK-107, TASK-118, TASK-276, TASK-311
+  Dependencies: TASK-107, TASK-118, TASK-276, TASK-311, TASK-383
 - ID: TASK-368
   Title: Task comment "Add comment" vs "Save changes" button distinction
   Status: Pending
@@ -196,6 +196,11 @@ Last reviewed: 2026-08-24
   Status: Pending
   Rationale: Add a search and filter surface above the Kanban board that finds authorized tasks by title, description, comments, labels, and other useful task text without exposing hidden or cross-project content. Let users click a label on a task card or in the filter controls to toggle that label filter, clearly show active search/filter state and result counts, support combining or clearing criteria, and keep matching behavior responsive for large boards.
   Dependencies: TASK-031, TASK-099, TASK-108, TASK-133
+- ID: TASK-383
+  Title: Fix stale Epic task count after task creation or linking
+  Status: Pending - bug remediation
+  Rationale: Reproduce and identify why an Epic's linked-task count and derived progress remain stale after creating a task in that Epic, then refresh only after the Epic edit form is opened and saved. Trace the task create/link/unlink/reassignment mutation path through server-derived Epic data and client state reconciliation, fix the root cause without relying on a no-op Epic save or full page reload, and add regression coverage proving the Epic area updates immediately after each relevant task mutation. This focused same-session correctness fix should land before TASK-367 expands cross-client realtime Epic refresh behavior.
+  Dependencies: TASK-107, TASK-118, TASK-276, TASK-311
 ### Collaboration Refinement Program (TASK-336 Audit)
 - ID: TASK-337
   Title: First-class project actor identity - human and agent assignment/provenance foundation

--- a/tasks/task-385-chatgpt-codex-connector-epic.md
+++ b/tasks/task-385-chatgpt-codex-connector-epic.md
@@ -52,11 +52,13 @@ The existing Agent REST API remains supported and regression-tested.
 
 ## Initial Tool Catalog
 
+- `list_projects`
 - `get_project_summary`
 - `list_epics`
 - `search_tasks`
 - `list_tasks`
 - `get_task`
+- `list_task_comments`
 - `create_task`
 - `update_task`
 - `move_task`
@@ -99,13 +101,33 @@ The existing Agent REST API remains supported and regression-tested.
 12. Revocation, disconnect, rollback, diagnostics, and emergency disablement
     procedures are documented and exercised.
 
+## Definition Of Done
+
+- TASK-386 records the supported account, workspace, ChatGPT, and Codex
+  surfaces and any rollout limitations that constrain acceptance.
+- The architecture ADR, tool catalog, security policy, OAuth/scopes model, and
+  shared-service boundaries are approved and represented by executable tasks.
+- The remote MCP server, read/write tools, OAuth flow, authorization mapping,
+  annotations, confirmations, security controls, audit, and observability meet
+  the Epic acceptance criteria.
+- The private plugin and NexusDash skill are versioned for preview and
+  production without embedded static user credentials or permanent-delete
+  tools.
+- Automated tests, agent evaluations, preview validation, and supported-client
+  journeys pass without regressing the Agent REST API.
+- The production-readiness runbook covers and exercises revocation, disconnect,
+  rollback, diagnostics, credential isolation, and emergency disablement before
+  production rollout; the final production smoke test passes.
+- TASK-386 through TASK-405 are complete and the backlog, journal, ADR index,
+  product documentation, and relevant runbooks reflect the delivered system.
+
 ## Delivery Tasks
 
 | Source item | NexusDash task | Outcome |
 | --- | --- | --- |
 | ND-MCP-00 | TASK-386 | Confirm account, workspace, and client availability. |
 | ND-MCP-01 | TASK-387 | Record the technical architecture and deployment model. |
-| ND-MCP-02 | TASK-388 | Define the initial MCP tool contracts. |
+| ND-MCP-02 | TASK-388 | Define the initial MCP tool contracts, including project and comment discovery. |
 | ND-MCP-03 | TASK-389 | Define tool security and confirmation policy. |
 | ND-MCP-04 | TASK-390 | Consolidate shared REST/MCP application services. |
 | ND-MCP-05 | TASK-391 | Build the Streamable HTTP MCP server. |
@@ -122,7 +144,7 @@ The existing Agent REST API remains supported and regression-tested.
 | ND-MCP-16 | TASK-402 | Deploy and validate the complete preview path. |
 | ND-MCP-17 | TASK-403 | Validate supported web, desktop, and mobile journeys. |
 | ND-MCP-18 | TASK-404 | Complete production security and deployment gates. |
-| ND-MCP-19 | TASK-405 | Document operation and maintenance. |
+| ND-MCP-19 | TASK-405 | Prepare and exercise the production-readiness and operations runbook. |
 
 ## Official Product References
 
@@ -130,4 +152,3 @@ The existing Agent REST API remains supported and regression-tested.
 - [Plugin authentication](https://developers.openai.com/plugins/build/auth)
 - [Connect and test a plugin](https://developers.openai.com/plugins/deploy/connect-chatgpt)
 - [Plugins in ChatGPT and Codex](https://learn.chatgpt.com/docs/plugins)
-

--- a/tasks/task-385-chatgpt-codex-connector-epic.md
+++ b/tasks/task-385-chatgpt-codex-connector-epic.md
@@ -101,10 +101,59 @@ The existing Agent REST API remains supported and regression-tested.
 12. Revocation, disconnect, rollback, diagnostics, and emergency disablement
     procedures are documented and exercised.
 
+## Runtime Assumptions
+
+- Local and CI validation have a reachable PostgreSQL database that satisfies
+  the repository's migration and runtime-role contract in
+  [`docs/runbooks/local-validation.md`](../docs/runbooks/local-validation.md)
+  and
+  [`docs/runbooks/database-connection-hardening.md`](../docs/runbooks/database-connection-hardening.md).
+- Preview and production retain separate database, OAuth, signing, encryption,
+  and plugin credentials. Required server variables and secrets are declared
+  through `lib/env.server.ts` and documented without values in
+  [`docs/runbooks/vercel-env-contract-and-secrets.md`](../docs/runbooks/vercel-env-contract-and-secrets.md).
+- TASK-387 decides whether MCP request handling is stateless or uses durable
+  session state and verifies that the selected design fits the Vercel runtime.
+- TASK-395 reuses the existing NexusDash user identity only where the ADR shows
+  that login, consent, token issuance, refresh, revocation, and audit semantics
+  remain safe and explicit.
+- Public preview and production origins can expose stable HTTPS MCP, OAuth
+  metadata, authorization, callback, revocation, health, and diagnostic paths.
+- TASK-386 is the authority for which ChatGPT and Codex clients can be included
+  in acceptance at validation time; an unavailable or policy-disabled surface
+  is documented rather than silently assumed.
+- The Agent REST API remains enabled throughout delivery and is validated from
+  the same branch and environment as the MCP connector.
+
+## Validation And Evidence Contract
+
+- Run the repository baseline from `agent.md`: lint, RLS inventory, unit/API
+  tests, coverage, and production build; add the real PostgreSQL RLS matrix
+  whenever models, migrations, runtime roles, or tenant policies change.
+- Add focused automated evidence for MCP initialization/discovery, every tool
+  schema and handler, OAuth metadata and PKCE, token expiry/refresh/revocation,
+  capability enforcement, confirmations, redaction, pagination, and Agent REST
+  non-regression.
+- Trigger the explicit branch through `deploy-vercel.yml` using `git_ref`, then
+  retain the workflow run, checked-out ref and revision, immutable preview URL,
+  environment/database identity, and artifact evidence described by
+  [`docs/runbooks/github-actions-workflows.md`](../docs/runbooks/github-actions-workflows.md).
+- Validate the immutable preview endpoint with MCP Inspector before connecting
+  the private plugin, then execute the TASK-401 evaluation suite and the
+  supported-client journeys recorded by TASK-386.
+- Exercise authorization failure, disconnect, compromised-session revocation,
+  credential rotation, rollback, and emergency disablement without recording
+  raw tokens or secrets. Reuse the safe preview-access evidence practices in
+  [`docs/runbooks/protected-preview-agent-access.md`](../docs/runbooks/protected-preview-agent-access.md).
+- Record final validation outcomes, residual client/rollout limitations,
+  production smoke evidence, and rollback readiness in the task briefs,
+  journal, and connector operations runbook before closing the Epic.
+
 ## Definition Of Done
 
 - TASK-386 records the supported account, workspace, ChatGPT, and Codex
-  surfaces and any rollout limitations that constrain acceptance.
+  surfaces in a dated evidence report and any rollout limitations that
+  constrain acceptance.
 - The architecture ADR, tool catalog, security policy, OAuth/scopes model, and
   shared-service boundaries are approved and represented by executable tasks.
 - The remote MCP server, read/write tools, OAuth flow, authorization mapping,

--- a/tasks/task-385-chatgpt-codex-connector-epic.md
+++ b/tasks/task-385-chatgpt-codex-connector-epic.md
@@ -44,9 +44,17 @@ The existing Agent REST API remains supported and regression-tested.
   registration strategy.
 - Never embed a NexusDash API key or another static user secret in the plugin.
 - Separate read and write tools and expose no permanent-delete tool in v1.
+- Issue only the OAuth scopes required by the v1 tool catalog; context-card and
+  roadmap write scopes remain unavailable until corresponding tools and
+  authorization coverage are separately approved.
 - Return concise, structured, paginated, model-readable results.
 - Annotate tool behavior, including read-only, destructive, and idempotent
-  characteristics, and require clear confirmation for sensitive writes.
+  characteristics, and require a server-validated, short-lived confirmation
+  intent for writes classified as sensitive rather than relying only on client
+  prompt behavior.
+- Treat relation changes as explicit additions or removals that preserve
+  unmentioned links; any complete replacement operation must be separately
+  named, preview its effect, and require confirmation.
 - Keep the transport compatible with the selected serverless deployment model
   and prevent sensitive data from entering logs or metrics.
 
@@ -90,7 +98,8 @@ The existing Agent REST API remains supported and regression-tested.
 6. A new conversation can rediscover the connected NexusDash tools without a
    local machine or local `.env` file.
 7. Sensitive writes present an accurate confirmation naming the resource and
-   operation.
+   operation and cannot execute without a server-validated intent bound to the
+   user, tool, resource, and proposed change.
 8. No permanent-delete tool is discoverable or callable in v1.
 9. The Agent REST API and its regression suite continue to pass.
 10. Preview validation covers transport, OAuth, authorization, schemas, tool
@@ -134,6 +143,10 @@ The existing Agent REST API remains supported and regression-tested.
   schema and handler, OAuth metadata and PKCE, token expiry/refresh/revocation,
   capability enforcement, confirmations, redaction, pagination, and Agent REST
   non-regression.
+- Use synthetic or sanitized fixtures for evaluations and stored validation
+  artifacts. Redact sensitive arguments, results, content, and identifiers;
+  retain only the minimum evidence and duration defined by the connector
+  runbook.
 - Trigger the explicit branch through `deploy-vercel.yml` using `git_ref`, then
   retain the workflow run, checked-out ref and revision, immutable preview URL,
   environment/database identity, and artifact evidence described by

--- a/tasks/task-385-chatgpt-codex-connector-epic.md
+++ b/tasks/task-385-chatgpt-codex-connector-epic.md
@@ -39,6 +39,9 @@ The existing Agent REST API remains supported and regression-tested.
   Streamable HTTP.
 - Protect private data and actions with OAuth 2.1 Authorization Code + PKCE,
   short-lived access tokens, and revocable rotating refresh tokens.
+- Keep the MCP tool endpoint disabled by default and fail closed when OAuth
+  enforcement or required metadata is absent, invalid, or misconfigured; no
+  unauthenticated implementation window may expose tool discovery or calls.
 - Publish the protected-resource and authorization-server metadata required by
   MCP clients, including correct `resource` propagation and a supported client
   registration strategy.
@@ -91,26 +94,28 @@ The existing Agent REST API remains supported and regression-tested.
 
 1. A stable MCP server is reachable over public HTTPS and protected by the
    selected OAuth 2.1 flow.
-2. No static NexusDash user secret is sent to or stored in ChatGPT or Codex.
-3. NexusDash project membership, role, and capability checks apply to every
+2. The MCP tool endpoint stays disabled or rejects access before OAuth
+   enforcement is active and fails closed for missing or invalid auth config.
+3. No static NexusDash user secret is sent to or stored in ChatGPT or Codex.
+4. NexusDash project membership, role, and capability checks apply to every
    tool call and prevent cross-project or cross-user access.
-4. The initial read and write tools work from the confirmed ChatGPT surfaces
+5. The initial read and write tools work from the confirmed ChatGPT surfaces
    and any confirmed Codex surfaces.
-5. Subject to TASK-386 availability findings, the owner can install and use the
+6. Subject to TASK-386 availability findings, the owner can install and use the
    private plugin on supported web, desktop, and mobile clients.
-6. A new conversation can rediscover the connected NexusDash tools without a
+7. A new conversation can rediscover the connected NexusDash tools without a
    local machine or local `.env` file.
-7. Sensitive writes present an accurate confirmation naming the resource and
+8. Sensitive writes present an accurate confirmation naming the resource and
    operation and cannot execute without a server-validated intent bound to the
    user, tool, resource, and proposed change.
-8. No permanent-delete tool is discoverable or callable in v1.
-9. The Agent REST API and its regression suite continue to pass.
-10. Preview validation covers transport, OAuth, authorization, schemas, tool
+9. No permanent-delete tool is discoverable or callable in v1.
+10. The Agent REST API and its regression suite continue to pass.
+11. Preview validation covers transport, OAuth, authorization, schemas, tool
     selection, confirmations, audit output, and REST non-regression before
     production deployment.
-11. Calls, authorization refusals, and failures are observable without logging
+12. Calls, authorization refusals, and failures are observable without logging
     tokens, secrets, or unnecessarily sensitive content.
-12. Revocation, disconnect, rollback, diagnostics, and emergency disablement
+13. Revocation, disconnect, rollback, diagnostics, and emergency disablement
     procedures are documented and exercised.
 
 ## Runtime Assumptions
@@ -183,8 +188,9 @@ The existing Agent REST API remains supported and regression-tested.
 - The production-readiness runbook covers and exercises revocation, disconnect,
   rollback, diagnostics, credential isolation, and emergency disablement before
   production rollout; the final production smoke test passes.
-- TASK-386 through TASK-405 are complete and the backlog, journal, ADR index,
-  product documentation, and relevant runbooks reflect the delivered system.
+- TASK-386 through TASK-405 are complete and `tasks/current.md`, the backlog,
+  journal, ADR index, product documentation, and relevant runbooks reflect the
+  delivered system.
 
 ## Delivery Tasks
 

--- a/tasks/task-385-chatgpt-codex-connector-epic.md
+++ b/tasks/task-385-chatgpt-codex-connector-epic.md
@@ -42,6 +42,8 @@ The existing Agent REST API remains supported and regression-tested.
 - Keep the MCP tool endpoint disabled by default and fail closed when OAuth
   enforcement or required metadata is absent, invalid, or misconfigured; no
   unauthenticated implementation window may expose tool discovery or calls.
+  TASK-402 is the first task allowed to activate `/mcp`, after its preflight
+  proves TASK-395 through TASK-400 are present and valid in that environment.
 - Publish the protected-resource and authorization-server metadata required by
   MCP clients, including correct `resource` propagation and a supported client
   registration strategy.
@@ -53,6 +55,12 @@ The existing Agent REST API remains supported and regression-tested.
 - Authorize account-level `list_projects` through a distinct project-discovery
   capability that returns only memberships visible to the current user;
   require project-bound scopes again for every project-specific operation.
+- Use a two-stage authorization path: an initial discovery-only grant can call
+  `list_projects`, then a post-discovery authorization/token exchange issues a
+  short-lived grant bound to one selected project and its approved operation
+  scopes. Multi-project use requires explicit grants per project rather than a
+  broad all-project bearer token; TASK-386 must confirm the client can complete
+  the selected incremental authorization flow.
 - Return concise, structured, paginated, model-readable results.
 - Annotate tool behavior, including read-only, destructive, and idempotent
   characteristics, and require a server-validated, short-lived confirmation
@@ -99,23 +107,26 @@ The existing Agent REST API remains supported and regression-tested.
 3. No static NexusDash user secret is sent to or stored in ChatGPT or Codex.
 4. NexusDash project membership, role, and capability checks apply to every
    tool call and prevent cross-project or cross-user access.
-5. The initial read and write tools work from the confirmed ChatGPT surfaces
+5. Project discovery never authorizes project data access by itself; every
+   project-specific call uses a short-lived grant bound to the selected project
+   and approved scopes, with separate explicit grants for additional projects.
+6. The initial read and write tools work from the confirmed ChatGPT surfaces
    and any confirmed Codex surfaces.
-6. Subject to TASK-386 availability findings, the owner can install and use the
+7. Subject to TASK-386 availability findings, the owner can install and use the
    private plugin on supported web, desktop, and mobile clients.
-7. A new conversation can rediscover the connected NexusDash tools without a
+8. A new conversation can rediscover the connected NexusDash tools without a
    local machine or local `.env` file.
-8. Sensitive writes present an accurate confirmation naming the resource and
+9. Sensitive writes present an accurate confirmation naming the resource and
    operation and cannot execute without a server-validated intent bound to the
    user, tool, resource, and proposed change.
-9. No permanent-delete tool is discoverable or callable in v1.
-10. The Agent REST API and its regression suite continue to pass.
-11. Preview validation covers transport, OAuth, authorization, schemas, tool
+10. No permanent-delete tool is discoverable or callable in v1.
+11. The Agent REST API and its regression suite continue to pass.
+12. Preview validation covers transport, OAuth, authorization, schemas, tool
     selection, confirmations, audit output, and REST non-regression before
     production deployment.
-12. Calls, authorization refusals, and failures are observable without logging
+13. Calls, authorization refusals, and failures are observable without logging
     tokens, secrets, or unnecessarily sensitive content.
-13. Revocation, disconnect, rollback, diagnostics, and emergency disablement
+14. Revocation, disconnect, rollback, diagnostics, and emergency disablement
     procedures are documented and exercised.
 
 ## Runtime Assumptions

--- a/tasks/task-385-chatgpt-codex-connector-epic.md
+++ b/tasks/task-385-chatgpt-codex-connector-epic.md
@@ -1,0 +1,133 @@
+# TASK-385 ChatGPT and Codex Connector Epic
+
+## Status
+
+Pending (non-executable Epic split into TASK-386 through TASK-405).
+
+## Objective
+
+Allow an authenticated user to discover and operate their authorized NexusDash
+projects from ChatGPT and supported Codex surfaces, including a new mobile
+conversation, without depending on a local computer or manually supplying an
+`.env` file.
+
+The initial integration uses a remotely hosted NexusDash MCP server protected
+by OAuth 2.1 and packaged as a private plugin. Account, workspace, and client
+availability must be confirmed by TASK-386 before implementation assumptions
+are locked.
+
+## Expected User Outcomes
+
+From a supported ChatGPT or Codex surface, an authenticated user can:
+
+- find and read authorized projects, Epics, tasks, comments, context cards,
+  and roadmap data;
+- filter tasks by project, Epic, label, status, or text;
+- create and partially update a task;
+- move a task to another status;
+- add a task comment;
+- reconnect from a new conversation without a local configuration file; and
+- retain the same effective permissions enforced by NexusDash.
+
+The existing Agent REST API remains supported and regression-tested.
+
+## Architecture Principles
+
+- Keep the existing Agent REST API and reuse the same internal application
+  services and authorization rules from both transports.
+- Expose a stable public HTTPS MCP endpoint, preferably `/mcp`, using
+  Streamable HTTP.
+- Protect private data and actions with OAuth 2.1 Authorization Code + PKCE,
+  short-lived access tokens, and revocable rotating refresh tokens.
+- Publish the protected-resource and authorization-server metadata required by
+  MCP clients, including correct `resource` propagation and a supported client
+  registration strategy.
+- Never embed a NexusDash API key or another static user secret in the plugin.
+- Separate read and write tools and expose no permanent-delete tool in v1.
+- Return concise, structured, paginated, model-readable results.
+- Annotate tool behavior, including read-only, destructive, and idempotent
+  characteristics, and require clear confirmation for sensitive writes.
+- Keep the transport compatible with the selected serverless deployment model
+  and prevent sensitive data from entering logs or metrics.
+
+## Initial Tool Catalog
+
+- `get_project_summary`
+- `list_epics`
+- `search_tasks`
+- `list_tasks`
+- `get_task`
+- `create_task`
+- `update_task`
+- `move_task`
+- `add_task_comment`
+- `list_context_cards`
+- `get_roadmap`
+
+## Out Of Scope For V1
+
+- Public marketplace publication.
+- A custom MCP user interface.
+- Permanent deletion of a task, context card, or other resource.
+- Replacement or removal of the Agent REST API.
+- AI services that are not compatible with the selected MCP/plugin contract.
+- Autonomous mutations without an explicit user request or appropriate
+  confirmation.
+
+## Acceptance Criteria
+
+1. A stable MCP server is reachable over public HTTPS and protected by the
+   selected OAuth 2.1 flow.
+2. No static NexusDash user secret is sent to or stored in ChatGPT or Codex.
+3. NexusDash project membership, role, and capability checks apply to every
+   tool call and prevent cross-project or cross-user access.
+4. The initial read and write tools work from the confirmed ChatGPT surfaces
+   and any confirmed Codex surfaces.
+5. Subject to TASK-386 availability findings, the owner can install and use the
+   private plugin on supported web, desktop, and mobile clients.
+6. A new conversation can rediscover the connected NexusDash tools without a
+   local machine or local `.env` file.
+7. Sensitive writes present an accurate confirmation naming the resource and
+   operation.
+8. No permanent-delete tool is discoverable or callable in v1.
+9. The Agent REST API and its regression suite continue to pass.
+10. Preview validation covers transport, OAuth, authorization, schemas, tool
+    selection, confirmations, audit output, and REST non-regression before
+    production deployment.
+11. Calls, authorization refusals, and failures are observable without logging
+    tokens, secrets, or unnecessarily sensitive content.
+12. Revocation, disconnect, rollback, diagnostics, and emergency disablement
+    procedures are documented and exercised.
+
+## Delivery Tasks
+
+| Source item | NexusDash task | Outcome |
+| --- | --- | --- |
+| ND-MCP-00 | TASK-386 | Confirm account, workspace, and client availability. |
+| ND-MCP-01 | TASK-387 | Record the technical architecture and deployment model. |
+| ND-MCP-02 | TASK-388 | Define the initial MCP tool contracts. |
+| ND-MCP-03 | TASK-389 | Define tool security and confirmation policy. |
+| ND-MCP-04 | TASK-390 | Consolidate shared REST/MCP application services. |
+| ND-MCP-05 | TASK-391 | Build the Streamable HTTP MCP server. |
+| ND-MCP-06 | TASK-392 | Implement read tools. |
+| ND-MCP-07 | TASK-393 | Implement write tools. |
+| ND-MCP-08 | TASK-394 | Add annotations and confirmation behavior. |
+| ND-MCP-09 | TASK-395 | Implement OAuth 2.1 for MCP. |
+| ND-MCP-10 | TASK-396 | Map OAuth scopes to NexusDash permissions. |
+| ND-MCP-11 | TASK-397 | Add security controls, quotas, audit, and metrics. |
+| ND-MCP-12 | TASK-398 | Create the NexusDash plugin skill. |
+| ND-MCP-13 | TASK-399 | Package the private plugin. |
+| ND-MCP-14 | TASK-400 | Add automated integration and regression coverage. |
+| ND-MCP-15 | TASK-401 | Build the agent evaluation suite. |
+| ND-MCP-16 | TASK-402 | Deploy and validate the complete preview path. |
+| ND-MCP-17 | TASK-403 | Validate supported web, desktop, and mobile journeys. |
+| ND-MCP-18 | TASK-404 | Complete production security and deployment gates. |
+| ND-MCP-19 | TASK-405 | Document operation and maintenance. |
+
+## Official Product References
+
+- [Build an MCP server](https://developers.openai.com/plugins/concepts/mcp-server)
+- [Plugin authentication](https://developers.openai.com/plugins/build/auth)
+- [Connect and test a plugin](https://developers.openai.com/plugins/deploy/connect-chatgpt)
+- [Plugins in ChatGPT and Codex](https://learn.chatgpt.com/docs/plugins)
+

--- a/tasks/task-385-chatgpt-codex-connector-epic.md
+++ b/tasks/task-385-chatgpt-codex-connector-epic.md
@@ -61,6 +61,12 @@ The existing Agent REST API remains supported and regression-tested.
   scopes. Multi-project use requires explicit grants per project rather than a
   broad all-project bearer token; TASK-386 must confirm the client can complete
   the selected incremental authorization flow.
+- Represent the binding in signed access-token claims: a discovery token has a
+  discovery-only token-use claim and no project grant, while an operational
+  token carries one immutable `project_id` (or ADR-approved equivalent), the
+  approved scopes, subject, audience/resource, token/session version, and
+  expiry. Every project-specific adapter compares its requested project ID to
+  the verified claim before calling shared services.
 - Return concise, structured, paginated, model-readable results.
 - Annotate tool behavior, including read-only, destructive, and idempotent
   characteristics, and require a server-validated, short-lived confirmation
@@ -191,11 +197,15 @@ The existing Agent REST API remains supported and regression-tested.
 - The remote MCP server, read/write tools, OAuth flow, authorization mapping,
   annotations, confirmations, security controls, audit, and observability meet
   the Epic acceptance criteria.
-- The private plugin and NexusDash skill are versioned for preview and
-  production without embedded static user credentials or permanent-delete
-  tools.
-- Automated tests, agent evaluations, preview validation, and supported-client
-  journeys pass without regressing the Agent REST API.
+- When TASK-386 confirms private-plugin delivery on the target account, the
+  plugin and NexusDash skill are versioned for preview and production without
+  embedded static user credentials or permanent-delete tools. If delivery is
+  unavailable, the Epic records a blocked-delivery decision and does not claim
+  implementation completion until a supported distribution path is approved.
+- Automated tests and agent evaluations pass without regressing the Agent REST
+  API. Preview and client journeys pass for every surface confirmed by
+  TASK-386; unavailable surfaces have dated evidence and an explicit blocked or
+  deferred rollout decision rather than a fabricated pass.
 - The production-readiness runbook covers and exercises revocation, disconnect,
   rollback, diagnostics, credential isolation, and emergency disablement before
   production rollout; the final production smoke test passes.

--- a/tasks/task-385-chatgpt-codex-connector-epic.md
+++ b/tasks/task-385-chatgpt-codex-connector-epic.md
@@ -47,6 +47,9 @@ The existing Agent REST API remains supported and regression-tested.
 - Issue only the OAuth scopes required by the v1 tool catalog; context-card and
   roadmap write scopes remain unavailable until corresponding tools and
   authorization coverage are separately approved.
+- Authorize account-level `list_projects` through a distinct project-discovery
+  capability that returns only memberships visible to the current user;
+  require project-bound scopes again for every project-specific operation.
 - Return concise, structured, paginated, model-readable results.
 - Annotate tool behavior, including read-only, destructive, and idempotent
   characteristics, and require a server-validated, short-lived confirmation
@@ -145,8 +148,8 @@ The existing Agent REST API remains supported and regression-tested.
   non-regression.
 - Use synthetic or sanitized fixtures for evaluations and stored validation
   artifacts. Redact sensitive arguments, results, content, and identifiers;
-  retain only the minimum evidence and duration defined by the connector
-  runbook.
+  retain only the minimum evidence and duration defined before evaluation by
+  TASK-397 and operationalized by the connector runbook in TASK-405.
 - Trigger the explicit branch through `deploy-vercel.yml` using `git_ref`, then
   retain the workflow run, checked-out ref and revision, immutable preview URL,
   environment/database identity, and artifact evidence described by


### PR DESCRIPTION
## Summary

This is one user-directed, documentation-only backlog-intake PR. It records planning entries but implements none of the queued tasks.

- capture the accumulated Codex-session feedback as TASK-371 through TASK-384
- add TASK-385, the remote NexusDash connector Epic for ChatGPT and Codex
- map all 20 attached ND-MCP work items to TASK-386 through TASK-405
- preserve Agent REST compatibility, shared service boundaries, OAuth 2.1, Streamable HTTP, private-plugin delivery, no-delete v1, testing, evaluation, preview, production, and operations scope
- keep client/account availability behind a discovery gate verified against current official OpenAI documentation
- record the planning work in the development journal

## Validation

- `git diff --check`
- verified every backlog `- ID: TASK-XXX` entry is unique
- verified TASK-385 through TASK-405 are all present
- verified the Epic brief maps all 20 ND-MCP items
- verified no undefined dependency is introduced in the connector program
- docs-only change; runtime validation suite not required by `agent.md`

## Branch scope

The user explicitly requested that all newly supplied backlog entries remain in this same branch. The PR's single purpose is backlog planning/intake; each executable TASK remains subject to `1 task = 1 branch = 1 PR` when implementation starts.

## Copilot review

- all findings are applied and all conversations are resolved
- a fresh review is requested after each review-driven change