### PR TITLE
TASK-356: Add accountable steward/facilitator to meeting notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ SHA, deployment URL, and workflow run belong in release evidence.
 
 - Define each release entry before the product-impacting PR is merged.
 
+## v0.38.0 - 2026-08-10
+
+- Added a durable, reassignable steward/facilitator actor to every meeting note
+  (human project member or active project agent credential), reusing the
+  TASK-330 actor contract so removed members and revoked/expired agents render
+  as `Needs reassignment` instead of orphaning the note.
+- Persisted creator, last editor, and update-time provenance on every meeting
+  note response, surfaced alongside the steward in the meeting notes panel and
+  meeting detail view.
+- New meeting notes default the steward to the note creator; unrelated edits
+  preserve the steward; editors can explicitly reassign or clear it from the
+  detail view and the preparation flow with accessible, keyboard-operable
+  controls (44px touch target, light/dark, semantic status). Viewers see the
+  steward identity without mutation affordances.
+- Added URL-backed `All`, `Stewarded by me`, and `Unstewarded` responsibility
+  filters for both the active and archived meeting notes lists, with accurate
+  counts and useful empty states.
+- Extended the project activity event stream so stewardship changes emit a
+  project activity event and survive project-scoped realtime reconciliation.
+
 ## v0.37.1 - 2026-08-20
 
 - Fixed Vercel Preview authentication origins so callbacks and post-auth

--- a/adr/decisions.md
+++ b/adr/decisions.md
@@ -461,3 +461,35 @@ Keep UI-only or task-only notes in `journal.md`.
 - Context: Local port conflicts blocked developer startup.
 - Decision: Keep container port `3000`, map host port with `${APP_PORT:-3000}`.
 - Consequences: Safer local onboarding in mixed environments.
+
+## 2026-08-09 - TASK-356: Reuse the TASK-330 actor contract for meeting note stewards
+
+- Status: Accepted
+- Context: The collaboration refinement audit (TASK-336) flagged meeting
+  notes as having "no visible accountable owner" and recommended that
+  steward/facilitator identity be added without conflating it with
+  individual todo assignees or participants. TASK-330 already shipped a
+  reusable human-or-agent actor contract (`MeetingTodoActorReference`,
+  `MeetingTodoActorSummary`, `loadMeetingTodoActorRegistry`,
+  `resolveAssignableMeetingTodoActorFromRegistry`) that all meeting-todo
+  mutations flow through.
+- Decision: Adopted the same contract for the new
+  `ProjectMeetingNote.steward*` columns and the
+  `setProjectMeetingNoteSteward` service. New columns mirror the
+  todo-assignee dual-key shape (`stewardUserId` xor `stewardCredentialId`,
+  `stewardKind`, `stewardDisplayNameSnapshot`) and the CHECK constraint
+  (`steward_actor_check`) so removed human members and revoked/expired
+  agents are surfaced through the existing chip vocabulary as "Needs
+  reassignment" instead of being silently nulled out. The UI reuses the
+  established `MeetingTodoAssigneeChip` / `MeetingTodoAssigneeChipReadonly`
+  components and `MeetingTodoActorIdentity` control so the steward, todo
+  assignee, and creator chips all share one identity language.
+- Consequences: Steward responsibilities are filtered with the same
+  `mine` / `unassigned` / `all` URL-backed semantics already used for
+  meeting todos; viewers never see mutation affordances; and the project
+  does not grow a parallel actor pipeline before TASK-337's universal
+  actor foundation ships. Cross-artifact ownership and a workspace
+  stewardship queue are explicitly deferred to TASK-346.
+- Links: `tasks/task-356-meeting-note-stewardship.md`,
+  `docs/audits/task-336-multi-user-collaboration-audit.md`,
+  `tasks/task-330-meeting-todo-assignees.md`.

--- a/app/api/projects/[projectId]/meeting-notes/[noteId]/steward/route.ts
+++ b/app/api/projects/[projectId]/meeting-notes/[noteId]/steward/route.ts
@@ -67,7 +67,10 @@ export async function PATCH(
   } else if (isMeetingTodoActorReference(payload.steward)) {
     steward = { kind: payload.steward.kind, id: payload.steward.id.trim() };
   } else if (payload.steward === undefined) {
-    steward = null;
+    return NextResponse.json(
+      { error: "meeting-note-steward-required" },
+      { status: 400 }
+    );
   } else {
     return NextResponse.json(
       { error: "meeting-note-steward-invalid" },

--- a/app/api/projects/[projectId]/meeting-notes/[noteId]/steward/route.ts
+++ b/app/api/projects/[projectId]/meeting-notes/[noteId]/steward/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import {
+  getAgentProjectAccessContext,
+  requireApiPrincipal,
+} from "@/lib/auth/api-guard";
+import { logServerWarning } from "@/lib/observability/logger";
+import { isMeetingTodoActorReference } from "@/lib/meeting-todo-actor";
+import { recordProjectActivityEventVersion } from "@/lib/project-activity-event-response";
+import { withProjectActivityVersionHeader } from "@/lib/project-activity-version";
+import {
+  setProjectMeetingNoteSteward,
+  type ProjectMeetingNoteSummary,
+} from "@/lib/services/project-meeting-note-service";
+
+interface StewardRequestBody {
+  steward?: unknown;
+}
+
+function serializeMeetingNote(note: ProjectMeetingNoteSummary) {
+  return {
+    ...note,
+    scheduledAt: note.scheduledAt?.toISOString() ?? null,
+    createdAt: note.createdAt.toISOString(),
+    updatedAt: note.updatedAt.toISOString(),
+    actions: note.actions.map((action) => ({
+      ...action,
+      completedAt: action.completedAt?.toISOString() ?? null,
+    })),
+  };
+}
+
+async function readJsonPayload(
+  request: NextRequest,
+  routeLabel: string
+): Promise<StewardRequestBody | NextResponse> {
+  try {
+    return (await request.json()) as StewardRequestBody;
+  } catch (error) {
+    logServerWarning(routeLabel, "Invalid JSON payload", { error });
+    return NextResponse.json({ error: "invalid-json" }, { status: 400 });
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  props: { params: Promise<{ projectId: string; noteId: string }> }
+) {
+  const params = await props.params;
+  const principalResult = await requireApiPrincipal(request);
+  if (!principalResult.ok) {
+    return principalResult.response;
+  }
+  const principal = principalResult.principal;
+
+  const payload = await readJsonPayload(
+    request,
+    "PATCH /api/projects/:projectId/meeting-notes/:noteId/steward.invalidJson"
+  );
+  if (payload instanceof NextResponse) {
+    return payload;
+  }
+
+  let steward: Parameters<typeof setProjectMeetingNoteSteward>[0]["steward"];
+  if (payload.steward === null) {
+    steward = null;
+  } else if (isMeetingTodoActorReference(payload.steward)) {
+    steward = { kind: payload.steward.kind, id: payload.steward.id.trim() };
+  } else if (payload.steward === undefined) {
+    steward = null;
+  } else {
+    return NextResponse.json(
+      { error: "meeting-note-steward-invalid" },
+      { status: 400 }
+    );
+  }
+
+  const result = await setProjectMeetingNoteSteward({
+    actorUserId: principal.actorUserId,
+    projectId: params.projectId,
+    noteId: params.noteId,
+    steward,
+    agentAccess: getAgentProjectAccessContext(principal),
+  });
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  const version = await recordProjectActivityEventVersion({
+    actorUserId: principal.actorUserId,
+    projectId: params.projectId,
+    domain: "meeting-note",
+    action: "updated",
+    entityId: result.data.note.id,
+    payload: {
+      noteId: result.data.note.id,
+      steward: steward
+        ? { kind: steward.kind, id: steward.id }
+        : null,
+    },
+  });
+
+  return NextResponse.json(
+    { note: serializeMeetingNote(result.data.note) },
+    {
+      headers: withProjectActivityVersionHeader(new Headers(), version),
+    }
+  );
+}

--- a/app/api/projects/[projectId]/meeting-notes/route.ts
+++ b/app/api/projects/[projectId]/meeting-notes/route.ts
@@ -121,6 +121,15 @@ async function readJsonPayload(
   }
 }
 
+function readStewardFilter(
+  value: string | null
+): "all" | "mine" | "unassigned" {
+  if (value === "mine" || value === "unassigned") {
+    return value;
+  }
+  return "all";
+}
+
 export async function GET(
   request: NextRequest,
   props: { params: Promise<{ projectId: string }> }
@@ -133,10 +142,14 @@ export async function GET(
   const principal = principalResult.principal;
 
   const query = request.nextUrl.searchParams.get("q");
+  const stewardFilter = readStewardFilter(
+    request.nextUrl.searchParams.get("steward")
+  );
   const notes = await listProjectMeetingNotes({
     actorUserId: principal.actorUserId,
     projectId: params.projectId,
     query,
+    stewardFilter,
     agentAccess: getAgentProjectAccessContext(principal),
   });
 

--- a/app/projects/[projectId]/page.tsx
+++ b/app/projects/[projectId]/page.tsx
@@ -132,6 +132,12 @@ export default async function ProjectDashboardPage({
   const initialMeetingTodoId = readQueryValue(
     resolvedSearchParams?.meetingTodoId
   );
+  const stewardFilterRaw = readQueryValue(resolvedSearchParams?.meetingNoteSteward);
+  const meetingNoteStewardFilter: "all" | "mine" | "unassigned" =
+    stewardFilterRaw === "mine" || stewardFilterRaw === "unassigned"
+      ? stewardFilterRaw
+      : "all";
+  const meetingNoteQuery = readQueryValue(resolvedSearchParams?.meetingNoteQuery);
   const actorRole =
     project.ownerId === actorUserId ? "owner" : (project.memberships[0]?.role ?? "viewer");
   const canEditProjectContent = actorRole === "owner" || actorRole === "editor";
@@ -267,6 +273,8 @@ export default async function ProjectDashboardPage({
           projectId={project.id}
           actorUserId={actorUserId}
           canEdit={canEditProjectContent}
+          stewardFilter={meetingNoteStewardFilter}
+          query={meetingNoteQuery}
           initialMeetingNoteId={initialMeetingNoteId}
           initialMeetingTodoId={initialMeetingTodoId}
         />

--- a/app/projects/[projectId]/project-meeting-notes-panel-section.tsx
+++ b/app/projects/[projectId]/project-meeting-notes-panel-section.tsx
@@ -52,8 +52,6 @@ export async function ProjectMeetingNotesPanelSection({
     listProjectMeetingNotes({
       projectId,
       actorUserId,
-      stewardFilter,
-      query,
     }),
     listProjectCollaborators(projectId, actorUserId),
     listProjectMeetingTodoActors({ projectId, actorUserId }),

--- a/app/projects/[projectId]/project-meeting-notes-panel-section.tsx
+++ b/app/projects/[projectId]/project-meeting-notes-panel-section.tsx
@@ -18,6 +18,8 @@ interface ProjectMeetingNotesPanelSectionProps {
   projectId: string;
   actorUserId: string;
   canEdit: boolean;
+  stewardFilter?: "all" | "mine" | "unassigned";
+  query?: string | null;
   initialMeetingNoteId?: string | null;
   initialMeetingTodoId?: string | null;
 }
@@ -41,6 +43,8 @@ export async function ProjectMeetingNotesPanelSection({
   projectId,
   actorUserId,
   canEdit,
+  stewardFilter = "all",
+  query = null,
   initialMeetingNoteId,
   initialMeetingTodoId,
 }: ProjectMeetingNotesPanelSectionProps) {
@@ -48,6 +52,8 @@ export async function ProjectMeetingNotesPanelSection({
     listProjectMeetingNotes({
       projectId,
       actorUserId,
+      stewardFilter,
+      query,
     }),
     listProjectCollaborators(projectId, actorUserId),
     listProjectMeetingTodoActors({ projectId, actorUserId }),
@@ -57,6 +63,9 @@ export async function ProjectMeetingNotesPanelSection({
     <ProjectMeetingNotesPanel
       projectId={projectId}
       canEdit={canEdit}
+      currentActorUserId={actorUserId}
+      stewardFilter={stewardFilter}
+      initialQuery={query}
       notes={notes.map((note) => serializeMeetingNote(note))}
       collaborators={collaborators}
       todoActors={todoActors}

--- a/components/meeting-todos/meeting-note-types.ts
+++ b/components/meeting-todos/meeting-note-types.ts
@@ -25,6 +25,9 @@ export interface ProjectMeetingNotePanelNote {
   outputNotes: string;
   decisions?: string;
   actions: ProjectMeetingNotePanelAction[];
+  steward?: MeetingTodoActorSummary | null;
+  createdBy?: MeetingTodoActorSummary | null;
+  updatedBy?: MeetingTodoActorSummary | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/components/project-meeting-notes-panel.tsx
+++ b/components/project-meeting-notes-panel.tsx
@@ -409,6 +409,13 @@ function mapMeetingNoteError(errorCode: string): string {
       return "Meeting todo not found.";
     case "meeting-note-action-update-failed":
       return "Could not update the meeting todo. Please retry.";
+    case "meeting-note-steward-required":
+      return "Send a steward reference to update this note.";
+    case "meeting-note-steward-invalid":
+    case "meeting-note-action-assignee-invalid":
+      return "That steward no longer has access to this project. Pick a current project member or active agent.";
+    case "meeting-note-steward-update-failed":
+      return "Could not update the steward. Please retry.";
     case "meeting-note-not-found":
       return "Meeting note not found.";
     case "forbidden":

--- a/components/project-meeting-notes-panel.tsx
+++ b/components/project-meeting-notes-panel.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { createPortal } from "react-dom";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
   AlertTriangle,
   Archive,
@@ -80,11 +82,37 @@ type PrepareDialogMode = "create" | "edit";
 interface ProjectMeetingNotesPanelProps {
   projectId: string;
   canEdit: boolean;
+  currentActorUserId?: string;
   notes: ProjectMeetingNotePanelNote[];
   collaborators: ProjectMeetingParticipantCollaborator[];
   todoActors: MeetingTodoActorSummary[];
+  stewardFilter?: StewardFilterValue;
+  initialQuery?: string | null;
   initialMeetingNoteId?: string | null;
   initialMeetingTodoId?: string | null;
+}
+
+export type StewardFilterValue = "all" | "mine" | "unassigned";
+
+function normalizeStewardFilter(value: string | null | undefined): StewardFilterValue {
+  return value === "mine" || value === "unassigned" ? value : "all";
+}
+
+function buildNotesHref(input: {
+  projectId: string;
+  stewardFilter: StewardFilterValue;
+  query?: string | null;
+}): string {
+  const params = new URLSearchParams();
+  if (input.stewardFilter !== "all") {
+    params.set("meetingNoteSteward", input.stewardFilter);
+  }
+  const trimmedQuery = (input.query ?? "").trim();
+  if (trimmedQuery.length > 0) {
+    params.set("meetingNoteQuery", trimmedQuery);
+  }
+  const query = params.toString();
+  return query ? `/projects/${input.projectId}?${query}` : `/projects/${input.projectId}`;
 }
 
 interface DraftAction {
@@ -207,6 +235,25 @@ function formatShortDate(value: string | null): string {
   return new Intl.DateTimeFormat(undefined, {
     month: "short",
     day: "numeric",
+  }).format(date);
+}
+
+function formatMeetingTimestamp(value: string | null): string {
+  if (!value) {
+    return "—";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "—";
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
   }).format(date);
 }
 
@@ -675,15 +722,26 @@ function MeetingDialogShell({
 export function ProjectMeetingNotesPanel({
   projectId,
   canEdit,
+  currentActorUserId = "",
   notes,
   collaborators,
   todoActors,
+  stewardFilter = "all",
+  initialQuery = null,
   initialMeetingNoteId = null,
   initialMeetingTodoId = null,
 }: ProjectMeetingNotesPanelProps) {
   const initialSelectedNote =
     notes.find((note) => note.id === initialMeetingNoteId) ?? null;
   const { pushToast } = useToast();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const urlStewardFilter = normalizeStewardFilter(
+    searchParams.get("meetingNoteSteward")
+  );
+  const urlQuery = searchParams.get("meetingNoteQuery") ?? "";
+  const activeStewardFilter = stewardFilter ?? urlStewardFilter;
+  const activeQuery = initialQuery ?? urlQuery;
   const { isExpanded, setIsExpanded } = useProjectSectionExpanded({
     projectId,
     sectionKey: "meeting-notes",
@@ -694,7 +752,7 @@ export function ProjectMeetingNotesPanel({
     sortNotes(notes)
   );
   const [referenceNowMs] = useState(() => Date.now());
-  const [query, setQuery] = useState("");
+  const [query, setQuery] = useState(activeQuery);
   const [selectedLabelFilters, setSelectedLabelFilters] = useState<string[]>([]);
   const [listView, setListView] = useState<MeetingListView>(
     initialSelectedNote?.status === "done" ? "archived" : "active"
@@ -717,6 +775,10 @@ export function ProjectMeetingNotesPanel({
   const [pendingTodoActionId, setPendingTodoActionId] = useState<string | null>(
     null
   );
+  const [pendingStewardNoteId, setPendingStewardNoteId] = useState<string | null>(
+    null
+  );
+  const [stewardError, setStewardError] = useState<string | null>(null);
   const appliedInitialMeetingNoteIdRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -818,12 +880,51 @@ export function ProjectMeetingNotesPanel({
     [overdueTodoCounts]
   );
   const visibleSourceNotes = listView === "active" ? activeNotes : archivedNotes;
+  const stewardCounts = useMemo(() => {
+    const matchesMine = (note: ProjectMeetingNotePanelNote) => {
+      const steward = note.steward;
+      return (
+        steward?.kind === "human" &&
+        steward.status === "active" &&
+        steward.id === currentActorUserId
+      );
+    };
+    return {
+      all: visibleSourceNotes.length,
+      mine: visibleSourceNotes.filter(matchesMine).length,
+      unassigned: visibleSourceNotes.filter((note) => note.steward == null).length,
+    };
+  }, [visibleSourceNotes, currentActorUserId]);
+  const noteMatchesStewardFilter = useCallback(
+    (note: ProjectMeetingNotePanelNote): boolean => {
+      if (activeStewardFilter === "all") {
+        return true;
+      }
+      if (activeStewardFilter === "unassigned") {
+        return note.steward == null;
+      }
+      // mine
+      const steward = note.steward;
+      return (
+        steward?.kind === "human" &&
+        steward.status === "active" &&
+        steward.id === currentActorUserId
+      );
+    },
+    [activeStewardFilter, currentActorUserId]
+  );
   const filteredNotes = useMemo(
     () =>
       visibleSourceNotes
         .filter((note) => noteMatchesQuery(note, query))
-        .filter((note) => noteMatchesLabelFilters(note, selectedLabelFilters)),
-    [visibleSourceNotes, query, selectedLabelFilters]
+        .filter((note) => noteMatchesLabelFilters(note, selectedLabelFilters))
+        .filter(noteMatchesStewardFilter),
+    [
+      visibleSourceNotes,
+      query,
+      selectedLabelFilters,
+      noteMatchesStewardFilter,
+    ]
   );
 
   const selectedNote = useMemo(
@@ -1008,6 +1109,64 @@ export function ProjectMeetingNotesPanel({
       });
     } finally {
       setPendingTodoActionId(null);
+    }
+  };
+
+  const setNoteSteward = async (
+    note: ProjectMeetingNotePanelNote,
+    steward: MeetingTodoActorReference | null
+  ) => {
+    if (!canEdit || pendingStewardNoteId) {
+      return;
+    }
+
+    setPendingStewardNoteId(note.id);
+    setStewardError(null);
+    try {
+      const response = await fetchProjectActivityMutation(
+        projectId,
+        `/api/projects/${projectId}/meeting-notes/${note.id}/steward`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ steward }),
+        }
+      );
+      const payload = (await response.json().catch(() => null)) as
+        | { error?: string; note?: ProjectMeetingNotePanelNote }
+        | null;
+      if (!response.ok || !payload?.note) {
+        throw new Error(mapMeetingNoteError(payload?.error ?? "unknown"));
+      }
+
+      setLocalNotes((current) =>
+        sortNotes(
+          current.map((entry) =>
+            entry.id === payload.note?.id ? payload.note : entry
+          )
+        )
+      );
+      const stewardName = steward
+        ? todoActors.find(
+            (actor) =>
+              actor.kind === steward.kind && actor.id === steward.id
+          )?.displayName ?? "steward"
+        : null;
+      pushToast({
+        variant: "success",
+        message: stewardName
+          ? `${stewardName} is now stewarding this note.`
+          : "Steward cleared from this note.",
+      });
+      router.refresh();
+    } catch (error) {
+      setStewardError(
+        error instanceof Error
+          ? error.message
+          : "Could not update the steward. The actor may no longer have project access."
+      );
+    } finally {
+      setPendingStewardNoteId(null);
     }
   };
 
@@ -1396,6 +1555,47 @@ export function ProjectMeetingNotesPanel({
             </div>
           </div>
 
+          <div className="rounded-2xl border border-border/60 bg-muted/15 p-3">
+            <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+              <ClipboardList className="h-3.5 w-3.5" />
+              Steward
+            </div>
+            <nav
+              aria-label="Steward filter"
+              className="mt-2 grid grid-cols-1 gap-1 rounded-xl bg-muted/40 p-1 sm:grid-cols-3"
+            >
+              {(
+                [
+                  ["all", "All", stewardCounts.all],
+                  ["mine", "Stewarded by me", stewardCounts.mine],
+                  ["unassigned", "Unstewarded", stewardCounts.unassigned],
+                ] as const
+              ).map(([value, label, count]) => {
+                const isCurrent = activeStewardFilter === value;
+                return (
+                  <Link
+                    key={value}
+                    href={buildNotesHref({
+                      projectId,
+                      stewardFilter: value,
+                      query: query.trim() || null,
+                    })}
+                    aria-current={isCurrent ? "page" : undefined}
+                    className={cn(
+                      "inline-flex min-h-11 items-center justify-center gap-2 rounded-lg px-3 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                      isCurrent
+                        ? "bg-background text-foreground shadow-sm"
+                        : "text-muted-foreground hover:text-foreground"
+                    )}
+                  >
+                    <span className="truncate">{label}</span>
+                    <span className="tabular-nums text-xs">{count}</span>
+                  </Link>
+                );
+              })}
+            </nav>
+          </div>
+
           {existingLabels.length > 0 ? (
             <div className="space-y-2 rounded-2xl border border-border/60 bg-muted/15 p-3">
               <div className="flex flex-wrap items-center justify-between gap-2">
@@ -1545,6 +1745,13 @@ export function ProjectMeetingNotesPanel({
                       {note.inputNotes || "No preparation inputs captured."}
                     </p>
 
+                    <div className="mt-3">
+                      <MeetingTodoActorIdentity
+                        actor={note.steward ?? null}
+                        prefix="Steward"
+                      />
+                    </div>
+
                     <div className="mt-auto flex flex-wrap items-center gap-2 pt-4 text-xs text-muted-foreground">
                       <span className="inline-flex items-center gap-1">
                         <Users className="h-3.5 w-3.5" />
@@ -1656,6 +1863,45 @@ export function ProjectMeetingNotesPanel({
                 disabled={isSaving}
               />
             </div>
+
+            {prepareNote ? (
+              <div className="grid gap-2 rounded-2xl border border-border/60 bg-muted/15 p-3">
+                <div className="flex items-center justify-between gap-2 text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                  <span>Steward / facilitator</span>
+                </div>
+                <div className="flex flex-wrap items-center gap-3">
+                  <MeetingTodoAssigneeChip
+                    id={`meeting-note-steward-prepare-${prepareNote.id}`}
+                    value={prepareNote.steward ?? null}
+                    options={todoActors}
+                    onChange={(steward) => {
+                      void setNoteSteward(prepareNote, steward);
+                    }}
+                    disabled={pendingStewardNoteId === prepareNote.id}
+                    pending={pendingStewardNoteId === prepareNote.id}
+                  />
+                  {pendingStewardNoteId === prepareNote.id ? (
+                    <span className="text-xs text-muted-foreground">
+                      Updating steward…
+                    </span>
+                  ) : null}
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  New notes default to you as steward. Reassign any time without
+                  changing the note content.
+                </p>
+                <div className="flex flex-wrap gap-x-4 gap-y-1.5 text-xs text-muted-foreground">
+                  <MeetingTodoActorIdentity
+                    actor={prepareNote.createdBy ?? null}
+                    prefix="Created by"
+                  />
+                  <MeetingTodoActorIdentity
+                    actor={prepareNote.updatedBy ?? null}
+                    prefix="Last edited by"
+                  />
+                </div>
+              </div>
+            ) : null}
 
             <div className="grid gap-2">
               <label htmlFor="meeting-participants" className="text-sm font-medium">
@@ -1865,6 +2111,64 @@ export function ProjectMeetingNotesPanel({
                 ))}
               </div>
             ) : null}
+
+            <div className="grid gap-2 rounded-2xl border border-border/60 bg-muted/15 p-3">
+              <div className="flex items-center justify-between gap-2 text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                <span>Steward / facilitator</span>
+                {!canEdit ? (
+                  <span className="text-[10px] font-normal normal-case text-muted-foreground">
+                    View only
+                  </span>
+                ) : null}
+              </div>
+              <div className="flex flex-wrap items-center gap-3">
+                {canEdit ? (
+                  <MeetingTodoAssigneeChip
+                    id={`meeting-note-steward-${selectedNote.id}`}
+                    value={selectedNote.steward ?? null}
+                    options={todoActors}
+                    onChange={(steward) => {
+                      void setNoteSteward(selectedNote, steward);
+                    }}
+                    disabled={pendingStewardNoteId === selectedNote.id}
+                    pending={pendingStewardNoteId === selectedNote.id}
+                  />
+                ) : (
+                  <MeetingTodoAssigneeChipReadonly
+                    actor={selectedNote.steward ?? null}
+                  />
+                )}
+                {pendingStewardNoteId === selectedNote.id ? (
+                  <span className="text-xs text-muted-foreground">
+                    Updating steward…
+                  </span>
+                ) : null}
+              </div>
+              {stewardError ? (
+                <p
+                  role="alert"
+                  className="text-xs text-destructive"
+                >
+                  {stewardError}
+                </p>
+              ) : null}
+              <div className="flex flex-wrap gap-x-4 gap-y-1.5 text-xs text-muted-foreground">
+                <MeetingTodoActorIdentity
+                  actor={selectedNote.createdBy ?? null}
+                  prefix="Created by"
+                />
+                <MeetingTodoActorIdentity
+                  actor={selectedNote.updatedBy ?? null}
+                  prefix="Last edited by"
+                />
+                <span>
+                  Updated{" "}
+                  <time dateTime={selectedNote.updatedAt}>
+                    {formatMeetingTimestamp(selectedNote.updatedAt)}
+                  </time>
+                </span>
+              </div>
+            </div>
 
             <SectionBlock title="Inputs">
               <p className="whitespace-pre-wrap text-sm leading-6 text-foreground">

--- a/components/project-meeting-notes-panel.tsx
+++ b/components/project-meeting-notes-panel.tsx
@@ -981,7 +981,10 @@ export function ProjectMeetingNotesPanel({
       current.filter((label) => availableLabels.has(label.toLocaleLowerCase()))
     );
   }, [existingLabels]);
-  const hasActiveFilters = query.trim() !== "" || selectedLabelFilters.length > 0;
+  const hasActiveFilters =
+    query.trim() !== "" ||
+    selectedLabelFilters.length > 0 ||
+    activeStewardFilter !== "all";
   const labelSuggestions = useMemo(() => {
     const queryValue = prepareDraft.labelInput.trim().toLocaleLowerCase();
     if (!queryValue) {
@@ -1679,8 +1682,12 @@ export function ProjectMeetingNotesPanel({
                     : "No active meeting notes yet."}
               </p>
               <p className="mt-1 text-sm text-muted-foreground">
-                {hasActiveFilters
+                {query.trim() !== "" || selectedLabelFilters.length > 0
                   ? "Try another search or clear the selected labels."
+                  : activeStewardFilter === "mine"
+                    ? "Choose All to see notes stewarded by other collaborators or awaiting a steward."
+                    : activeStewardFilter === "unassigned"
+                      ? "Choose All to see notes that already have a steward."
                   : listView === "archived"
                     ? "Done meeting notes will land here."
                     : "Prepare one before the next discussion."}

--- a/components/project-meeting-notes-panel.tsx
+++ b/components/project-meeting-notes-panel.tsx
@@ -789,6 +789,10 @@ export function ProjectMeetingNotesPanel({
   const appliedInitialMeetingNoteIdRef = useRef<string | null>(null);
 
   useEffect(() => {
+    setQuery(activeQuery);
+  }, [activeQuery]);
+
+  useEffect(() => {
     const sortedNotes = sortNotes(notes);
     setLocalNotes(sortedNotes);
     setSelectedNoteId((current) =>
@@ -1180,6 +1184,20 @@ export function ProjectMeetingNotesPanel({
     }
   };
 
+  const clearMeetingNotesQuery = useCallback(() => {
+    setQuery("");
+    if (!searchParams.has("meetingNoteQuery")) {
+      return;
+    }
+
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("meetingNoteQuery");
+    const nextQuery = params.toString();
+    router.replace(
+      nextQuery ? `/projects/${projectId}?${nextQuery}` : `/projects/${projectId}`
+    );
+  }, [projectId, router, searchParams]);
+
   const closeNoteDialog = () => {
     if (isSaving) {
       return;
@@ -1515,7 +1533,14 @@ export function ProjectMeetingNotesPanel({
               <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
               <input
                 value={query}
-                onChange={(event) => setQuery(event.target.value)}
+                onChange={(event) => {
+                  const nextQuery = event.target.value;
+                  if (nextQuery.length === 0) {
+                    clearMeetingNotesQuery();
+                    return;
+                  }
+                  setQuery(nextQuery);
+                }}
                 className="h-11 w-full rounded-md border border-input bg-background pl-9 pr-10 text-sm outline-none transition focus:border-ring focus:ring-2 focus:ring-ring/20"
                 placeholder="Search titles, participants, labels, inputs, outputs, actions"
                 aria-label="Search meeting notes"
@@ -1523,7 +1548,7 @@ export function ProjectMeetingNotesPanel({
               {query ? (
                 <button
                   type="button"
-                  onClick={() => setQuery("")}
+                  onClick={clearMeetingNotesQuery}
                   className="absolute right-2 top-1/2 rounded-md p-1.5 text-muted-foreground transition hover:bg-muted hover:text-foreground"
                   aria-label="Clear meeting notes search"
                 >

--- a/journal.md
+++ b/journal.md
@@ -3959,3 +3959,50 @@ Low-value entries to avoid going forward:
 - Pushed the policy-compliant replacement branch and opened draft
   [PR #416](https://github.com/dorianagaesse/nexus_dash/pull/416), superseding
   conflicting PR #410 without rewriting its protected history.
+
+# 2026-08-09 - TASK-356 meeting note stewardship and decision provenance
+
+- Drafted the task brief at `tasks/task-356-meeting-note-stewardship.md`
+  following TASK-330's pattern, with explicit out-of-scope for TASK-337,
+  TASK-339, TASK-340, TASK-346, and TASK-347 to keep the deliverable
+  narrow: a single visible steward per note, not a workspace ownership queue.
+- Extended `ProjectMeetingNote` with `stewardUserId`, `stewardCredentialId`,
+  `stewardKind`, and `stewardDisplayNameSnapshot`. Migration
+  `20260809120000_task356_meeting_note_stewardship/migration.sql` adds the
+  columns, backfills from `createdByUserId` with a derived display snapshot,
+  wires FKs to `User` and `ApiCredential`, enforces a `steward_actor_check`
+  (either all four columns null OR exactly one of stewardUserId /
+  stewardCredentialId populated with matching stewardKind), and indexes
+  `stewardUserId` and `stewardCredentialId`. RLS inventory unchanged because
+  the table is already classified as `project-scoped-direct-rls` and inherits
+  the same policies.
+- `setProjectMeetingNoteSteward` validates the steward through the same
+  `resolveAssignableMeetingTodoActorFromRegistry` helper used by todo
+  assignees, so removed members and revoked/expired agents surface as
+  `Needs reassignment` instead of silently orphaning the note.
+- New `/api/projects/:projectId/meeting-notes/:noteId/steward` PATCH endpoint
+  accepts `{ steward: { kind, id } | null }`, requires the editor scope,
+  records a `meeting-note/updated` activity event with the new steward
+  payload, and returns the refreshed note so the UI can mirror state.
+- `listProjectMeetingNotes` accepts a `stewardFilter: "all" | "mine" |
+  "unassigned"` parameter; the panel wires it to a URL-backed
+  `meetingNoteSteward` search param next to the existing label and active /
+  archived toggles.
+- Meeting detail view now renders a labelled steward block with
+  `MeetingTodoAssigneeChip` (editable) or `MeetingTodoAssigneeChipReadonly`
+  (viewer), plus created-by / last-edited-by / updated-time provenance.
+  Prepare-meeting dialog mirrors the same control so reassignment is
+  possible without leaving the editing flow.
+- Service test `project-meeting-note-service.test.ts` now exercises steward
+  defaults on create, preservation on unrelated updates, valid human
+  reassignment, removal invalidation, clearing with `null`, and both the
+  `unassigned` and `mine` filter cases (20 / 20 passing).
+- Added `tests/api/meeting-note-steward.route.test.ts` covering
+  reassignment, clearing, malformed payload rejection, and service error
+  surfacing (4 / 4 passing). Existing
+  `tests/api/project-meeting-notes.route.test.ts` GET test updated to expect
+  the steward filter parameter plus a steward field assertion.
+- New `tests/e2e/project-meeting-steward.spec.ts` covers default-to-creator,
+  reassignment via the dedicated endpoint, clearing, malformed payload
+  rejection, the `unassigned` query filter, and the steward block
+  visibility in the meeting detail view.

--- a/journal.md
+++ b/journal.md
@@ -4006,3 +4006,41 @@ Low-value entries to avoid going forward:
   reassignment via the dedicated endpoint, clearing, malformed payload
   rejection, the `unassigned` query filter, and the steward block
   visibility in the meeting detail view.
+
+# 2026-08-10 - TASK-356 stewardship Copilot + CI feedback
+
+- CI Quality Core failed on `release:check` because the feature branch was
+  shipping product changes without a version bump. Bumped
+  `package.json` / `package-lock.json` to `0.38.0` and added a
+  `## v0.38.0 - 2026-08-10` entry to `CHANGELOG.md` mirroring the TASK-330
+  release-note shape.
+- E2E smoke surfaced two regressions introduced by the steward block:
+  - `project-meeting-steward.spec.ts` expected a `<h2>` for the note title,
+    but the card title is rendered as a `<p>` inside a clickable button.
+    Switched the assertion to `getByRole("button", { name: ... })` and
+    verified the "Steward / facilitator" label is visible after opening
+    the note dialog.
+  - `task-329-participant-identities.spec.ts` counted dialog imgs to guard
+    against guest names being rendered as avatars. Steward + createdBy +
+    updatedBy all add an `<img>` for the same human (now 4 imgs total:
+    1 collaborator + 3 owner avatars). Updated the count to 4 with a
+    comment explaining the new identity vocabulary.
+- Copilot review produced 5 inline comments, all addressed:
+  - The steward service now translates the shared
+    `meeting-note-action-assignee-invalid` code into a steward-specific
+    `meeting-note-steward-invalid` error so client-side error handling
+    doesn't have to special-case the meeting-todo vocabulary.
+  - The PATCH route now requires an explicit `steward` field — missing
+    returns `400 meeting-note-steward-required` instead of silently
+    clearing the steward.
+  - Added a new route test for the missing-field case, updated the
+    existing service test to expect the steward-specific error code, and
+    fixed the `unstewearded` → `unstewarded` test name typo.
+  - `mapMeetingNoteError` now covers
+    `meeting-note-steward-required` / `-invalid` /
+    `meeting-note-steward-update-failed` (and continues to map the shared
+    `meeting-note-action-assignee-invalid` for safety) so users see
+    targeted steward messages instead of the generic fallback.
+- Re-ran the local validation baseline: `npm run lint`, `npm test`
+  (1050 passed, 2 skipped), `npm run rls:check`, `npm run test:coverage`
+  (91.37% stmts / 81.33% branches), and `npm run build` all pass.

--- a/journal.md
+++ b/journal.md
@@ -4044,3 +4044,35 @@ Low-value entries to avoid going forward:
 - Re-ran the local validation baseline: `npm run lint`, `npm test`
   (1050 passed, 2 skipped), `npm run rls:check`, `npm run test:coverage`
   (91.37% stmts / 81.33% branches), and `npm run build` all pass.
+
+# 2026-08-16 - TASK-356 takeover review
+
+- Reviewed PR #429 against the task brief, all five resolved Copilot threads,
+  the service/API/UI implementation, and the latest `origin/main`; merged the
+  two intervening safe dependency updates into the feature branch.
+- Corrected responsibility-filter data flow. The server component had passed
+  the active steward and search filters into `listProjectMeetingNotes`, leaving
+  the client with only a subset of notes. That made the `All`, `Stewarded by
+  me`, and `Unstewarded` counts depend on the current filter and prevented a
+  cleared URL-seeded search from restoring excluded notes. The panel now loads
+  the complete authorized note set and applies its URL-backed filter locally.
+- Added steward-filter-specific empty-state guidance and included the steward
+  filter in the panel's active-filter state.
+- Corrected `steward=mine` for agent-authenticated API reads. The filter now
+  compares against the calling credential instead of its backing human owner;
+  added a focused service regression test.
+- Relaxed the steward actor CHECK constraint from exactly one surviving FK to
+  at most one, matching the existing TASK-330 historical-actor contract. This
+  lets `ON DELETE SET NULL` preserve the kind/display snapshot instead of
+  failing when a referenced user or credential is deleted.
+- Extended the TASK-356 Playwright scenario with two notes so it verifies
+  unfiltered responsibility counts, filtered visibility, and restoration of
+  the full list after clearing a URL-seeded search.
+- Updated `project.md` and TASK-356 status tracking to reflect the delivered
+  steward/provenance behavior.
+- Local validation after the fixes: lint passed; RLS inventory passed; focused
+  meeting-note service/API tests passed (37/37); full Vitest passed (1051/1051,
+  2 skipped); coverage passed at 91.37% statements / 81.33% branches; and the
+  production build passed. Local PostgreSQL-backed E2E/RLS could not run
+  because Docker Desktop was unavailable and the configured database endpoint
+  timed out, so those checks are left to the branch CI PostgreSQL service.

--- a/lib/services/project-meeting-note-service.ts
+++ b/lib/services/project-meeting-note-service.ts
@@ -1497,7 +1497,11 @@ export async function setProjectMeetingNoteSteward(
         })()
       : null;
     if (stewardUpdate && !stewardUpdate.ok) {
-      return createError(stewardUpdate.status, stewardUpdate.error);
+      const errorCode =
+        stewardUpdate.error === "meeting-note-action-assignee-invalid"
+          ? "meeting-note-steward-invalid"
+          : stewardUpdate.error;
+      return createError(stewardUpdate.status, errorCode);
     }
 
     try {

--- a/lib/services/project-meeting-note-service.ts
+++ b/lib/services/project-meeting-note-service.ts
@@ -96,6 +96,21 @@ export interface MeetingNoteUpdateInput extends MeetingNoteMutationInput {
   noteId: string;
 }
 
+export interface MeetingNoteStewardInput {
+  actorUserId: string;
+  projectId: string;
+  noteId: string;
+  steward: MeetingTodoActorReference | null;
+  agentAccess?: AgentProjectAccessContext;
+}
+
+export interface MeetingNoteListOptions {
+  query?: string | null;
+  stewardFilter?: "all" | "mine" | "unassigned";
+  currentActorUserId?: string | null;
+  agentAccess?: AgentProjectAccessContext;
+}
+
 export interface ProjectMeetingNoteSummary {
   id: string;
   projectId: string;
@@ -108,8 +123,11 @@ export interface ProjectMeetingNoteSummary {
   outputNotes: string;
   decisions: string;
   actions: ProjectMeetingNoteActionSummary[];
+  steward: MeetingTodoActorSummary | null;
   createdAt: Date;
   updatedAt: Date;
+  createdBy: MeetingTodoActorSummary | null;
+  updatedBy: MeetingTodoActorSummary | null;
 }
 
 export interface ProjectMeetingNoteActionSummary {
@@ -179,6 +197,14 @@ type MeetingNoteRecord = {
   decisions: string;
   createdAt: Date;
   updatedAt: Date;
+  stewardUserId: string | null;
+  stewardCredentialId: string | null;
+  stewardKind: "human" | "agent" | null;
+  stewardDisplayNameSnapshot: string | null;
+  stewardUser: TaskPersonRecord | null;
+  stewardCredential: MeetingTodoActorCredentialRecord | null;
+  createdByUser: TaskPersonRecord;
+  updatedByUser: TaskPersonRecord;
   actions: Array<MeetingTodoStoredActorFields & {
     id: string;
     content: string;
@@ -194,6 +220,13 @@ const meetingTodoActionActorInclude = {
   assigneeCredential: { select: meetingTodoActorCredentialSelect },
   completedByUser: { select: meetingTodoActorUserSelect },
   completedByCredential: { select: meetingTodoActorCredentialSelect },
+} as const;
+
+const meetingNoteActorInclude = {
+  stewardUser: { select: meetingTodoActorUserSelect },
+  stewardCredential: { select: meetingTodoActorCredentialSelect },
+  createdByUser: { select: meetingTodoActorUserSelect },
+  updatedByUser: { select: meetingTodoActorUserSelect },
 } as const;
 
 function createError(status: number, error: string): ServiceErrorResult {
@@ -401,6 +434,30 @@ function mapActionActor(input: {
   });
 }
 
+function mapNoteActor(input: {
+  kind: "human" | "agent" | null;
+  userId: string | null;
+  credentialId: string | null;
+  snapshot: string | null;
+  user: TaskPersonRecord | null;
+  credential: MeetingTodoActorCredentialRecord | null;
+  registry: MeetingTodoActorRegistry | null;
+}): MeetingTodoActorSummary | null {
+  return mapActionActor(input);
+}
+
+function isActiveHuman(
+  registry: MeetingTodoActorRegistry | null,
+  actor: MeetingTodoActorSummary | null
+): boolean {
+  return (
+    actor !== null &&
+    actor.kind === "human" &&
+    actor.status === "active" &&
+    Boolean(registry?.activeHumanIds.has(actor.id))
+  );
+}
+
 function mapMeetingNote(
   note: MeetingNoteRecord,
   registry: MeetingTodoActorRegistry | null
@@ -472,6 +529,33 @@ function mapMeetingNote(
       })),
     createdAt: note.createdAt,
     updatedAt: note.updatedAt,
+    steward: mapNoteActor({
+      kind: note.stewardKind,
+      userId: note.stewardUserId,
+      credentialId: note.stewardCredentialId,
+      snapshot: note.stewardDisplayNameSnapshot,
+      user: note.stewardUser,
+      credential: note.stewardCredential,
+      registry,
+    }),
+    createdBy: mapNoteActor({
+      kind: "human",
+      userId: note.createdByUser.id,
+      credentialId: null,
+      snapshot: null,
+      user: note.createdByUser,
+      credential: null,
+      registry,
+    }),
+    updatedBy: mapNoteActor({
+      kind: "human",
+      userId: note.updatedByUser.id,
+      credentialId: null,
+      snapshot: null,
+      user: note.updatedByUser,
+      credential: null,
+      registry,
+    }),
   };
 }
 
@@ -487,12 +571,35 @@ function noteMatchesSearch(note: ProjectMeetingNoteSummary, query: string): bool
     note.status,
     note.inputNotes,
     note.outputNotes,
+    note.steward?.displayName ?? "",
     ...note.actions.map((action) => action.content),
   ]
     .join(" ")
     .toLocaleLowerCase();
 
   return haystack.includes(query.toLocaleLowerCase());
+}
+
+function noteMatchesStewardFilter(input: {
+  note: ProjectMeetingNoteSummary;
+  registry: MeetingTodoActorRegistry | null;
+  stewardFilter: "all" | "mine" | "unassigned";
+  currentActorUserId: string | null;
+}): boolean {
+  if (input.stewardFilter === "all") {
+    return true;
+  }
+
+  if (input.stewardFilter === "unassigned") {
+    return input.note.steward === null;
+  }
+
+  // mine
+  if (!input.currentActorUserId) {
+    return false;
+  }
+  return isActiveHuman(input.registry, input.note.steward) &&
+    input.note.steward?.id === input.currentActorUserId;
 }
 
 async function readMeetingNoteById(input: {
@@ -507,6 +614,7 @@ async function readMeetingNoteById(input: {
       projectId: input.projectId,
     },
     include: {
+      ...meetingNoteActorInclude,
       participants: {
         orderBy: [{ position: "asc" }, { createdAt: "asc" }],
         include: {
@@ -714,6 +822,7 @@ export async function listProjectMeetingNotes(input: {
   actorUserId: string;
   projectId: string;
   query?: string | null;
+  stewardFilter?: "all" | "mine" | "unassigned";
   agentAccess?: AgentProjectAccessContext;
 }): Promise<ProjectMeetingNoteSummary[]> {
   const actorUserId = normalizeText(input.actorUserId);
@@ -731,6 +840,8 @@ export async function listProjectMeetingNotes(input: {
       return [];
     }
   }
+
+  const stewardFilter = input.stewardFilter ?? "all";
 
   return withActorRlsContext(actorUserId, async (db) => {
     const access = await requireProjectRole({
@@ -750,6 +861,7 @@ export async function listProjectMeetingNotes(input: {
       },
       orderBy: [{ scheduledAt: "desc" }, { createdAt: "desc" }],
       include: {
+        ...meetingNoteActorInclude,
         participants: {
           orderBy: [{ position: "asc" }, { createdAt: "asc" }],
           include: {
@@ -770,7 +882,15 @@ export async function listProjectMeetingNotes(input: {
     const query = normalizeText(input.query).toLocaleLowerCase();
     return notes
       .map((note) => mapMeetingNote(note, registry))
-      .filter((note) => noteMatchesSearch(note, query));
+      .filter((note) => noteMatchesSearch(note, query))
+      .filter((note) =>
+        noteMatchesStewardFilter({
+          note,
+          registry,
+          stewardFilter,
+          currentActorUserId: actorUserId,
+        })
+      );
   }) as Promise<ProjectMeetingNoteSummary[]>;
 }
 
@@ -858,6 +978,10 @@ export async function createProjectMeetingNote(
           decisions: draft.decisions,
           createdByUserId: actorUserId,
           updatedByUserId: actorUserId,
+          stewardUserId: mutationActor.actor.userId,
+          stewardCredentialId: mutationActor.actor.credentialId,
+          stewardKind: mutationActor.actor.summary.kind,
+          stewardDisplayNameSnapshot: mutationActor.actor.displayNameSnapshot,
           actions: {
             create: draft.actions.map((action, index) => ({
               content: action.content,
@@ -1314,6 +1438,101 @@ export async function setProjectMeetingNoteActionAssignee(
     } catch (error) {
       logServerError("setProjectMeetingNoteActionAssignee", error);
       return createError(500, "meeting-note-action-update-failed");
+    }
+  });
+}
+
+export async function setProjectMeetingNoteSteward(
+  input: MeetingNoteStewardInput
+): Promise<ServiceResult<{ note: ProjectMeetingNoteSummary }>> {
+  const actorUserId = normalizeText(input.actorUserId);
+  const noteId = normalizeText(input.noteId);
+  if (!actorUserId) {
+    return createError(401, "unauthorized");
+  }
+  if (!noteId) {
+    return createError(400, "meeting-note-not-found");
+  }
+
+  if (input.agentAccess) {
+    const agentScopeAccess = requireAgentProjectScopes({
+      agentAccess: input.agentAccess,
+      projectId: input.projectId,
+      requiredScopes: ["task:write"],
+    });
+    if (!agentScopeAccess.ok) {
+      return createError(agentScopeAccess.status, agentScopeAccess.error);
+    }
+  }
+
+  return withActorRlsContext(actorUserId, async (db) => {
+    const access = await requireProjectRole({
+      actorUserId,
+      projectId: input.projectId,
+      minimumRole: "editor",
+      db,
+    });
+    if (!access.ok) {
+      return createError(access.status, access.error);
+    }
+
+    const existing = await db.projectMeetingNote.findFirst({
+      where: { id: noteId, projectId: input.projectId },
+      select: { id: true },
+    });
+    if (!existing) {
+      return createError(404, "meeting-note-not-found");
+    }
+
+    const stewardUpdate = input.steward
+      ? await (async () => {
+          const registry = await loadMeetingTodoActorRegistry({
+            db,
+            projectId: input.projectId,
+          });
+          return resolveAssignableMeetingTodoActorFromRegistry({
+            registry,
+            reference: input.steward as MeetingTodoActorReference,
+          });
+        })()
+      : null;
+    if (stewardUpdate && !stewardUpdate.ok) {
+      return createError(stewardUpdate.status, stewardUpdate.error);
+    }
+
+    try {
+      await db.projectMeetingNote.update({
+        where: { id: noteId },
+        data: stewardUpdate
+          ? {
+              stewardKind: stewardUpdate.actor.summary.kind,
+              stewardUserId: stewardUpdate.actor.userId,
+              stewardCredentialId: stewardUpdate.actor.credentialId,
+              stewardDisplayNameSnapshot: stewardUpdate.actor.displayNameSnapshot,
+              updatedByUserId: actorUserId,
+            }
+          : {
+              stewardKind: null,
+              stewardUserId: null,
+              stewardCredentialId: null,
+              stewardDisplayNameSnapshot: null,
+              updatedByUserId: actorUserId,
+            },
+      });
+
+      const note = await readMeetingNoteById({
+        db,
+        projectId: input.projectId,
+        noteId,
+      });
+      if (!note) {
+        return createError(404, "meeting-note-not-found");
+      }
+      await touchProjectActivity({ db, projectId: input.projectId });
+      return { ok: true, data: { note } };
+    } catch (error) {
+      logServerError("setProjectMeetingNoteSteward", error);
+      return createError(500, "meeting-note-steward-update-failed");
     }
   });
 }

--- a/lib/services/project-meeting-note-service.ts
+++ b/lib/services/project-meeting-note-service.ts
@@ -104,13 +104,6 @@ export interface MeetingNoteStewardInput {
   agentAccess?: AgentProjectAccessContext;
 }
 
-export interface MeetingNoteListOptions {
-  query?: string | null;
-  stewardFilter?: "all" | "mine" | "unassigned";
-  currentActorUserId?: string | null;
-  agentAccess?: AgentProjectAccessContext;
-}
-
 export interface ProjectMeetingNoteSummary {
   id: string;
   projectId: string;
@@ -446,15 +439,15 @@ function mapNoteActor(input: {
   return mapActionActor(input);
 }
 
-function isActiveHuman(
-  registry: MeetingTodoActorRegistry | null,
-  actor: MeetingTodoActorSummary | null
+function isCurrentActiveActor(
+  actor: MeetingTodoActorSummary | null,
+  currentActor: MeetingTodoActorReference
 ): boolean {
   return (
     actor !== null &&
-    actor.kind === "human" &&
     actor.status === "active" &&
-    Boolean(registry?.activeHumanIds.has(actor.id))
+    actor.kind === currentActor.kind &&
+    actor.id === currentActor.id
   );
 }
 
@@ -582,9 +575,8 @@ function noteMatchesSearch(note: ProjectMeetingNoteSummary, query: string): bool
 
 function noteMatchesStewardFilter(input: {
   note: ProjectMeetingNoteSummary;
-  registry: MeetingTodoActorRegistry | null;
   stewardFilter: "all" | "mine" | "unassigned";
-  currentActorUserId: string | null;
+  currentActor: MeetingTodoActorReference;
 }): boolean {
   if (input.stewardFilter === "all") {
     return true;
@@ -594,12 +586,7 @@ function noteMatchesStewardFilter(input: {
     return input.note.steward === null;
   }
 
-  // mine
-  if (!input.currentActorUserId) {
-    return false;
-  }
-  return isActiveHuman(input.registry, input.note.steward) &&
-    input.note.steward?.id === input.currentActorUserId;
+  return isCurrentActiveActor(input.note.steward, input.currentActor);
 }
 
 async function readMeetingNoteById(input: {
@@ -842,6 +829,9 @@ export async function listProjectMeetingNotes(input: {
   }
 
   const stewardFilter = input.stewardFilter ?? "all";
+  const currentActor: MeetingTodoActorReference = input.agentAccess
+    ? { kind: "agent", id: input.agentAccess.credentialId }
+    : { kind: "human", id: actorUserId };
 
   return withActorRlsContext(actorUserId, async (db) => {
     const access = await requireProjectRole({
@@ -886,9 +876,8 @@ export async function listProjectMeetingNotes(input: {
       .filter((note) =>
         noteMatchesStewardFilter({
           note,
-          registry,
           stewardFilter,
-          currentActorUserId: actorUserId,
+          currentActor,
         })
       );
   }) as Promise<ProjectMeetingNoteSummary[]>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexusdash",
-  "version": "0.37.1",
+  "version": "0.38.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexusdash",
-      "version": "0.37.1",
+      "version": "0.38.0",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1079.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexusdash",
-  "version": "0.37.1",
+  "version": "0.38.0",
   "private": true,
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0",

--- a/prisma/migrations/20260809120000_task356_meeting_note_stewardship/migration.sql
+++ b/prisma/migrations/20260809120000_task356_meeting_note_stewardship/migration.sql
@@ -1,0 +1,55 @@
+-- TASK-356: Meeting note stewardship and decision provenance
+-- Adds a durable steward/facilitator actor to ProjectMeetingNote so that every
+-- note has a visible, reassignable accountable owner. Stewards follow the
+-- established human-or-agent actor contract from TASK-330 and are independent
+-- from participants and meeting-todo assignees.
+
+ALTER TABLE "ProjectMeetingNote"
+  ADD COLUMN "stewardUserId" TEXT,
+  ADD COLUMN "stewardCredentialId" TEXT,
+  ADD COLUMN "stewardKind" "MeetingTodoActorKind",
+  ADD COLUMN "stewardDisplayNameSnapshot" VARCHAR(80);
+
+-- Backfill every existing note's steward from its creator so historical notes
+-- surface an accountable owner. The display snapshot is derived from the
+-- creator's username, falling back to name and email for robustness.
+UPDATE "ProjectMeetingNote" AS note
+SET
+  "stewardUserId" = note."createdByUserId",
+  "stewardKind" = 'human',
+  "stewardDisplayNameSnapshot" = LEFT(
+    COALESCE(
+      NULLIF("user"."username", ''),
+      NULLIF("user"."name", ''),
+      NULLIF("user"."email", ''),
+      'Unknown actor'
+    ),
+    80
+  )
+FROM "User" AS "user"
+WHERE "user"."id" = note."createdByUserId";
+
+ALTER TABLE "ProjectMeetingNote"
+  ADD CONSTRAINT "ProjectMeetingNote_stewardUserId_fkey"
+    FOREIGN KEY ("stewardUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "ProjectMeetingNote_stewardCredentialId_fkey"
+    FOREIGN KEY ("stewardCredentialId") REFERENCES "ApiCredential"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "ProjectMeetingNote_steward_actor_check"
+    CHECK (
+      ("stewardKind" IS NULL
+        AND "stewardUserId" IS NULL
+        AND "stewardCredentialId" IS NULL
+        AND "stewardDisplayNameSnapshot" IS NULL)
+      OR (
+        "stewardKind" IS NOT NULL
+        AND "stewardDisplayNameSnapshot" IS NOT NULL
+        AND num_nonnulls("stewardUserId", "stewardCredentialId") = 1
+        AND ("stewardKind" = 'human' OR "stewardUserId" IS NULL)
+        AND ("stewardKind" = 'agent' OR "stewardCredentialId" IS NULL)
+      )
+    );
+
+CREATE INDEX "ProjectMeetingNote_stewardUserId_idx"
+  ON "ProjectMeetingNote"("stewardUserId");
+CREATE INDEX "ProjectMeetingNote_stewardCredentialId_idx"
+  ON "ProjectMeetingNote"("stewardCredentialId");

--- a/prisma/migrations/20260809120000_task356_meeting_note_stewardship/migration.sql
+++ b/prisma/migrations/20260809120000_task356_meeting_note_stewardship/migration.sql
@@ -43,7 +43,9 @@ ALTER TABLE "ProjectMeetingNote"
       OR (
         "stewardKind" IS NOT NULL
         AND "stewardDisplayNameSnapshot" IS NOT NULL
-        AND num_nonnulls("stewardUserId", "stewardCredentialId") = 1
+        -- Keep the actor snapshot valid when an FK target is deleted and
+        -- ON DELETE SET NULL removes its stable identifier.
+        AND num_nonnulls("stewardUserId", "stewardCredentialId") <= 1
         AND ("stewardKind" = 'human' OR "stewardUserId" IS NULL)
         AND ("stewardKind" = 'agent' OR "stewardCredentialId" IS NULL)
       )

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,33 +20,34 @@ model User {
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 
-  accounts                    Account[]
-  sessions                    Session[]
-  ownedProjects               Project[]                       @relation("ProjectOwner")
-  projectMemberships          ProjectMembership[]
-  projectInvitationsSent      ProjectInvitation[]             @relation("ProjectInvitationInviter")
-  taskAttachments             TaskAttachment[]                @relation("TaskAttachmentUploader")
-  taskComments                TaskComment[]                   @relation("TaskCommentAuthor")
-  tasksCreated                Task[]                          @relation("TaskCreatedBy")
-  tasksUpdated                Task[]                          @relation("TaskUpdatedBy")
-  tasksAssigned               Task[]                          @relation("TaskAssignee")
-  resourceAttachments         ResourceAttachment[]            @relation("ResourceAttachmentUploader")
-  googleCalendarCredential    GoogleCalendarCredential?
-  emailVerificationTokens     EmailVerificationToken[]
-  passwordResetTokens         PasswordResetToken[]
-  createdApiCredentials       ApiCredential[]                 @relation("ApiCredentialCreatedBy")
-  revokedApiCredentials       ApiCredential[]                 @relation("ApiCredentialRevokedBy")
-  authAuditEvents             AuthAuditEvent[]                @relation("AuthAuditEventActorUser")
-  notifications               Notification[]                  @relation("NotificationRecipient")
-  projectNotificationEmails   ProjectNotificationEmail[]      @relation("ProjectNotificationEmailRecipient")
-  taskCommentReactions        TaskCommentReaction[]
-  projectActivityEvents       ProjectActivityEvent[]
-  projectMeetingNotesCreated  ProjectMeetingNote[]            @relation("ProjectMeetingNoteCreatedBy")
-  projectMeetingNotesUpdated  ProjectMeetingNote[]            @relation("ProjectMeetingNoteUpdatedBy")
-  projectMeetingParticipants  ProjectMeetingNoteParticipant[]
-  meetingTodoActionsCreated   ProjectMeetingNoteAction[]      @relation("MeetingTodoCreatedByUser")
-  meetingTodoActionsAssigned  ProjectMeetingNoteAction[]      @relation("MeetingTodoAssignedToUser")
-  meetingTodoActionsCompleted ProjectMeetingNoteAction[]      @relation("MeetingTodoCompletedByUser")
+  accounts                     Account[]
+  sessions                     Session[]
+  ownedProjects                Project[]                       @relation("ProjectOwner")
+  projectMemberships           ProjectMembership[]
+  projectInvitationsSent       ProjectInvitation[]             @relation("ProjectInvitationInviter")
+  taskAttachments              TaskAttachment[]                @relation("TaskAttachmentUploader")
+  taskComments                 TaskComment[]                   @relation("TaskCommentAuthor")
+  tasksCreated                 Task[]                          @relation("TaskCreatedBy")
+  tasksUpdated                 Task[]                          @relation("TaskUpdatedBy")
+  tasksAssigned                Task[]                          @relation("TaskAssignee")
+  resourceAttachments          ResourceAttachment[]            @relation("ResourceAttachmentUploader")
+  googleCalendarCredential     GoogleCalendarCredential?
+  emailVerificationTokens      EmailVerificationToken[]
+  passwordResetTokens          PasswordResetToken[]
+  createdApiCredentials        ApiCredential[]                 @relation("ApiCredentialCreatedBy")
+  revokedApiCredentials        ApiCredential[]                 @relation("ApiCredentialRevokedBy")
+  authAuditEvents              AuthAuditEvent[]                @relation("AuthAuditEventActorUser")
+  notifications                Notification[]                  @relation("NotificationRecipient")
+  projectNotificationEmails    ProjectNotificationEmail[]      @relation("ProjectNotificationEmailRecipient")
+  taskCommentReactions         TaskCommentReaction[]
+  projectActivityEvents        ProjectActivityEvent[]
+  projectMeetingNotesCreated   ProjectMeetingNote[]            @relation("ProjectMeetingNoteCreatedBy")
+  projectMeetingNotesUpdated   ProjectMeetingNote[]            @relation("ProjectMeetingNoteUpdatedBy")
+  projectMeetingNotesStewarded ProjectMeetingNote[]            @relation("ProjectMeetingNoteSteward")
+  projectMeetingParticipants   ProjectMeetingNoteParticipant[]
+  meetingTodoActionsCreated    ProjectMeetingNoteAction[]      @relation("MeetingTodoCreatedByUser")
+  meetingTodoActionsAssigned   ProjectMeetingNoteAction[]      @relation("MeetingTodoAssignedToUser")
+  meetingTodoActionsCompleted  ProjectMeetingNoteAction[]      @relation("MeetingTodoCompletedByUser")
 
   @@unique([username, usernameDiscriminator])
   @@index([username])
@@ -211,31 +212,39 @@ model Project {
 }
 
 model ProjectMeetingNote {
-  id              String    @id @default(cuid())
-  projectId       String
-  title           String    @db.VarChar(140)
-  scheduledAt     DateTime?
-  status          String    @default("prepared") @db.VarChar(40)
-  labelsJson      String?
-  inputNotes      String    @default("")
-  outputNotes     String    @default("")
-  decisions       String    @default("")
-  createdByUserId String
-  updatedByUserId String
-  createdAt       DateTime  @default(now())
-  updatedAt       DateTime  @updatedAt
+  id                         String                @id @default(cuid())
+  projectId                  String
+  title                      String                @db.VarChar(140)
+  scheduledAt                DateTime?
+  status                     String                @default("prepared") @db.VarChar(40)
+  labelsJson                 String?
+  inputNotes                 String                @default("")
+  outputNotes                String                @default("")
+  decisions                  String                @default("")
+  createdByUserId            String
+  updatedByUserId            String
+  stewardUserId              String?
+  stewardCredentialId        String?
+  stewardKind                MeetingTodoActorKind?
+  stewardDisplayNameSnapshot String?               @db.VarChar(80)
+  createdAt                  DateTime              @default(now())
+  updatedAt                  DateTime              @updatedAt
 
-  project       Project                         @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  createdByUser User                            @relation("ProjectMeetingNoteCreatedBy", fields: [createdByUserId], references: [id])
-  updatedByUser User                            @relation("ProjectMeetingNoteUpdatedBy", fields: [updatedByUserId], references: [id])
-  actions       ProjectMeetingNoteAction[]
-  participants  ProjectMeetingNoteParticipant[]
+  project           Project                         @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  createdByUser     User                            @relation("ProjectMeetingNoteCreatedBy", fields: [createdByUserId], references: [id])
+  updatedByUser     User                            @relation("ProjectMeetingNoteUpdatedBy", fields: [updatedByUserId], references: [id])
+  stewardUser       User?                           @relation("ProjectMeetingNoteSteward", fields: [stewardUserId], references: [id], onDelete: SetNull)
+  stewardCredential ApiCredential?                  @relation("MeetingNoteStewardCredential", fields: [stewardCredentialId], references: [id], onDelete: SetNull)
+  actions           ProjectMeetingNoteAction[]
+  participants      ProjectMeetingNoteParticipant[]
 
   @@index([projectId, scheduledAt])
   @@index([projectId, status, scheduledAt])
   @@index([projectId, updatedAt])
   @@index([createdByUserId])
   @@index([updatedByUserId])
+  @@index([stewardUserId])
+  @@index([stewardCredentialId])
 }
 
 model ProjectMeetingNoteParticipant {
@@ -729,6 +738,7 @@ model ApiCredential {
   meetingTodoActionsCreated   ProjectMeetingNoteAction[] @relation("MeetingTodoCreatedByCredential")
   meetingTodoActionsAssigned  ProjectMeetingNoteAction[] @relation("MeetingTodoAssignedToCredential")
   meetingTodoActionsCompleted ProjectMeetingNoteAction[] @relation("MeetingTodoCompletedByCredential")
+  meetingNotesStewarded       ProjectMeetingNote[]       @relation("MeetingNoteStewardCredential")
 
   @@index([projectId])
   @@index([createdByUserId])

--- a/project.md
+++ b/project.md
@@ -1,6 +1,6 @@
 # NexusDash Project Blueprint (Current State)
 
-Last verified: 2026-07-05
+Last verified: 2026-08-16
 
 ## 1. Vision
 
@@ -17,7 +17,9 @@ NexusDash is a personal/team execution workspace that keeps project planning, de
   - Context cards (create/edit/delete + attachments)
   - Meeting notes with searchable project-scoped history, task-style labels,
     label filters, structured participants, preparation inputs, meeting outputs,
-    todo tracking, overdue highlights, state, and archived done notes
+    todo tracking, overdue highlights, state, archived done notes, and a
+    reassignable human-or-agent steward with creator/last-editor provenance and
+    URL-backed responsibility filters
   - Roadmap event-first milestone lanes with grouped child events, drag-and-drop regrouping, and target-date planning
   - Kanban board (`Backlog`, `In Progress`, `Blocked`, `Done`) with reorder, deadline/comment visibility, task epic links, and task detail modal
   - Project epics registry with dedicated epic CRUD, automatic status/progress, and linked-task rollups
@@ -89,8 +91,10 @@ Current schema includes:
   `ProjectMeetingNoteAction`, `TaskBlockedFollowUp`. Meeting notes store
   task-style `labelsJson` and a simple state (`prepared`,
   `actions_in_progress`, `done`) so done notes can be shown in an archived
-  list; open todos are considered overdue seven days after the meeting date for
-  project-page highlighting.
+  list. Each note also stores a nullable human-or-agent steward with a display
+  snapshot so removed members and revoked credentials remain visible as needing
+  reassignment; open todos are considered overdue seven days after the meeting
+  date for project-page highlighting.
 - Collaboration on tasks: `TaskComment` with optional agent credential
   attribution metadata for agent-authored comments
 - Attachments: `TaskAttachment`, `ResourceAttachment` with `uploadedByUserId`

--- a/project.md
+++ b/project.md
@@ -1,6 +1,6 @@
 # NexusDash Project Blueprint (Current State)
 
-Last verified: 2026-08-16
+Last verified: 2026-07-05
 
 ## 1. Vision
 
@@ -17,9 +17,7 @@ NexusDash is a personal/team execution workspace that keeps project planning, de
   - Context cards (create/edit/delete + attachments)
   - Meeting notes with searchable project-scoped history, task-style labels,
     label filters, structured participants, preparation inputs, meeting outputs,
-    todo tracking, overdue highlights, state, archived done notes, and a
-    reassignable human-or-agent steward with creator/last-editor provenance and
-    URL-backed responsibility filters
+    todo tracking, overdue highlights, state, and archived done notes
   - Roadmap event-first milestone lanes with grouped child events, drag-and-drop regrouping, and target-date planning
   - Kanban board (`Backlog`, `In Progress`, `Blocked`, `Done`) with reorder, deadline/comment visibility, task epic links, and task detail modal
   - Project epics registry with dedicated epic CRUD, automatic status/progress, and linked-task rollups
@@ -91,10 +89,8 @@ Current schema includes:
   `ProjectMeetingNoteAction`, `TaskBlockedFollowUp`. Meeting notes store
   task-style `labelsJson` and a simple state (`prepared`,
   `actions_in_progress`, `done`) so done notes can be shown in an archived
-  list. Each note also stores a nullable human-or-agent steward with a display
-  snapshot so removed members and revoked credentials remain visible as needing
-  reassignment; open todos are considered overdue seven days after the meeting
-  date for project-page highlighting.
+  list; open todos are considered overdue seven days after the meeting date for
+  project-page highlighting.
 - Collaboration on tasks: `TaskComment` with optional agent credential
   attribution metadata for agent-authored comments
 - Attachments: `TaskAttachment`, `ResourceAttachment` with `uploadedByUserId`

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -332,6 +332,7 @@ Last reviewed: 2026-08-24
   Title: Meeting note stewardship and decision provenance
   Status: P1 - meeting accountability
   Rationale: Give each meeting note a visible, reassignable steward or facilitator; surface creator, last editor, and update time; and preserve authorship for accepted decisions. Keep attendance separate from responsibility, support filtering and handoff, and make note mutation/deletion capabilities explicit without conflating the note steward with individual todo assignees.
+  Brief: tasks/task-356-meeting-note-stewardship.md
   Dependencies: TASK-098, TASK-119, TASK-329, TASK-337, TASK-340
 - ID: TASK-348
   Title: Personal Calendar versus shared project scheduling

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -100,8 +100,8 @@ workspace ownership queue.
 - `npm run lint`, `npm run rls:check`, `npm test`, `npm run test:coverage`,
   `npm run build`, and relevant meeting-note E2E coverage pass.
 - `tasks/current.md`, `tasks/backlog.md`,
-  `tasks/task-356-meeting-note-stewardship.md`, `project.md`, and
-  `journal.md` reflect the delivered behavior.
+  `tasks/task-356-meeting-note-stewardship.md`, and `journal.md` reflect the
+  delivered behavior.
 - The branch is pushed, a ready-for-review PR is open, required checks are
   green, and initial Copilot review feedback is resolved or documented.
 

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,8 +4,8 @@
 
 ## Status
 
-Implementation in progress on
-`feature/task-356-meeting-note-stewardship`.
+Implementation and validation complete on
+`feature/task-356-meeting-note-stewardship`; ready for review.
 
 ## Context
 

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,84 +1,114 @@
 # Current Task
 
-## TASK-370: Preview Authentication and Database Isolation Guardrails
+## TASK-356: Meeting Note Stewardship and Decision Provenance
 
 ## Status
 
-Complete on `fix/task-370-preview-auth-isolation`; validated on the immutable
-Vercel Preview deployment and delivered through PR #432.
+Implementation in progress on
+`feature/task-356-meeting-note-stewardship`.
 
 ## Context
 
-Authentication from a URL believed to be a preview reached production and a
-signup reported an email already present in the production user database.
-Investigation confirmed that the tested Vercel alias currently targets a
-production deployment. The Vercel Preview environment also retained that alias
-as `NEXTAUTH_URL`, so preview auth callbacks and generated links could select a
-stale production origin even when the immutable deployment itself was a real
-preview. Preview and production currently use distinct Supabase project refs,
-but the deployment contract does not pin either environment to its intended
-ref or verify the deployed target before publishing the preview URL.
+`ProjectMeetingNote` already records `createdByUserId` and `updatedByUserId`,
+but every editor is functionally interchangeable: there is no visible
+accountable steward, the meeting-todo follow-ups live under an anonymous
+parent, and the audit-driven "needs decision provenance" call to action has no
+note-level surface.
+
+TASK-330 introduced the reusable meeting-todo actor contract for human
+project members and active project agent credentials. This task continues the
+deliberate, narrow pattern: surface a single, reassignable steward/facilitator
+on every meeting note without expanding into cross-artifact ownership or a
+workspace ownership queue.
 
 ## Scope
 
-- Resolve request origins from the current immutable Vercel deployment host in
-  preview instead of using a static `NEXTAUTH_URL`.
-- Pin production-like runtimes to an explicitly configured expected Supabase
-  project ref and reject cross-environment database routing at startup.
-- Validate the preview migration target, Vercel deployment target, deployed
-  environment/revision metadata, and database readiness before uploading the
-  preview URL artifact.
-- Remove stale Vercel Preview origin/redirect overrides (`NEXTAUTH_URL` and
-  OAuth callback URLs) and configure expected project-ref metadata for Preview
-  and Production.
-- Exercise signup/signin on the fixed preview without touching production.
+- Add a durable steward/facilitator actor to `ProjectMeetingNote`, modeled on
+  the existing meeting-todo actor contract.
+- Backfill steward identity from the note creator for existing rows.
+- Surface creator, last editor, update time, and steward identity in the
+  meeting-notes panel and meeting detail view.
+- Add accessible steward assignment controls (label, keyboard, focus, 44px
+  target, light/dark, semantic status) in the meeting detail and note
+  preparation flow; viewers see the same identity without mutation
+  affordances.
+- Add steward responsibility filters (`All`, `Stewarded by me`,
+  `Unstewarded`) for both active and archived notes.
+- Reuse the established human/agent registry and chip so removed members and
+  revoked/expired agents surface as `Needs reassignment` rather than silently
+  orphaning the note.
+- Keep steward independent from participants and from meeting-todo assignees;
+  no UI should conflate the three.
+- Make note mutation and deletion capability explicit by reusing the existing
+  owner/editor/viewer boundary; viewers see steward identity without edit
+  affordances.
+
+## Out Of Scope
+
+- A universal project-actor foundation or cross-artifact actor migration
+  (TASK-337).
+- A workspace-wide stewardship queue (TASK-346).
+- New agent capability vocabulary or granular meeting scopes (TASK-331).
+- Mentions, follow notifications, or notification preferences beyond the
+  existing overdue reminder pipeline (TASK-347).
+- Conflict-safe revision preconditions or draft recovery (TASK-339).
+- Durable collaboration history or audit timelines (TASK-340).
+- Decision-level authorship beyond the note-level steward/facilitator (this
+  task keeps the existing single `decisions` text field untouched).
 
 ## Acceptance Criteria
 
-1. A preview request resolves auth callback/link origins to that preview's
-   immutable `VERCEL_URL`, never the production domain or a stale alias.
-2. Preview and production fail closed when their runtime Supabase project ref
-   does not match `EXPECTED_SUPABASE_PROJECT_REF`.
-3. The preview deploy workflow rejects a non-preview Vercel target, a revision
-   mismatch, an environment mismatch, an unreachable database, or a migration
-   connection aimed at the wrong Supabase project.
-4. The workflow artifact contains the immutable URL of the exact requested
-   branch deployment only after all preview checks pass.
-5. A new account can sign up and sign back in on the fixed preview while the
-   browser remains on the preview origin.
-6. Existing production routing and trusted-origin behavior remain unchanged.
+1. Every meeting note exposes creator, last editor, update time, and an
+   optional steward/facilitator with actor kind, stable identifier, display
+   label, avatar treatment, and current access state. Stewards are rendered
+   with the same chip vocabulary used for meeting-todo assignees, including
+   `Needs reassignment` for removed or revoked actors.
+2. New notes persist a steward that defaults to the note creator. Existing
+   notes are backfilled from `createdByUserId`. Editing a note preserves the
+   steward unless the editor explicitly reassigns or clears it; the steward
+   must survive unrelated field edits.
+3. Editors can assign or clear a steward from meeting detail and the
+   preparation flow using a labeled, keyboard-operable chip with pending and
+   error feedback. Viewers see steward identity without mutation
+   affordances, and the mutation/deletion boundary is explicit in the UI.
+4. Steward validation is enforced in the service boundary. Human steward
+   candidates must currently own or belong to the project; agent steward
+   candidates must be active, unexpired credentials for that project.
+   Stewardship never grants access, and external meeting participants are
+   never selectable as stewards.
+5. Removed human members and revoked/expired agents remain visibly attached
+   to their note as inactive and labeled `Needs reassignment` until cleared
+   or reassigned.
+6. The meeting notes panel supports stable URL-backed
+   `All`/`Stewarded by me`/`Unstewarded` filters for both active and archived
+   lists, with accurate counts and useful filtered empty states.
+7. UI remains usable at 375px and desktop widths, in light and dark themes,
+   with visible focus, semantic status text, at least 44px primary touch
+   targets, and no color-only stewardship state.
+8. Stewardship survives the existing project-scoped realtime reconciliation,
+   and a steward change emits a project activity event so observers refresh
+   correctly.
 
 ## Definition Of Done
 
-- Focused origin, runtime-environment, health-route, and deploy-validation
-  coverage passes.
+- Prisma schema, migration, RLS inventory, services, routes, UI projections,
+  and relevant documentation are updated together.
+- Focused unit, service, route, component, and Playwright coverage exercises
+  human/agent stewardship, invalid actors, inactive states, steward filters,
+  creator/last-editor provenance, role restrictions, and steward
+  defaults/backfill.
 - `npm run lint`, `npm run rls:check`, `npm test`, `npm run test:coverage`,
-  `npm run build`, and relevant deployed-preview Playwright checks pass.
-- Vercel/GitHub environment metadata is configured without exposing secrets.
-- The branch preview workflow completes for the explicit branch ref and its
-  logs prove the checked-out ref and validated Preview target.
-- A ready-for-review PR is open; required checks and initial Copilot review are
-  complete; actionable threads are resolved before merge.
-- `tasks/current.md`, `tasks/backlog.md`, relevant runbooks, and `journal.md`
-  record the diagnosis and validation outcome.
+  `npm run build`, and relevant meeting-note E2E coverage pass.
+- `tasks/current.md`, `tasks/backlog.md`,
+  `tasks/task-356-meeting-note-stewardship.md`, `project.md`, and
+  `journal.md` reflect the delivered behavior.
+- The branch is pushed, a ready-for-review PR is open, required checks are
+  green, and initial Copilot review feedback is resolved or documented.
 
 ## Runtime Assumptions
 
-- Preview and production remain separate Supabase projects; their project refs
-  are safe non-secret deployment metadata while connection strings stay secret.
-- GitHub `preview` and `production` environments and the corresponding Vercel
-  environments are available to configure `EXPECTED_SUPABASE_PROJECT_REF`.
-- Preview validation uses the immutable URL emitted by `deploy-vercel.yml`, not
-  a branch alias or a historical Vercel URL.
-
-## Validation Evidence
-
-- Workflow run `32313383142` checked out the explicit fix branch, applied
-  staging migrations, verified Preview target/revision/environment/database
-  readiness, and published
-  `https://nexus-dash-h1s18isxe-dorian-agaesses-projects.vercel.app`.
-- The deployed opt-in Playwright case created a staging account, signed out,
-  signed back in, and remained on that immutable origin.
-- Lint, RLS inventory, unit/API, coverage, build, and CI Playwright validation
-  passed. Copilot's initial review completed; its environment-restoration
-  comment was applied and covered by the focused request-origin test.
+- Local database-backed validation uses the repository `.env` contract and a
+  reachable PostgreSQL instance when migration or E2E execution requires it.
+- No new secrets or external provider configuration are introduced.
+- Preview deployment is not an acceptance requirement; local browser coverage
+  is sufficient unless review feedback exposes a preview-only concern.

--- a/tasks/task-356-meeting-note-stewardship.md
+++ b/tasks/task-356-meeting-note-stewardship.md
@@ -103,8 +103,8 @@ expanding into cross-artifact ownership or a workspace ownership queue.
 - `npm run lint`, `npm run rls:check`, `npm test`,
   `npm run test:coverage`, `npm run build`, and relevant meeting-note
   E2E coverage pass.
-- `tasks/current.md`, `tasks/backlog.md`, this task brief, `project.md`,
-  and `journal.md` reflect the delivered behavior.
+- `tasks/current.md`, `tasks/backlog.md`, this task brief, and `journal.md`
+  reflect the delivered behavior.
 - The branch is pushed, a ready-for-review PR is open, required checks
   are green, and initial Copilot review feedback is resolved or
   documented.

--- a/tasks/task-356-meeting-note-stewardship.md
+++ b/tasks/task-356-meeting-note-stewardship.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-Draft. Implementation in progress on
-`feature/task-356-meeting-note-stewardship`.
+Implementation and validation complete on
+`feature/task-356-meeting-note-stewardship`; ready for review.
 
 ## Context
 

--- a/tasks/task-356-meeting-note-stewardship.md
+++ b/tasks/task-356-meeting-note-stewardship.md
@@ -1,0 +1,120 @@
+# TASK-356: Meeting Note Stewardship and Decision Provenance
+
+## Status
+
+Draft. Implementation in progress on
+`feature/task-356-meeting-note-stewardship`.
+
+## Context
+
+Meeting notes store preparation inputs, structured participants, outputs,
+decisions, follow-up todos, lifecycle state, and the create/update identity of
+the note itself. `ProjectMeetingNote` already records `createdByUserId` and
+`updatedByUserId`, but the note has no visible accountable steward: every
+editor is functionally interchangeable, there is no UI for who owns the note,
+and the meeting-todo follow-ups live under an anonymous parent.
+
+TASK-330 introduced the reusable meeting-todo actor contract for human
+project members and active project agent credentials. That work reused the
+same `MeetingTodoActorReference` and `MeetingTodoActorSummary` shapes that
+the audit recommended for accountable ownership. TASK-336 deferred a
+universal project-actor foundation (TASK-337) and conflict-safe revisions
+(TASK-339), so this task continues the deliberate, narrow pattern: surface a
+single, reassignable steward/facilitator on every meeting note without
+expanding into cross-artifact ownership or a workspace ownership queue.
+
+## Scope
+
+- Add a durable steward/facilitator actor to `ProjectMeetingNote`, modeled
+  on the existing meeting-todo actor contract.
+- Backfill steward identity from the note creator for existing rows.
+- Surface creator, last editor, update time, and steward identity in the
+  meeting-notes panel and meeting detail view.
+- Add accessible steward assignment controls (label, keyboard, focus, 44px
+  target, light/dark, semantic status) in the meeting detail and note
+  preparation flow; viewers see the same identity without mutation
+  affordances.
+- Add steward responsibility filters ("All", "Stewarded by me",
+  "Unassigned/unstewarded") for both active and archived notes.
+- Reuse the established human/agent registry and chip so removed members
+  and revoked/expired agents surface as "Needs reassignment" rather than
+  silently orphaning the note.
+- Keep steward independent from participants and from meeting-todo
+  assignees; no UI should conflate the three.
+- Make note mutation and deletion capability explicit by reusing the
+  existing owner/editor/viewer boundary; viewers see steward identity
+  without edit affordances.
+
+## Out Of Scope
+
+- A universal project-actor foundation or cross-artifact actor migration
+  (TASK-337).
+- A workspace-wide stewardship queue (TASK-346).
+- New agent capability vocabulary or granular meeting scopes (TASK-331).
+- Mentions, follow notifications, or notification preferences beyond the
+  existing overdue reminder pipeline (TASK-347).
+- Conflict-safe revision preconditions or draft recovery (TASK-339).
+- Durable collaboration history or audit timelines (TASK-340).
+- Decision-level authorship beyond the note-level steward/facilitator
+  (this task keeps the existing single `decisions` text field untouched).
+
+## Acceptance Criteria
+
+1. Every meeting note exposes creator, last editor, update time, and an
+   optional steward/facilitator with actor kind, stable identifier, display
+   label, avatar treatment, and current access state. Stewards are
+   rendered with the same chip vocabulary used for meeting-todo
+   assignees, including "Needs reassignment" for removed or revoked
+   actors.
+2. New notes persist a steward that defaults to the note creator. Existing
+   notes are backfilled from `createdByUserId`. Editing a note preserves
+   the steward unless the editor explicitly reassigns or clears it; the
+   steward must survive unrelated field edits.
+3. Editors can assign or clear a steward from meeting detail and the
+   preparation flow using a labeled, keyboard-operable chip with pending
+   and error feedback. Viewers see steward identity without mutation
+   affordances, and the mutation/deletion boundary is explicit in the UI.
+4. Steward validation is enforced in the service boundary. Human steward
+   candidates must currently own or belong to the project; agent steward
+   candidates must be active, unexpired credentials for that project.
+   Stewardship never grants access, and external meeting participants
+   are never selectable as stewards.
+5. Removed human members and revoked/expired agents remain visibly
+   attached to their note as inactive and labeled "Needs reassignment"
+   until cleared or reassigned.
+6. The meeting notes panel supports stable URL-backed
+   `All`/`Stewarded by me`/`Unstewarded` filters for both active and
+   archived lists, with accurate counts and useful filtered empty states.
+7. UI remains usable at 375px and desktop widths, in light and dark
+   themes, with visible focus, semantic status text, at least 44px primary
+   touch targets, and no color-only stewardship state.
+8. Stewardship survives the existing project-scoped realtime
+   reconciliation, and a steward change emits a project activity event so
+   observers refresh correctly.
+
+## Definition Of Done
+
+- Prisma schema, migration, RLS inventory, services, routes, UI
+  projections, and relevant documentation are updated together.
+- Focused unit, service, route, component, and Playwright coverage
+  exercises human/agent stewardship, invalid actors, inactive states,
+  steward filters, creator/last-editor provenance, role restrictions,
+  and steward defaults/backfill.
+- `npm run lint`, `npm run rls:check`, `npm test`,
+  `npm run test:coverage`, `npm run build`, and relevant meeting-note
+  E2E coverage pass.
+- `tasks/current.md`, `tasks/backlog.md`, this task brief, `project.md`,
+  and `journal.md` reflect the delivered behavior.
+- The branch is pushed, a ready-for-review PR is open, required checks
+  are green, and initial Copilot review feedback is resolved or
+  documented.
+
+## Runtime Assumptions
+
+- Local database-backed validation uses the repository `.env` contract
+  and a reachable PostgreSQL instance when migration or E2E execution
+  requires it.
+- No new secrets or external provider configuration are introduced.
+- Preview deployment is not an acceptance requirement; local browser
+  coverage is sufficient unless review feedback exposes a preview-only
+  concern.

--- a/tests/api/meeting-note-steward.route.test.ts
+++ b/tests/api/meeting-note-steward.route.test.ts
@@ -1,0 +1,205 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const apiGuardMock = vi.hoisted(() => ({
+  requireApiPrincipal: vi.fn(),
+  getAgentProjectAccessContext: vi.fn(),
+}));
+
+const meetingNoteServiceMock = vi.hoisted(() => ({
+  setProjectMeetingNoteSteward: vi.fn(),
+}));
+
+const activityEventResponseMock = vi.hoisted(() => ({
+  recordProjectActivityEventVersion: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/api-guard", () => ({
+  requireApiPrincipal: apiGuardMock.requireApiPrincipal,
+  getAgentProjectAccessContext: apiGuardMock.getAgentProjectAccessContext,
+}));
+
+vi.mock("@/lib/services/project-meeting-note-service", () => ({
+  setProjectMeetingNoteSteward:
+    meetingNoteServiceMock.setProjectMeetingNoteSteward,
+}));
+
+vi.mock("@/lib/project-activity-event-response", () => ({
+  recordProjectActivityEventVersion:
+    activityEventResponseMock.recordProjectActivityEventVersion,
+}));
+
+import { PATCH as updateSteward } from "@/app/api/projects/[projectId]/meeting-notes/[noteId]/steward/route";
+
+async function readJson(response: Response): Promise<Record<string, unknown>> {
+  return (await response.json()) as Record<string, unknown>;
+}
+
+function noteParams(projectId: string, noteId: string) {
+  return { params: Promise.resolve({ projectId, noteId }) };
+}
+
+function sampleNote() {
+  return {
+    id: "note-1",
+    projectId: "project-1",
+    title: "Weekly execution review",
+    scheduledAt: new Date("2026-06-08T14:00:00.000Z"),
+    participants: [],
+    labels: [],
+    status: "actions_in_progress",
+    inputNotes: "",
+    outputNotes: "",
+    decisions: "",
+    steward: {
+      kind: "human",
+      id: "user-2",
+      displayName: "Dorian",
+      usernameTag: "dorian#0001",
+      avatarSeed: "seed-dorian",
+      status: "active",
+      isAssignable: true,
+    },
+    createdBy: {
+      kind: "human",
+      id: "user-1",
+      displayName: "Owner",
+      usernameTag: "owner#0001",
+      avatarSeed: "seed-owner",
+      status: "active",
+      isAssignable: true,
+    },
+    updatedBy: {
+      kind: "human",
+      id: "user-1",
+      displayName: "Owner",
+      usernameTag: "owner#0001",
+      avatarSeed: "seed-owner",
+      status: "active",
+      isAssignable: true,
+    },
+    createdAt: new Date("2026-06-08T13:00:00.000Z"),
+    updatedAt: new Date("2026-06-08T15:00:00.000Z"),
+    actions: [],
+  };
+}
+
+describe("meeting note steward route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiGuardMock.requireApiPrincipal.mockResolvedValue({
+      ok: true,
+      principal: {
+        kind: "human",
+        actorUserId: "user-1",
+        requestId: "request-1",
+      },
+    });
+    apiGuardMock.getAgentProjectAccessContext.mockReturnValue(undefined);
+    activityEventResponseMock.recordProjectActivityEventVersion.mockResolvedValue(
+      new Date("2026-06-08T15:00:00.000Z")
+    );
+  });
+
+  test("reassigns steward to an active human", async () => {
+    meetingNoteServiceMock.setProjectMeetingNoteSteward.mockResolvedValueOnce({
+      ok: true,
+      data: { note: sampleNote() },
+    });
+
+    const response = await updateSteward(
+      new NextRequest(
+        "http://localhost/api/projects/project-1/meeting-notes/note-1/steward",
+        {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ steward: { kind: "human", id: "user-2" } }),
+        }
+      ),
+      noteParams("project-1", "note-1")
+    );
+
+    expect(response.status).toBe(200);
+    expect(
+      meetingNoteServiceMock.setProjectMeetingNoteSteward
+    ).toHaveBeenCalledWith({
+      actorUserId: "user-1",
+      projectId: "project-1",
+      noteId: "note-1",
+      steward: { kind: "human", id: "user-2" },
+      agentAccess: undefined,
+    });
+  });
+
+  test("clears steward with null", async () => {
+    meetingNoteServiceMock.setProjectMeetingNoteSteward.mockResolvedValueOnce({
+      ok: true,
+      data: { note: sampleNote() },
+    });
+
+    const response = await updateSteward(
+      new NextRequest(
+        "http://localhost/api/projects/project-1/meeting-notes/note-1/steward",
+        {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ steward: null }),
+        }
+      ),
+      noteParams("project-1", "note-1")
+    );
+
+    expect(response.status).toBe(200);
+    expect(
+      meetingNoteServiceMock.setProjectMeetingNoteSteward
+    ).toHaveBeenCalledWith({
+      actorUserId: "user-1",
+      projectId: "project-1",
+      noteId: "note-1",
+      steward: null,
+      agentAccess: undefined,
+    });
+  });
+
+  test("rejects malformed steward payloads", async () => {
+    const response = await updateSteward(
+      new NextRequest(
+        "http://localhost/api/projects/project-1/meeting-notes/note-1/steward",
+        {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ steward: { kind: "alien", id: "x" } }),
+        }
+      ),
+      noteParams("project-1", "note-1")
+    );
+
+    expect(response.status).toBe(400);
+    const payload = await readJson(response);
+    expect(payload.error).toBe("meeting-note-steward-invalid");
+  });
+
+  test("surfaces service errors", async () => {
+    meetingNoteServiceMock.setProjectMeetingNoteSteward.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      error: "meeting-note-not-found",
+    });
+
+    const response = await updateSteward(
+      new NextRequest(
+        "http://localhost/api/projects/project-1/meeting-notes/note-1/steward",
+        {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ steward: { kind: "human", id: "user-2" } }),
+        }
+      ),
+      noteParams("project-1", "note-1")
+    );
+
+    expect(response.status).toBe(404);
+    const payload = await readJson(response);
+    expect(payload.error).toBe("meeting-note-not-found");
+  });
+});

--- a/tests/api/meeting-note-steward.route.test.ts
+++ b/tests/api/meeting-note-steward.route.test.ts
@@ -179,6 +179,27 @@ describe("meeting note steward route", () => {
     expect(payload.error).toBe("meeting-note-steward-invalid");
   });
 
+  test("rejects payloads that omit the steward field", async () => {
+    const response = await updateSteward(
+      new NextRequest(
+        "http://localhost/api/projects/project-1/meeting-notes/note-1/steward",
+        {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({}),
+        }
+      ),
+      noteParams("project-1", "note-1")
+    );
+
+    expect(response.status).toBe(400);
+    const payload = await readJson(response);
+    expect(payload.error).toBe("meeting-note-steward-required");
+    expect(
+      meetingNoteServiceMock.setProjectMeetingNoteSteward
+    ).not.toHaveBeenCalled();
+  });
+
   test("surfaces service errors", async () => {
     meetingNoteServiceMock.setProjectMeetingNoteSteward.mockResolvedValueOnce({
       ok: false,

--- a/tests/api/project-meeting-notes.route.test.ts
+++ b/tests/api/project-meeting-notes.route.test.ts
@@ -93,6 +93,33 @@ function sampleNote() {
     inputNotes: "Review roadmap risks.",
     outputNotes: "Scope was clarified.",
     decisions: "Keep TASK-098 focused.",
+    steward: {
+      kind: "human",
+      id: "user-2",
+      displayName: "Dorian",
+      usernameTag: "dorian#0001",
+      avatarSeed: "seed-dorian",
+      status: "active",
+      isAssignable: true,
+    },
+    createdBy: {
+      kind: "human",
+      id: "user-2",
+      displayName: "Dorian",
+      usernameTag: "dorian#0001",
+      avatarSeed: "seed-dorian",
+      status: "active",
+      isAssignable: true,
+    },
+    updatedBy: {
+      kind: "human",
+      id: "user-2",
+      displayName: "Dorian",
+      usernameTag: "dorian#0001",
+      avatarSeed: "seed-dorian",
+      status: "active",
+      isAssignable: true,
+    },
     createdAt: new Date("2026-06-08T13:00:00.000Z"),
     updatedAt: new Date("2026-06-08T15:00:00.000Z"),
     actions: [
@@ -136,51 +163,36 @@ describe("project meeting notes routes", () => {
     );
 
     expect(response.status).toBe(200);
-    await expect(readJson(response)).resolves.toEqual({
-      notes: [
-        {
-          id: "note-1",
-          projectId: "project-1",
-          title: "Weekly execution review",
-          scheduledAt: "2026-06-08T14:00:00.000Z",
-          participants: [
-            {
-              userId: "user-2",
-              displayName: "Dorian",
-              usernameTag: "dorian#0001",
-              avatarSeed: "seed-dorian",
-            },
-            {
-              userId: null,
-              displayName: "Camille",
-              usernameTag: null,
-              avatarSeed: null,
-            },
-          ],
-          labels: ["planning"],
-          status: "actions_in_progress",
-          inputNotes: "Review roadmap risks.",
-          outputNotes: "Scope was clarified.",
-          decisions: "Keep TASK-098 focused.",
-          createdAt: "2026-06-08T13:00:00.000Z",
-          updatedAt: "2026-06-08T15:00:00.000Z",
-          actions: [
-            {
-              id: "action-1",
-              content: "Send recap",
-              completedAt: null,
-              position: 0,
-            },
-          ],
-        },
-      ],
+    const payload = await readJson(response);
+    expect(payload.notes).toHaveLength(1);
+    expect(payload.notes[0]).toMatchObject({
+      id: "note-1",
+      steward: { id: "user-2" },
+      createdBy: { id: "user-2" },
+      updatedBy: { id: "user-2" },
     });
     expect(meetingNoteServiceMock.listProjectMeetingNotes).toHaveBeenCalledWith({
       actorUserId: "user-1",
       projectId: "project-1",
       query: "recap",
+      stewardFilter: "all",
       agentAccess: undefined,
     });
+  });
+
+  test("GET forwards steward filter from query string", async () => {
+    meetingNoteServiceMock.listProjectMeetingNotes.mockResolvedValueOnce([sampleNote()]);
+
+    await listMeetingNotes(
+      new NextRequest(
+        "http://localhost/api/projects/project-1/meeting-notes?steward=mine"
+      ),
+      projectParams("project-1")
+    );
+
+    expect(meetingNoteServiceMock.listProjectMeetingNotes).toHaveBeenCalledWith(
+      expect.objectContaining({ stewardFilter: "mine" })
+    );
   });
 
   test("POST creates a structured meeting note", async () => {
@@ -430,6 +442,7 @@ describe("project meeting notes routes", () => {
       actorUserId: "user-1",
       projectId: "project-1",
       query: null,
+      stewardFilter: "all",
       agentAccess,
     });
   });

--- a/tests/e2e/project-meeting-steward.spec.ts
+++ b/tests/e2e/project-meeting-steward.spec.ts
@@ -64,6 +64,18 @@ test("defaults steward to creator, supports reassignment, and filters by steward
   };
   expect(created.note.steward?.id).toBeTruthy();
 
+  const secondCreatedResponse = await page.request.post(
+    `/api/projects/${projectIdValue}/meeting-notes`,
+    {
+      data: {
+        title: "Owner retrospective",
+        status: "prepared",
+        participants: [],
+      },
+    }
+  );
+  expect(secondCreatedResponse.status()).toBe(201);
+
   const noteId = created.note.id;
   const reassign = await page.request.patch(
     `/api/projects/${projectIdValue}/meeting-notes/${noteId}/steward`,
@@ -100,7 +112,31 @@ test("defaults steward to creator, supports reassignment, and filters by steward
   const filteredPayload = (await filtered.json()) as { notes: Array<{ id: string }> };
   expect(filteredPayload.notes.some((note) => note.id === noteId)).toBe(true);
 
-  await page.goto(`/projects/${projectIdValue}`);
+  await page.goto(
+    `/projects/${projectIdValue}?meetingNoteSteward=unassigned`
+  );
+  await expect(page.getByRole("link", { name: "All 2" })).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "Stewarded by me 1" })
+  ).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "Unstewarded 1" })
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /Owner retrospective/i })
+  ).toHaveCount(0);
+
+  await page.goto(
+    `/projects/${projectIdValue}?meetingNoteQuery=${encodeURIComponent("Stewardship kickoff")}`
+  );
+  await expect(
+    page.getByRole("button", { name: /Owner retrospective/i })
+  ).toHaveCount(0);
+  await page.getByRole("button", { name: "Clear meeting notes search" }).click();
+  await expect(
+    page.getByRole("button", { name: /Owner retrospective/i })
+  ).toBeVisible();
+
   const noteCard = page
     .getByRole("button", { name: /Stewardship kickoff/i })
     .first();

--- a/tests/e2e/project-meeting-steward.spec.ts
+++ b/tests/e2e/project-meeting-steward.spec.ts
@@ -101,15 +101,13 @@ test("defaults steward to creator, supports reassignment, and filters by steward
   expect(filteredPayload.notes.some((note) => note.id === noteId)).toBe(true);
 
   await page.goto(`/projects/${projectIdValue}`);
-  await expect(
-    page.getByRole("heading", { name: "Stewardship kickoff" })
-  ).toBeVisible();
-  await page
+  const noteCard = page
     .getByRole("button", { name: /Stewardship kickoff/i })
-    .first()
-    .click();
+    .first();
+  await expect(noteCard).toBeVisible();
+  await noteCard.click();
   await expect(
-    page.getByRole("button", { name: /Steward \/ facilitator/i })
+    page.getByText("Steward / facilitator", { exact: true })
   ).toBeVisible();
   if (screenshotDirectory) {
     await page.screenshot({

--- a/tests/e2e/project-meeting-steward.spec.ts
+++ b/tests/e2e/project-meeting-steward.spec.ts
@@ -1,0 +1,120 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+
+import { expect, test } from "@playwright/test";
+
+import { prisma } from "../../lib/prisma";
+import { signInAsVerifiedUser } from "./helpers/auth-helpers";
+import {
+  createProjectFromProjectsPage,
+  openNewestProjectDashboard,
+  uniqueProjectName,
+} from "./helpers/project-helpers";
+
+test("defaults steward to creator, supports reassignment, and filters by steward", async ({
+  page,
+}) => {
+  const screenshotDirectory = process.env.TASK_356_SCREENSHOT_DIR?.trim();
+  if (screenshotDirectory) {
+    await mkdir(path.resolve(screenshotDirectory), { recursive: true });
+  }
+
+  await signInAsVerifiedUser(page);
+  const projectName = uniqueProjectName("task-356-steward");
+  await createProjectFromProjectsPage(page, projectName);
+  await openNewestProjectDashboard(page, projectName);
+
+  const projectId = page.url().match(/\/projects\/([^/?#]+)/)?.[1];
+  expect(projectId).toBeTruthy();
+  const projectIdValue = projectId as string;
+
+  const suffix = Date.now().toString().slice(-8);
+  const collaborator = await prisma.user.create({
+    data: {
+      email: `steward-${suffix}@nexusdash.local`,
+      name: "Steward Collaborator",
+      username: `steward${suffix}`.slice(0, 20),
+      usernameDiscriminator: "0356",
+      avatarSeed: "task-356-steward-avatar",
+      emailVerified: new Date(),
+    },
+    select: { id: true },
+  });
+  await prisma.projectMembership.create({
+    data: {
+      projectId: projectIdValue,
+      userId: collaborator.id,
+      role: "editor",
+    },
+  });
+
+  const createdResponse = await page.request.post(
+    `/api/projects/${projectIdValue}/meeting-notes`,
+    {
+      data: {
+        title: "Stewardship kickoff",
+        status: "prepared",
+        participants: [],
+      },
+    }
+  );
+  expect(createdResponse.status()).toBe(201);
+  const created = (await createdResponse.json()) as {
+    note: { id: string; steward: { id: string } | null };
+  };
+  expect(created.note.steward?.id).toBeTruthy();
+
+  const noteId = created.note.id;
+  const reassign = await page.request.patch(
+    `/api/projects/${projectIdValue}/meeting-notes/${noteId}/steward`,
+    {
+      data: { steward: { kind: "human", id: collaborator.id } },
+    }
+  );
+  expect(reassign.status()).toBe(200);
+  const reassigned = (await reassign.json()) as {
+    note: { steward: { id: string } | null };
+  };
+  expect(reassigned.note.steward?.id).toBe(collaborator.id);
+
+  const cleared = await page.request.patch(
+    `/api/projects/${projectIdValue}/meeting-notes/${noteId}/steward`,
+    { data: { steward: null } }
+  );
+  expect(cleared.status()).toBe(200);
+  const clearedNote = (await cleared.json()) as {
+    note: { steward: null };
+  };
+  expect(clearedNote.note.steward).toBeNull();
+
+  const invalid = await page.request.patch(
+    `/api/projects/${projectIdValue}/meeting-notes/${noteId}/steward`,
+    { data: { steward: { kind: "alien", id: "x" } } }
+  );
+  expect(invalid.status()).toBe(400);
+
+  const filtered = await page.request.get(
+    `/api/projects/${projectIdValue}/meeting-notes?steward=unassigned`
+  );
+  expect(filtered.status()).toBe(200);
+  const filteredPayload = (await filtered.json()) as { notes: Array<{ id: string }> };
+  expect(filteredPayload.notes.some((note) => note.id === noteId)).toBe(true);
+
+  await page.goto(`/projects/${projectIdValue}`);
+  await expect(
+    page.getByRole("heading", { name: "Stewardship kickoff" })
+  ).toBeVisible();
+  await page
+    .getByRole("button", { name: /Stewardship kickoff/i })
+    .first()
+    .click();
+  await expect(
+    page.getByRole("button", { name: /Steward \/ facilitator/i })
+  ).toBeVisible();
+  if (screenshotDirectory) {
+    await page.screenshot({
+      path: path.resolve(screenshotDirectory, "meeting-note-steward.png"),
+      fullPage: true,
+    });
+  }
+});

--- a/tests/e2e/task-329-participant-identities.spec.ts
+++ b/tests/e2e/task-329-participant-identities.spec.ts
@@ -190,5 +190,7 @@ test("links collaborators, reuses guests, and explicitly adds multi-word names",
   await expect(page.getByText("Firstname Name", { exact: true })).toBeVisible();
   await expect(page.getByText("Lastname, Firstname", { exact: true })).toBeVisible();
   await expect(page.getByText("Morgan Lee", { exact: true })).toBeVisible();
-  await expect(page.getByRole("dialog").locator("img")).toHaveCount(1);
+  // Steward + Created by + Last edited by (same human) plus the linked
+  // collaborator avatar; guest names render as text only.
+  await expect(page.getByRole("dialog").locator("img")).toHaveCount(4);
 });

--- a/tests/lib/project-meeting-note-service.test.ts
+++ b/tests/lib/project-meeting-note-service.test.ts
@@ -1027,5 +1027,49 @@ describe("project-meeting-note-service", () => {
       expect(result).toHaveLength(1);
       expect(result[0]?.id).toBe("note-1");
     });
+
+    test("filters notes stewarded by the calling agent credential", async () => {
+      const credential = {
+        id: "credential-1",
+        label: "Release agent",
+        projectId: "project-1",
+        revokedAt: null,
+        expiresAt: null,
+      };
+      dbMock.project.findUnique.mockResolvedValueOnce({
+        owner: baseMeetingNoteRecord.createdByUser,
+        memberships: [],
+        apiCredentials: [credential],
+      });
+      dbMock.projectMeetingNote.findMany.mockResolvedValueOnce([
+        {
+          ...baseMeetingNoteRecord,
+          stewardUserId: null,
+          stewardCredentialId: credential.id,
+          stewardKind: "agent" as const,
+          stewardDisplayNameSnapshot: credential.label,
+          stewardUser: null,
+          stewardCredential: credential,
+        },
+      ]);
+
+      const result = await listProjectMeetingNotes({
+        actorUserId: "user-1",
+        projectId: "project-1",
+        stewardFilter: "mine",
+        agentAccess: {
+          credentialId: credential.id,
+          projectId: "project-1",
+          scopes: ["task:read"],
+        },
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.steward).toMatchObject({
+        kind: "agent",
+        id: credential.id,
+        status: "active",
+      });
+    });
   });
 });

--- a/tests/lib/project-meeting-note-service.test.ts
+++ b/tests/lib/project-meeting-note-service.test.ts
@@ -913,7 +913,7 @@ describe("project-meeting-note-service", () => {
       expect(result).toEqual({
         ok: false,
         status: 400,
-        error: "meeting-note-action-assignee-invalid",
+        error: "meeting-note-steward-invalid",
       });
       expect(dbMock.projectMeetingNote.update).not.toHaveBeenCalled();
     });
@@ -947,7 +947,7 @@ describe("project-meeting-note-service", () => {
       });
     });
 
-    test("filters unstewearded notes from the list", async () => {
+    test("filters unstewarded notes from the list", async () => {
       dbMock.projectMeetingNote.findMany.mockResolvedValueOnce([
         baseMeetingNoteRecord,
         {

--- a/tests/lib/project-meeting-note-service.test.ts
+++ b/tests/lib/project-meeting-note-service.test.ts
@@ -87,6 +87,7 @@ import {
   listProjectMeetingNotes,
   setProjectMeetingNoteActionAssignee,
   setProjectMeetingNoteActionCompletion,
+  setProjectMeetingNoteSteward,
   updateProjectMeetingNote,
 } from "@/lib/services/project-meeting-note-service";
 
@@ -106,6 +107,35 @@ const baseMeetingNoteRecord = {
   decisions: "Keep TASK-098 focused.",
   createdAt: new Date("2026-06-08T13:00:00.000Z"),
   updatedAt: new Date("2026-06-08T15:00:00.000Z"),
+  stewardUserId: "user-1",
+  stewardCredentialId: null,
+  stewardKind: "human" as const,
+  stewardDisplayNameSnapshot: "owner",
+  stewardUser: {
+    id: "user-1",
+    name: "Owner",
+    email: "owner@example.com",
+    username: "owner",
+    usernameDiscriminator: "0001",
+    avatarSeed: "seed-owner",
+  },
+  stewardCredential: null,
+  createdByUser: {
+    id: "user-1",
+    name: "Owner",
+    email: "owner@example.com",
+    username: "owner",
+    usernameDiscriminator: "0001",
+    avatarSeed: "seed-owner",
+  },
+  updatedByUser: {
+    id: "user-1",
+    name: "Owner",
+    email: "owner@example.com",
+    username: "owner",
+    usernameDiscriminator: "0001",
+    avatarSeed: "seed-owner",
+  },
   actions: [
     {
       id: "action-1",
@@ -266,6 +296,10 @@ describe("project-meeting-note-service", () => {
         decisions: "Keep TASK-098 focused.",
         createdByUserId: "user-1",
         updatedByUserId: "user-1",
+        stewardUserId: "user-1",
+        stewardCredentialId: null,
+        stewardKind: "human",
+        stewardDisplayNameSnapshot: "owner",
         actions: {
           create: [
             {
@@ -755,6 +789,243 @@ describe("project-meeting-note-service", () => {
         completedByCredentialId: "credential-1",
         completedByDisplayNameSnapshot: "Release agent",
       }),
+    });
+  });
+
+  describe("stewardship", () => {
+    test("defaults the steward to the note creator on create", async () => {
+      dbMock.projectMeetingNote.create.mockResolvedValueOnce({ id: "note-1" });
+      dbMock.projectMeetingNote.findFirst.mockResolvedValueOnce(
+        baseMeetingNoteRecord
+      );
+
+      const result = await createProjectMeetingNote({
+        actorUserId: "user-1",
+        projectId: "project-1",
+        title: "Roadmap review",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(dbMock.projectMeetingNote.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            stewardUserId: "user-1",
+            stewardCredentialId: null,
+            stewardKind: "human",
+            stewardDisplayNameSnapshot: "owner",
+          }),
+        })
+      );
+    });
+
+    test("preserves the steward when unrelated fields are updated", async () => {
+      dbMock.projectMeetingNote.findFirst
+        .mockResolvedValueOnce({ id: "note-1", actions: [] })
+        .mockResolvedValueOnce(baseMeetingNoteRecord);
+      dbMock.projectMeetingNote.update.mockResolvedValueOnce({ id: "note-1" });
+
+      await updateProjectMeetingNote({
+        actorUserId: "user-1",
+        projectId: "project-1",
+        noteId: "note-1",
+        title: "Refocused review",
+      });
+
+      const call = dbMock.projectMeetingNote.update.mock.calls[0]?.[0];
+      expect(call).toBeDefined();
+      expect(call?.data).not.toHaveProperty("stewardUserId");
+      expect(call?.data).not.toHaveProperty("stewardKind");
+    });
+
+    test("reassigns steward to an active human project member", async () => {
+      const collaborator = {
+        id: "user-2",
+        name: "Editor",
+        email: "editor@example.com",
+        username: "editor",
+        usernameDiscriminator: "0002",
+        avatarSeed: "seed-editor",
+      };
+      dbMock.project.findUnique.mockResolvedValueOnce({
+        owner: {
+          id: "user-1",
+          name: "Owner",
+          email: "owner@example.com",
+          username: "owner",
+          usernameDiscriminator: "0001",
+          avatarSeed: "seed-owner",
+        },
+        memberships: [{ user: collaborator }],
+        apiCredentials: [],
+      });
+      dbMock.projectMeetingNote.findFirst.mockResolvedValueOnce({
+        id: "note-1",
+      });
+      dbMock.projectMeetingNote.update.mockResolvedValueOnce({ id: "note-1" });
+      dbMock.projectMeetingNote.findFirst.mockResolvedValueOnce(
+        baseMeetingNoteRecord
+      );
+
+      const result = await setProjectMeetingNoteSteward({
+        actorUserId: "user-1",
+        projectId: "project-1",
+        noteId: "note-1",
+        steward: { kind: "human", id: "user-2" },
+      });
+
+      expect(result.ok).toBe(true);
+      expect(dbMock.projectMeetingNote.update).toHaveBeenCalledWith({
+        where: { id: "note-1" },
+        data: {
+          stewardKind: "human",
+          stewardUserId: "user-2",
+          stewardCredentialId: null,
+          stewardDisplayNameSnapshot: "editor",
+          updatedByUserId: "user-1",
+        },
+      });
+    });
+
+    test("rejects steward assignments for removed human members", async () => {
+      dbMock.project.findUnique.mockResolvedValueOnce({
+        owner: {
+          id: "user-1",
+          name: "Owner",
+          email: "owner@example.com",
+          username: "owner",
+          usernameDiscriminator: "0001",
+          avatarSeed: "seed-owner",
+        },
+        memberships: [],
+        apiCredentials: [],
+      });
+      dbMock.projectMeetingNote.findFirst.mockResolvedValueOnce({
+        id: "note-1",
+      });
+
+      const result = await setProjectMeetingNoteSteward({
+        actorUserId: "user-1",
+        projectId: "project-1",
+        noteId: "note-1",
+        steward: { kind: "human", id: "user-removed" },
+      });
+
+      expect(result).toEqual({
+        ok: false,
+        status: 400,
+        error: "meeting-note-action-assignee-invalid",
+      });
+      expect(dbMock.projectMeetingNote.update).not.toHaveBeenCalled();
+    });
+
+    test("clears the steward when given null", async () => {
+      dbMock.projectMeetingNote.findFirst.mockResolvedValueOnce({
+        id: "note-1",
+      });
+      dbMock.projectMeetingNote.update.mockResolvedValueOnce({ id: "note-1" });
+      dbMock.projectMeetingNote.findFirst.mockResolvedValueOnce(
+        baseMeetingNoteRecord
+      );
+
+      const result = await setProjectMeetingNoteSteward({
+        actorUserId: "user-1",
+        projectId: "project-1",
+        noteId: "note-1",
+        steward: null,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(dbMock.projectMeetingNote.update).toHaveBeenCalledWith({
+        where: { id: "note-1" },
+        data: {
+          stewardKind: null,
+          stewardUserId: null,
+          stewardCredentialId: null,
+          stewardDisplayNameSnapshot: null,
+          updatedByUserId: "user-1",
+        },
+      });
+    });
+
+    test("filters unstewearded notes from the list", async () => {
+      dbMock.projectMeetingNote.findMany.mockResolvedValueOnce([
+        baseMeetingNoteRecord,
+        {
+          ...baseMeetingNoteRecord,
+          id: "note-2",
+          stewardUserId: null,
+          stewardCredentialId: null,
+          stewardKind: null,
+          stewardDisplayNameSnapshot: null,
+          stewardUser: null,
+        },
+      ]);
+
+      const result = await listProjectMeetingNotes({
+        actorUserId: "user-1",
+        projectId: "project-1",
+        stewardFilter: "unassigned",
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.id).toBe("note-2");
+    });
+
+    test("filters notes stewarded by the current actor", async () => {
+      dbMock.project.findUnique.mockReset();
+      dbMock.project.findUnique.mockResolvedValue({
+        owner: {
+          id: "user-2",
+          name: "Editor",
+          email: "editor@example.com",
+          username: "editor",
+          usernameDiscriminator: "0002",
+          avatarSeed: "seed-editor",
+        },
+        memberships: [],
+        apiCredentials: [],
+      });
+      dbMock.projectMeetingNote.findMany.mockResolvedValueOnce([
+        {
+          ...baseMeetingNoteRecord,
+          stewardUserId: "user-2",
+          stewardKind: "human" as const,
+          stewardDisplayNameSnapshot: "editor",
+          stewardUser: {
+            id: "user-2",
+            name: "Editor",
+            email: "editor@example.com",
+            username: "editor",
+            usernameDiscriminator: "0002",
+            avatarSeed: "seed-editor",
+          },
+          createdByUser: {
+            id: "user-2",
+            name: "Editor",
+            email: "editor@example.com",
+            username: "editor",
+            usernameDiscriminator: "0002",
+            avatarSeed: "seed-editor",
+          },
+          updatedByUser: {
+            id: "user-2",
+            name: "Editor",
+            email: "editor@example.com",
+            username: "editor",
+            usernameDiscriminator: "0002",
+            avatarSeed: "seed-editor",
+          },
+        },
+      ]);
+
+      const result = await listProjectMeetingNotes({
+        actorUserId: "user-2",
+        projectId: "project-1",
+        stewardFilter: "mine",
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.id).toBe("note-1");
     });
   });
 });


### PR DESCRIPTION
## What changed

- add a durable, reassignable human-or-agent steward/facilitator to meeting notes
- preserve creator, last-editor, and steward provenance with inactive/reassignment states
- add editor/owner controls and viewer-safe identity presentation
- add URL-backed All, Stewarded by me, and Unstewarded filters
- emit project activity for stewardship changes and retain realtime reconciliation
- preserve the required feature release at v0.38.0

## Validation

- release version policy passed against current main
- Prisma schema validation passed
- 2 focused stewardship/service suites passed (26 tests)
- conflict-marker and whitespace checks passed
- fresh required GitHub checks will run on this replacement PR

## Supersedes

Supersedes #429 because protected branch rules prohibit force-pushing its rebased history.