### PR TITLE
TASK-326: Harden Google Calendar connection ownership

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ GOOGLE_CLIENT_SECRET=
 # Keep this only if you intentionally pin a non-standard callback origin.
 # For Google OAuth, at least one of TRUSTED_ORIGINS or NEXTAUTH_URL must be set if GOOGLE_REDIRECT_URI is unset.
 GOOGLE_REDIRECT_URI=
-# Required in production when Google OAuth is enabled. Used to encrypt Google access/refresh tokens at rest.
+# Required whenever Google Calendar OAuth is enabled outside tests. Used to encrypt Google access/refresh tokens at rest.
 GOOGLE_TOKEN_ENCRYPTION_KEY=
 GOOGLE_CALENDAR_ID=primary
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ SHA, deployment URL, and workflow run belong in release evidence.
 
 - Define each release entry before the product-impacting PR is merged.
 
+## v0.38.0 - 2026-08-16
+
+- Made Google Calendar credential reads, refreshes, target updates, and project
+  connection status fail closed for revoked credentials.
+- Added a true authenticated-user disconnect that blocks local use first,
+  attempts Google token revocation, permanently removes stored tokens, and
+  provides a recovery warning when upstream revocation is unconfirmed.
+- Required encrypted Calendar token storage whenever OAuth is configured
+  outside tests and added lazy encryption for legacy plaintext local rows.
+- Added an accessible Settings confirmation flow and repaired the project
+  Calendar summary request by including its project authorization context.
+- Expanded service, API, component, environment, and real PostgreSQL RLS
+  coverage for user-owned Calendar credentials and lifecycle failures.
+
 ## v0.37.1 - 2026-08-20
 
 - Fixed Vercel Preview authentication origins so callbacks and post-auth
@@ -35,7 +49,6 @@ SHA, deployment URL, and workflow run belong in release evidence.
 - Added schema constraints, backfill migration, service/API/component tests, and
   responsive identity presentation across the meeting dialog, quick panel, and
   project-wide Todos destination.
-
 ## v0.36.0 - 2026-08-05
 
 - Added an exact active meeting-todo count to the current project's `Todos`

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ Implemented today:
   - Calendar panel (Google Calendar list/create/update/delete)
   - Task comments with agent-authored comment attribution through the project
     credential label and a shared agent avatar
-- Per-user Google Calendar connection, target setting, and revocation-aware
-  disconnect (`/account/settings`)
+- Per-user Google Calendar connection and calendar target setting (`/account/settings`)
 - Attachment storage abstraction:
   - `local` provider (filesystem)
   - `r2` provider (Cloudflare R2)
@@ -194,9 +193,7 @@ Environment access/validation is centralized in `lib/env.server.ts` and executed
   metadata. The user-facing app version does not include the commit SHA.
 - `APP_REPOSITORY_URL` is optional and defaults to the NexusDash GitHub
   repository.
-- Outside tests, when Google Calendar OAuth is enabled,
-  `GOOGLE_TOKEN_ENCRYPTION_KEY` is required. Legacy plaintext local tokens are
-  encrypted on their next authenticated read.
+- In production, when Google OAuth is enabled, `GOOGLE_TOKEN_ENCRYPTION_KEY` is required.
 - `AGENT_ACCESS_TOKEN_TTL_SECONDS` is optional, defaults to `600`, and must stay between `300` and `900`.
 - `GOOGLE_CALENDAR_ID` must be unset or `primary`.
 - `RESEND_FROM_EMAIL` defaults to `NexusDash <noreply@nexus-dash.app>` when unset.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Implemented today:
   - Calendar panel (Google Calendar list/create/update/delete)
   - Task comments with agent-authored comment attribution through the project
     credential label and a shared agent avatar
-- Per-user Google Calendar connection and calendar target setting (`/account/settings`)
+- Per-user Google Calendar connection, target setting, and revocation-aware
+  disconnect (`/account/settings`)
 - Attachment storage abstraction:
   - `local` provider (filesystem)
   - `r2` provider (Cloudflare R2)
@@ -193,7 +194,9 @@ Environment access/validation is centralized in `lib/env.server.ts` and executed
   metadata. The user-facing app version does not include the commit SHA.
 - `APP_REPOSITORY_URL` is optional and defaults to the NexusDash GitHub
   repository.
-- In production, when Google OAuth is enabled, `GOOGLE_TOKEN_ENCRYPTION_KEY` is required.
+- Outside tests, when Google Calendar OAuth is enabled,
+  `GOOGLE_TOKEN_ENCRYPTION_KEY` is required. Legacy plaintext local tokens are
+  encrypted on their next authenticated read.
 - `AGENT_ACCESS_TOKEN_TTL_SECONDS` is optional, defaults to `600`, and must stay between `300` and `900`.
 - `GOOGLE_CALENDAR_ID` must be unset or `primary`.
 - `RESEND_FROM_EMAIL` defaults to `NexusDash <noreply@nexus-dash.app>` when unset.

--- a/adr/decisions.md
+++ b/adr/decisions.md
@@ -16,6 +16,22 @@ Keep UI-only or task-only notes in `journal.md`.
 
 ## Active Decisions
 
+## 2026-08-06 - Make Google Calendar disconnect fail-closed and user-owned
+- Status: Accepted
+- Context: The existing Calendar credential is user-scoped, but its revocation
+  marker was not enforced and the settings DELETE route only reset the target
+  calendar instead of terminating access.
+- Decision: Treat revoked credentials as unusable, require encrypted token
+  storage whenever Calendar OAuth is configured outside tests, and disconnect
+  by marking the signed-in user's row revoked before attempting Google token
+  revocation and permanently deleting the local credential.
+- Consequences: A failed provider call cannot reactivate local Calendar access;
+  users receive a safe Google Account recovery path when upstream revocation is
+  unconfirmed. PATCH remains the target-reset contract, while DELETE now means
+  disconnect.
+- Links: `tasks/task-326-google-calendar-connection-ownership.md`,
+  `docs/audits/task-325-google-calendar-integration-audit.md`
+
 ## 2026-07-30 - Keep meeting todos within current-project navigation
 - Status: Accepted; supersedes the cross-project portion of the 2026-07-27
   TASK-332 decision.

--- a/app/account/settings/page.tsx
+++ b/app/account/settings/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import { AccountSettingsShell } from "@/components/account/account-settings-shell";
 import { AppAboutCard } from "@/components/account/app-about-card";
+import { GoogleCalendarDisconnectControl } from "@/components/account/google-calendar-disconnect-control";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { requireSessionUserIdFromServer } from "@/lib/auth/server-guard";
@@ -19,6 +20,9 @@ type SearchParams = Record<string, string | string[] | undefined>;
 const STATUS_MESSAGES: Record<string, string> = {
   "calendar-updated": "Google Calendar target saved successfully.",
   "calendar-reset": "Google Calendar target reset to primary.",
+  "calendar-disconnected": "Google Calendar disconnected and stored credentials removed.",
+  "calendar-disconnected-revocation-warning":
+    "Google Calendar disconnected locally. Google did not confirm revocation; review NexusDash access in your Google Account permissions.",
 };
 
 const ERROR_MESSAGES: Record<string, string> = {
@@ -142,6 +146,19 @@ export default async function AccountSettingsPage({
               </Button>
             </div>
           </form>
+
+          {hasCalendarConnection ? (
+            <div className="space-y-3 border-t border-border/60 pt-4">
+              <div className="space-y-1">
+                <h3 className="text-sm font-semibold">Disconnect this account</h3>
+                <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+                  Disconnecting removes NexusDash&apos;s stored Google tokens. It does
+                  not delete events from Google Calendar.
+                </p>
+              </div>
+              <GoogleCalendarDisconnectControl />
+            </div>
+          ) : null}
         </CardContent>
       </Card>
       <AppAboutCard />

--- a/app/api/account/settings/google-calendar/route.ts
+++ b/app/api/account/settings/google-calendar/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAuthenticatedApiUser } from "@/lib/auth/api-guard";
 import { logServerWarning } from "@/lib/observability/logger";
 import {
+  disconnectGoogleCalendar,
   getGoogleCalendarTargetSettings,
   updateGoogleCalendarTargetSettings,
 } from "@/lib/services/account-settings-service";
@@ -12,6 +13,7 @@ interface UpdateGoogleCalendarSettingsRequestBody {
 }
 
 type GoogleCalendarSettingsResult =
+  | Awaited<ReturnType<typeof disconnectGoogleCalendar>>
   | Awaited<ReturnType<typeof getGoogleCalendarTargetSettings>>
   | Awaited<ReturnType<typeof updateGoogleCalendarTargetSettings>>;
 
@@ -67,9 +69,8 @@ export async function DELETE(request: NextRequest) {
   }
 
   return jsonServiceResult(
-    await updateGoogleCalendarTargetSettings({
+    await disconnectGoogleCalendar({
       actorUserId: authenticatedUser.userId,
-      calendarIdRaw: "",
     })
   );
 }

--- a/app/projects/[projectId]/page.tsx
+++ b/app/projects/[projectId]/page.tsx
@@ -233,6 +233,7 @@ export default async function ProjectDashboardPage({
               className="w-[8.75rem] shrink-0 snap-start md:w-auto"
             />
             <CalendarSummaryStatCard
+              projectId={project.id}
               isConnected={project.stats.isCalendarConnected}
               className="w-[8.75rem] shrink-0 snap-start md:w-auto"
             />

--- a/components/account/google-calendar-disconnect-control.tsx
+++ b/components/account/google-calendar-disconnect-control.tsx
@@ -49,7 +49,7 @@ export function GoogleCalendarDisconnectControl() {
       router.refresh();
     } catch {
       setError(
-        "Could not disconnect Google Calendar. Your connection remains blocked; retry to remove the stored credentials."
+        "Could not finish disconnecting Google Calendar. Retry, and review NexusDash access in your Google Account permissions if the problem continues."
       );
     } finally {
       setIsDisconnecting(false);

--- a/components/account/google-calendar-disconnect-control.tsx
+++ b/components/account/google-calendar-disconnect-control.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Unplug } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { Button } from "@/components/ui/button";
+
+interface DisconnectResponse {
+  settings?: {
+    revocationStatus?: "revoked" | "not-connected" | "unconfirmed";
+  };
+  error?: string;
+}
+
+export function GoogleCalendarDisconnectControl() {
+  const router = useRouter();
+  const [isOpen, setIsOpen] = useState(false);
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const disconnect = async () => {
+    setIsDisconnecting(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/account/settings/google-calendar", {
+        method: "DELETE",
+      });
+      const payload = (await response.json().catch(() => null)) as
+        | DisconnectResponse
+        | null;
+
+      if (!response.ok) {
+        throw new Error(payload?.error ?? "disconnect-failed");
+      }
+
+      const target = new URL(window.location.href);
+      target.searchParams.delete("error");
+      target.searchParams.set(
+        "status",
+        payload?.settings?.revocationStatus === "unconfirmed"
+          ? "calendar-disconnected-revocation-warning"
+          : "calendar-disconnected"
+      );
+      setIsOpen(false);
+      router.replace(`${target.pathname}${target.search}`);
+      router.refresh();
+    } catch {
+      setError(
+        "Could not disconnect Google Calendar. Your connection remains blocked; retry to remove the stored credentials."
+      );
+    } finally {
+      setIsDisconnecting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <Button
+        type="button"
+        variant="destructive"
+        className="min-h-11 w-full sm:w-auto"
+        onClick={() => setIsOpen(true)}
+      >
+        <Unplug className="h-4 w-4" />
+        Disconnect Google Calendar
+      </Button>
+      {error ? (
+        <p role="alert" className="max-w-2xl text-sm text-destructive">
+          {error}
+        </p>
+      ) : null}
+      <ConfirmDialog
+        isOpen={isOpen}
+        title="Disconnect Google Calendar?"
+        description="NexusDash will stop using this Google account and permanently remove its stored tokens. Existing events in Google Calendar will not be deleted."
+        confirmLabel="Disconnect"
+        confirmingLabel="Disconnecting..."
+        isConfirming={isDisconnecting}
+        onConfirm={disconnect}
+        onCancel={() => setIsOpen(false)}
+      />
+    </div>
+  );
+}

--- a/components/project-dashboard/calendar-summary-stat-card.tsx
+++ b/components/project-dashboard/calendar-summary-stat-card.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/project-dashboard";
 
 interface CalendarSummaryStatCardProps {
+  projectId: string;
   isConnected: boolean;
   className?: string;
 }
@@ -29,7 +30,12 @@ interface CalendarEventsPayload {
   }>;
 }
 
+export function buildCalendarSummaryEventsUrl(projectId: string): string {
+  return `/api/calendar/events?range=current-week&projectId=${encodeURIComponent(projectId)}`;
+}
+
 export function CalendarSummaryStatCard({
+  projectId,
   isConnected,
   className,
 }: CalendarSummaryStatCardProps) {
@@ -49,10 +55,13 @@ export function CalendarSummaryStatCard({
       setIsLoading(true);
 
       try {
-        const response = await fetch("/api/calendar/events?range=current-week", {
+        const response = await fetch(
+          buildCalendarSummaryEventsUrl(projectId),
+          {
           cache: "no-store",
           signal: controller.signal,
-        });
+          }
+        );
         const payload = (await response.json().catch(() => null)) as
           | CalendarEventsPayload
           | null;
@@ -77,7 +86,7 @@ export function CalendarSummaryStatCard({
     void loadEvents();
 
     return () => controller.abort();
-  }, [isConnected]);
+  }, [isConnected, projectId]);
 
   if (!isConnected) {
     return (

--- a/components/ui/confirm-dialog.tsx
+++ b/components/ui/confirm-dialog.tsx
@@ -17,6 +17,7 @@ interface ConfirmDialogProps {
   title: string;
   description: string;
   confirmLabel: string;
+  confirmingLabel?: string;
   isConfirming?: boolean;
   onConfirm: () => void | Promise<void>;
   onCancel: () => void;
@@ -27,6 +28,7 @@ export function ConfirmDialog({
   title,
   description,
   confirmLabel,
+  confirmingLabel = "Deleting...",
   isConfirming = false,
   onConfirm,
   onCancel,
@@ -76,7 +78,7 @@ export function ConfirmDialog({
                 }
               }}
             >
-              {isConfirming ? "Deleting..." : confirmLabel}
+              {isConfirming ? confirmingLabel : confirmLabel}
             </Button>
             <DialogClose asChild>
               <Button

--- a/components/ui/confirm-dialog.tsx
+++ b/components/ui/confirm-dialog.tsx
@@ -64,7 +64,7 @@ export function ConfirmDialog({
               type="button"
               variant="destructive"
               disabled={isConfirming}
-              className="w-full sm:w-auto"
+              className="min-h-11 w-full sm:w-auto"
               onClick={() => {
                 try {
                   const result = onConfirm();
@@ -86,7 +86,7 @@ export function ConfirmDialog({
                 type="button"
                 variant="ghost"
                 disabled={isConfirming}
-                className="w-full sm:w-auto"
+                className="min-h-11 w-full sm:w-auto"
               >
                 Cancel
               </Button>

--- a/docs/runbooks/vercel-env-contract-and-secrets.md
+++ b/docs/runbooks/vercel-env-contract-and-secrets.md
@@ -173,8 +173,9 @@ If Google OAuth is enabled:
 
 - `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and `GOOGLE_REDIRECT_URI` must
   be configured together.
-- `GOOGLE_TOKEN_ENCRYPTION_KEY` must be configured for environments running
-  production runtime checks (production and preview in this project).
+- `GOOGLE_TOKEN_ENCRYPTION_KEY` must be configured in every non-test
+  environment where Google Calendar OAuth is enabled, including local
+  development, preview, and production.
 
 ## Sensitivity Policy
 
@@ -256,6 +257,10 @@ Important:
 - Keep `GOOGLE_TOKEN_ENCRYPTION_KEY` stable per environment. Rotating it
   requires token re-authorization because existing encrypted tokens may become
   unreadable.
+- Disconnect marks the current user's credential revoked before contacting
+  Google, attempts refresh-token revocation, and then removes the local row.
+  When Google cannot confirm revocation, direct the user to Google Account
+  permissions; NexusDash still deletes its local token copy.
 - Keep `AGENT_TOKEN_SIGNING_SECRET` stable per environment. Rotating it
   invalidates all outstanding short-lived bearer tokens immediately and should
   be coordinated with any active agent clients.

--- a/journal.md
+++ b/journal.md
@@ -115,6 +115,23 @@ Use it for important implementation milestones, blockers, validation runs, and r
 - Focused regression validation passed: 4 files, 88 tests covering request
   origin selection, environment validation, health metadata, and migration
   project-ref validation.
+# 2026-08-16 - TASK-326 review refreshed after TASK-325 merge
+
+- Merged TASK-325 through PR #418, retargeted PR #419 to `main`, and merged the
+  current base into `feature/task-326-calendar-ownership` without changing the
+  ownership or disconnect contracts.
+- Reviewed active-only credential access, fail-closed disconnect ordering,
+  provider revocation recovery, lazy token encryption, project summary context,
+  and cross-user RLS coverage against the current service architecture.
+- Advanced the feature version from `0.37.0` to `0.38.0` because current `main`
+  already owns `0.37.0`. Added 44px confirmation controls and recovery copy that
+  does not claim local revocation succeeded when the request fails early.
+- Local validation passed: 171 focused Calendar/ownership tests, 1,048 full-suite
+  tests with two expected skips, coverage at 91.42% statements / 81.33%
+  branches, lint, RLS inventory, version policy, and production build.
+- The local real-RLS rerun is unavailable because Docker Desktop is not running;
+  the required GitHub PostgreSQL RLS job remains the authoritative refreshed
+  matrix for this review.
 
 # 2026-08-08 - TASK-330 assignee control rebuilt as inline Participants-style chip
 

--- a/journal.md
+++ b/journal.md
@@ -204,6 +204,22 @@ Use it for important implementation milestones, blockers, validation runs, and r
   non-`P2021` error still propagates. All 11 tests in that file pass; full
   `npm test` is 936 passing / 1 skipped, with 13 pre-existing integration
   files failing only because the workstation has no `DATABASE_URL`.
+# 2026-08-06 - TASK-326 Google Calendar ownership hardening completed
+
+- Made Calendar credential reads, refreshes, and target changes active-only,
+  added lazy encryption for legacy plaintext values, and made encryption
+  mandatory whenever Calendar OAuth is configured outside tests.
+- Replaced target reset over `DELETE` with an authenticated-user-only,
+  idempotent disconnect that revokes upstream when possible and always removes
+  local tokens. Preserved target reset through `PATCH`.
+- Added accessible disconnect/recovery UI, configurable pending confirmation
+  copy, and repaired project Calendar summary requests by supplying `projectId`.
+- Expanded unit/API/component coverage and the real PostgreSQL RLS matrix for
+  two-user Calendar credential isolation and forged cross-user operations.
+- Validation: lint and RLS inventory passed; 147 test files passed with 1,031
+  tests (two expected skips); coverage passed at 91.42% statements and 81.33%
+  branches; production build passed; PostgreSQL RLS setup/matrix passed; full
+  Playwright passed 32/32 Chromium tests.
 
 # 2026-08-06 - TASK-325 Google Calendar integration audit completed
 

--- a/journal.md
+++ b/journal.md
@@ -220,6 +220,10 @@ Use it for important implementation milestones, blockers, validation runs, and r
   tests (two expected skips); coverage passed at 91.42% statements and 81.33%
   branches; production build passed; PostgreSQL RLS setup/matrix passed; full
   Playwright passed 32/32 Chromium tests.
+- Preview: workflow run `31096210298` explicitly checked out
+  `feature/task-326-calendar-ownership` at `e899238`, deployed
+  `https://nexus-dash-lvexl0fhe-dorian-agaesses-projects.vercel.app`, and the
+  external preview Playwright entry walkthrough passed 5/5 Chromium tests.
 
 # 2026-08-06 - TASK-325 Google Calendar integration audit completed
 

--- a/lib/env.server.ts
+++ b/lib/env.server.ts
@@ -786,12 +786,12 @@ export function validateServerRuntimeConfig(
   }
 
   if (
-    runtimeEnvironment === "production" &&
+    runtimeEnvironment !== "test" &&
     googleClientId &&
     !getOptionalServerEnv("GOOGLE_TOKEN_ENCRYPTION_KEY")
   ) {
     throw new Error(
-      "GOOGLE_TOKEN_ENCRYPTION_KEY is required in production when Google Calendar OAuth is enabled."
+      "GOOGLE_TOKEN_ENCRYPTION_KEY is required when Google Calendar OAuth is enabled outside tests."
     );
   }
 

--- a/lib/google-calendar.ts
+++ b/lib/google-calendar.ts
@@ -5,6 +5,7 @@ export { normalizeReturnToPath } from "@/lib/navigation/return-to";
 
 const GOOGLE_AUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+const GOOGLE_REVOKE_ENDPOINT = "https://oauth2.googleapis.com/revoke";
 export const GOOGLE_OAUTH_CALLBACK_PATH = "/api/auth/callback/google";
 export const GOOGLE_CALENDAR_SCOPE_EVENTS =
   "https://www.googleapis.com/auth/calendar.events";
@@ -185,6 +186,19 @@ export async function refreshAccessToken(
   });
 
   return postTokenForm(body);
+}
+
+export async function revokeGoogleToken(token: string): Promise<boolean> {
+  const response = await fetch(GOOGLE_REVOKE_ENDPOINT, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({ token }),
+    cache: "no-store",
+  });
+
+  return response.ok;
 }
 
 export function createExpiryDate(expiresInSeconds: number): Date {

--- a/lib/services/account-settings-service.ts
+++ b/lib/services/account-settings-service.ts
@@ -1,10 +1,14 @@
 import {
+  deleteGoogleCalendarCredential,
   DEFAULT_GOOGLE_CALENDAR_ID,
   MAX_GOOGLE_CALENDAR_ID_LENGTH,
   findGoogleCalendarCredentialCalendarId,
+  markGoogleCalendarCredentialRevokedForDisconnect,
   normalizeGoogleCalendarId,
   updateGoogleCalendarCredentialCalendarId,
 } from "@/lib/services/google-calendar-credential-service";
+import { revokeGoogleToken } from "@/lib/google-calendar";
+import { logServerWarning } from "@/lib/observability/logger";
 
 interface AccountSettingsSuccess<T extends Record<string, unknown>> {
   ok: true;
@@ -25,6 +29,11 @@ type AccountSettingsResult<T extends Record<string, unknown>> =
 interface UpdateGoogleCalendarTargetInput {
   actorUserId: string;
   calendarIdRaw: string;
+  subjectUserId?: string;
+}
+
+interface DisconnectGoogleCalendarInput {
+  actorUserId: string;
   subjectUserId?: string;
 }
 
@@ -124,5 +133,54 @@ export async function updateGoogleCalendarTargetSettings(
 
   return createSuccess(200, {
     calendarId: normalizedCalendarId,
+  });
+}
+
+export async function disconnectGoogleCalendar(
+  input: DisconnectGoogleCalendarInput
+): Promise<
+  AccountSettingsResult<{
+    hasCalendarConnection: false;
+    revocationStatus: "revoked" | "not-connected" | "unconfirmed";
+  }>
+> {
+  const normalizedActorUserId = normalizeUserId(input.actorUserId);
+  if (!normalizedActorUserId) {
+    return createError(401, "unauthorized");
+  }
+
+  const normalizedSubjectUserId = normalizeUserId(input.subjectUserId);
+  if (normalizedSubjectUserId && normalizedSubjectUserId !== normalizedActorUserId) {
+    return createError(403, "forbidden");
+  }
+
+  const credential = await markGoogleCalendarCredentialRevokedForDisconnect(
+    normalizedActorUserId
+  );
+  if (!credential) {
+    return createSuccess(200, {
+      hasCalendarConnection: false as const,
+      revocationStatus: "not-connected" as const,
+    });
+  }
+
+  let revocationStatus: "revoked" | "unconfirmed" = "unconfirmed";
+  try {
+    revocationStatus = (await revokeGoogleToken(credential.refreshToken))
+      ? "revoked"
+      : "unconfirmed";
+  } catch (error) {
+    logServerWarning(
+      "disconnectGoogleCalendar.providerRevocationFailed",
+      "Google token revocation could not be confirmed",
+      { error }
+    );
+  } finally {
+    await deleteGoogleCalendarCredential(normalizedActorUserId);
+  }
+
+  return createSuccess(200, {
+    hasCalendarConnection: false as const,
+    revocationStatus,
   });
 }

--- a/lib/services/google-calendar-credential-service.ts
+++ b/lib/services/google-calendar-credential-service.ts
@@ -5,6 +5,8 @@ import {
 import {
   decryptGoogleToken,
   encryptGoogleToken,
+  hasGoogleTokenEncryptionKey,
+  isEncryptedGoogleToken,
 } from "@/lib/services/google-token-crypto";
 import { withActorRlsContext } from "@/lib/services/rls-context";
 
@@ -61,23 +63,43 @@ export async function findGoogleCalendarCredential(
     return null;
   }
 
-  const credential = await withActorRlsContext(normalizedUserId, (db) =>
-    db.googleCalendarCredential.findUnique({
+  return withActorRlsContext(normalizedUserId, async (db) => {
+    const credential = await db.googleCalendarCredential.findUnique({
       where: { userId: normalizedUserId },
-    })
-  );
+    });
 
-  if (!credential) {
-    return null;
-  }
+    if (!credential || credential.revokedAt) {
+      return null;
+    }
 
-  return {
-    ...credential,
-    accessToken: credential.accessToken
+    const accessToken = credential.accessToken
       ? decryptGoogleToken(credential.accessToken)
-      : null,
-    refreshToken: decryptGoogleToken(credential.refreshToken),
-  };
+      : null;
+    const refreshToken = decryptGoogleToken(credential.refreshToken);
+
+    if (
+      hasGoogleTokenEncryptionKey() &&
+      ((credential.accessToken && !isEncryptedGoogleToken(credential.accessToken)) ||
+        !isEncryptedGoogleToken(credential.refreshToken))
+    ) {
+      await db.googleCalendarCredential.updateMany({
+        where: {
+          userId: normalizedUserId,
+          revokedAt: null,
+        },
+        data: {
+          accessToken: accessToken ? encryptGoogleToken(accessToken) : null,
+          refreshToken: encryptGoogleToken(refreshToken),
+        },
+      });
+    }
+
+    return {
+      ...credential,
+      accessToken,
+      refreshToken,
+    };
+  });
 }
 
 export async function findGoogleCalendarCredentialCalendarId(userId: string) {
@@ -89,11 +111,11 @@ export async function findGoogleCalendarCredentialCalendarId(userId: string) {
   const credential = await withActorRlsContext(normalizedUserId, (db) =>
     db.googleCalendarCredential.findUnique({
       where: { userId: normalizedUserId },
-      select: { calendarId: true },
+      select: { calendarId: true, revokedAt: true },
     })
   );
 
-  if (!credential) {
+  if (!credential || credential.revokedAt) {
     return null;
   }
 
@@ -104,9 +126,9 @@ export async function updateGoogleCalendarCredentialTokens(
   input: GoogleCalendarTokenUpdateInput
 ) {
   const normalizedUserId = normalizeUserId(input.userId);
-  return withActorRlsContext(normalizedUserId, (db) =>
-    db.googleCalendarCredential.update({
-      where: { userId: normalizedUserId },
+  return withActorRlsContext(normalizedUserId, async (db) => {
+    const result = await db.googleCalendarCredential.updateMany({
+      where: { userId: normalizedUserId, revokedAt: null },
       data: {
         accessToken: encryptGoogleToken(input.accessToken),
         refreshToken: encryptGoogleToken(input.refreshToken),
@@ -114,8 +136,12 @@ export async function updateGoogleCalendarCredentialTokens(
         scope: input.scope,
         expiresAt: createExpiryDate(input.expiresIn),
       },
-    })
-  );
+    });
+
+    if (result.count === 0) {
+      throw new Error("calendar-not-connected");
+    }
+  });
 }
 
 export async function updateGoogleCalendarCredentialCalendarId(
@@ -124,7 +150,7 @@ export async function updateGoogleCalendarCredentialCalendarId(
   const normalizedUserId = normalizeUserId(input.userId);
   const result = await withActorRlsContext(normalizedUserId, (db) =>
     db.googleCalendarCredential.updateMany({
-      where: { userId: normalizedUserId },
+      where: { userId: normalizedUserId, revokedAt: null },
       data: {
         calendarId: normalizeGoogleCalendarId(input.calendarId),
       },
@@ -132,6 +158,48 @@ export async function updateGoogleCalendarCredentialCalendarId(
   );
 
   return result.count > 0;
+}
+
+export async function markGoogleCalendarCredentialRevokedForDisconnect(
+  userId: string
+): Promise<{ refreshToken: string } | null> {
+  const normalizedUserId = normalizeUserId(userId);
+  if (!normalizedUserId) {
+    return null;
+  }
+
+  return withActorRlsContext(normalizedUserId, async (db) => {
+    const credential = await db.googleCalendarCredential.findUnique({
+      where: { userId: normalizedUserId },
+      select: { refreshToken: true, revokedAt: true },
+    });
+
+    if (!credential) {
+      return null;
+    }
+
+    if (!credential.revokedAt) {
+      await db.googleCalendarCredential.updateMany({
+        where: { userId: normalizedUserId, revokedAt: null },
+        data: { revokedAt: new Date() },
+      });
+    }
+
+    return { refreshToken: decryptGoogleToken(credential.refreshToken) };
+  });
+}
+
+export async function deleteGoogleCalendarCredential(userId: string): Promise<void> {
+  const normalizedUserId = normalizeUserId(userId);
+  if (!normalizedUserId) {
+    return;
+  }
+
+  await withActorRlsContext(normalizedUserId, (db) =>
+    db.googleCalendarCredential.deleteMany({
+      where: { userId: normalizedUserId },
+    })
+  );
 }
 
 export async function upsertGoogleCalendarCredentialTokens(

--- a/lib/services/google-token-crypto.ts
+++ b/lib/services/google-token-crypto.ts
@@ -15,6 +15,14 @@ function getGoogleTokenEncryptionKey(): Buffer | null {
   return createHash("sha256").update(rawKey).digest();
 }
 
+export function hasGoogleTokenEncryptionKey(): boolean {
+  return getGoogleTokenEncryptionKey() !== null;
+}
+
+export function isEncryptedGoogleToken(storedToken: string): boolean {
+  return storedToken.startsWith(`${ENCRYPTED_TOKEN_PREFIX}:`);
+}
+
 export function encryptGoogleToken(rawToken: string): string {
   const key = getGoogleTokenEncryptionKey();
   if (!key) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexusdash",
-  "version": "0.37.1",
+  "version": "0.38.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexusdash",
-      "version": "0.37.1",
+      "version": "0.38.0",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1079.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexusdash",
-  "version": "0.37.1",
+  "version": "0.38.0",
   "private": true,
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0",

--- a/scripts/test-rls-isolation.mjs
+++ b/scripts/test-rls-isolation.mjs
@@ -39,6 +39,8 @@ const ids = {
   credentialB: `rls_credential_b_${suffix}`,
   auditA: `rls_audit_a_${suffix}`,
   auditB: `rls_audit_b_${suffix}`,
+  calendarA: `rls_calendar_a_${suffix}`,
+  calendarB: `rls_calendar_b_${suffix}`,
 };
 
 const admin = new Client({ connectionString: adminDatabaseUrl });
@@ -207,6 +209,14 @@ async function seed() {
       ids.credentialB,
       ids.ownerB,
     ]
+  );
+  await admin.query(
+    `INSERT INTO "GoogleCalendarCredential"
+      ("id", "userId", "calendarId", "refreshToken", "createdAt", "updatedAt")
+     VALUES
+       ($1, $2, 'primary', 'refresh-a', NOW(), NOW()),
+       ($3, $4, 'primary', 'refresh-b', NOW(), NOW())`,
+    [ids.calendarA, ids.ownerA, ids.calendarB, ids.ownerB]
   );
 }
 
@@ -439,6 +449,44 @@ try {
   );
   assert.deepEqual(ownerAAudit.rows.map((row) => row.id), [ids.auditA]);
 
+  const ownerACalendarCredentials = await runtimeTransaction(ids.ownerA, () =>
+    runtime.query(
+      `SELECT "id" FROM "GoogleCalendarCredential" WHERE "id" IN ($1, $2)`,
+      [ids.calendarA, ids.calendarB]
+    )
+  );
+  assert.deepEqual(ownerACalendarCredentials.rows.map((row) => row.id), [
+    ids.calendarA,
+  ]);
+
+  const crossCalendarUpdate = await runtimeTransaction(ids.ownerA, () =>
+    runtime.query(
+      `UPDATE "GoogleCalendarCredential" SET "calendarId" = 'blocked' WHERE "id" = $1`,
+      [ids.calendarB]
+    )
+  );
+  assert.equal(crossCalendarUpdate.rowCount, 0);
+
+  const crossCalendarDelete = await runtimeTransaction(ids.ownerA, () =>
+    runtime.query(`DELETE FROM "GoogleCalendarCredential" WHERE "id" = $1`, [
+      ids.calendarB,
+    ])
+  );
+  assert.equal(crossCalendarDelete.rowCount, 0);
+
+  await expectRlsViolation(
+    () =>
+      runtimeTransaction(ids.ownerA, () =>
+        runtime.query(
+          `INSERT INTO "GoogleCalendarCredential"
+            ("id", "userId", "calendarId", "refreshToken", "createdAt", "updatedAt")
+           VALUES ($1, $2, 'primary', 'blocked', NOW(), NOW())`,
+          [`rls_cross_calendar_${suffix}`, ids.ownerB]
+        )
+      ),
+    "cross-user calendar credential insert"
+  );
+
   const crossCredentialUpdate = await runtimeTransaction(ids.ownerA, () =>
     runtime.query(`UPDATE "ApiCredential" SET "label" = 'Cross' WHERE "id" = $1`, [
       ids.credentialB,
@@ -467,7 +515,7 @@ try {
   assert.equal(missingLookup.rowCount, 0);
 
   console.log(
-    "RLS isolation matrix passed for absent actors, cross-project CRUD, role differences, child rows, revoked membership, and agent credentials."
+    "RLS isolation matrix passed for absent actors, cross-project CRUD, role differences, child rows, revoked membership, calendar credentials, and agent credentials."
   );
 } finally {
   await cleanup().catch(() => undefined);

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -48,7 +48,7 @@ Last reviewed: 2026-08-24
   Brief: `tasks/task-325-google-calendar-integration-audit.md`
 - ID: TASK-326
   Title: Google Calendar connection ownership - enforce user-scoped rather than project-scoped integration
-  Status: Next 7 - calendar ownership verification and remediation
+  Status: In review (2026-08-06; stacked after TASK-325)
   Rationale: Verify and enforce that each Google Calendar authorization, credential, target-calendar preference, refresh lifecycle, and disconnect action belongs to the authenticated user rather than an individual project, while ensuring project calendar views use only the current user's connection and cannot expose another member's credentials or settings.
   Dependencies: TASK-076, TASK-083, TASK-325
   Brief: `tasks/task-326-google-calendar-connection-ownership.md`

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,84 +1,41 @@
-# Current Task
-
-## TASK-370: Preview Authentication and Database Isolation Guardrails
+# TASK-326: Google Calendar Connection Ownership Hardening
 
 ## Status
 
-Complete on `fix/task-370-preview-auth-isolation`; validated on the immutable
-Vercel Preview deployment and delivered through PR #432.
+Implementation complete on `feature/task-326-calendar-ownership`; review and
+validation refreshed against current `main` after TASK-325 merged.
 
-## Context
+## Objective
 
-Authentication from a URL believed to be a preview reached production and a
-signup reported an email already present in the production user database.
-Investigation confirmed that the tested Vercel alias currently targets a
-production deployment. The Vercel Preview environment also retained that alias
-as `NEXTAUTH_URL`, so preview auth callbacks and generated links could select a
-stale production origin even when the immutable deployment itself was a real
-preview. Preview and production currently use distinct Supabase project refs,
-but the deployment contract does not pin either environment to its intended
-ref or verify the deployed target before publishing the preview URL.
+Close the lifecycle and enforcement gaps in the existing single-Google-
+connection model while preserving strict authenticated-user ownership.
 
 ## Scope
 
-- Resolve request origins from the current immutable Vercel deployment host in
-  preview instead of using a static `NEXTAUTH_URL`.
-- Pin production-like runtimes to an explicitly configured expected Supabase
-  project ref and reject cross-environment database routing at startup.
-- Validate the preview migration target, Vercel deployment target, deployed
-  environment/revision metadata, and database readiness before uploading the
-  preview URL artifact.
-- Remove stale Vercel Preview origin/redirect overrides (`NEXTAUTH_URL` and
-  OAuth callback URLs) and configure expected project-ref metadata for Preview
-  and Production.
-- Exercise signup/signin on the fixed preview without touching production.
+- Enforce active-only credential reads, refreshes, and target updates.
+- Implement idempotent, fail-closed disconnect with provider revocation and
+  unconditional local token removal.
+- Require token encryption whenever Calendar OAuth is configured outside tests
+  and upgrade legacy plaintext rows when read.
+- Add accessible disconnect UX and repair the dashboard summary request.
+- Prove ownership in unit/API/UI and real PostgreSQL RLS tests.
 
 ## Acceptance Criteria
 
-1. A preview request resolves auth callback/link origins to that preview's
-   immutable `VERCEL_URL`, never the production domain or a stale alias.
-2. Preview and production fail closed when their runtime Supabase project ref
-   does not match `EXPECTED_SUPABASE_PROJECT_REF`.
-3. The preview deploy workflow rejects a non-preview Vercel target, a revision
-   mismatch, an environment mismatch, an unreachable database, or a migration
-   connection aimed at the wrong Supabase project.
-4. The workflow artifact contains the immutable URL of the exact requested
-   branch deployment only after all preview checks pass.
-5. A new account can sign up and sign back in on the fixed preview while the
-   browser remains on the preview origin.
-6. Existing production routing and trusted-origin behavior remain unchanged.
+1. Revoked credentials cannot authorize Calendar operations.
+2. Disconnect affects only the signed-in user, removes local tokens even when
+   provider revocation fails, and reports a safe revocation status.
+3. Target reset remains available through PATCH while DELETE disconnects.
+4. Configured non-test Calendar OAuth requires token encryption and legacy
+   plaintext tokens are rewritten encrypted.
+5. Calendar summary requests include their project authorization context.
+6. Automated and real-database coverage proves the ownership boundary.
 
 ## Definition Of Done
 
-- Focused origin, runtime-environment, health-route, and deploy-validation
-  coverage passes.
-- `npm run lint`, `npm run rls:check`, `npm test`, `npm run test:coverage`,
-  `npm run build`, and relevant deployed-preview Playwright checks pass.
-- Vercel/GitHub environment metadata is configured without exposing secrets.
-- The branch preview workflow completes for the explicit branch ref and its
-  logs prove the checked-out ref and validated Preview target.
-- A ready-for-review PR is open; required checks and initial Copilot review are
-  complete; actionable threads are resolved before merge.
-- `tasks/current.md`, `tasks/backlog.md`, relevant runbooks, and `journal.md`
-  record the diagnosis and validation outcome.
-
-## Runtime Assumptions
-
-- Preview and production remain separate Supabase projects; their project refs
-  are safe non-secret deployment metadata while connection strings stay secret.
-- GitHub `preview` and `production` environments and the corresponding Vercel
-  environments are available to configure `EXPECTED_SUPABASE_PROJECT_REF`.
-- Preview validation uses the immutable URL emitted by `deploy-vercel.yml`, not
-  a branch alias or a historical Vercel URL.
-
-## Validation Evidence
-
-- Workflow run `32313383142` checked out the explicit fix branch, applied
-  staging migrations, verified Preview target/revision/environment/database
-  readiness, and published
-  `https://nexus-dash-h1s18isxe-dorian-agaesses-projects.vercel.app`.
-- The deployed opt-in Playwright case created a staging account, signed out,
-  signed back in, and remained on that immutable origin.
-- Lint, RLS inventory, unit/API, coverage, build, and CI Playwright validation
-  passed. Copilot's initial review completed; its environment-restoration
-  comment was applied and covered by the focused request-origin test.
+- Runtime, tests, docs, ADR index, changelog, version, and tracking documents
+  are consistent.
+- Lint, RLS inventory/matrix, tests, coverage, build, and E2E pass.
+- An explicit-ref preview is validated.
+- The branch is pushed and a ready-for-review PR is open with automated feedback
+  handled.

--- a/tasks/task-326-google-calendar-connection-ownership.md
+++ b/tasks/task-326-google-calendar-connection-ownership.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Pending after TASK-325.
+Implementation complete (2026-08-06); ready for stacked review after TASK-325.
 
 ## Objective
 

--- a/tests/api/account-settings.route.test.ts
+++ b/tests/api/account-settings.route.test.ts
@@ -8,6 +8,7 @@ const apiGuardMock = vi.hoisted(() => ({
 const settingsServiceMock = vi.hoisted(() => ({
   getGoogleCalendarTargetSettings: vi.fn(),
   updateGoogleCalendarTargetSettings: vi.fn(),
+  disconnectGoogleCalendar: vi.fn(),
 }));
 
 const logServerWarningMock = vi.hoisted(() => vi.fn());
@@ -25,6 +26,7 @@ vi.mock("@/lib/services/account-settings-service", () => ({
     settingsServiceMock.getGoogleCalendarTargetSettings,
   updateGoogleCalendarTargetSettings:
     settingsServiceMock.updateGoogleCalendarTargetSettings,
+  disconnectGoogleCalendar: settingsServiceMock.disconnectGoogleCalendar,
 }));
 
 import {
@@ -131,12 +133,13 @@ describe("account Google Calendar settings route", () => {
     expect(settingsServiceMock.updateGoogleCalendarTargetSettings).not.toHaveBeenCalled();
   });
 
-  test("DELETE resets target calendar to default", async () => {
-    settingsServiceMock.updateGoogleCalendarTargetSettings.mockResolvedValueOnce({
+  test("DELETE disconnects the authenticated user's calendar", async () => {
+    settingsServiceMock.disconnectGoogleCalendar.mockResolvedValueOnce({
       ok: true,
       status: 200,
       data: {
-        calendarId: "primary",
+        hasCalendarConnection: false,
+        revocationStatus: "revoked",
       },
     });
 
@@ -149,12 +152,12 @@ describe("account Google Calendar settings route", () => {
     expect(response.status).toBe(200);
     await expect(readJson(response)).resolves.toEqual({
       settings: {
-        calendarId: "primary",
+        hasCalendarConnection: false,
+        revocationStatus: "revoked",
       },
     });
-    expect(settingsServiceMock.updateGoogleCalendarTargetSettings).toHaveBeenCalledWith({
+    expect(settingsServiceMock.disconnectGoogleCalendar).toHaveBeenCalledWith({
       actorUserId: "user-1",
-      calendarIdRaw: "",
     });
   });
 });

--- a/tests/components/google-calendar-ownership-controls.test.tsx
+++ b/tests/components/google-calendar-ownership-controls.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn(), refresh: vi.fn() }),
+}));
+
+import { GoogleCalendarDisconnectControl } from "@/components/account/google-calendar-disconnect-control";
+import { buildCalendarSummaryEventsUrl } from "@/components/project-dashboard/calendar-summary-stat-card";
+
+(globalThis as { React?: typeof React }).React = React;
+
+describe("Google Calendar ownership controls", () => {
+  test("renders an explicit destructive disconnect action", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(GoogleCalendarDisconnectControl)
+    );
+
+    expect(markup).toContain("Disconnect Google Calendar");
+    expect(markup).toContain("min-h-11");
+  });
+
+  test("includes the project authorization context in summary requests", () => {
+    expect(buildCalendarSummaryEventsUrl("project / one")).toBe(
+      "/api/calendar/events?range=current-week&amp;projectId=project%20%2F%20one".replace(
+        "&amp;",
+        "&"
+      )
+    );
+  });
+});

--- a/tests/lib/account-settings-service.test.ts
+++ b/tests/lib/account-settings-service.test.ts
@@ -3,6 +3,12 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 const googleCalendarCredentialServiceMock = vi.hoisted(() => ({
   findGoogleCalendarCredentialCalendarId: vi.fn(),
   updateGoogleCalendarCredentialCalendarId: vi.fn(),
+  markGoogleCalendarCredentialRevokedForDisconnect: vi.fn(),
+  deleteGoogleCalendarCredential: vi.fn(),
+}));
+
+const googleCalendarMock = vi.hoisted(() => ({
+  revokeGoogleToken: vi.fn(),
 }));
 
 vi.mock("@/lib/services/google-calendar-credential-service", async () => {
@@ -16,10 +22,22 @@ vi.mock("@/lib/services/google-calendar-credential-service", async () => {
       googleCalendarCredentialServiceMock.findGoogleCalendarCredentialCalendarId,
     updateGoogleCalendarCredentialCalendarId:
       googleCalendarCredentialServiceMock.updateGoogleCalendarCredentialCalendarId,
+    markGoogleCalendarCredentialRevokedForDisconnect:
+      googleCalendarCredentialServiceMock.markGoogleCalendarCredentialRevokedForDisconnect,
+    deleteGoogleCalendarCredential:
+      googleCalendarCredentialServiceMock.deleteGoogleCalendarCredential,
   };
 });
 
+vi.mock("@/lib/google-calendar", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/google-calendar")>(
+    "@/lib/google-calendar"
+  );
+  return { ...actual, revokeGoogleToken: googleCalendarMock.revokeGoogleToken };
+});
+
 import {
+  disconnectGoogleCalendar,
   getGoogleCalendarTargetSettings,
   updateGoogleCalendarTargetSettings,
 } from "@/lib/services/account-settings-service";
@@ -31,6 +49,9 @@ import {
 describe("account-settings-service", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    googleCalendarCredentialServiceMock.deleteGoogleCalendarCredential.mockResolvedValue(
+      undefined
+    );
   });
 
   test("returns primary and disconnected status when user has no credential", async () => {
@@ -153,5 +174,69 @@ describe("account-settings-service", () => {
       status: 409,
       error: "calendar-not-connected",
     });
+  });
+
+  test("rejects cross-user disconnect attempts", async () => {
+    const result = await disconnectGoogleCalendar({
+      actorUserId: "user-1",
+      subjectUserId: "user-2",
+    });
+
+    expect(result).toEqual({ ok: false, status: 403, error: "forbidden" });
+    expect(
+      googleCalendarCredentialServiceMock.markGoogleCalendarCredentialRevokedForDisconnect
+    ).not.toHaveBeenCalled();
+  });
+
+  test("disconnect is idempotent when no credential exists", async () => {
+    googleCalendarCredentialServiceMock.markGoogleCalendarCredentialRevokedForDisconnect.mockResolvedValueOnce(
+      null
+    );
+
+    await expect(
+      disconnectGoogleCalendar({ actorUserId: "user-1" })
+    ).resolves.toEqual({
+      ok: true,
+      status: 200,
+      data: {
+        hasCalendarConnection: false,
+        revocationStatus: "not-connected",
+      },
+    });
+    expect(googleCalendarMock.revokeGoogleToken).not.toHaveBeenCalled();
+  });
+
+  test("deletes local credentials after confirmed provider revocation", async () => {
+    googleCalendarCredentialServiceMock.markGoogleCalendarCredentialRevokedForDisconnect.mockResolvedValueOnce(
+      { refreshToken: "refresh-token" }
+    );
+    googleCalendarMock.revokeGoogleToken.mockResolvedValueOnce(true);
+
+    await expect(
+      disconnectGoogleCalendar({ actorUserId: "user-1" })
+    ).resolves.toMatchObject({
+      ok: true,
+      data: { revocationStatus: "revoked" },
+    });
+    expect(
+      googleCalendarCredentialServiceMock.deleteGoogleCalendarCredential
+    ).toHaveBeenCalledWith("user-1");
+  });
+
+  test("deletes local credentials when provider revocation is unconfirmed", async () => {
+    googleCalendarCredentialServiceMock.markGoogleCalendarCredentialRevokedForDisconnect.mockResolvedValueOnce(
+      { refreshToken: "refresh-token" }
+    );
+    googleCalendarMock.revokeGoogleToken.mockRejectedValueOnce(new Error("network"));
+
+    await expect(
+      disconnectGoogleCalendar({ actorUserId: "user-1" })
+    ).resolves.toMatchObject({
+      ok: true,
+      data: { revocationStatus: "unconfirmed" },
+    });
+    expect(
+      googleCalendarCredentialServiceMock.deleteGoogleCalendarCredential
+    ).toHaveBeenCalledWith("user-1");
   });
 });

--- a/tests/lib/env.server.test.ts
+++ b/tests/lib/env.server.test.ts
@@ -527,7 +527,21 @@ describe("env.server", () => {
     vi.stubEnv("GOOGLE_TOKEN_ENCRYPTION_KEY", "");
 
     expect(() => validateServerRuntimeConfig()).toThrow(
-      "GOOGLE_TOKEN_ENCRYPTION_KEY is required in production when Google Calendar OAuth is enabled."
+      "GOOGLE_TOKEN_ENCRYPTION_KEY is required when Google Calendar OAuth is enabled outside tests."
+    );
+  });
+
+  test("fails development validation when google oauth is enabled without token encryption key", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("DATABASE_URL", "postgresql://localhost:5432/postgres");
+    vi.stubEnv("DIRECT_URL", "postgresql://localhost:5433/postgres");
+    vi.stubEnv("GOOGLE_CLIENT_ID", "client-id");
+    vi.stubEnv("GOOGLE_CLIENT_SECRET", "client-secret");
+    vi.stubEnv("GOOGLE_REDIRECT_URI", "http://localhost:3000/api/auth/callback/google");
+    vi.stubEnv("GOOGLE_TOKEN_ENCRYPTION_KEY", "");
+
+    expect(() => validateServerRuntimeConfig()).toThrow(
+      "GOOGLE_TOKEN_ENCRYPTION_KEY is required when Google Calendar OAuth is enabled outside tests."
     );
   });
 

--- a/tests/lib/google-calendar-credential-service.test.ts
+++ b/tests/lib/google-calendar-credential-service.test.ts
@@ -5,6 +5,7 @@ const prismaMock = vi.hoisted(() => ({
     findUnique: vi.fn(),
     update: vi.fn(),
     updateMany: vi.fn(),
+    deleteMany: vi.fn(),
     upsert: vi.fn(),
   },
 }));
@@ -16,6 +17,8 @@ const googleCalendarMock = vi.hoisted(() => ({
 const googleTokenCryptoMock = vi.hoisted(() => ({
   encryptGoogleToken: vi.fn((value: string) => value),
   decryptGoogleToken: vi.fn((value: string) => value),
+  hasGoogleTokenEncryptionKey: vi.fn(() => false),
+  isEncryptedGoogleToken: vi.fn((value: string) => value.startsWith("enc:v1:")),
 }));
 
 vi.mock("@/lib/prisma", () => ({
@@ -29,12 +32,16 @@ vi.mock("@/lib/google-calendar", () => ({
 vi.mock("@/lib/services/google-token-crypto", () => ({
   encryptGoogleToken: googleTokenCryptoMock.encryptGoogleToken,
   decryptGoogleToken: googleTokenCryptoMock.decryptGoogleToken,
+  hasGoogleTokenEncryptionKey: googleTokenCryptoMock.hasGoogleTokenEncryptionKey,
+  isEncryptedGoogleToken: googleTokenCryptoMock.isEncryptedGoogleToken,
 }));
 
 import {
   DEFAULT_GOOGLE_CALENDAR_ID,
   findGoogleCalendarCredential,
   findGoogleCalendarCredentialCalendarId,
+  deleteGoogleCalendarCredential,
+  markGoogleCalendarCredentialRevokedForDisconnect,
   normalizeGoogleCalendarId,
   updateGoogleCalendarCredentialCalendarId,
   updateGoogleCalendarCredentialTokens,
@@ -46,6 +53,12 @@ describe("google-calendar-credential-service", () => {
     vi.clearAllMocks();
     googleCalendarMock.createExpiryDate.mockReturnValue(
       new Date("2026-02-16T00:00:00.000Z")
+    );
+    googleTokenCryptoMock.hasGoogleTokenEncryptionKey.mockReturnValue(false);
+    googleTokenCryptoMock.encryptGoogleToken.mockImplementation((value: string) => value);
+    googleTokenCryptoMock.decryptGoogleToken.mockImplementation((value: string) => value);
+    googleTokenCryptoMock.isEncryptedGoogleToken.mockImplementation((value: string) =>
+      value.startsWith("enc:v1:")
     );
   });
 
@@ -69,7 +82,7 @@ describe("google-calendar-credential-service", () => {
   });
 
   test("updates credential tokens with refreshed expiry", async () => {
-    prismaMock.googleCalendarCredential.update.mockResolvedValueOnce({});
+    prismaMock.googleCalendarCredential.updateMany.mockResolvedValueOnce({ count: 1 });
 
     await updateGoogleCalendarCredentialTokens({
       userId: "user-1",
@@ -81,8 +94,8 @@ describe("google-calendar-credential-service", () => {
     });
 
     expect(googleCalendarMock.createExpiryDate).toHaveBeenCalledWith(3600);
-    expect(prismaMock.googleCalendarCredential.update).toHaveBeenCalledWith({
-      where: { userId: "user-1" },
+    expect(prismaMock.googleCalendarCredential.updateMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", revokedAt: null },
       data: {
         accessToken: "new-access",
         refreshToken: "refresh",
@@ -103,7 +116,7 @@ describe("google-calendar-credential-service", () => {
     expect(result).toBe(DEFAULT_GOOGLE_CALENDAR_ID);
     expect(prismaMock.googleCalendarCredential.findUnique).toHaveBeenCalledWith({
       where: { userId: "user-1" },
-      select: { calendarId: true },
+      select: { calendarId: true, revokedAt: true },
     });
   });
 
@@ -117,8 +130,66 @@ describe("google-calendar-credential-service", () => {
 
     expect(didUpdate).toBe(true);
     expect(prismaMock.googleCalendarCredential.updateMany).toHaveBeenCalledWith({
-      where: { userId: "user-1" },
+      where: { userId: "user-1", revokedAt: null },
       data: { calendarId: "team@example.com" },
+    });
+  });
+
+  test("treats revoked credentials as disconnected", async () => {
+    prismaMock.googleCalendarCredential.findUnique.mockResolvedValueOnce({
+      userId: "user-1",
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      revokedAt: new Date("2026-08-06T10:00:00.000Z"),
+    });
+
+    await expect(findGoogleCalendarCredential("user-1")).resolves.toBeNull();
+    expect(googleTokenCryptoMock.decryptGoogleToken).not.toHaveBeenCalled();
+  });
+
+  test("rewrites plaintext tokens when an encryption key is available", async () => {
+    googleTokenCryptoMock.hasGoogleTokenEncryptionKey.mockReturnValue(true);
+    googleTokenCryptoMock.encryptGoogleToken.mockImplementation(
+      (value: string) => `enc:v1:${value}`
+    );
+    prismaMock.googleCalendarCredential.findUnique.mockResolvedValueOnce({
+      userId: "user-1",
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      revokedAt: null,
+    });
+    prismaMock.googleCalendarCredential.updateMany.mockResolvedValueOnce({ count: 1 });
+
+    await findGoogleCalendarCredential("user-1");
+
+    expect(prismaMock.googleCalendarCredential.updateMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", revokedAt: null },
+      data: {
+        accessToken: "enc:v1:access-token",
+        refreshToken: "enc:v1:refresh-token",
+      },
+    });
+  });
+
+  test("marks a credential revoked before disconnect and then deletes it", async () => {
+    prismaMock.googleCalendarCredential.findUnique.mockResolvedValueOnce({
+      refreshToken: "refresh-token",
+      revokedAt: null,
+    });
+    prismaMock.googleCalendarCredential.updateMany.mockResolvedValueOnce({ count: 1 });
+    prismaMock.googleCalendarCredential.deleteMany.mockResolvedValueOnce({ count: 1 });
+
+    await expect(
+      markGoogleCalendarCredentialRevokedForDisconnect("user-1")
+    ).resolves.toEqual({ refreshToken: "refresh-token" });
+    await deleteGoogleCalendarCredential("user-1");
+
+    expect(prismaMock.googleCalendarCredential.updateMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", revokedAt: null },
+      data: { revokedAt: expect.any(Date) },
+    });
+    expect(prismaMock.googleCalendarCredential.deleteMany).toHaveBeenCalledWith({
+      where: { userId: "user-1" },
     });
   });
 

--- a/tests/lib/google-calendar.test.ts
+++ b/tests/lib/google-calendar.test.ts
@@ -9,6 +9,7 @@ import {
   normalizeReturnToPath,
   parseTokenResponse,
   refreshAccessToken,
+  revokeGoogleToken,
   resolveGoogleOAuthRedirectUri,
 } from "@/lib/google-calendar";
 
@@ -142,5 +143,17 @@ describe("google-calendar", () => {
     );
 
     await expect(refreshAccessToken("bad-refresh")).rejects.toThrow("invalid_grant");
+  });
+
+  test("revokes a refresh token through Google's server endpoint", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 200 }));
+
+    await expect(revokeGoogleToken("refresh-token")).resolves.toBe(true);
+    const request = fetchSpy.mock.calls[0];
+    expect(request[0]).toBe("https://oauth2.googleapis.com/revoke");
+    expect(request[1]).toMatchObject({ method: "POST" });
+    expect((request[1]?.body as URLSearchParams).get("token")).toBe("refresh-token");
   });
 });

--- a/tests/lib/google-token-crypto.test.ts
+++ b/tests/lib/google-token-crypto.test.ts
@@ -3,6 +3,8 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   decryptGoogleToken,
   encryptGoogleToken,
+  hasGoogleTokenEncryptionKey,
+  isEncryptedGoogleToken,
 } from "@/lib/services/google-token-crypto";
 
 describe("google-token-crypto", () => {
@@ -18,6 +20,8 @@ describe("google-token-crypto", () => {
 
     expect(encrypted).toBe("token-abc");
     expect(decrypted).toBe("token-abc");
+    expect(hasGoogleTokenEncryptionKey()).toBe(false);
+    expect(isEncryptedGoogleToken(encrypted)).toBe(false);
   });
 
   test("encrypts and decrypts token payload with configured key", () => {
@@ -28,6 +32,8 @@ describe("google-token-crypto", () => {
 
     expect(encrypted).not.toBe("token-abc");
     expect(encrypted.startsWith("enc:v1:")).toBe(true);
+    expect(hasGoogleTokenEncryptionKey()).toBe(true);
+    expect(isEncryptedGoogleToken(encrypted)).toBe(true);
     expect(decrypted).toBe("token-abc");
   });
 });


### PR DESCRIPTION
## What changed

- enforce active-only Google Calendar credentials and lazily encrypt legacy plaintext tokens
- make DELETE an idempotent, fail-closed disconnect with upstream revocation status and unconditional local token removal
- add accessible Settings disconnect/recovery UI and repair project Calendar summary authorization context
- expand API, service, component, environment, and real PostgreSQL RLS coverage
- preserve the required feature release at v0.38.0

## Why

TASK-325 found that revoked credentials remained readable, disconnect only reset the target calendar, local OAuth could retain plaintext tokens, and the project summary omitted `projectId`. These changes close those ownership and lifecycle gaps before multi-account expansion.

## Validation

The original validation passed lint, RLS inventory and matrix, 1,048 tests with two expected skips, coverage, production build, and Playwright. This replacement rebases the feature onto current `main`; fresh required checks will run here.

## Supersedes

Supersedes #419 because protected branch rules prohibit force-pushing its rebased history.