### PR TITLE
TASK-342: Context knowledge stewardship and attachment provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ SHA, deployment URL, and workflow run belong in release evidence.
 
 - Define each release entry before the product-impacting PR is merged.
 
+## v0.38.0 - 2026-08-16
+
+- Added durable creator, last-editor, and optional human or agent steward
+  identity to context cards, with display snapshots that remain readable after
+  membership removal or credential revocation.
+- Added accessible stewardship controls for project editors and owners, while
+  preserving read-only identity details for viewers and validating every
+  assignment at the service boundary.
+- Surfaced attachment-uploader provenance and explicit inactive-actor states so
+  historical knowledge sources remain attributable.
+- Added a configurable derived `Needs review` signal across context-card grid,
+  preview, and edit surfaces for cards that have not been updated recently.
+- Added migration, service, route, component, and browser coverage for actor
+  assignment, inactive identities, attachment attribution, permissions, and
+  responsive stewardship presentation.
+
 ## v0.37.1 - 2026-08-20
 
 - Fixed Vercel Preview authentication origins so callbacks and post-auth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ SHA, deployment URL, and workflow run belong in release evidence.
 
 - Define each release entry before the product-impacting PR is merged.
 
-## v0.38.0 - 2026-08-16
+## v0.38.0 - 2026-08-24
 
 - Added durable creator, last-editor, and optional human or agent steward
   identity to context cards, with display snapshots that remain readable after

--- a/app/api/projects/[projectId]/context-cards/[cardId]/route.ts
+++ b/app/api/projects/[projectId]/context-cards/[cardId]/route.ts
@@ -111,16 +111,22 @@ export async function PATCH(
     entityId: cardId,
     payload: {
       card: {
-        id: cardId,
-        title,
-        content,
-        color,
+        id: result.data.id,
+        title: result.data.title,
+        content: result.data.content,
+        color: result.data.color,
       },
     },
   });
 
   return NextResponse.json(
-    { ok: true },
+    {
+      card: {
+        ...result.data,
+        createdAt: result.data.createdAt.toISOString(),
+        updatedAt: result.data.updatedAt.toISOString(),
+      },
+    },
     { headers: withProjectActivityVersionHeader(timing.headers(), version) }
   );
 }

--- a/app/api/projects/[projectId]/context-cards/[cardId]/route.ts
+++ b/app/api/projects/[projectId]/context-cards/[cardId]/route.ts
@@ -11,6 +11,7 @@ import { withProjectActivityVersionHeader } from "@/lib/project-activity-version
 import {
   deleteContextCardForProject,
   updateContextCardForProject,
+  type ContextCardResponse,
 } from "@/lib/services/context-card-service";
 
 interface ContextCardUpdateJsonRequestBody {
@@ -29,6 +30,25 @@ function readText(formData: FormData, key: string): string {
 
 function isJsonRequest(request: NextRequest): boolean {
   return request.headers.get("content-type")?.includes("application/json") ?? false;
+}
+
+function serializeContextCard(card: ContextCardResponse) {
+  return {
+    ...card,
+    createdAt: card.createdAt.toISOString(),
+    updatedAt: card.updatedAt.toISOString(),
+    projection: {
+      ...card.projection,
+      review: {
+        ...card.projection.review,
+        lastEditedAt: card.projection.review.lastEditedAt.toISOString(),
+      },
+      attachments: card.projection.attachments.map((attachment) => ({
+        ...attachment,
+        uploadedAt: attachment.uploadedAt.toISOString(),
+      })),
+    },
+  };
 }
 
 export async function PATCH(
@@ -103,6 +123,7 @@ export async function PATCH(
     );
   }
 
+  const serializedCard = serializeContextCard(result.data);
   const version = await recordProjectActivityEventVersion({
     actorUserId,
     projectId,
@@ -110,22 +131,13 @@ export async function PATCH(
     action: "updated",
     entityId: cardId,
     payload: {
-      card: {
-        id: result.data.id,
-        title: result.data.title,
-        content: result.data.content,
-        color: result.data.color,
-      },
+      card: serializedCard,
     },
   });
 
   return NextResponse.json(
     {
-      card: {
-        ...result.data,
-        createdAt: result.data.createdAt.toISOString(),
-        updatedAt: result.data.updatedAt.toISOString(),
-      },
+      card: serializedCard,
     },
     { headers: withProjectActivityVersionHeader(timing.headers(), version) }
   );

--- a/app/api/projects/[projectId]/context-cards/[cardId]/stewardship/route.ts
+++ b/app/api/projects/[projectId]/context-cards/[cardId]/stewardship/route.ts
@@ -17,6 +17,10 @@ interface ContextCardStewardshipRequestBody {
   steward?: unknown;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
 export async function PATCH(
   request: NextRequest,
   props: { params: Promise<{ projectId: string; cardId: string }> }
@@ -35,7 +39,11 @@ export async function PATCH(
 
   let payload: ContextCardStewardshipRequestBody;
   try {
-    payload = (await request.json()) as ContextCardStewardshipRequestBody;
+    const parsedPayload: unknown = await request.json();
+    if (!isRecord(parsedPayload)) {
+      return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 });
+    }
+    payload = parsedPayload;
   } catch (error) {
     logServerWarning(
       "PATCH /api/projects/:projectId/context-cards/:cardId/stewardship.invalidJson",
@@ -84,7 +92,22 @@ export async function PATCH(
     action: "updated",
     entityId: cardId,
     payload: {
-      cardId,
+      card: {
+        id: result.data.cardId,
+        updatedAt: result.data.updatedAt.toISOString(),
+        projection: {
+          ...result.data.projection,
+          review: {
+            ...result.data.projection.review,
+            lastEditedAt:
+              result.data.projection.review.lastEditedAt.toISOString(),
+          },
+          attachments: result.data.projection.attachments.map((attachment) => ({
+            ...attachment,
+            uploadedAt: attachment.uploadedAt.toISOString(),
+          })),
+        },
+      },
       change: "stewardship",
       steward: result.data.steward
         ? {
@@ -104,6 +127,7 @@ export async function PATCH(
         thresholdDays: result.data.thresholdDays,
         lastEditedAt: result.data.lastEditedAt.toISOString(),
       },
+      updatedAt: result.data.updatedAt.toISOString(),
     },
     {
       headers: withProjectActivityVersionHeader(new Headers(), version),

--- a/app/api/projects/[projectId]/context-cards/[cardId]/stewardship/route.ts
+++ b/app/api/projects/[projectId]/context-cards/[cardId]/stewardship/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import {
+  getAgentProjectAccessContext,
+  requireApiPrincipal,
+} from "@/lib/auth/api-guard";
+import {
+  isContextCardActorReference,
+  type ContextCardActorReference,
+} from "@/lib/context-card-actor";
+import { logServerWarning } from "@/lib/observability/logger";
+import { recordProjectActivityEventVersion } from "@/lib/project-activity-event-response";
+import { withProjectActivityVersionHeader } from "@/lib/project-activity-version";
+import { assignContextCardSteward } from "@/lib/services/context-card-stewardship-service";
+
+interface ContextCardStewardshipRequestBody {
+  steward?: unknown;
+}
+
+export async function PATCH(
+  request: NextRequest,
+  props: { params: Promise<{ projectId: string; cardId: string }> }
+) {
+  const params = await props.params;
+  const principalResult = await requireApiPrincipal(request);
+  if (!principalResult.ok) {
+    return principalResult.response;
+  }
+  const actorUserId = principalResult.principal.actorUserId;
+  const agentAccess = getAgentProjectAccessContext(principalResult.principal);
+  const { projectId, cardId } = params;
+  if (!projectId || !cardId) {
+    return NextResponse.json({ error: "Missing route parameters" }, { status: 400 });
+  }
+
+  let payload: ContextCardStewardshipRequestBody;
+  try {
+    payload = (await request.json()) as ContextCardStewardshipRequestBody;
+  } catch (error) {
+    logServerWarning(
+      "PATCH /api/projects/:projectId/context-cards/:cardId/stewardship.invalidJson",
+      "Invalid JSON payload",
+      { error }
+    );
+    return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 });
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(payload, "steward")) {
+    return NextResponse.json(
+      { error: "context-card-stewardship-missing" },
+      { status: 400 }
+    );
+  }
+
+  const stewardRaw = payload.steward;
+  let steward: ContextCardActorReference | null;
+  if (stewardRaw === null) {
+    steward = null;
+  } else if (isContextCardActorReference(stewardRaw)) {
+    steward = stewardRaw;
+  } else {
+    return NextResponse.json(
+      { error: "context-card-steward-invalid" },
+      { status: 400 }
+    );
+  }
+
+  const result = await assignContextCardSteward({
+    actorUserId,
+    projectId,
+    cardId,
+    steward,
+    agentAccess,
+  });
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  const version = await recordProjectActivityEventVersion({
+    actorUserId,
+    projectId,
+    domain: "context-card",
+    action: "updated",
+    entityId: cardId,
+    payload: {
+      cardId,
+      change: "stewardship",
+      steward: result.data.steward
+        ? {
+            kind: result.data.steward.kind,
+            id: result.data.steward.id,
+          }
+        : null,
+    },
+  });
+
+  return NextResponse.json(
+    {
+      cardId: result.data.cardId,
+      steward: result.data.steward,
+      review: {
+        needsReview: result.data.needsReview,
+        thresholdDays: result.data.thresholdDays,
+        lastEditedAt: result.data.lastEditedAt.toISOString(),
+      },
+    },
+    {
+      headers: withProjectActivityVersionHeader(new Headers(), version),
+    }
+  );
+}

--- a/app/api/projects/[projectId]/context-cards/route.ts
+++ b/app/api/projects/[projectId]/context-cards/route.ts
@@ -9,16 +9,17 @@ import { startServerTiming } from "@/lib/observability/server-timing";
 import { recordProjectActivityEventVersion } from "@/lib/project-activity-event-response";
 import { withProjectActivityVersionHeader } from "@/lib/project-activity-version";
 import { createContextCardForProject } from "@/lib/services/context-card-service";
-import { listProjectContextCardActors } from "@/lib/services/context-card-actor-service";
-import { projectContextCard } from "@/lib/services/context-card-stewardship-service";
+
+import {
+  projectContextCard,
+  loadContextCardActorRegistryForProject,
+  type ContextCardCardRecord,
+} from "@/lib/services/context-card-stewardship-service";
 import { mapContextAttachmentResponse } from "@/lib/services/project-attachment-service";
 import { listProjectContextResources } from "@/lib/services/project-service";
 import { requireAgentProjectScopes } from "@/lib/services/project-access-service";
 
 const ATTACHMENT_FILES_FIELD = "attachmentFiles";
-type ContextCardRecord =
-  Awaited<ReturnType<typeof listProjectContextResources>>[number];
-type ContextCardAttachment = ContextCardRecord["attachments"][number];
 
 interface ContextCardCreateJsonRequestBody {
   title?: unknown;
@@ -84,29 +85,28 @@ export async function GET(request: NextRequest, props: { params: Promise<{ proje
     agentAccess
   );
 
-  const assignableActors = await listProjectContextCardActors({
+  const registry = await loadContextCardActorRegistryForProject({
     actorUserId: principalResult.principal.actorUserId,
     projectId: params.projectId,
   });
+  const assignableActors = registry?.assignable ?? [];
 
   return NextResponse.json(
     {
       cards: cards.map((card) => {
-        const projection = projectContextCard({ card });
+        const cardRecord = card as unknown as ContextCardCardRecord;
+        const projection = projectContextCard({ card: cardRecord, registry });
         return {
           id: card.id,
           title: card.name,
           content: card.content,
           color: card.color,
           createdAt: card.createdAt.toISOString(),
-          updatedAt: card.updatedAt.toISOString(),
-          attachments: card.attachments.map((attachment: ContextCardAttachment) =>
+          updatedAt: cardRecord.updatedAt.toISOString(),
+          attachments: card.attachments.map((attachment) =>
             mapContextAttachmentResponse(params.projectId, card.id, attachment)
           ),
-          projection: {
-            ...projection,
-            lastEditedAt: card.updatedAt.toISOString(),
-          },
+          projection,
         };
       }),
       assignableActors,

--- a/app/api/projects/[projectId]/context-cards/route.ts
+++ b/app/api/projects/[projectId]/context-cards/route.ts
@@ -9,13 +9,16 @@ import { startServerTiming } from "@/lib/observability/server-timing";
 import { recordProjectActivityEventVersion } from "@/lib/project-activity-event-response";
 import { withProjectActivityVersionHeader } from "@/lib/project-activity-version";
 import { createContextCardForProject } from "@/lib/services/context-card-service";
+import { listProjectContextCardActors } from "@/lib/services/context-card-actor-service";
+import { projectContextCard } from "@/lib/services/context-card-stewardship-service";
 import { mapContextAttachmentResponse } from "@/lib/services/project-attachment-service";
 import { listProjectContextResources } from "@/lib/services/project-service";
 import { requireAgentProjectScopes } from "@/lib/services/project-access-service";
 
 const ATTACHMENT_FILES_FIELD = "attachmentFiles";
-type ContextCardAttachment =
-  Awaited<ReturnType<typeof listProjectContextResources>>[number]["attachments"][number];
+type ContextCardRecord =
+  Awaited<ReturnType<typeof listProjectContextResources>>[number];
+type ContextCardAttachment = ContextCardRecord["attachments"][number];
 
 interface ContextCardCreateJsonRequestBody {
   title?: unknown;
@@ -81,18 +84,32 @@ export async function GET(request: NextRequest, props: { params: Promise<{ proje
     agentAccess
   );
 
+  const assignableActors = await listProjectContextCardActors({
+    actorUserId: principalResult.principal.actorUserId,
+    projectId: params.projectId,
+  });
+
   return NextResponse.json(
     {
-      cards: cards.map((card) => ({
-        id: card.id,
-        title: card.name,
-        content: card.content,
-        color: card.color,
-        createdAt: card.createdAt,
-        attachments: card.attachments.map((attachment: ContextCardAttachment) =>
-          mapContextAttachmentResponse(params.projectId, card.id, attachment)
-        ),
-      })),
+      cards: cards.map((card) => {
+        const projection = projectContextCard({ card });
+        return {
+          id: card.id,
+          title: card.name,
+          content: card.content,
+          color: card.color,
+          createdAt: card.createdAt.toISOString(),
+          updatedAt: card.updatedAt.toISOString(),
+          attachments: card.attachments.map((attachment: ContextCardAttachment) =>
+            mapContextAttachmentResponse(params.projectId, card.id, attachment)
+          ),
+          projection: {
+            ...projection,
+            lastEditedAt: card.updatedAt.toISOString(),
+          },
+        };
+      }),
+      assignableActors,
     },
     { headers: timing.headers() }
   );

--- a/app/projects/[projectId]/project-context-panel-section.tsx
+++ b/app/projects/[projectId]/project-context-panel-section.tsx
@@ -69,7 +69,7 @@ export async function ProjectContextPanelSection({
     );
 
     const attachmentProjections: ProjectContextAttachmentProjection[] =
-      projection.attachments.map((attachmentProjection, index) => ({
+      projection.attachments.map((attachmentProjection) => ({
         id: attachmentProjection.id,
         kind: attachmentProjection.kind,
         name: attachmentProjection.name,

--- a/app/projects/[projectId]/project-context-panel-section.tsx
+++ b/app/projects/[projectId]/project-context-panel-section.tsx
@@ -12,8 +12,12 @@ import {
 } from "@/components/project-context-panel-types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getContextCardColorFromSeed } from "@/lib/context-card-colors";
-import { listProjectContextCardActors } from "@/lib/services/context-card-actor-service";
-import { projectContextCard } from "@/lib/services/context-card-stewardship-service";
+
+import {
+  projectContextCard,
+  loadContextCardActorRegistryForProject,
+  type ContextCardCardRecord,
+} from "@/lib/services/context-card-stewardship-service";
 import { listProjectContextResources } from "@/lib/services/project-service";
 import { ATTACHMENT_KIND_FILE } from "@/lib/task-attachment";
 
@@ -34,14 +38,20 @@ export async function ProjectContextPanelSection({
   storageProvider,
 }: ProjectContextPanelSectionProps) {
   const resources = await listProjectContextResources(projectId, actorUserId);
-  const assignableActors = await listProjectContextCardActors({
+  const registry = await loadContextCardActorRegistryForProject({
     actorUserId,
     projectId,
   });
+  const assignableActors = registry?.assignable ?? [];
   const now = new Date();
 
   const cards = resources.map((resource) => {
-    const projection = projectContextCard({ card: resource, now });
+    const cardRecord = resource as unknown as ContextCardCardRecord;
+    const projection = projectContextCard({
+      card: cardRecord,
+      now,
+      registry,
+    });
 
     const attachments = resource.attachments.map(
       (attachment: ContextCardAttachment) => ({
@@ -89,7 +99,7 @@ export async function ProjectContextPanelSection({
       content: resource.content,
       color: resource.color ?? getContextCardColorFromSeed(resource.id),
       createdAt: resource.createdAt.toISOString(),
-      updatedAt: resource.updatedAt.toISOString(),
+      updatedAt: cardRecord.updatedAt.toISOString(),
       attachments,
       projection: {
         id: projection.id,

--- a/app/projects/[projectId]/project-context-panel-section.tsx
+++ b/app/projects/[projectId]/project-context-panel-section.tsx
@@ -6,8 +6,14 @@ import {
   PROJECT_SECTION_HEADER_CLASS,
 } from "@/components/project-dashboard/project-section-chrome";
 import { ProjectContextPanel } from "@/components/project-context-panel";
+import {
+  type ProjectContextActorSummary,
+  type ProjectContextAttachmentProjection,
+} from "@/components/project-context-panel-types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getContextCardColorFromSeed } from "@/lib/context-card-colors";
+import { listProjectContextCardActors } from "@/lib/services/context-card-actor-service";
+import { projectContextCard } from "@/lib/services/context-card-stewardship-service";
 import { listProjectContextResources } from "@/lib/services/project-service";
 import { ATTACHMENT_KIND_FILE } from "@/lib/task-attachment";
 
@@ -28,25 +34,77 @@ export async function ProjectContextPanelSection({
   storageProvider,
 }: ProjectContextPanelSectionProps) {
   const resources = await listProjectContextResources(projectId, actorUserId);
+  const assignableActors = await listProjectContextCardActors({
+    actorUserId,
+    projectId,
+  });
+  const now = new Date();
 
-  const cards = resources.map((resource) => ({
-    id: resource.id,
-    title: resource.name,
-    content: resource.content,
-    color: resource.color ?? getContextCardColorFromSeed(resource.id),
-    attachments: resource.attachments.map((attachment: ContextCardAttachment) => ({
-      id: attachment.id,
-      kind: attachment.kind,
-      name: attachment.name,
-      url: attachment.url,
-      mimeType: attachment.mimeType,
-      sizeBytes: attachment.sizeBytes,
-      downloadUrl:
-        attachment.kind === ATTACHMENT_KIND_FILE
-          ? `/api/projects/${projectId}/context-cards/${resource.id}/attachments/${attachment.id}/download`
-          : null,
-    })),
-  }));
+  const cards = resources.map((resource) => {
+    const projection = projectContextCard({ card: resource, now });
+
+    const attachments = resource.attachments.map(
+      (attachment: ContextCardAttachment) => ({
+        id: attachment.id,
+        kind: attachment.kind,
+        name: attachment.name,
+        url: attachment.url,
+        mimeType: attachment.mimeType,
+        sizeBytes: attachment.sizeBytes,
+        downloadUrl:
+          attachment.kind === ATTACHMENT_KIND_FILE
+            ? `/api/projects/${projectId}/context-cards/${resource.id}/attachments/${attachment.id}/download`
+            : null,
+      })
+    );
+
+    const attachmentProjections: ProjectContextAttachmentProjection[] =
+      projection.attachments.map((attachmentProjection, index) => ({
+        id: attachmentProjection.id,
+        kind: attachmentProjection.kind,
+        name: attachmentProjection.name,
+        url: attachmentProjection.url,
+        mimeType: attachmentProjection.mimeType,
+        sizeBytes: attachmentProjection.sizeBytes,
+        uploadedBy:
+          (attachmentProjection.uploadedBy as ProjectContextActorSummary | null) ??
+          null,
+        uploadedByDisplayNameSnapshot:
+          attachmentProjection.uploadedByDisplayNameSnapshot,
+        uploadedAt:
+          attachmentProjection.uploadedAt instanceof Date
+            ? attachmentProjection.uploadedAt.toISOString()
+            : (attachmentProjection.uploadedAt as unknown as string),
+      }));
+
+    const lastEditedAt = (
+      projection.review.lastEditedAt instanceof Date
+        ? projection.review.lastEditedAt.toISOString()
+        : projection.review.lastEditedAt
+    ) as string;
+
+    return {
+      id: resource.id,
+      title: resource.name,
+      content: resource.content,
+      color: resource.color ?? getContextCardColorFromSeed(resource.id),
+      createdAt: resource.createdAt.toISOString(),
+      updatedAt: resource.updatedAt.toISOString(),
+      attachments,
+      projection: {
+        id: projection.id,
+        creator: projection.creator as ProjectContextActorSummary | null,
+        lastEditor: projection.lastEditor as ProjectContextActorSummary | null,
+        steward: projection.steward as ProjectContextActorSummary | null,
+        review: {
+          needsReview: projection.review.needsReview,
+          thresholdDays: projection.review.thresholdDays,
+          lastEditedAt,
+        },
+        attachments: attachmentProjections,
+      },
+    };
+  });
 
   return (
     <ProjectContextPanel
@@ -54,6 +112,7 @@ export async function ProjectContextPanelSection({
       projectId={projectId}
       storageProvider={storageProvider}
       cards={cards}
+      assignableActors={assignableActors as ProjectContextActorSummary[]}
     />
   );
 }

--- a/components/context-panel/context-card-actor-chip.tsx
+++ b/components/context-panel/context-card-actor-chip.tsx
@@ -1,6 +1,8 @@
-import { Bot, UserRound } from "lucide-react";
+import { UserRound } from "lucide-react";
 
 import type { ProjectContextActorSummary } from "@/components/project-context-panel-types";
+import { AgentAvatar } from "@/components/ui/agent-avatar";
+import { UserAvatar } from "@/components/ui/user-avatar";
 import { cn } from "@/lib/utils";
 
 interface ContextCardActorChipProps {
@@ -8,6 +10,7 @@ interface ContextCardActorChipProps {
   fallback: string;
   label?: string;
   className?: string;
+  needsReassignment?: boolean;
 }
 
 const STATUS_LABEL: Record<ProjectContextActorSummary["status"], string> = {
@@ -22,6 +25,7 @@ export function ContextCardActorChip({
   fallback,
   label,
   className,
+  needsReassignment = false,
 }: ContextCardActorChipProps) {
   if (!actor) {
     return (
@@ -37,9 +41,10 @@ export function ContextCardActorChip({
     );
   }
 
-  const Icon = actor.kind === "agent" ? Bot : UserRound;
   const statusLabel =
     actor.status === "active" ? "" : ` · ${STATUS_LABEL[actor.status]}`;
+  const reassignmentLabel =
+    needsReassignment && !actor.isAssignable ? " · Needs reassignment" : "";
 
   return (
     <span
@@ -48,11 +53,29 @@ export function ContextCardActorChip({
         className
       )}
     >
-      <Icon className="h-3 w-3" aria-hidden="true" />
+      {actor.kind === "agent" ? (
+        <AgentAvatar
+          displayName={actor.displayName}
+          decorative
+          className="h-4 w-4"
+        />
+      ) : (
+        <UserAvatar
+          avatarSeed={actor.avatarSeed ?? actor.id}
+          displayName={actor.displayName}
+          decorative
+          className="h-4 w-4"
+        />
+      )}
       <span className="truncate">
         {label ? `${label}: ` : ""}
         <span className="font-medium">{actor.displayName}</span>
         <span className="text-muted-foreground">{statusLabel}</span>
+        {reassignmentLabel ? (
+          <span className="font-medium text-amber-700 dark:text-amber-200">
+            {reassignmentLabel}
+          </span>
+        ) : null}
       </span>
     </span>
   );

--- a/components/context-panel/context-card-actor-chip.tsx
+++ b/components/context-panel/context-card-actor-chip.tsx
@@ -1,0 +1,59 @@
+import { Bot, UserRound } from "lucide-react";
+
+import type { ProjectContextActorSummary } from "@/components/project-context-panel-types";
+import { cn } from "@/lib/utils";
+
+interface ContextCardActorChipProps {
+  actor: ProjectContextActorSummary | null;
+  fallback: string;
+  label?: string;
+  className?: string;
+}
+
+const STATUS_LABEL: Record<ProjectContextActorSummary["status"], string> = {
+  active: "active",
+  inactive: "former member",
+  revoked: "revoked credential",
+  expired: "expired credential",
+};
+
+export function ContextCardActorChip({
+  actor,
+  fallback,
+  label,
+  className,
+}: ContextCardActorChipProps) {
+  if (!actor) {
+    return (
+      <span
+        className={cn(
+          "inline-flex items-center gap-1 rounded-full border border-border/60 bg-background/70 px-2 py-0.5 text-[11px] text-muted-foreground",
+          className
+        )}
+      >
+        <UserRound className="h-3 w-3" aria-hidden="true" />
+        <span className="truncate">{label ? `${label}: ` : ""}{fallback}</span>
+      </span>
+    );
+  }
+
+  const Icon = actor.kind === "agent" ? Bot : UserRound;
+  const statusLabel =
+    actor.status === "active" ? "" : ` · ${STATUS_LABEL[actor.status]}`;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border border-border/60 bg-background/70 px-2 py-0.5 text-[11px] text-slate-800",
+        className
+      )}
+    >
+      <Icon className="h-3 w-3" aria-hidden="true" />
+      <span className="truncate">
+        {label ? `${label}: ` : ""}
+        <span className="font-medium">{actor.displayName}</span>
+        <span className="text-muted-foreground">{statusLabel}</span>
+      </span>
+    </span>
+  );
+}

--- a/components/context-panel/context-card-review-badge.tsx
+++ b/components/context-panel/context-card-review-badge.tsx
@@ -1,0 +1,68 @@
+import { AlertTriangle, Clock } from "lucide-react";
+
+import type { ProjectContextReviewState } from "@/components/project-context-panel-types";
+import { cn } from "@/lib/utils";
+
+interface ContextCardReviewBadgeProps {
+  review: ProjectContextReviewState;
+  className?: string;
+}
+
+function formatRelativeDays(days: number): string {
+  if (days <= 1) {
+    return "today";
+  }
+  if (days < 7) {
+    return `${days} days ago`;
+  }
+  if (days < 30) {
+    const weeks = Math.round(days / 7);
+    return `${weeks} week${weeks === 1 ? "" : "s"} ago`;
+  }
+  if (days < 365) {
+    const months = Math.round(days / 30);
+    return `${months} month${months === 1 ? "" : "s"} ago`;
+  }
+  const years = Math.round(days / 365);
+  return `${years} year${years === 1 ? "" : "s"} ago`;
+}
+
+function daysSinceLastEdit(lastEditedAt: string, now: Date = new Date()): number {
+  const lastEdited = new Date(lastEditedAt).getTime();
+  if (Number.isNaN(lastEdited)) {
+    return 0;
+  }
+  return Math.max(0, Math.floor((now.getTime() - lastEdited) / (24 * 60 * 60 * 1000)));
+}
+
+export function ContextCardReviewBadge({
+  review,
+  className,
+}: ContextCardReviewBadgeProps) {
+  const days = daysSinceLastEdit(review.lastEditedAt);
+  const tone = review.needsReview
+    ? "border-amber-500/50 bg-amber-100/80 text-amber-900"
+    : "border-border/60 bg-background/70 text-muted-foreground";
+  const Icon = review.needsReview ? AlertTriangle : Clock;
+  const label = review.needsReview
+    ? `Needs review (${review.thresholdDays}d)`
+    : `Reviewed ${formatRelativeDays(days)}`;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium",
+        tone,
+        className
+      )}
+      title={
+        review.needsReview
+          ? `Last edited more than ${review.thresholdDays} days ago`
+          : `Last edited ${formatRelativeDays(days)}`
+      }
+    >
+      <Icon className="h-3 w-3" aria-hidden="true" />
+      <span>{label}</span>
+    </span>
+  );
+}

--- a/components/context-panel/context-card-steward-picker.tsx
+++ b/components/context-panel/context-card-steward-picker.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { ChevronDown, Search, X } from "lucide-react";
+
+import { ContextCardActorChip } from "@/components/context-panel/context-card-actor-chip";
+import type { ProjectContextActorSummary } from "@/components/project-context-panel-types";
+import { cn } from "@/lib/utils";
+
+interface ContextCardStewardPickerProps {
+  actors: ProjectContextActorSummary[];
+  selected: ProjectContextActorSummary | null;
+  cleared: boolean;
+  disabled: boolean;
+  onChange: (actor: ProjectContextActorSummary | null) => void;
+}
+
+function actorKey(actor: ProjectContextActorSummary): string {
+  return `${actor.kind}:${actor.id}`;
+}
+
+function sameActor(
+  a: ProjectContextActorSummary | null,
+  b: ProjectContextActorSummary | null
+): boolean {
+  if (!a || !b) {
+    return false;
+  }
+  return actorKey(a) === actorKey(b);
+}
+
+export function ContextCardStewardPicker({
+  actors,
+  selected,
+  cleared,
+  disabled,
+  onChange,
+}: ContextCardStewardPickerProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const buttonId = useId();
+  const listId = useId();
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+    };
+  }, [isOpen]);
+
+  const filteredActors = useMemo(() => {
+    const trimmed = query.trim().toLowerCase();
+    if (!trimmed) {
+      return actors;
+    }
+    return actors.filter((actor) =>
+      actor.displayName.toLowerCase().includes(trimmed)
+    );
+  }, [actors, query]);
+
+  const summary: ProjectContextActorSummary | null = cleared
+    ? null
+    : selected;
+
+  return (
+    <div className="flex items-center gap-2">
+      <div ref={containerRef} className="relative flex-1">
+        <button
+          id={buttonId}
+          type="button"
+          className={cn(
+            "flex h-10 w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-3 text-sm",
+            disabled && "opacity-60"
+          )}
+          aria-haspopup="listbox"
+          aria-expanded={isOpen}
+          aria-controls={listId}
+          disabled={disabled}
+          onClick={() => setIsOpen((previous) => !previous)}
+        >
+          <span className="truncate text-left">
+            {summary ? summary.displayName : "Unassigned"}
+          </span>
+          <ChevronDown className="h-4 w-4 text-muted-foreground" />
+        </button>
+        {isOpen ? (
+          <div
+            className="absolute z-10 mt-1 flex max-h-64 w-full flex-col rounded-md border border-border/60 bg-popover shadow-md"
+            role="dialog"
+          >
+            <div className="flex items-center gap-1 border-b border-border/40 px-2 py-1">
+              <Search className="h-3 w-3 text-muted-foreground" />
+              <input
+                autoFocus
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search members or agents"
+                className="h-8 w-full bg-transparent text-xs outline-none"
+              />
+            </div>
+            <ul
+              id={listId}
+              role="listbox"
+              className="max-h-56 overflow-y-auto py-1 text-sm"
+            >
+              <li>
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={summary === null}
+                  className={cn(
+                    "flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left hover:bg-muted/60",
+                    summary === null && "bg-muted/40"
+                  )}
+                  onClick={() => {
+                    onChange(null);
+                    setIsOpen(false);
+                  }}
+                >
+                  <span className="truncate">Unassigned</span>
+                </button>
+              </li>
+              {filteredActors.length === 0 ? (
+                <li className="px-3 py-2 text-xs text-muted-foreground">
+                  No matching assignable members.
+                </li>
+              ) : (
+                filteredActors.map((actor) => (
+                  <li key={actorKey(actor)}>
+                    <button
+                      type="button"
+                      role="option"
+                      aria-selected={sameActor(summary, actor)}
+                      className={cn(
+                        "flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left hover:bg-muted/60",
+                        sameActor(summary, actor) && "bg-muted/40"
+                      )}
+                      onClick={() => {
+                        onChange(actor);
+                        setIsOpen(false);
+                      }}
+                    >
+                      <ContextCardActorChip
+                        actor={actor}
+                        fallback={actor.displayName}
+                      />
+                    </button>
+                  </li>
+                ))
+              )}
+            </ul>
+          </div>
+        ) : null}
+      </div>
+      <button
+        type="button"
+        className="flex h-10 items-center gap-1 rounded-md border border-input bg-background px-2 text-xs text-muted-foreground"
+        disabled={disabled || (!summary && !cleared)}
+        onClick={() => {
+          onChange(null);
+          setQuery("");
+        }}
+        aria-label="Clear steward"
+      >
+        <X className="h-3 w-3" />
+        Clear
+      </button>
+    </div>
+  );
+}

--- a/components/context-panel/context-card-steward-picker.tsx
+++ b/components/context-panel/context-card-steward-picker.tsx
@@ -6,6 +6,7 @@ import type { ProjectContextActorSummary } from "@/components/project-context-pa
 import { cn } from "@/lib/utils";
 
 interface ContextCardStewardPickerProps {
+  id?: string;
   actors: ProjectContextActorSummary[];
   selected: ProjectContextActorSummary | null;
   cleared: boolean;
@@ -28,6 +29,7 @@ function sameActor(
 }
 
 export function ContextCardStewardPicker({
+  id,
   actors,
   selected,
   cleared,
@@ -36,7 +38,9 @@ export function ContextCardStewardPicker({
 }: ContextCardStewardPickerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
   const buttonId = useId();
   const listId = useId();
 
@@ -68,20 +72,30 @@ export function ContextCardStewardPicker({
   const summary: ProjectContextActorSummary | null = cleared
     ? null
     : selected;
+  const optionCount = filteredActors.length + 1;
+
+  const chooseOption = (index: number) => {
+    onChange(index === 0 ? null : filteredActors[index - 1] ?? null);
+    setIsOpen(false);
+    setQuery("");
+    buttonRef.current?.focus();
+  };
 
   return (
     <div className="flex items-center gap-2">
       <div ref={containerRef} className="relative flex-1">
         <button
-          id={buttonId}
+          ref={buttonRef}
+          id={id ?? buttonId}
           type="button"
           className={cn(
-            "flex h-10 w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-3 text-sm",
+            "flex min-h-11 w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-3 text-sm",
             disabled && "opacity-60"
           )}
           aria-haspopup="listbox"
           aria-expanded={isOpen}
           aria-controls={listId}
+          aria-label={`Knowledge steward, current selection: ${summary?.displayName ?? "Unassigned"}`}
           disabled={disabled}
           onClick={() => setIsOpen((previous) => !previous)}
         >
@@ -100,7 +114,32 @@ export function ContextCardStewardPicker({
               <input
                 autoFocus
                 value={query}
-                onChange={(event) => setQuery(event.target.value)}
+                role="combobox"
+                aria-expanded="true"
+                aria-controls={listId}
+                aria-activedescendant={`${listId}-option-${activeIndex}`}
+                onChange={(event) => {
+                  setQuery(event.target.value);
+                  setActiveIndex(0);
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === "ArrowDown") {
+                    event.preventDefault();
+                    setActiveIndex((current) => (current + 1) % optionCount);
+                  } else if (event.key === "ArrowUp") {
+                    event.preventDefault();
+                    setActiveIndex(
+                      (current) => (current - 1 + optionCount) % optionCount
+                    );
+                  } else if (event.key === "Enter") {
+                    event.preventDefault();
+                    chooseOption(activeIndex);
+                  } else if (event.key === "Escape") {
+                    event.preventDefault();
+                    setIsOpen(false);
+                    buttonRef.current?.focus();
+                  }
+                }}
                 placeholder="Search members or agents"
                 className="h-8 w-full bg-transparent text-xs outline-none"
               />
@@ -112,12 +151,13 @@ export function ContextCardStewardPicker({
             >
               <li>
                 <button
+                  id={`${listId}-option-0`}
                   type="button"
                   role="option"
                   aria-selected={summary === null}
                   className={cn(
-                    "flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left hover:bg-muted/60",
-                    summary === null && "bg-muted/40"
+                    "flex min-h-11 w-full items-center justify-between gap-2 px-3 py-1.5 text-left hover:bg-muted/60",
+                    (summary === null || activeIndex === 0) && "bg-muted/40"
                   )}
                   onClick={() => {
                     onChange(null);
@@ -132,15 +172,17 @@ export function ContextCardStewardPicker({
                   No matching assignable members.
                 </li>
               ) : (
-                filteredActors.map((actor) => (
+                filteredActors.map((actor, index) => (
                   <li key={actorKey(actor)}>
                     <button
+                      id={`${listId}-option-${index + 1}`}
                       type="button"
                       role="option"
                       aria-selected={sameActor(summary, actor)}
                       className={cn(
-                        "flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left hover:bg-muted/60",
-                        sameActor(summary, actor) && "bg-muted/40"
+                        "flex min-h-11 w-full items-center justify-between gap-2 px-3 py-1.5 text-left hover:bg-muted/60",
+                        (sameActor(summary, actor) || activeIndex === index + 1) &&
+                          "bg-muted/40"
                       )}
                       onClick={() => {
                         onChange(actor);
@@ -161,7 +203,7 @@ export function ContextCardStewardPicker({
       </div>
       <button
         type="button"
-        className="flex h-10 items-center gap-1 rounded-md border border-input bg-background px-2 text-xs text-muted-foreground"
+        className="flex min-h-11 items-center gap-1 rounded-md border border-input bg-background px-3 text-xs text-muted-foreground"
         disabled={disabled || (!summary && !cleared)}
         onClick={() => {
           onChange(null);

--- a/components/context-panel/context-cards-grid.tsx
+++ b/components/context-panel/context-cards-grid.tsx
@@ -1,6 +1,12 @@
 import { useState } from "react";
 import { MoreHorizontal, Paperclip, Pencil, PlusSquare, Trash2 } from "lucide-react";
 
+import {
+  ContextCardActorChip,
+} from "@/components/context-panel/context-card-actor-chip";
+import {
+  ContextCardReviewBadge,
+} from "@/components/context-panel/context-card-review-badge";
 import type {
   ProjectContextAttachment,
   ProjectContextCard,
@@ -55,7 +61,7 @@ export function ContextCardsGrid({
         return (
           <article
             key={card.id}
-            className="flex h-[152px] cursor-pointer flex-col overflow-hidden rounded-xl border p-3 transition duration-150 hover:-translate-y-0.5 hover:shadow-[0_12px_28px_-18px_rgba(15,23,42,0.45)] hover:ring-2 hover:ring-slate-900/10"
+            className="flex h-[200px] cursor-pointer flex-col overflow-hidden rounded-xl border p-3 transition duration-150 hover:-translate-y-0.5 hover:shadow-[0_12px_28px_-18px_rgba(15,23,42,0.45)] hover:ring-2 hover:ring-slate-900/10"
             style={{ backgroundColor: card.color, borderColor: "rgb(15 23 42 / 0.15)" }}
             onClick={() => onOpenPreview(card.id)}
           >
@@ -103,6 +109,15 @@ export function ContextCardsGrid({
                 style={{
                   background: `linear-gradient(to top, ${card.color}, transparent)`,
                 }}
+              />
+            </div>
+
+            <div className="mt-2 flex flex-wrap items-center gap-1">
+              <ContextCardReviewBadge review={card.projection.review} />
+              <ContextCardActorChip
+                actor={card.projection.steward}
+                label="Steward"
+                fallback="Unassigned"
               />
             </div>
 

--- a/components/context-panel/context-cards-grid.tsx
+++ b/components/context-panel/context-cards-grid.tsx
@@ -118,6 +118,7 @@ export function ContextCardsGrid({
                 actor={card.projection.steward}
                 label="Steward"
                 fallback="Unassigned"
+                needsReassignment
               />
             </div>
 

--- a/components/context-panel/context-edit-modal.tsx
+++ b/components/context-panel/context-edit-modal.tsx
@@ -1,9 +1,14 @@
 import type { FormEvent } from "react";
 import { Link2, Trash2, Upload } from "lucide-react";
 
+import {
+  ContextCardActorChip,
+} from "@/components/context-panel/context-card-actor-chip";
+import { ContextCardStewardPicker } from "@/components/context-panel/context-card-steward-picker";
 import { ContextColorPicker } from "@/components/context-panel/context-color-picker";
 import { ContextModalFrame } from "@/components/context-panel/context-modal-frame";
 import type {
+  ProjectContextActorSummary,
   ProjectContextAttachment,
   ProjectContextCard,
 } from "@/components/project-context-panel-types";
@@ -28,6 +33,11 @@ interface ContextEditModalProps {
   editingColor: string;
   editContent: string;
   editingCardAttachments: ProjectContextAttachment[];
+  assignableActors: ProjectContextActorSummary[];
+  selectedSteward: ProjectContextActorSummary | null;
+  stewardCleared: boolean;
+  isUpdatingSteward: boolean;
+  stewardError: string | null;
   isUpdatingCard: boolean;
   isSubmittingAttachment: boolean;
   isEditLinkComposerOpen: boolean;
@@ -45,6 +55,7 @@ interface ContextEditModalProps {
   onAddFileAttachment: (file: File | null) => void | Promise<void>;
   onEditLinkUrlChange: (value: string) => void;
   onAddLinkAttachment: () => void | Promise<void>;
+  onSelectSteward: (actor: ProjectContextActorSummary | null) => void;
 }
 
 export function ContextEditModal({
@@ -52,6 +63,11 @@ export function ContextEditModal({
   editingColor,
   editContent,
   editingCardAttachments,
+  assignableActors,
+  selectedSteward,
+  stewardCleared,
+  isUpdatingSteward,
+  stewardError,
   isUpdatingCard,
   isSubmittingAttachment,
   isEditLinkComposerOpen,
@@ -69,10 +85,15 @@ export function ContextEditModal({
   onAddFileAttachment,
   onEditLinkUrlChange,
   onAddLinkAttachment,
+  onSelectSteward,
 }: ContextEditModalProps) {
   if (!editingCard) {
     return null;
   }
+
+  const stewardActor = stewardCleared
+    ? null
+    : selectedSteward ?? editingCard.projection.steward;
 
   return (
     <ContextModalFrame
@@ -114,6 +135,28 @@ export function ContextEditModal({
 
         <ContextColorPicker selectedColor={editingColor} onSelect={onEditingColorChange} />
         <input type="hidden" name="color" value={editingColor} />
+
+        <div className="space-y-2 rounded-md border border-border/60 bg-background/70 p-3">
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-sm font-medium">Knowledge steward</p>
+            <ContextCardActorChip
+              actor={stewardActor}
+              fallback="Unassigned"
+            />
+          </div>
+          <ContextCardStewardPicker
+            actors={assignableActors}
+            selected={stewardActor}
+            cleared={stewardCleared}
+            disabled={isUpdatingSteward || isUpdatingCard}
+            onChange={onSelectSteward}
+          />
+          {stewardError ? (
+            <div className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+              {stewardError}
+            </div>
+          ) : null}
+        </div>
 
         <div className="space-y-2">
           {editingCardAttachments.length === 0 ? (

--- a/components/context-panel/context-edit-modal.tsx
+++ b/components/context-panel/context-edit-modal.tsx
@@ -5,6 +5,7 @@ import {
   ContextCardActorChip,
 } from "@/components/context-panel/context-card-actor-chip";
 import { ContextCardStewardPicker } from "@/components/context-panel/context-card-steward-picker";
+import { ContextCardReviewBadge } from "@/components/context-panel/context-card-review-badge";
 import { ContextColorPicker } from "@/components/context-panel/context-color-picker";
 import { ContextModalFrame } from "@/components/context-panel/context-modal-frame";
 import type {
@@ -138,13 +139,20 @@ export function ContextEditModal({
 
         <div className="space-y-2 rounded-md border border-border/60 bg-background/70 p-3">
           <div className="flex items-center justify-between gap-2">
-            <p className="text-sm font-medium">Knowledge steward</p>
-            <ContextCardActorChip
-              actor={stewardActor}
-              fallback="Unassigned"
-            />
+            <label htmlFor="context-edit-steward-picker" className="text-sm font-medium">
+              Knowledge steward
+            </label>
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <ContextCardReviewBadge review={editingCard.projection.review} />
+              <ContextCardActorChip
+                actor={stewardActor}
+                fallback="Unassigned"
+                needsReassignment
+              />
+            </div>
           </div>
           <ContextCardStewardPicker
+            id="context-edit-steward-picker"
             actors={assignableActors}
             selected={stewardActor}
             cleared={stewardCleared}
@@ -152,7 +160,7 @@ export function ContextEditModal({
             onChange={onSelectSteward}
           />
           {stewardError ? (
-            <div className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+            <div role="alert" className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-xs text-destructive">
               {stewardError}
             </div>
           ) : null}

--- a/components/context-panel/context-preview-modal.tsx
+++ b/components/context-panel/context-preview-modal.tsx
@@ -8,7 +8,9 @@ import {
 import {
   ContextCardReviewBadge,
 } from "@/components/context-panel/context-card-review-badge";
+import { ContextCardStewardPicker } from "@/components/context-panel/context-card-steward-picker";
 import type {
+  ProjectContextActorSummary,
   ProjectContextAttachment,
   ProjectContextCard,
 } from "@/components/project-context-panel-types";
@@ -27,8 +29,12 @@ interface ContextPreviewModalProps {
   isOpen: boolean;
   card: ProjectContextCard | null;
   attachments: ProjectContextAttachment[];
+  assignableActors: ProjectContextActorSummary[];
+  isUpdatingSteward: boolean;
+  stewardError: string | null;
   onClose: () => void;
   onEdit: (cardId: string) => void;
+  onSelectSteward: (actor: ProjectContextActorSummary | null) => void;
   onPreviewAttachment: (attachment: ProjectContextAttachment) => void;
 }
 
@@ -37,8 +43,12 @@ export function ContextPreviewModal({
   isOpen,
   card,
   attachments,
+  assignableActors,
+  isUpdatingSteward,
+  stewardError,
   onClose,
   onEdit,
+  onSelectSteward,
   onPreviewAttachment,
 }: ContextPreviewModalProps) {
   return (
@@ -88,6 +98,7 @@ export function ContextPreviewModal({
               actor={card.projection.steward}
               label="Steward"
               fallback="Unassigned"
+              needsReassignment
             />
             <ContextCardActorChip
               actor={card.projection.lastEditor}
@@ -102,6 +113,33 @@ export function ContextPreviewModal({
           </div>
         </CardHeader>
         <CardContent className="min-h-0 flex-1 space-y-4 overflow-y-auto">
+          {canEdit ? (
+            <div className="space-y-2 rounded-md border border-slate-900/15 bg-white/45 p-3">
+              <label
+                htmlFor="context-preview-steward-picker"
+                className="text-sm font-medium text-slate-900"
+              >
+                Knowledge steward
+              </label>
+              <ContextCardStewardPicker
+                id="context-preview-steward-picker"
+                actors={assignableActors}
+                selected={card.projection.steward}
+                cleared={card.projection.steward === null}
+                disabled={isUpdatingSteward}
+                onChange={onSelectSteward}
+              />
+              {stewardError ? (
+                <div
+                  role="alert"
+                  className="rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+                >
+                  {stewardError}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+
           <RichTextContent
             html={card.content}
             emptyContentHtml="<p>No content.</p>"

--- a/components/context-panel/context-preview-modal.tsx
+++ b/components/context-panel/context-preview-modal.tsx
@@ -2,6 +2,12 @@
 
 import { Paperclip, X } from "lucide-react";
 
+import {
+  ContextCardActorChip,
+} from "@/components/context-panel/context-card-actor-chip";
+import {
+  ContextCardReviewBadge,
+} from "@/components/context-panel/context-card-review-badge";
 import type {
   ProjectContextAttachment,
   ProjectContextCard,
@@ -51,29 +57,49 @@ export function ContextPreviewModal({
           onClose();
         }}
       >
-        <CardHeader className="flex shrink-0 flex-row items-start justify-between gap-3 space-y-0">
-          <DialogTitle
-            className="text-xl text-slate-900"
-            onDoubleClick={() => {
-              if (!canEdit) {
-                return;
-              }
+        <CardHeader className="flex shrink-0 flex-col items-start gap-3 space-y-0">
+          <div className="flex w-full items-start justify-between gap-3">
+            <DialogTitle
+              className="text-xl text-slate-900"
+              onDoubleClick={() => {
+                if (!canEdit) {
+                  return;
+                }
 
-              onEdit(card.id);
-            }}
-          >
-            {card.title}
-          </DialogTitle>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="text-slate-800 hover:bg-slate-900/10"
-            onClick={onClose}
-            aria-label="Close context preview"
-          >
-            <X className="h-4 w-4" />
-          </Button>
+                onEdit(card.id);
+              }}
+            >
+              {card.title}
+            </DialogTitle>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="text-slate-800 hover:bg-slate-900/10"
+              onClick={onClose}
+              aria-label="Close context preview"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <ContextCardReviewBadge review={card.projection.review} />
+            <ContextCardActorChip
+              actor={card.projection.steward}
+              label="Steward"
+              fallback="Unassigned"
+            />
+            <ContextCardActorChip
+              actor={card.projection.lastEditor}
+              label="Last edit"
+              fallback="No edits yet"
+            />
+            <ContextCardActorChip
+              actor={card.projection.creator}
+              label="Created"
+              fallback="Unknown"
+            />
+          </div>
         </CardHeader>
         <CardContent className="min-h-0 flex-1 space-y-4 overflow-y-auto">
           <RichTextContent

--- a/components/project-context-panel-types.ts
+++ b/components/project-context-panel-types.ts
@@ -8,12 +8,52 @@ export interface ProjectContextAttachment {
   downloadUrl: string | null;
 }
 
+export interface ProjectContextAttachmentProjection {
+  id: string;
+  kind: string;
+  name: string;
+  url: string | null;
+  mimeType: string | null;
+  sizeBytes: number | null;
+  uploadedBy: ProjectContextActorSummary | null;
+  uploadedByDisplayNameSnapshot: string;
+  uploadedAt: string;
+}
+
+export interface ProjectContextActorSummary {
+  kind: "human" | "agent";
+  id: string;
+  displayName: string;
+  usernameTag: string | null;
+  avatarSeed: string | null;
+  status: "active" | "inactive" | "revoked" | "expired";
+  isAssignable: boolean;
+}
+
+export interface ProjectContextReviewState {
+  needsReview: boolean;
+  thresholdDays: number;
+  lastEditedAt: string;
+}
+
+export interface ProjectContextCardProjection {
+  id: string;
+  creator: ProjectContextActorSummary | null;
+  lastEditor: ProjectContextActorSummary | null;
+  steward: ProjectContextActorSummary | null;
+  review: ProjectContextReviewState;
+  attachments: ProjectContextAttachmentProjection[];
+}
+
 export interface ProjectContextCard {
   id: string;
   title: string;
   content: string;
   color: string;
+  createdAt: string;
+  updatedAt: string;
   attachments: ProjectContextAttachment[];
+  projection: ProjectContextCardProjection;
 }
 
 export interface PendingAttachmentLink {

--- a/components/project-context-panel.tsx
+++ b/components/project-context-panel.tsx
@@ -26,6 +26,7 @@ import { useToast } from "@/components/toast-provider";
 import { CONTEXT_CARD_COLORS } from "@/lib/context-card-colors";
 import type {
   PendingAttachmentLink,
+  ProjectContextActorSummary,
   ProjectContextAttachment,
   ProjectContextCard,
 } from "@/components/project-context-panel-types";
@@ -64,6 +65,7 @@ interface ProjectContextPanelProps {
   projectId: string;
   storageProvider: "local" | "r2";
   cards: ProjectContextCard[];
+  assignableActors: ProjectContextActorSummary[];
 }
 
 type RemoteContextCardPayload = Omit<Partial<ProjectContextCard>, "attachments"> & {
@@ -119,6 +121,7 @@ export function ProjectContextPanel({
   projectId,
   storageProvider,
   cards,
+  assignableActors,
 }: ProjectContextPanelProps) {
   const isMountedRef = useRef(true);
   const router = useRouter();
@@ -157,6 +160,11 @@ export function ProjectContextPanel({
     useState<ProjectContextAttachment | null>(null);
   const [previewCardId, setPreviewCardId] = useState<string | null>(null);
   const [pendingDeleteCardId, setPendingDeleteCardId] = useState<string | null>(null);
+  const [selectedSteward, setSelectedSteward] =
+    useState<ProjectContextActorSummary | null>(null);
+  const [stewardCleared, setStewardCleared] = useState(false);
+  const [isUpdatingSteward, setIsUpdatingSteward] = useState(false);
+  const [stewardError, setStewardError] = useState<string | null>(null);
   const [localCards, setLocalCards] = useState<ProjectContextCard[]>(() =>
     cards.map((card) => ({
       ...card,
@@ -410,6 +418,9 @@ export function ProjectContextPanel({
     setEditContent("");
     setEditError(null);
     setAttachmentError(null);
+    setStewardError(null);
+    setSelectedSteward(null);
+    setStewardCleared(false);
     setPreviewAttachment(null);
   };
 
@@ -428,11 +439,137 @@ export function ProjectContextPanel({
     setEditContent(normalizeContextCardContentHtml(cardToEdit.content));
     setEditError(null);
     setAttachmentError(null);
+    setStewardError(null);
     setIsEditLinkComposerOpen(false);
     setEditLinkUrl("");
     setEditFileInputKey((previous) => previous + 1);
     setPreviewAttachment(null);
+    setSelectedSteward(cardToEdit.projection.steward);
+    setStewardCleared(cardToEdit.projection.steward === null);
     setEditingCardId(cardId);
+  };
+
+  const handleSelectSteward = (actor: ProjectContextActorSummary | null) => {
+    if (!editingCard || isUpdatingSteward) {
+      return;
+    }
+
+    const previousSteward = editingCard.projection.steward;
+    const previousCleared = previousSteward === null;
+    const nextCleared = actor === null;
+    const isUnchanged =
+      (actor === null && previousCleared) ||
+      (actor !== null &&
+        previousSteward !== null &&
+        actor.kind === previousSteward.kind &&
+        actor.id === previousSteward.id);
+    if (isUnchanged) {
+      return;
+    }
+
+    if (actor === null) {
+      setSelectedSteward(null);
+      setStewardCleared(true);
+    } else {
+      setSelectedSteward(actor);
+      setStewardCleared(false);
+    }
+    setIsUpdatingSteward(true);
+    setStewardError(null);
+
+    const targetCardId = editingCard.id;
+    const payload = actor
+      ? { steward: { kind: actor.kind, id: actor.id } }
+      : { steward: null };
+
+    void (async () => {
+      try {
+        const response = await fetchProjectActivityMutation(
+          projectId,
+          `/api/projects/${projectId}/context-cards/${targetCardId}/stewardship`,
+          {
+            method: "PATCH",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(payload),
+          }
+        );
+
+        if (!response.ok) {
+          const errorPayload = (await response.json().catch(() => null)) as
+            | { error?: string }
+            | null;
+          if (!isMountedRef.current) {
+            return;
+          }
+          setSelectedSteward(previousSteward);
+          setStewardCleared(previousCleared);
+          setStewardError(
+            mapStewardshipError(
+              errorPayload?.error ?? "context-card-stewardship-update-failed"
+            )
+          );
+          pushToast({
+            variant: "error",
+            message: "Could not update knowledge steward.",
+          });
+          return;
+        }
+
+        const resultPayload = (await response.json().catch(() => null)) as
+          | {
+              steward: ProjectContextActorSummary | null;
+              review: { lastEditedAt: string };
+            }
+          | null;
+
+        if (!isMountedRef.current) {
+          return;
+        }
+
+        setLocalCards((previous) =>
+          previous.map((card) =>
+            card.id === targetCardId
+              ? {
+                  ...card,
+                  projection: {
+                    ...card.projection,
+                    steward: resultPayload?.steward ?? actor,
+                    review: {
+                      ...card.projection.review,
+                      lastEditedAt:
+                        resultPayload?.review.lastEditedAt ??
+                        card.projection.review.lastEditedAt,
+                    },
+                  },
+                }
+              : card
+          )
+        );
+
+        pushToast({
+          variant: "success",
+          message: actor
+            ? `Steward set to ${actor.displayName}.`
+            : "Steward cleared.",
+        });
+      } catch (error) {
+        console.error("[ProjectContextPanel.handleSelectSteward]", error);
+        if (!isMountedRef.current) {
+          return;
+        }
+        setSelectedSteward(previousSteward);
+        setStewardCleared(previousCleared);
+        setStewardError("Could not update knowledge steward.");
+        pushToast({
+          variant: "error",
+          message: "Could not update knowledge steward.",
+        });
+      } finally {
+        if (isMountedRef.current) {
+          setIsUpdatingSteward(false);
+        }
+      }
+    })();
   };
 
   const handleStageCreateLink = () => {
@@ -507,6 +644,20 @@ export function ProjectContextPanel({
     }
   };
 
+  const mapStewardshipError = (errorCode: string): string => {
+    switch (errorCode) {
+      case "context-card-steward-invalid":
+      case "context-card-stewardship-missing":
+        return "Selected steward is not assignable.";
+      case "context-card-not-found":
+        return "Context card not found.";
+      case "forbidden":
+        return "You do not have permission to update the steward.";
+      default:
+        return "Could not update knowledge steward.";
+    }
+  };
+
   const handleCreateCardSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (isCreatingCard) {
@@ -550,13 +701,28 @@ export function ProjectContextPanel({
 
     closeCreateModal();
     setIsCreatingCard(false);
+    const optimisticNow = new Date().toISOString();
     setLocalCards((previous) => [
       {
         id: optimisticCardId,
         title: optimisticTitle,
         content: normalizeContextCardContentHtml(optimisticContent),
         color: optimisticColor,
+        createdAt: optimisticNow,
+        updatedAt: optimisticNow,
         attachments: optimisticAttachments,
+        projection: {
+          id: optimisticCardId,
+          creator: null,
+          lastEditor: null,
+          steward: null,
+          review: {
+            needsReview: false,
+            thresholdDays: 90,
+            lastEditedAt: optimisticNow,
+          },
+          attachments: [],
+        },
       },
       ...previous,
     ]);
@@ -580,11 +746,7 @@ export function ProjectContextPanel({
           | {
               error?: string;
               cardId?: string;
-              card?: {
-                id: string;
-                title: string;
-                content: string;
-                color: string;
+              card?: Omit<ProjectContextCard, "attachments"> & {
                 attachments: Omit<ProjectContextAttachment, "downloadUrl">[];
               };
             }
@@ -1174,6 +1336,11 @@ export function ProjectContextPanel({
         editingColor={editingColor}
         editContent={editContent}
         editingCardAttachments={editingCardAttachments}
+        assignableActors={assignableActors}
+        selectedSteward={selectedSteward}
+        stewardCleared={stewardCleared}
+        isUpdatingSteward={isUpdatingSteward}
+        stewardError={stewardError}
         isUpdatingCard={isUpdatingCard}
         isSubmittingAttachment={isSubmittingAttachment}
         isEditLinkComposerOpen={isEditLinkComposerOpen}
@@ -1193,6 +1360,7 @@ export function ProjectContextPanel({
         onAddFileAttachment={handleAddFileAttachment}
         onEditLinkUrlChange={setEditLinkUrl}
         onAddLinkAttachment={handleAddLinkAttachment}
+        onSelectSteward={handleSelectSteward}
       />
 
       <ContextPreviewModal

--- a/components/project-context-panel.tsx
+++ b/components/project-context-panel.tsx
@@ -358,6 +358,20 @@ export function ProjectContextPanel({
                     typeof remoteCard.color === "string"
                       ? remoteCard.color
                       : card.color,
+                  updatedAt:
+                    typeof remoteCard.updatedAt === "string"
+                      ? remoteCard.updatedAt
+                      : card.updatedAt,
+                  projection: remoteCard.projection
+                    ? {
+                        ...card.projection,
+                        ...remoteCard.projection,
+                        review: {
+                          ...card.projection.review,
+                          ...remoteCard.projection.review,
+                        },
+                      }
+                    : card.projection,
                 }
               : card
           )
@@ -450,11 +464,12 @@ export function ProjectContextPanel({
   };
 
   const handleSelectSteward = (actor: ProjectContextActorSummary | null) => {
-    if (!editingCard || isUpdatingSteward) {
+    const targetCard = editingCard ?? previewCard;
+    if (!targetCard || isUpdatingSteward) {
       return;
     }
 
-    const previousSteward = editingCard.projection.steward;
+    const previousSteward = targetCard.projection.steward;
     const previousCleared = previousSteward === null;
     const nextCleared = actor === null;
     const isUnchanged =
@@ -477,7 +492,7 @@ export function ProjectContextPanel({
     setIsUpdatingSteward(true);
     setStewardError(null);
 
-    const targetCardId = editingCard.id;
+    const targetCardId = targetCard.id;
     const payload = actor
       ? { steward: { kind: actor.kind, id: actor.id } }
       : { steward: null };
@@ -518,7 +533,12 @@ export function ProjectContextPanel({
         const resultPayload = (await response.json().catch(() => null)) as
           | {
               steward: ProjectContextActorSummary | null;
-              review: { lastEditedAt: string };
+              review: {
+                needsReview: boolean;
+                thresholdDays: number;
+                lastEditedAt: string;
+              };
+              updatedAt: string;
             }
           | null;
 
@@ -531,14 +551,13 @@ export function ProjectContextPanel({
             card.id === targetCardId
               ? {
                   ...card,
+                  updatedAt: resultPayload?.updatedAt ?? card.updatedAt,
                   projection: {
                     ...card.projection,
                     steward: resultPayload?.steward ?? actor,
                     review: {
                       ...card.projection.review,
-                      lastEditedAt:
-                        resultPayload?.review.lastEditedAt ??
-                        card.projection.review.lastEditedAt,
+                      ...(resultPayload?.review ?? {}),
                     },
                   },
                 }
@@ -1368,8 +1387,12 @@ export function ProjectContextPanel({
         isOpen={Boolean(previewCard)}
         card={previewCard}
         attachments={previewCardAttachments}
+        assignableActors={assignableActors}
+        isUpdatingSteward={isUpdatingSteward}
+        stewardError={stewardError}
         onClose={() => setPreviewCardId(null)}
         onEdit={openEditModal}
+        onSelectSteward={handleSelectSteward}
         onPreviewAttachment={(attachment) => setPreviewAttachment(attachment)}
       />
 

--- a/docs/runbooks/task-059-agent-access-preview-validation.md
+++ b/docs/runbooks/task-059-agent-access-preview-validation.md
@@ -62,9 +62,9 @@ are recorded, and rotation/revocation take effect immediately for new exchanges.
      `context:write` returns `200` and the updated card including the
      `projection` block.
    - `PATCH /api/projects/:projectId/context-cards/:cardId/stewardship` with
-     `context:write` returns `200` and the updated steward + review state; a
-     request referencing a non-assignable actor returns `400
-     context-card-steward-invalid`.
+     `context:write` returns `200` and the updated steward + review state;
+     a request referencing a non-assignable actor returns
+     `400 context-card-steward-invalid`.
    - `DELETE /api/projects/:projectId/context-cards/:cardId` without
      `context:delete` returns `403`.
 

--- a/docs/runbooks/task-059-agent-access-preview-validation.md
+++ b/docs/runbooks/task-059-agent-access-preview-validation.md
@@ -56,9 +56,15 @@ are recorded, and rotation/revocation take effect immediately for new exchanges.
    - `POST /api/projects/:projectId/context-cards` with `context:write`
      returns `201`.
    - `GET /api/projects/:projectId/context-cards` with `context:read` returns
-     `200`.
+     `200` and includes the `projection` block (creator/lastEditor/steward/review)
+     and the project-wide `assignableActors` list.
    - `PATCH /api/projects/:projectId/context-cards/:cardId` with
-     `context:write` returns `200`.
+     `context:write` returns `200` and the updated card including the
+     `projection` block.
+   - `PATCH /api/projects/:projectId/context-cards/:cardId/stewardship` with
+     `context:write` returns `200` and the updated steward + review state; a
+     request referencing a non-assignable actor returns `400
+     context-card-steward-invalid`.
    - `DELETE /api/projects/:projectId/context-cards/:cardId` without
      `context:delete` returns `403`.
 

--- a/journal.md
+++ b/journal.md
@@ -3959,3 +3959,37 @@ Low-value entries to avoid going forward:
 - Pushed the policy-compliant replacement branch and opened draft
   [PR #416](https://github.com/dorianagaesse/nexus_dash/pull/416), superseding
   conflicting PR #410 without rewriting its protected history.
+
+# 2026-08-09 - TASK-342 context knowledge stewardship and attachment provenance
+
+- Started the task on `feature/task-342-context-knowledge-stewardship` cut from
+  `origin/main`. Drafted `tasks/task-342-context-knowledge-stewardship.md` plus
+  the Acceptance Criteria/Definition of Done in `tasks/current.md`; bumped the
+  backlog entry to Now 1.
+- Added the `ContextCardActorKind` enum and 13 stewardship/provenance columns
+  on `Resource` (creator/lastEditor/steward × user/credential/kind/snapshot,
+  plus `updatedAt`). Added `uploadedByKind` and
+  `uploadedByDisplayNameSnapshot` to `ResourceAttachment` with a CHECK
+  constraint enforcing human-only uploads. Migration
+  `20260809120000_task342_context_knowledge_stewardship` backfills existing
+  rows from the existing `uploadedByUserId` and resets `Resource.updatedAt`
+  to `createdAt`.
+- Mirrored the TASK-330 actor pattern via `lib/context-card-actor.ts` and
+  `lib/services/context-card-actor-service.ts`. New
+  `lib/services/context-card-stewardship-service.ts` exposes the review
+  threshold (env-overridable via `CONTEXT_CARD_REVIEW_THRESHOLD_DAYS`,
+  defaulting to 90), `projectContextCard`, `assignContextCardSteward`, and
+  `recordContextCardCreator`/`recordContextCardEditor` write helpers.
+- Updated `lib/services/context-card-service.ts` so create/update persist the
+  creator/last editor snapshots and return the full `ContextCardResponse`
+  with the projection block. `lib/services/project-attachment-service.ts`
+  resolves the uploader display snapshot via a new `resolveUploaderDisplaySnapshot`
+  helper for both form and direct-upload paths.
+- Added `PATCH /api/projects/:projectId/context-cards/:cardId/stewardship`
+  with editor-role eligibility and surface the new `projection` block +
+  project-wide `assignableActors` in the list/get responses.
+- UI: new `ContextCardActorChip`, `ContextCardReviewBadge`, and searchable
+  `ContextCardStewardPicker` (combobox). Wired into the preview header and
+  edit modal. Cards now show a review/steward chip strip on the grid surface.
+- Validation: `npm run lint`, `npm test` (969 passing — 27 new), `npm run
+  rls:check`, and `npm run build` all clean in the worktree.

--- a/journal.md
+++ b/journal.md
@@ -3993,3 +3993,15 @@ Low-value entries to avoid going forward:
   edit modal. Cards now show a review/steward chip strip on the grid surface.
 - Validation: `npm run lint`, `npm test` (969 passing — 27 new), `npm run
   rls:check`, and `npm run build` all clean in the worktree.
+- PR #428 CI repair: Quality Core stopped at `release:check` because
+  `package.json` had advanced to `0.38.0` while the lockfile remained at
+  `0.37.0`, and the feature release had no matching changelog entry. Aligned
+  both root lockfile versions and documented `v0.38.0` in `CHANGELOG.md`.
+- The repaired release gate exposed three stale route-test fixtures: the
+  context-card list test did not mock the new stewardship projection/registry,
+  and update-route mocks omitted timestamps now serialized in the response.
+  Updated those mocks and expectations without changing production behavior.
+- Repair validation passed: release policy, lint, RLS inventory, 12 focused
+  route tests, the full unit/API suite (1064 passed, 2 skipped), coverage
+  (91.37% statements / 81.33% branches / 92.2% functions / 91.88% lines),
+  and the production build. No deployment was triggered.

--- a/journal.md
+++ b/journal.md
@@ -4005,3 +4005,19 @@ Low-value entries to avoid going forward:
   route tests, the full unit/API suite (1064 passed, 2 skipped), coverage
   (91.37% statements / 81.33% branches / 92.2% functions / 91.88% lines),
   and the production build. No deployment was triggered.
+- Replacement PR #446 Copilot review identified stale realtime projections,
+  RLS-hidden actor choices, incomplete preview stewardship controls, and agent
+  attachment attribution gaps. Added a display-safe SECURITY DEFINER actor
+  projection, preserved card edit timestamps during stewardship-only writes,
+  and now reject agent-authenticated attachment creation until the attachment
+  schema can persist credential identity without misattribution.
+- Realtime context-card updates now carry timestamps and complete stewardship
+  projections. The grid, preview, and edit surfaces use shared user/agent
+  avatars, explicitly call out inactive stewards as needing reassignment, and
+  expose labeled 44px keyboard-operable assignment controls with pending/error
+  behavior. Added focused component, route, and service regressions.
+- Review-fix validation passed: release policy, lint, RLS inventory, Prisma
+  validation, production build, 1,080 unit/API/component tests (2 skipped), and
+  coverage (91.37% statements / 81.33% branches / 92.2% functions / 91.88%
+  lines). The standalone project-ref script test remains a Windows CRLF/shebang
+  loader limitation and is covered by the Linux CI run.

--- a/lib/context-card-actor.ts
+++ b/lib/context-card-actor.ts
@@ -1,0 +1,49 @@
+export type ContextCardActorKind = "human" | "agent";
+export type ContextCardActorStatus =
+  | "active"
+  | "inactive"
+  | "revoked"
+  | "expired";
+
+export interface ContextCardActorReference {
+  kind: ContextCardActorKind;
+  id: string;
+}
+
+export interface ContextCardActorSummary extends ContextCardActorReference {
+  displayName: string;
+  usernameTag: string | null;
+  avatarSeed: string | null;
+  status: ContextCardActorStatus;
+  isAssignable: boolean;
+}
+
+export function getContextCardActorKey(
+  actor: Pick<ContextCardActorReference, "kind" | "id">
+): string {
+  return `${actor.kind}:${actor.id}`;
+}
+
+export function getHistoricalContextCardActorId(input: {
+  kind: ContextCardActorKind;
+  displayNameSnapshot: string;
+}): string {
+  return `historical-${input.kind}-${encodeURIComponent(
+    input.displayNameSnapshot.trim()
+  )}`;
+}
+
+export function isContextCardActorReference(
+  value: unknown
+): value is ContextCardActorReference {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    (record.kind === "human" || record.kind === "agent") &&
+    typeof record.id === "string" &&
+    record.id.trim().length > 0
+  );
+}

--- a/lib/services/context-card-actor-service.ts
+++ b/lib/services/context-card-actor-service.ts
@@ -1,3 +1,5 @@
+import { Prisma } from "@prisma/client";
+
 import { resolveAgentCredentialStatus } from "@/lib/agent-access";
 import type {
   ContextCardActorReference,
@@ -46,6 +48,19 @@ export interface ResolvedContextCardActorPersistence {
   credentialId: string | null;
   displayNameSnapshot: string;
   summary: ContextCardActorSummary;
+}
+
+interface RlsSafeContextCardActorRow {
+  kind: "human" | "agent";
+  actorId: string;
+  name: string | null;
+  email: string | null;
+  username: string | null;
+  usernameDiscriminator: string | null;
+  avatarSeed: string | null;
+  label: string | null;
+  revokedAt: Date | null;
+  expiresAt: Date | null;
 }
 
 interface ActorResolutionError {
@@ -170,21 +185,11 @@ export async function loadContextCardActorRegistry(input: {
   projectId: string;
   now?: Date;
 }): Promise<ContextCardActorRegistry | null> {
-  const project = await input.db.project.findUnique({
-    where: { id: input.projectId },
-    select: {
-      owner: { select: contextCardActorUserSelect },
-      memberships: {
-        orderBy: [{ createdAt: "asc" }],
-        select: { user: { select: contextCardActorUserSelect } },
-      },
-      apiCredentials: {
-        orderBy: [{ label: "asc" }, { createdAt: "asc" }],
-        select: contextCardActorCredentialSelect,
-      },
-    },
-  });
-  if (!project) {
+  const rows = await input.db.$queryRaw<RlsSafeContextCardActorRow[]>(Prisma.sql`
+    SELECT *
+    FROM app.list_project_context_card_actors(${input.projectId})
+  `);
+  if (rows.length === 0) {
     return null;
   }
 
@@ -192,17 +197,38 @@ export async function loadContextCardActorRegistry(input: {
   const humanById = new Map<string, ContextCardActorSummary>();
   const credentialById = new Map<string, ContextCardActorSummary>();
 
-  for (const user of [project.owner, ...project.memberships.map((item) => item.user)]) {
-    if (activeHumanIds.has(user.id)) {
+  const now = input.now ?? new Date();
+  for (const row of rows) {
+    if (row.kind === "human") {
+      if (activeHumanIds.has(row.actorId)) {
+        continue;
+      }
+      const user = {
+        id: row.actorId,
+        name: row.name,
+        email: row.email,
+        username: row.username,
+        usernameDiscriminator: row.usernameDiscriminator,
+        avatarSeed: row.avatarSeed,
+      };
+      activeHumanIds.add(row.actorId);
+      humanById.set(row.actorId, mapHuman(user, "active"));
       continue;
     }
-    activeHumanIds.add(user.id);
-    humanById.set(user.id, mapHuman(user, "active"));
-  }
 
-  const now = input.now ?? new Date();
-  for (const credential of project.apiCredentials) {
-    credentialById.set(credential.id, mapCredential(credential, now));
+    credentialById.set(
+      row.actorId,
+      mapCredential(
+        {
+          id: row.actorId,
+          label: row.label ?? "Project agent",
+          projectId: input.projectId,
+          revokedAt: row.revokedAt,
+          expiresAt: row.expiresAt,
+        },
+        now
+      )
+    );
   }
 
   const assignable = [

--- a/lib/services/context-card-actor-service.ts
+++ b/lib/services/context-card-actor-service.ts
@@ -1,0 +1,346 @@
+import { resolveAgentCredentialStatus } from "@/lib/agent-access";
+import type {
+  ContextCardActorReference,
+  ContextCardActorSummary,
+} from "@/lib/context-card-actor";
+import { getHistoricalContextCardActorId } from "@/lib/context-card-actor";
+import {
+  buildProjectPrincipalWhere,
+  requireProjectRole,
+  type AgentProjectAccessContext,
+} from "@/lib/services/project-access-service";
+import { type DbClient, withActorRlsContext } from "@/lib/services/rls-context";
+import {
+  mapTaskPersonSummary,
+  taskPersonSummarySelect,
+  type TaskPersonRecord,
+} from "@/lib/task-person";
+
+export const contextCardActorUserSelect = taskPersonSummarySelect;
+
+export const contextCardActorCredentialSelect = {
+  id: true,
+  label: true,
+  projectId: true,
+  revokedAt: true,
+  expiresAt: true,
+} as const;
+
+export interface ContextCardActorCredentialRecord {
+  id: string;
+  label: string;
+  projectId: string;
+  revokedAt: Date | null;
+  expiresAt: Date | null;
+}
+
+export interface ContextCardActorRegistry {
+  activeHumanIds: Set<string>;
+  humanById: Map<string, ContextCardActorSummary>;
+  credentialById: Map<string, ContextCardActorSummary>;
+  assignable: ContextCardActorSummary[];
+}
+
+export interface ResolvedContextCardActorPersistence {
+  userId: string | null;
+  credentialId: string | null;
+  displayNameSnapshot: string;
+  summary: ContextCardActorSummary;
+}
+
+interface ActorResolutionError {
+  ok: false;
+  status: number;
+  error: string;
+}
+
+interface ActorResolutionSuccess {
+  ok: true;
+  actor: ResolvedContextCardActorPersistence;
+}
+
+export type ContextCardActorResolution =
+  | ActorResolutionError
+  | ActorResolutionSuccess;
+
+function normalizeIdentifier(value: string | null | undefined): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function mapHuman(
+  user: TaskPersonRecord,
+  status: "active" | "inactive"
+): ContextCardActorSummary {
+  const person = mapTaskPersonSummary(user);
+  if (!person) {
+    throw new Error("context-card-human-identity-invalid");
+  }
+
+  return {
+    kind: "human",
+    id: person.id,
+    displayName: person.displayName,
+    usernameTag: person.usernameTag,
+    avatarSeed: person.avatarSeed,
+    status,
+    isAssignable: status === "active",
+  };
+}
+
+function mapCredential(
+  credential: ContextCardActorCredentialRecord,
+  now: Date
+): ContextCardActorSummary {
+  const status = resolveAgentCredentialStatus({
+    revokedAt: credential.revokedAt,
+    expiresAt: credential.expiresAt,
+    now,
+  });
+
+  return {
+    kind: "agent",
+    id: credential.id,
+    displayName: credential.label,
+    usernameTag: null,
+    avatarSeed: null,
+    status,
+    isAssignable: status === "active",
+  };
+}
+
+export function mapStoredContextCardActor(input: {
+  kind: "human" | "agent";
+  id: string | null;
+  displayNameSnapshot: string | null;
+  user?: TaskPersonRecord | null;
+  credential?: ContextCardActorCredentialRecord | null;
+  isCurrentProjectHuman?: boolean;
+  now?: Date;
+}): ContextCardActorSummary | null {
+  const id = normalizeIdentifier(input.id);
+  const snapshot = normalizeIdentifier(input.displayNameSnapshot);
+  if (!id && !snapshot) {
+    return null;
+  }
+
+  if (input.kind === "human") {
+    if (input.user && id) {
+      return mapHuman(
+        input.user,
+        input.isCurrentProjectHuman ? "active" : "inactive"
+      );
+    }
+    return {
+      kind: "human",
+      id:
+        id ||
+        getHistoricalContextCardActorId({
+          kind: "human",
+          displayNameSnapshot: snapshot,
+        }),
+      displayName: snapshot || "Former project member",
+      usernameTag: null,
+      avatarSeed: null,
+      status: "inactive",
+      isAssignable: false,
+    };
+  }
+
+  if (input.credential && id) {
+    return mapCredential(input.credential, input.now ?? new Date());
+  }
+  return {
+    kind: "agent",
+    id:
+      id ||
+      getHistoricalContextCardActorId({
+        kind: "agent",
+        displayNameSnapshot: snapshot,
+      }),
+    displayName: snapshot || "Former project agent",
+    usernameTag: null,
+    avatarSeed: null,
+    status: "revoked",
+    isAssignable: false,
+  };
+}
+
+export async function loadContextCardActorRegistry(input: {
+  db: DbClient;
+  projectId: string;
+  now?: Date;
+}): Promise<ContextCardActorRegistry | null> {
+  const project = await input.db.project.findUnique({
+    where: { id: input.projectId },
+    select: {
+      owner: { select: contextCardActorUserSelect },
+      memberships: {
+        orderBy: [{ createdAt: "asc" }],
+        select: { user: { select: contextCardActorUserSelect } },
+      },
+      apiCredentials: {
+        orderBy: [{ label: "asc" }, { createdAt: "asc" }],
+        select: contextCardActorCredentialSelect,
+      },
+    },
+  });
+  if (!project) {
+    return null;
+  }
+
+  const activeHumanIds = new Set<string>();
+  const humanById = new Map<string, ContextCardActorSummary>();
+  const credentialById = new Map<string, ContextCardActorSummary>();
+
+  for (const user of [project.owner, ...project.memberships.map((item) => item.user)]) {
+    if (activeHumanIds.has(user.id)) {
+      continue;
+    }
+    activeHumanIds.add(user.id);
+    humanById.set(user.id, mapHuman(user, "active"));
+  }
+
+  const now = input.now ?? new Date();
+  for (const credential of project.apiCredentials) {
+    credentialById.set(credential.id, mapCredential(credential, now));
+  }
+
+  const assignable = [
+    ...humanById.values(),
+    ...credentialById.values(),
+  ].filter((actor) => actor.isAssignable);
+
+  return { activeHumanIds, humanById, credentialById, assignable };
+}
+
+export async function listProjectContextCardActors(input: {
+  actorUserId: string;
+  projectId: string;
+}): Promise<ContextCardActorSummary[]> {
+  const actorUserId = normalizeIdentifier(input.actorUserId);
+  const projectId = normalizeIdentifier(input.projectId);
+  if (!actorUserId || !projectId) {
+    return [];
+  }
+
+  return withActorRlsContext(actorUserId, async (db) => {
+    const project = await db.project.findFirst({
+      where: {
+        id: projectId,
+        ...buildProjectPrincipalWhere(actorUserId),
+      },
+      select: { id: true },
+    });
+    if (!project) {
+      return [];
+    }
+
+    const registry = await loadContextCardActorRegistry({ db, projectId });
+    return registry?.assignable ?? [];
+  }) as Promise<ContextCardActorSummary[]>;
+}
+
+export async function resolveAssignableContextCardActor(input: {
+  db: DbClient;
+  projectId: string;
+  reference: ContextCardActorReference;
+  now?: Date;
+}): Promise<ContextCardActorResolution> {
+  const registry = await loadContextCardActorRegistry({
+    db: input.db,
+    projectId: input.projectId,
+    now: input.now,
+  });
+  return resolveAssignableContextCardActorFromRegistry({
+    registry,
+    reference: input.reference,
+  });
+}
+
+export function resolveAssignableContextCardActorFromRegistry(input: {
+  registry: ContextCardActorRegistry | null;
+  reference: ContextCardActorReference;
+}): ContextCardActorResolution {
+  const actor =
+    input.reference.kind === "human"
+      ? input.registry?.humanById.get(input.reference.id)
+      : input.registry?.credentialById.get(input.reference.id);
+  if (!actor?.isAssignable) {
+    return {
+      ok: false,
+      status: 400,
+      error: "context-card-steward-invalid",
+    };
+  }
+
+  return {
+    ok: true,
+    actor: {
+      userId: actor.kind === "human" ? actor.id : null,
+      credentialId: actor.kind === "agent" ? actor.id : null,
+      displayNameSnapshot: actor.displayName,
+      summary: actor,
+    },
+  };
+}
+
+export async function resolveContextCardMutationActor(input: {
+  db: DbClient;
+  actorUserId: string;
+  projectId: string;
+  agentAccess?: AgentProjectAccessContext;
+}): Promise<ContextCardActorResolution> {
+  if (input.agentAccess) {
+    const credential = await input.db.apiCredential.findFirst({
+      where: {
+        id: input.agentAccess.credentialId,
+        projectId: input.projectId,
+      },
+      select: contextCardActorCredentialSelect,
+    });
+    if (!credential) {
+      return { ok: false, status: 403, error: "forbidden" };
+    }
+    const summary = mapCredential(credential, new Date());
+    if (!summary.isAssignable) {
+      return { ok: false, status: 403, error: "forbidden" };
+    }
+    return {
+      ok: true,
+      actor: {
+        userId: null,
+        credentialId: summary.id,
+        displayNameSnapshot: summary.displayName,
+        summary,
+      },
+    };
+  }
+
+  const access = await requireProjectRole({
+    actorUserId: input.actorUserId,
+    projectId: input.projectId,
+    minimumRole: "viewer",
+    db: input.db,
+  });
+  if (!access.ok) {
+    return { ok: false, status: access.status, error: access.error };
+  }
+
+  const user = await input.db.user.findUnique({
+    where: { id: input.actorUserId },
+    select: contextCardActorUserSelect,
+  });
+  if (!user) {
+    return { ok: false, status: 401, error: "unauthorized" };
+  }
+  const summary = mapHuman(user, "active");
+  return {
+    ok: true,
+    actor: {
+      userId: summary.id,
+      credentialId: null,
+      displayNameSnapshot: summary.displayName,
+      summary,
+    },
+  };
+}

--- a/lib/services/context-card-service.ts
+++ b/lib/services/context-card-service.ts
@@ -206,6 +206,13 @@ export async function createContextCardForProject(
     return createError(agentScopeAccess.status, agentScopeAccess.error);
   }
 
+  if (
+    input.agentAccess &&
+    (parsedLinks.links.length > 0 || input.attachmentFiles.length > 0)
+  ) {
+    return createError(403, "agent-context-attachments-unsupported");
+  }
+
   let createdCardId: string | null = null;
 
   return withActorRlsContext(actorUserId, async (db) => {

--- a/lib/services/context-card-service.ts
+++ b/lib/services/context-card-service.ts
@@ -14,6 +14,7 @@ import {
   createContextAttachmentsFromDraft,
   mapContextAttachmentResponse,
 } from "@/lib/services/project-attachment-service";
+import { loadContextCardActorRegistry } from "@/lib/services/context-card-actor-service";
 import {
   requireAgentProjectScopes,
   requireProjectRole,
@@ -280,8 +281,13 @@ export async function createContextCardForProject(
 
       await touchProjectActivity({ db, projectId: input.projectId });
 
+      const registry = await loadContextCardActorRegistry({
+        db,
+        projectId: input.projectId,
+      });
       const projection = projectContextCard({
         card: createdCardWithAttachments,
+        registry,
       });
 
       const response = mapContextCardResponse({
@@ -437,8 +443,13 @@ export async function updateContextCardForProject(
 
       await touchProjectActivity({ db, projectId: input.projectId });
 
+      const registry = await loadContextCardActorRegistry({
+        db,
+        projectId: input.projectId,
+      });
       const projection = projectContextCard({
         card: updatedCard,
+        registry,
       });
 
       return {

--- a/lib/services/context-card-service.ts
+++ b/lib/services/context-card-service.ts
@@ -20,6 +20,15 @@ import {
   type AgentProjectAccessContext,
 } from "@/lib/services/project-access-service";
 import { withActorRlsContext } from "@/lib/services/rls-context";
+import {
+  contextCardAttachmentSelect,
+  contextCardCardSelect,
+  projectContextCard,
+  recordContextCardCreator,
+  recordContextCardEditor,
+  resolveContextCardMutationActor,
+  type ContextCardProjection,
+} from "@/lib/services/context-card-stewardship-service";
 
 const MIN_TITLE_LENGTH = 2;
 const MAX_CONTEXT_TITLE_LENGTH = 120;
@@ -66,21 +75,25 @@ interface DeleteContextCardInput {
   agentAccess?: AgentProjectAccessContext;
 }
 
-interface ContextCardAttachmentRecord {
+export interface ContextCardAttachmentResponsePayload {
   id: string;
   kind: string;
   name: string;
   url: string | null;
   mimeType: string | null;
   sizeBytes: number | null;
+  downloadUrl: string | null;
 }
 
-interface ContextCardRecord {
+export interface ContextCardResponse {
   id: string;
-  name: string;
+  title: string;
   content: string;
-  color: string | null;
-  attachments: ContextCardAttachmentRecord[];
+  color: string;
+  createdAt: Date;
+  updatedAt: Date;
+  attachments: ContextCardAttachmentResponsePayload[];
+  projection: ContextCardProjection;
 }
 
 function createError(status: number, error: string): ServiceErrorResult {
@@ -106,15 +119,37 @@ function resolveContextColor(value: string): string | null {
   return value;
 }
 
-function mapContextCardRecord(projectId: string, card: ContextCardRecord) {
+function mapContextCardResponse(input: {
+  projectId: string;
+  card: {
+    id: string;
+    name: string;
+    content: string;
+    color: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+  };
+  attachments: Array<{
+    id: string;
+    kind: string;
+    name: string;
+    url: string | null;
+    mimeType: string | null;
+    sizeBytes: number | null;
+  }>;
+  projection: ContextCardProjection;
+}): ContextCardResponse {
   return {
-    id: card.id,
-    title: card.name,
-    content: card.content,
-    color: card.color ?? CONTEXT_CARD_COLORS[0],
-    attachments: card.attachments.map((attachment) =>
-      mapContextAttachmentResponse(projectId, card.id, attachment)
+    id: input.card.id,
+    title: input.card.name,
+    content: input.card.content,
+    color: input.card.color ?? CONTEXT_CARD_COLORS[0],
+    createdAt: input.card.createdAt,
+    updatedAt: input.card.updatedAt,
+    attachments: input.attachments.map((attachment) =>
+      mapContextAttachmentResponse(input.projectId, input.card.id, attachment)
     ),
+    projection: input.projection,
   };
 }
 
@@ -123,7 +158,7 @@ export async function createContextCardForProject(
 ): Promise<
   ServiceResult<{
     id: string;
-    card: ReturnType<typeof mapContextCardRecord>;
+    card: ContextCardResponse;
   }>
 > {
   const actorUserId = normalizeText(input.actorUserId);
@@ -183,6 +218,16 @@ export async function createContextCardForProject(
       return createError(access.status, access.error);
     }
 
+    const mutationActor = await resolveContextCardMutationActor({
+      db,
+      actorUserId,
+      projectId: input.projectId,
+      agentAccess: input.agentAccess,
+    });
+    if (!mutationActor.ok) {
+      return createError(mutationActor.status, mutationActor.error);
+    }
+
     try {
       const createdCard = await db.resource.create({
         data: {
@@ -196,6 +241,17 @@ export async function createContextCardForProject(
       });
       createdCardId = createdCard.id;
 
+      await recordContextCardCreator({
+        db,
+        cardId: createdCard.id,
+        creator: {
+          userId: mutationActor.actor.userId,
+          credentialId: mutationActor.actor.credentialId,
+          displayNameSnapshot: mutationActor.actor.displayNameSnapshot,
+          kind: mutationActor.actor.summary.kind,
+        },
+      });
+
       await createContextAttachmentsFromDraft({
         actorUserId,
         projectId: input.projectId,
@@ -203,25 +259,17 @@ export async function createContextCardForProject(
         links: parsedLinks.links,
         files: input.attachmentFiles,
         db,
+        uploaderDisplayNameSnapshot: mutationActor.actor.displayNameSnapshot,
       });
 
       const createdCardWithAttachments = await db.resource.findUnique({
         where: { id: createdCard.id },
         select: {
-          id: true,
-          name: true,
-          content: true,
-          color: true,
+          ...contextCardCardSelect,
+          createdAt: true,
           attachments: {
             orderBy: [{ createdAt: "desc" }],
-            select: {
-              id: true,
-              kind: true,
-              name: true,
-              url: true,
-              mimeType: true,
-              sizeBytes: true,
-            },
+            select: contextCardAttachmentSelect,
           },
         },
       });
@@ -232,11 +280,29 @@ export async function createContextCardForProject(
 
       await touchProjectActivity({ db, projectId: input.projectId });
 
+      const projection = projectContextCard({
+        card: createdCardWithAttachments,
+      });
+
+      const response = mapContextCardResponse({
+        projectId: input.projectId,
+        card: {
+          id: createdCard.id,
+          name: title,
+          content,
+          color,
+          createdAt: createdCardWithAttachments.createdAt,
+          updatedAt: createdCardWithAttachments.updatedAt,
+        },
+        attachments: createdCardWithAttachments.attachments,
+        projection,
+      });
+
       return {
         ok: true,
         data: {
           id: createdCard.id,
-          card: mapContextCardRecord(input.projectId, createdCardWithAttachments),
+          card: response,
         },
       };
     } catch (error) {
@@ -258,7 +324,7 @@ export async function createContextCardForProject(
 
 export async function updateContextCardForProject(
   input: UpdateContextCardInput
-): Promise<ServiceResult<{ ok: true }>> {
+): Promise<ServiceResult<ContextCardResponse>> {
   const actorUserId = normalizeText(input.actorUserId);
   if (!actorUserId) {
     return createError(401, "unauthorized");
@@ -309,17 +375,27 @@ export async function updateContextCardForProject(
       return createError(access.status, access.error);
     }
 
+    const mutationActor = await resolveContextCardMutationActor({
+      db,
+      actorUserId,
+      projectId: input.projectId,
+      agentAccess: input.agentAccess,
+    });
+    if (!mutationActor.ok) {
+      return createError(mutationActor.status, mutationActor.error);
+    }
+
     try {
-      const existingCard = await db.resource.findUnique({
-        where: { id: cardId },
-        select: { id: true, projectId: true, type: true },
+      const existingCard = await db.resource.findFirst({
+        where: {
+          id: cardId,
+          projectId: input.projectId,
+          type: RESOURCE_TYPE_CONTEXT_CARD,
+        },
+        select: { id: true },
       });
 
-      if (
-        !existingCard ||
-        existingCard.projectId !== input.projectId ||
-        existingCard.type !== RESOURCE_TYPE_CONTEXT_CARD
-      ) {
+      if (!existingCard) {
         return createError(404, "context-card-not-found");
       }
 
@@ -332,11 +408,54 @@ export async function updateContextCardForProject(
         },
       });
 
+      await recordContextCardEditor({
+        db,
+        cardId,
+        editor: {
+          userId: mutationActor.actor.userId,
+          credentialId: mutationActor.actor.credentialId,
+          displayNameSnapshot: mutationActor.actor.displayNameSnapshot,
+          kind: mutationActor.actor.summary.kind,
+        },
+      });
+
+      const updatedCard = await db.resource.findUnique({
+        where: { id: cardId },
+        select: {
+          ...contextCardCardSelect,
+          createdAt: true,
+          attachments: {
+            orderBy: [{ createdAt: "desc" }],
+            select: contextCardAttachmentSelect,
+          },
+        },
+      });
+
+      if (!updatedCard) {
+        return createError(500, "context-update-failed");
+      }
+
       await touchProjectActivity({ db, projectId: input.projectId });
+
+      const projection = projectContextCard({
+        card: updatedCard,
+      });
 
       return {
         ok: true,
-        data: { ok: true },
+        data: mapContextCardResponse({
+          projectId: input.projectId,
+          card: {
+            id: updatedCard.id,
+            name: title,
+            content,
+            color,
+            createdAt: updatedCard.createdAt,
+            updatedAt: updatedCard.updatedAt,
+          },
+          attachments: updatedCard.attachments,
+          projection,
+        }),
       };
     } catch (error) {
       logServerError("updateContextCardForProject", error);
@@ -380,16 +499,16 @@ export async function deleteContextCardForProject(
     }
 
     try {
-      const existingCard = await db.resource.findUnique({
-        where: { id: cardId },
-        select: { id: true, projectId: true, type: true },
+      const existingCard = await db.resource.findFirst({
+        where: {
+          id: cardId,
+          projectId: input.projectId,
+          type: RESOURCE_TYPE_CONTEXT_CARD,
+        },
+        select: { id: true },
       });
 
-      if (
-        !existingCard ||
-        existingCard.projectId !== input.projectId ||
-        existingCard.type !== RESOURCE_TYPE_CONTEXT_CARD
-      ) {
+      if (!existingCard) {
         return createError(404, "context-card-not-found");
       }
 

--- a/lib/services/context-card-stewardship-service.ts
+++ b/lib/services/context-card-stewardship-service.ts
@@ -1,0 +1,543 @@
+import { Prisma } from "@prisma/client";
+
+import {
+  type ContextCardActorReference,
+  type ContextCardActorSummary,
+  isContextCardActorReference,
+} from "@/lib/context-card-actor";
+import { logServerError } from "@/lib/observability/logger";
+import { touchProjectActivity } from "@/lib/services/project-activity-service";
+import {
+  buildProjectPrincipalWhere,
+  requireAgentProjectScopes,
+  requireProjectRole,
+  type AgentProjectAccessContext,
+} from "@/lib/services/project-access-service";
+import {
+  loadContextCardActorRegistry,
+  mapStoredContextCardActor,
+  resolveContextCardMutationActor,
+  resolveAssignableContextCardActor,
+  contextCardActorCredentialSelect,
+  contextCardActorUserSelect,
+  type ContextCardActorRegistry,
+} from "@/lib/services/context-card-actor-service";
+import {
+  RESOURCE_TYPE_CONTEXT_CARD,
+} from "@/lib/resource-type";
+import { withActorRlsContext } from "@/lib/services/rls-context";
+
+const DEFAULT_CONTEXT_CARD_REVIEW_THRESHOLD_DAYS = 90;
+
+export interface ContextCardReviewState {
+  needsReview: boolean;
+  thresholdDays: number;
+  lastEditedAt: Date;
+}
+
+export interface ContextCardProjection {
+  id: string;
+  creator: ContextCardActorSummary | null;
+  lastEditor: ContextCardActorSummary | null;
+  steward: ContextCardActorSummary | null;
+  review: ContextCardReviewState;
+  attachments: ContextCardAttachmentProjection[];
+}
+
+export interface ContextCardAttachmentProjection {
+  id: string;
+  kind: string;
+  name: string;
+  url: string | null;
+  mimeType: string | null;
+  sizeBytes: number | null;
+  uploadedBy: ContextCardActorSummary | null;
+  uploadedByDisplayNameSnapshot: string;
+  uploadedAt: Date;
+}
+
+export interface ContextCardStewardshipSummary {
+  cardId: string;
+  steward: ContextCardActorSummary | null;
+  needsReview: boolean;
+  thresholdDays: number;
+  lastEditedAt: Date;
+}
+
+interface ServiceErrorResult {
+  ok: false;
+  status: number;
+  error: string;
+}
+
+interface ServiceSuccessResult<T> {
+  ok: true;
+  data: T;
+}
+
+type ServiceResult<T> = ServiceSuccessResult<T> | ServiceErrorResult;
+
+export interface ContextCardCardRecord {
+  id: string;
+  projectId: string;
+  updatedAt: Date;
+  createdByUserId: string | null;
+  createdByCredentialId: string | null;
+  creatorKind: "human" | "agent";
+  creatorDisplayNameSnapshot: string;
+  lastEditedByUserId: string | null;
+  lastEditedByCredentialId: string | null;
+  lastEditorKind: "human" | "agent" | null;
+  lastEditorDisplayNameSnapshot: string | null;
+  stewardUserId: string | null;
+  stewardCredentialId: string | null;
+  stewardKind: "human" | "agent" | null;
+  stewardDisplayNameSnapshot: string | null;
+  createdByUser?: {
+    id: string;
+    name: string | null;
+    email: string | null;
+    username: string | null;
+    usernameDiscriminator: string | null;
+    avatarSeed: string | null;
+  } | null;
+  createdByCredential?: {
+    id: string;
+    label: string;
+    projectId: string;
+    revokedAt: Date | null;
+    expiresAt: Date | null;
+  } | null;
+  lastEditedByUser?: {
+    id: string;
+    name: string | null;
+    email: string | null;
+    username: string | null;
+    usernameDiscriminator: string | null;
+    avatarSeed: string | null;
+  } | null;
+  lastEditedByCredential?: {
+    id: string;
+    label: string;
+    projectId: string;
+    revokedAt: Date | null;
+    expiresAt: Date | null;
+  } | null;
+  stewardUser?: {
+    id: string;
+    name: string | null;
+    email: string | null;
+    username: string | null;
+    usernameDiscriminator: string | null;
+    avatarSeed: string | null;
+  } | null;
+  stewardCredential?: {
+    id: string;
+    label: string;
+    projectId: string;
+    revokedAt: Date | null;
+    expiresAt: Date | null;
+  } | null;
+  attachments?: ContextCardAttachmentRecord[];
+}
+
+export interface ContextCardAttachmentRecord {
+  id: string;
+  kind: string;
+  name: string;
+  url: string | null;
+  mimeType: string | null;
+  sizeBytes: number | null;
+  uploadedByUserId: string;
+  uploadedByKind: "human" | "agent";
+  uploadedByDisplayNameSnapshot: string;
+  createdAt: Date;
+  uploadedBy?: {
+    id: string;
+    name: string | null;
+    email: string | null;
+    username: string | null;
+    usernameDiscriminator: string | null;
+    avatarSeed: string | null;
+  } | null;
+}
+
+function normalizeIdentifier(value: string | null | undefined): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function createError(status: number, error: string): ServiceErrorResult {
+  return { ok: false, status, error };
+}
+
+export function getContextCardReviewThresholdDays(): number {
+  const fromEnv = Number.parseInt(
+    process.env.CONTEXT_CARD_REVIEW_THRESHOLD_DAYS ?? "",
+    10
+  );
+  if (Number.isFinite(fromEnv) && fromEnv > 0) {
+    return fromEnv;
+  }
+  return DEFAULT_CONTEXT_CARD_REVIEW_THRESHOLD_DAYS;
+}
+
+export function resolveContextCardReviewState(input: {
+  updatedAt: Date;
+  referenceNowMs?: number;
+  thresholdDays?: number;
+}): ContextCardReviewState {
+  const thresholdDays = input.thresholdDays ?? getContextCardReviewThresholdDays();
+  const referenceNowMs = input.referenceNowMs ?? Date.now();
+  const lastEditedAt = input.updatedAt;
+  const ageMs = referenceNowMs - lastEditedAt.getTime();
+  const thresholdMs = thresholdDays * 24 * 60 * 60 * 1000;
+  return {
+    needsReview: ageMs >= thresholdMs,
+    thresholdDays,
+    lastEditedAt,
+  };
+}
+
+function mapAttachmentProjection(
+  attachment: ContextCardAttachmentRecord,
+  registry: ContextCardActorRegistry | null,
+  now: Date
+): ContextCardAttachmentProjection {
+  const uploader =
+    attachment.uploadedByKind === "human"
+      ? mapStoredContextCardActor({
+          kind: "human",
+          id: attachment.uploadedByUserId,
+          displayNameSnapshot: attachment.uploadedByDisplayNameSnapshot,
+          user: attachment.uploadedBy,
+          isCurrentProjectHuman: Boolean(
+            attachment.uploadedByUserId &&
+              registry?.activeHumanIds.has(attachment.uploadedByUserId)
+          ),
+        })
+      : mapStoredContextCardActor({
+          kind: "agent",
+          id: attachment.uploadedByUserId,
+          displayNameSnapshot: attachment.uploadedByDisplayNameSnapshot,
+        });
+  return {
+    id: attachment.id,
+    kind: attachment.kind,
+    name: attachment.name,
+    url: attachment.url,
+    mimeType: attachment.mimeType,
+    sizeBytes: attachment.sizeBytes,
+    uploadedBy: uploader,
+    uploadedByDisplayNameSnapshot: attachment.uploadedByDisplayNameSnapshot,
+    uploadedAt: attachment.createdAt,
+  };
+}
+
+export function projectContextCard(input: {
+  card: ContextCardCardRecord;
+  referenceNowMs?: number;
+  thresholdDays?: number;
+  now?: Date;
+}): ContextCardProjection {
+  const registry =
+    input.card.stewardUser !== undefined ||
+    input.card.lastEditedByUser !== undefined ||
+    input.card.createdByUser !== undefined ||
+    input.card.attachments !== undefined
+      ? null
+      : null;
+  const now = input.now ?? new Date();
+  return {
+    id: input.card.id,
+    creator: mapStoredContextCardActor({
+      kind: input.card.creatorKind,
+      id:
+        input.card.creatorKind === "human"
+          ? input.card.createdByUserId
+          : input.card.createdByCredentialId,
+      displayNameSnapshot: input.card.creatorDisplayNameSnapshot,
+      user: input.card.createdByUser,
+      credential: input.card.createdByCredential,
+    }),
+    lastEditor:
+      input.card.lastEditorKind && input.card.lastEditorDisplayNameSnapshot
+        ? mapStoredContextCardActor({
+            kind: input.card.lastEditorKind,
+            id:
+              input.card.lastEditorKind === "human"
+                ? input.card.lastEditedByUserId
+                : input.card.lastEditedByCredentialId,
+            displayNameSnapshot: input.card.lastEditorDisplayNameSnapshot,
+            user: input.card.lastEditedByUser,
+            credential: input.card.lastEditedByCredential,
+          })
+        : null,
+    steward:
+      input.card.stewardKind && input.card.stewardDisplayNameSnapshot
+        ? mapStoredContextCardActor({
+            kind: input.card.stewardKind,
+            id:
+              input.card.stewardKind === "human"
+                ? input.card.stewardUserId
+                : input.card.stewardCredentialId,
+            displayNameSnapshot: input.card.stewardDisplayNameSnapshot,
+            user: input.card.stewardUser,
+            credential: input.card.stewardCredential,
+          })
+        : null,
+    review: resolveContextCardReviewState({
+      updatedAt: input.card.updatedAt,
+      referenceNowMs: input.referenceNowMs,
+      thresholdDays: input.thresholdDays,
+    }),
+    attachments: (input.card.attachments ?? []).map((attachment) =>
+      mapAttachmentProjection(attachment, registry, now)
+    ),
+  };
+}
+
+export const contextCardCardSelect = {
+  id: true,
+  projectId: true,
+  updatedAt: true,
+  createdByUserId: true,
+  createdByCredentialId: true,
+  creatorKind: true,
+  creatorDisplayNameSnapshot: true,
+  lastEditedByUserId: true,
+  lastEditedByCredentialId: true,
+  lastEditorKind: true,
+  lastEditorDisplayNameSnapshot: true,
+  stewardUserId: true,
+  stewardCredentialId: true,
+  stewardKind: true,
+  stewardDisplayNameSnapshot: true,
+  createdByUser: { select: contextCardActorUserSelect },
+  createdByCredential: { select: contextCardActorCredentialSelect },
+  lastEditedByUser: { select: contextCardActorUserSelect },
+  lastEditedByCredential: { select: contextCardActorCredentialSelect },
+  stewardUser: { select: contextCardActorUserSelect },
+  stewardCredential: { select: contextCardActorCredentialSelect },
+} satisfies Prisma.ResourceSelect;
+
+export const contextCardAttachmentSelect = {
+  id: true,
+  kind: true,
+  name: true,
+  url: true,
+  mimeType: true,
+  sizeBytes: true,
+  uploadedByUserId: true,
+  uploadedByKind: true,
+  uploadedByDisplayNameSnapshot: true,
+  createdAt: true,
+  uploadedBy: { select: contextCardActorUserSelect },
+} satisfies Prisma.ResourceAttachmentSelect;
+
+export async function findContextCardForProject(input: {
+  db: Prisma.TransactionClient;
+  projectId: string;
+  cardId: string;
+}): Promise<ContextCardCardRecord | null> {
+  return input.db.resource.findFirst({
+    where: {
+      id: input.cardId,
+      projectId: input.projectId,
+      type: RESOURCE_TYPE_CONTEXT_CARD,
+    },
+    select: contextCardCardSelect,
+  }) as Promise<ContextCardCardRecord | null>;
+}
+
+export async function assignContextCardSteward(input: {
+  actorUserId: string;
+  projectId: string;
+  cardId: string;
+  steward: ContextCardActorReference | null;
+  agentAccess?: AgentProjectAccessContext;
+  referenceNowMs?: number;
+  thresholdDays?: number;
+}): Promise<ServiceResult<ContextCardStewardshipSummary>> {
+  const actorUserId = normalizeIdentifier(input.actorUserId);
+  const projectId = normalizeIdentifier(input.projectId);
+  const cardId = normalizeIdentifier(input.cardId);
+  if (!actorUserId) {
+    return createError(401, "unauthorized");
+  }
+  if (!projectId || !cardId) {
+    return createError(400, "context-card-missing");
+  }
+
+  const agentScopeAccess = requireAgentProjectScopes({
+    agentAccess: input.agentAccess,
+    projectId,
+    requiredScopes: ["context:write"],
+  });
+  if (!agentScopeAccess.ok) {
+    return createError(agentScopeAccess.status, agentScopeAccess.error);
+  }
+
+  return withActorRlsContext(actorUserId, async (db) => {
+    const access = await requireProjectRole({
+      actorUserId,
+      projectId,
+      minimumRole: "editor",
+      db,
+    });
+    if (!access.ok) {
+      return createError(access.status, access.error);
+    }
+
+    const existingCard = await db.resource.findFirst({
+      where: {
+        id: cardId,
+        projectId,
+        type: RESOURCE_TYPE_CONTEXT_CARD,
+      },
+      select: { id: true },
+    });
+    if (!existingCard) {
+      return createError(404, "context-card-not-found");
+    }
+
+    let stewardPersistence: {
+      userId: string | null;
+      credentialId: string | null;
+      displayNameSnapshot: string;
+    } | null = null;
+    if (input.steward !== null) {
+      if (!isContextCardActorReference(input.steward)) {
+        return createError(400, "context-card-steward-invalid");
+      }
+      const resolved = await resolveAssignableContextCardActor({
+        db,
+        projectId,
+        reference: input.steward,
+      });
+      if (!resolved.ok) {
+        return createError(resolved.status, resolved.error);
+      }
+      stewardPersistence = {
+        userId: resolved.actor.userId,
+        credentialId: resolved.actor.credentialId,
+        displayNameSnapshot: resolved.actor.displayNameSnapshot,
+      };
+    }
+
+    try {
+      const updatedCard = await db.resource.update({
+        where: { id: cardId },
+        data: stewardPersistence
+          ? {
+              stewardUserId: stewardPersistence.userId,
+              stewardCredentialId: stewardPersistence.credentialId,
+              stewardKind: input.steward?.kind ?? null,
+              stewardDisplayNameSnapshot: stewardPersistence.displayNameSnapshot,
+            }
+          : {
+              stewardUserId: null,
+              stewardCredentialId: null,
+              stewardKind: null,
+              stewardDisplayNameSnapshot: null,
+            },
+        select: contextCardCardSelect,
+      });
+
+      await touchProjectActivity({ db, projectId });
+
+      const projection = projectContextCard({
+        card: updatedCard as ContextCardCardRecord,
+        referenceNowMs: input.referenceNowMs,
+        thresholdDays: input.thresholdDays,
+      });
+
+      return {
+        ok: true,
+        data: {
+          cardId: updatedCard.id,
+          steward: projection.steward,
+          needsReview: projection.review.needsReview,
+          thresholdDays: projection.review.thresholdDays,
+          lastEditedAt: projection.review.lastEditedAt,
+        },
+      };
+    } catch (error) {
+      logServerError("assignContextCardSteward", error);
+      return createError(500, "context-card-stewardship-update-failed");
+    }
+  });
+}
+
+export async function recordContextCardEditor(input: {
+  db: Prisma.TransactionClient;
+  cardId: string;
+  editor: { userId: string | null; credentialId: string | null; displayNameSnapshot: string; kind: "human" | "agent" };
+}): Promise<void> {
+  await input.db.resource.update({
+    where: { id: input.cardId },
+    data: {
+      lastEditedByUserId: input.editor.userId,
+      lastEditedByCredentialId: input.editor.credentialId,
+      lastEditorKind: input.editor.kind,
+      lastEditorDisplayNameSnapshot: input.editor.displayNameSnapshot,
+    },
+  });
+}
+
+export async function recordContextCardCreator(input: {
+  db: Prisma.TransactionClient;
+  cardId: string;
+  creator: { userId: string | null; credentialId: string | null; displayNameSnapshot: string; kind: "human" | "agent" };
+}): Promise<void> {
+  await input.db.resource.update({
+    where: { id: input.cardId },
+    data: {
+      createdByUserId: input.creator.userId,
+      createdByCredentialId: input.creator.credentialId,
+      creatorKind: input.creator.kind,
+      creatorDisplayNameSnapshot: input.creator.displayNameSnapshot,
+      lastEditedByUserId: input.creator.userId,
+      lastEditedByCredentialId: input.creator.credentialId,
+      lastEditorKind: input.creator.kind,
+      lastEditorDisplayNameSnapshot: input.creator.displayNameSnapshot,
+    },
+  });
+}
+
+export function getContextCardStewardshipActorContext(input: {
+  actorUserId: string;
+  agentAccess?: AgentProjectAccessContext;
+}) {
+  return {
+    actorUserId: input.actorUserId,
+    agentAccess: input.agentAccess,
+  };
+}
+
+// Expose registry helper for callers (e.g., dashboard loader) that need to
+// hydrate stewards/creators without going through the service boundary.
+export async function loadContextCardActorRegistryForProject(input: {
+  actorUserId: string;
+  projectId: string;
+}): Promise<ContextCardActorRegistry | null> {
+  const actorUserId = normalizeIdentifier(input.actorUserId);
+  const projectId = normalizeIdentifier(input.projectId);
+  if (!actorUserId || !projectId) {
+    return null;
+  }
+  return withActorRlsContext(actorUserId, async (db) => {
+    const project = await db.project.findFirst({
+      where: {
+        id: projectId,
+        ...buildProjectPrincipalWhere(actorUserId),
+      },
+      select: { id: true },
+    });
+    if (!project) {
+      return null;
+    }
+    return loadContextCardActorRegistry({ db, projectId });
+  }) as Promise<ContextCardActorRegistry | null>;
+}
+
+export { resolveContextCardMutationActor };

--- a/lib/services/context-card-stewardship-service.ts
+++ b/lib/services/context-card-stewardship-service.ts
@@ -238,15 +238,18 @@ export function projectContextCard(input: {
   referenceNowMs?: number;
   thresholdDays?: number;
   now?: Date;
+  registry?: ContextCardActorRegistry | null;
 }): ContextCardProjection {
-  const registry =
-    input.card.stewardUser !== undefined ||
-    input.card.lastEditedByUser !== undefined ||
-    input.card.createdByUser !== undefined ||
-    input.card.attachments !== undefined
-      ? null
-      : null;
+  const registry = input.registry ?? null;
   const now = input.now ?? new Date();
+
+  function isCurrentHuman(userId: string | null): boolean | undefined {
+    if (!userId || !registry) {
+      return undefined;
+    }
+    return registry.activeHumanIds.has(userId);
+  }
+
   return {
     id: input.card.id,
     creator: mapStoredContextCardActor({
@@ -258,6 +261,7 @@ export function projectContextCard(input: {
       displayNameSnapshot: input.card.creatorDisplayNameSnapshot,
       user: input.card.createdByUser,
       credential: input.card.createdByCredential,
+      isCurrentProjectHuman: isCurrentHuman(input.card.createdByUserId),
     }),
     lastEditor:
       input.card.lastEditorKind && input.card.lastEditorDisplayNameSnapshot
@@ -270,6 +274,7 @@ export function projectContextCard(input: {
             displayNameSnapshot: input.card.lastEditorDisplayNameSnapshot,
             user: input.card.lastEditedByUser,
             credential: input.card.lastEditedByCredential,
+            isCurrentProjectHuman: isCurrentHuman(input.card.lastEditedByUserId),
           })
         : null,
     steward:
@@ -283,6 +288,7 @@ export function projectContextCard(input: {
             displayNameSnapshot: input.card.stewardDisplayNameSnapshot,
             user: input.card.stewardUser,
             credential: input.card.stewardCredential,
+            isCurrentProjectHuman: isCurrentHuman(input.card.stewardUserId),
           })
         : null,
     review: resolveContextCardReviewState({
@@ -445,10 +451,12 @@ export async function assignContextCardSteward(input: {
 
       await touchProjectActivity({ db, projectId });
 
+      const registry = await loadContextCardActorRegistry({ db, projectId });
       const projection = projectContextCard({
         card: updatedCard as ContextCardCardRecord,
         referenceNowMs: input.referenceNowMs,
         thresholdDays: input.thresholdDays,
+        registry,
       });
 
       return {

--- a/lib/services/context-card-stewardship-service.ts
+++ b/lib/services/context-card-stewardship-service.ts
@@ -62,6 +62,8 @@ export interface ContextCardStewardshipSummary {
   needsReview: boolean;
   thresholdDays: number;
   lastEditedAt: Date;
+  updatedAt: Date;
+  projection: ContextCardProjection;
 }
 
 interface ServiceErrorResult {
@@ -400,7 +402,7 @@ export async function assignContextCardSteward(input: {
         projectId,
         type: RESOURCE_TYPE_CONTEXT_CARD,
       },
-      select: { id: true },
+      select: { id: true, updatedAt: true },
     });
     if (!existingCard) {
       return createError(404, "context-card-not-found");
@@ -439,12 +441,14 @@ export async function assignContextCardSteward(input: {
               stewardCredentialId: stewardPersistence.credentialId,
               stewardKind: input.steward?.kind ?? null,
               stewardDisplayNameSnapshot: stewardPersistence.displayNameSnapshot,
+              updatedAt: existingCard.updatedAt,
             }
           : {
               stewardUserId: null,
               stewardCredentialId: null,
               stewardKind: null,
               stewardDisplayNameSnapshot: null,
+              updatedAt: existingCard.updatedAt,
             },
         select: contextCardCardSelect,
       });
@@ -467,6 +471,8 @@ export async function assignContextCardSteward(input: {
           needsReview: projection.review.needsReview,
           thresholdDays: projection.review.thresholdDays,
           lastEditedAt: projection.review.lastEditedAt,
+          updatedAt: updatedCard.updatedAt,
+          projection,
         },
       };
     } catch (error) {

--- a/lib/services/project-attachment-service.ts
+++ b/lib/services/project-attachment-service.ts
@@ -997,6 +997,10 @@ export async function createContextAttachmentUploadTarget(input: {
     return agentScopeError;
   }
 
+  if (input.agentAccess) {
+    return createError(403, "agent-context-attachments-unsupported");
+  }
+
   return withActorRlsContext(actorUserId, async (db) => {
     const access = await requireProjectRole({
       actorUserId,
@@ -1088,6 +1092,10 @@ export async function finalizeContextAttachmentDirectUpload(input: {
   });
   if (agentScopeError) {
     return agentScopeError;
+  }
+
+  if (input.agentAccess) {
+    return createError(403, "agent-context-attachments-unsupported");
   }
 
   return withActorRlsContext(actorUserId, async (db) => {

--- a/lib/services/project-attachment-service.ts
+++ b/lib/services/project-attachment-service.ts
@@ -92,6 +92,32 @@ function createError(status: number, error: string): ServiceErrorResult {
   return { ok: false, status, error };
 }
 
+async function resolveUploaderDisplaySnapshot(input: {
+  db: DbClient;
+  actorUserId: string;
+}): Promise<string> {
+  const user = await input.db.user.findUnique({
+    where: { id: input.actorUserId },
+    select: {
+      name: true,
+      email: true,
+      username: true,
+      usernameDiscriminator: true,
+      avatarSeed: true,
+      id: true,
+    },
+  });
+  if (!user) {
+    return "Unknown uploader";
+  }
+  return (
+    user.username?.trim() ||
+    user.name?.trim() ||
+    user.email?.split("@", 1)[0]?.trim() ||
+    "Unknown uploader"
+  );
+}
+
 function normalizeActorUserId(actorUserId: string | null | undefined): string {
   if (typeof actorUserId !== "string") {
     return "";
@@ -317,9 +343,13 @@ export async function createContextAttachmentsFromDraft(input: {
   links: ParsedAttachmentLink[];
   files: File[];
   db?: DbClient;
+  uploaderDisplayNameSnapshot?: string;
 }): Promise<void> {
   const db = input.db ?? prisma;
   const savedStorageKeys: string[] = [];
+
+  const uploaderDisplayNameSnapshot =
+    input.uploaderDisplayNameSnapshot ?? "Unknown uploader";
 
   try {
     if (input.links.length > 0) {
@@ -327,6 +357,8 @@ export async function createContextAttachmentsFromDraft(input: {
         data: input.links.map((link) => ({
           resourceId: input.cardId,
           uploadedByUserId: input.actorUserId,
+          uploadedByKind: "human" as const,
+          uploadedByDisplayNameSnapshot: uploaderDisplayNameSnapshot,
           kind: ATTACHMENT_KIND_LINK,
           name: link.name,
           url: link.url,
@@ -352,6 +384,8 @@ export async function createContextAttachmentsFromDraft(input: {
         data: {
           resourceId: input.cardId,
           uploadedByUserId: input.actorUserId,
+          uploadedByKind: "human",
+          uploadedByDisplayNameSnapshot: uploaderDisplayNameSnapshot,
           kind: ATTACHMENT_KIND_FILE,
           name: storedFile.originalName,
           storageKey: storedFile.storageKey,
@@ -570,6 +604,11 @@ export async function createContextAttachmentFromForm(input: {
       return createError(404, "Context card not found");
     }
 
+    const uploaderDisplayNameSnapshot = await resolveUploaderDisplaySnapshot({
+      db,
+      actorUserId,
+    });
+
     const kind = readText(input.formData, "kind");
 
     if (!isAttachmentKind(kind)) {
@@ -590,6 +629,8 @@ export async function createContextAttachmentFromForm(input: {
           data: {
             resourceId: input.cardId,
             uploadedByUserId: actorUserId,
+            uploadedByKind: "human",
+            uploadedByDisplayNameSnapshot: uploaderDisplayNameSnapshot,
             kind: ATTACHMENT_KIND_LINK,
             name: providedName || new URL(normalizedUrl).hostname,
             url: normalizedUrl,
@@ -666,6 +707,8 @@ export async function createContextAttachmentFromForm(input: {
         data: {
           resourceId: input.cardId,
           uploadedByUserId: actorUserId,
+          uploadedByKind: "human",
+          uploadedByDisplayNameSnapshot: uploaderDisplayNameSnapshot,
           kind: ATTACHMENT_KIND_FILE,
           name: providedName || storedFile.originalName,
           storageKey: storedFile.storageKey,
@@ -1094,6 +1137,11 @@ export async function finalizeContextAttachmentDirectUpload(input: {
       return normalizedUpload;
     }
 
+    const uploaderDisplayNameSnapshot = await resolveUploaderDisplaySnapshot({
+      db,
+      actorUserId,
+    });
+
     try {
       const metadata = await readAttachmentStoredFileMetadata(normalizedStorageKey);
       if (!metadata) {
@@ -1136,6 +1184,8 @@ export async function finalizeContextAttachmentDirectUpload(input: {
         data: {
           resourceId: input.cardId,
           uploadedByUserId: actorUserId,
+          uploadedByKind: "human",
+          uploadedByDisplayNameSnapshot: uploaderDisplayNameSnapshot,
           kind: ATTACHMENT_KIND_FILE,
           name: normalizedUpload.data.name,
           storageKey: normalizedStorageKey,

--- a/lib/services/project-service.ts
+++ b/lib/services/project-service.ts
@@ -92,7 +92,77 @@ type ProjectKanbanTaskRecord = Prisma.TaskGetPayload<{
 
 type ProjectContextResourceRecord = Prisma.ResourceGetPayload<{
   include: {
-    attachments: true;
+    attachments: {
+      include: {
+        uploadedBy: {
+          select: {
+            id: true;
+            name: true;
+            email: true;
+            username: true;
+            usernameDiscriminator: true;
+            avatarSeed: true;
+          };
+        };
+      };
+    };
+    createdByUser: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+        username: true;
+        usernameDiscriminator: true;
+        avatarSeed: true;
+      };
+    };
+    createdByCredential: {
+      select: {
+        id: true;
+        label: true;
+        projectId: true;
+        revokedAt: true;
+        expiresAt: true;
+      };
+    };
+    lastEditedByUser: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+        username: true;
+        usernameDiscriminator: true;
+        avatarSeed: true;
+      };
+    };
+    lastEditedByCredential: {
+      select: {
+        id: true;
+        label: true;
+        projectId: true;
+        revokedAt: true;
+        expiresAt: true;
+      };
+    };
+    stewardUser: {
+      select: {
+        id: true;
+        name: true;
+        email: true;
+        username: true;
+        usernameDiscriminator: true;
+        avatarSeed: true;
+      };
+    };
+    stewardCredential: {
+      select: {
+        id: true;
+        label: true;
+        projectId: true;
+        revokedAt: true;
+        expiresAt: true;
+      };
+    };
   };
 }>;
 
@@ -769,6 +839,75 @@ export async function listProjectContextResources(
       include: {
         attachments: {
           orderBy: [{ createdAt: "desc" }],
+          include: {
+            uploadedBy: {
+              select: {
+                id: true,
+                name: true,
+                email: true,
+                username: true,
+                usernameDiscriminator: true,
+                avatarSeed: true,
+              },
+            },
+          },
+        },
+        createdByUser: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            username: true,
+            usernameDiscriminator: true,
+            avatarSeed: true,
+          },
+        },
+        createdByCredential: {
+          select: {
+            id: true,
+            label: true,
+            projectId: true,
+            revokedAt: true,
+            expiresAt: true,
+          },
+        },
+        lastEditedByUser: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            username: true,
+            usernameDiscriminator: true,
+            avatarSeed: true,
+          },
+        },
+        lastEditedByCredential: {
+          select: {
+            id: true,
+            label: true,
+            projectId: true,
+            revokedAt: true,
+            expiresAt: true,
+          },
+        },
+        stewardUser: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            username: true,
+            usernameDiscriminator: true,
+            avatarSeed: true,
+          },
+        },
+        stewardCredential: {
+          select: {
+            id: true,
+            label: true,
+            projectId: true,
+            revokedAt: true,
+            expiresAt: true,
+          },
         },
       },
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexusdash",
-  "version": "0.37.1",
+  "version": "0.38.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexusdash",
-      "version": "0.37.1",
+      "version": "0.38.0",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1079.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexusdash",
-  "version": "0.37.1",
+  "version": "0.38.0",
   "private": true,
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0",

--- a/prisma/migrations/20260809120000_task342_context_knowledge_stewardship/migration.sql
+++ b/prisma/migrations/20260809120000_task342_context_knowledge_stewardship/migration.sql
@@ -1,0 +1,111 @@
+CREATE TYPE "ContextCardActorKind" AS ENUM ('human', 'agent');
+
+ALTER TABLE "Resource"
+  ADD COLUMN "createdByUserId" TEXT,
+  ADD COLUMN "createdByCredentialId" TEXT,
+  ADD COLUMN "creatorKind" "ContextCardActorKind" NOT NULL DEFAULT 'human',
+  ADD COLUMN "creatorDisplayNameSnapshot" VARCHAR(80) NOT NULL DEFAULT 'Unknown actor',
+  ADD COLUMN "lastEditedByUserId" TEXT,
+  ADD COLUMN "lastEditedByCredentialId" TEXT,
+  ADD COLUMN "lastEditorKind" "ContextCardActorKind",
+  ADD COLUMN "lastEditorDisplayNameSnapshot" VARCHAR(80),
+  ADD COLUMN "stewardUserId" TEXT,
+  ADD COLUMN "stewardCredentialId" TEXT,
+  ADD COLUMN "stewardKind" "ContextCardActorKind",
+  ADD COLUMN "stewardDisplayNameSnapshot" VARCHAR(80),
+  ADD COLUMN "updatedAt" TIMESTAMP(3);
+
+UPDATE "Resource"
+SET "updatedAt" = "createdAt"
+WHERE "updatedAt" IS NULL;
+
+ALTER TABLE "Resource"
+  ALTER COLUMN "updatedAt" SET NOT NULL,
+  ALTER COLUMN "updatedAt" SET DEFAULT CURRENT_TIMESTAMP;
+
+ALTER TABLE "Resource"
+  ADD CONSTRAINT "Resource_createdByUserId_fkey"
+    FOREIGN KEY ("createdByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "Resource_createdByCredentialId_fkey"
+    FOREIGN KEY ("createdByCredentialId") REFERENCES "ApiCredential"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "Resource_lastEditedByUserId_fkey"
+    FOREIGN KEY ("lastEditedByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "Resource_lastEditedByCredentialId_fkey"
+    FOREIGN KEY ("lastEditedByCredentialId") REFERENCES "ApiCredential"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "Resource_stewardUserId_fkey"
+    FOREIGN KEY ("stewardUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "Resource_stewardCredentialId_fkey"
+    FOREIGN KEY ("stewardCredentialId") REFERENCES "ApiCredential"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "Resource_creator_actor_check"
+    CHECK (
+      num_nonnulls("createdByUserId", "createdByCredentialId") <= 1
+      AND ("creatorKind" = 'human' OR "createdByUserId" IS NULL)
+      AND ("creatorKind" = 'agent' OR "createdByCredentialId" IS NULL)
+    ),
+  ADD CONSTRAINT "Resource_last_editor_actor_check"
+    CHECK (
+      (
+        "lastEditorKind" IS NULL
+        AND "lastEditedByUserId" IS NULL
+        AND "lastEditedByCredentialId" IS NULL
+        AND "lastEditorDisplayNameSnapshot" IS NULL
+      )
+      OR (
+        "lastEditorKind" IS NOT NULL
+        AND "lastEditorDisplayNameSnapshot" IS NOT NULL
+        AND num_nonnulls("lastEditedByUserId", "lastEditedByCredentialId") <= 1
+        AND ("lastEditorKind" = 'human' OR "lastEditedByUserId" IS NULL)
+        AND ("lastEditorKind" = 'agent' OR "lastEditedByCredentialId" IS NULL)
+      )
+    ),
+  ADD CONSTRAINT "Resource_steward_actor_check"
+    CHECK (
+      ("stewardKind" IS NULL AND "stewardUserId" IS NULL AND "stewardCredentialId" IS NULL AND "stewardDisplayNameSnapshot" IS NULL)
+      OR (
+        "stewardKind" IS NOT NULL
+        AND "stewardDisplayNameSnapshot" IS NOT NULL
+        AND num_nonnulls("stewardUserId", "stewardCredentialId") <= 1
+        AND ("stewardKind" = 'human' OR "stewardUserId" IS NULL)
+        AND ("stewardKind" = 'agent' OR "stewardCredentialId" IS NULL)
+      )
+    );
+
+CREATE INDEX "Resource_createdByUserId_idx"
+  ON "Resource"("createdByUserId");
+CREATE INDEX "Resource_createdByCredentialId_idx"
+  ON "Resource"("createdByCredentialId");
+CREATE INDEX "Resource_lastEditedByUserId_idx"
+  ON "Resource"("lastEditedByUserId");
+CREATE INDEX "Resource_lastEditedByCredentialId_idx"
+  ON "Resource"("lastEditedByCredentialId");
+CREATE INDEX "Resource_stewardUserId_idx"
+  ON "Resource"("stewardUserId");
+CREATE INDEX "Resource_stewardCredentialId_idx"
+  ON "Resource"("stewardCredentialId");
+CREATE INDEX "Resource_projectId_updatedAt_idx"
+  ON "Resource"("projectId", "updatedAt");
+
+ALTER TABLE "ResourceAttachment"
+  ADD COLUMN "uploadedByKind" "ContextCardActorKind" NOT NULL DEFAULT 'human',
+  ADD COLUMN "uploadedByDisplayNameSnapshot" VARCHAR(80) NOT NULL DEFAULT 'Unknown uploader';
+
+UPDATE "ResourceAttachment"
+SET "uploadedByDisplayNameSnapshot" = LEFT(
+  COALESCE(
+    NULLIF("user"."username", ''),
+    NULLIF("user"."name", ''),
+    NULLIF("user"."email", ''),
+    'Unknown uploader'
+  ),
+  80
+)
+FROM "User" AS "user"
+WHERE "ResourceAttachment"."uploadedByUserId" = "user"."id";
+
+ALTER TABLE "ResourceAttachment"
+  ADD CONSTRAINT "ResourceAttachment_uploader_actor_check"
+    CHECK (
+      "uploadedByUserId" IS NOT NULL
+      AND "uploadedByKind" = 'human'
+      AND "uploadedByDisplayNameSnapshot" IS NOT NULL
+    );

--- a/prisma/migrations/20260824190000_task342_context_stewardship_review_fixes/migration.sql
+++ b/prisma/migrations/20260824190000_task342_context_stewardship_review_fixes/migration.sql
@@ -1,0 +1,82 @@
+-- Backfill historical cards and expose a display-safe actor projection under RLS.
+
+UPDATE "Resource"
+SET
+  "lastEditorKind" = 'human',
+  "lastEditorDisplayNameSnapshot" = 'Unknown actor'
+WHERE "type" = 'context-card'
+  AND "lastEditorKind" IS NULL;
+
+CREATE OR REPLACE FUNCTION app.list_project_context_card_actors(target_project_id TEXT)
+RETURNS TABLE (
+  "kind" TEXT,
+  "actorId" TEXT,
+  "name" TEXT,
+  "email" TEXT,
+  "username" TEXT,
+  "usernameDiscriminator" TEXT,
+  "avatarSeed" TEXT,
+  "label" TEXT,
+  "revokedAt" TIMESTAMP(3),
+  "expiresAt" TIMESTAMP(3)
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, app, pg_temp
+AS $$
+  WITH accessible_project AS (
+    SELECT project.id, project."ownerId"
+    FROM "Project" project
+    WHERE project.id = target_project_id
+      AND (
+        project."ownerId" = app.current_user_id()
+        OR EXISTS (
+          SELECT 1
+          FROM "ProjectMembership" access_membership
+          WHERE access_membership."projectId" = project.id
+            AND access_membership."userId" = app.current_user_id()
+        )
+      )
+  ),
+  project_humans AS (
+    SELECT accessible_project."ownerId" AS "userId"
+    FROM accessible_project
+    UNION
+    SELECT membership."userId"
+    FROM accessible_project
+    JOIN "ProjectMembership" membership
+      ON membership."projectId" = accessible_project.id
+  )
+  SELECT
+    'human'::TEXT AS "kind",
+    project_user.id AS "actorId",
+    project_user.name,
+    project_user.email,
+    project_user.username::TEXT,
+    project_user."usernameDiscriminator"::TEXT,
+    project_user."avatarSeed"::TEXT,
+    NULL::TEXT AS "label",
+    NULL::TIMESTAMP(3) AS "revokedAt",
+    NULL::TIMESTAMP(3) AS "expiresAt"
+  FROM project_humans
+  JOIN "User" project_user ON project_user.id = project_humans."userId"
+  UNION ALL
+  SELECT
+    'agent'::TEXT AS "kind",
+    credential.id AS "actorId",
+    NULL::TEXT AS "name",
+    NULL::TEXT AS "email",
+    NULL::TEXT AS "username",
+    NULL::TEXT AS "usernameDiscriminator",
+    NULL::TEXT AS "avatarSeed",
+    credential.label::TEXT,
+    credential."revokedAt",
+    credential."expiresAt"
+  FROM accessible_project
+  JOIN "ApiCredential" credential
+    ON credential."projectId" = accessible_project.id;
+$$;
+
+REVOKE ALL ON FUNCTION app.list_project_context_card_actors(TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION app.list_project_context_card_actors(TEXT) TO PUBLIC;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,6 +47,9 @@ model User {
   meetingTodoActionsCreated   ProjectMeetingNoteAction[]      @relation("MeetingTodoCreatedByUser")
   meetingTodoActionsAssigned  ProjectMeetingNoteAction[]      @relation("MeetingTodoAssignedToUser")
   meetingTodoActionsCompleted ProjectMeetingNoteAction[]      @relation("MeetingTodoCompletedByUser")
+  contextCardsCreated         Resource[]                      @relation("ContextCardCreatedByUser")
+  contextCardsLastEdited      Resource[]                      @relation("ContextCardLastEditedByUser")
+  contextCardsStewarded       Resource[]                      @relation("ContextCardStewardedUser")
 
   @@unique([username, usernameDiscriminator])
   @@index([username])
@@ -174,6 +177,11 @@ enum ProjectMembershipRole {
 }
 
 enum MeetingTodoActorKind {
+  human
+  agent
+}
+
+enum ContextCardActorKind {
   human
   agent
 }
@@ -591,17 +599,44 @@ model TaskRelation {
 }
 
 model Resource {
-  id          String               @id @default(cuid())
-  type        String
-  name        String
-  content     String
-  color       String?
-  projectId   String
-  project     Project              @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  attachments ResourceAttachment[]
-  createdAt   DateTime             @default(now())
+  id                            String                @id @default(cuid())
+  type                          String
+  name                          String
+  content                       String
+  color                         String?
+  projectId                     String
+  project                       Project               @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  attachments                   ResourceAttachment[]
+  createdByUserId               String?
+  createdByCredentialId         String?
+  creatorKind                   ContextCardActorKind  @default(human)
+  creatorDisplayNameSnapshot    String                @default("Unknown actor") @db.VarChar(80)
+  lastEditedByUserId            String?
+  lastEditedByCredentialId      String?
+  lastEditorKind                ContextCardActorKind?
+  lastEditorDisplayNameSnapshot String?               @db.VarChar(80)
+  stewardUserId                 String?
+  stewardCredentialId           String?
+  stewardKind                   ContextCardActorKind?
+  stewardDisplayNameSnapshot    String?               @db.VarChar(80)
+  createdAt                     DateTime              @default(now())
+  updatedAt                     DateTime              @updatedAt
+
+  createdByUser          User?          @relation("ContextCardCreatedByUser", fields: [createdByUserId], references: [id], onDelete: SetNull)
+  createdByCredential    ApiCredential? @relation("ContextCardCreatedByCredential", fields: [createdByCredentialId], references: [id], onDelete: SetNull)
+  lastEditedByUser       User?          @relation("ContextCardLastEditedByUser", fields: [lastEditedByUserId], references: [id], onDelete: SetNull)
+  lastEditedByCredential ApiCredential? @relation("ContextCardLastEditedByCredential", fields: [lastEditedByCredentialId], references: [id], onDelete: SetNull)
+  stewardUser            User?          @relation("ContextCardStewardedUser", fields: [stewardUserId], references: [id], onDelete: SetNull)
+  stewardCredential      ApiCredential? @relation("ContextCardStewardedCredential", fields: [stewardCredentialId], references: [id], onDelete: SetNull)
 
   @@index([projectId])
+  @@index([createdByUserId])
+  @@index([createdByCredentialId])
+  @@index([lastEditedByUserId])
+  @@index([lastEditedByCredentialId])
+  @@index([stewardUserId])
+  @@index([stewardCredentialId])
+  @@index([projectId, updatedAt])
 }
 
 model TaskAttachment {
@@ -623,18 +658,20 @@ model TaskAttachment {
 }
 
 model ResourceAttachment {
-  id               String   @id @default(cuid())
-  resourceId       String
-  uploadedByUserId String
-  resource         Resource @relation(fields: [resourceId], references: [id], onDelete: Cascade)
-  uploadedBy       User     @relation("ResourceAttachmentUploader", fields: [uploadedByUserId], references: [id], onDelete: Cascade)
-  kind             String
-  name             String
-  url              String?
-  storageKey       String?
-  mimeType         String?
-  sizeBytes        Int?
-  createdAt        DateTime @default(now())
+  id                            String               @id @default(cuid())
+  resourceId                    String
+  uploadedByUserId              String
+  uploadedByKind                ContextCardActorKind @default(human)
+  uploadedByDisplayNameSnapshot String               @default("Unknown uploader") @db.VarChar(80)
+  resource                      Resource             @relation(fields: [resourceId], references: [id], onDelete: Cascade)
+  uploadedBy                    User                 @relation("ResourceAttachmentUploader", fields: [uploadedByUserId], references: [id], onDelete: Cascade)
+  kind                          String
+  name                          String
+  url                           String?
+  storageKey                    String?
+  mimeType                      String?
+  sizeBytes                     Int?
+  createdAt                     DateTime             @default(now())
 
   @@index([resourceId])
   @@index([uploadedByUserId])
@@ -729,6 +766,9 @@ model ApiCredential {
   meetingTodoActionsCreated   ProjectMeetingNoteAction[] @relation("MeetingTodoCreatedByCredential")
   meetingTodoActionsAssigned  ProjectMeetingNoteAction[] @relation("MeetingTodoAssignedToCredential")
   meetingTodoActionsCompleted ProjectMeetingNoteAction[] @relation("MeetingTodoCompletedByCredential")
+  contextCardsCreated         Resource[]                 @relation("ContextCardCreatedByCredential")
+  contextCardsLastEdited      Resource[]                 @relation("ContextCardLastEditedByCredential")
+  contextCardsStewarded       Resource[]                 @relation("ContextCardStewardedCredential")
 
   @@index([projectId])
   @@index([createdByUserId])

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -340,9 +340,10 @@ Last reviewed: 2026-08-24
   Dependencies: TASK-325, TASK-326, TASK-327, TASK-337, TASK-344
 - ID: TASK-342
   Title: Context knowledge stewardship and attachment provenance
-  Status: P2 - shared knowledge accountability
+  Status: Done 2026-08-09 - shared knowledge accountability
   Rationale: Add a visible, reassignable knowledge steward plus creator, last editor, update time, and review or staleness state to context cards. Surface the already-stored attachment uploader, record attachment lifecycle events, and retain provenance through member removal without turning every reader into an owner.
   Dependencies: TASK-004, TASK-065, TASK-337, TASK-340
+  Brief: `tasks/task-342-context-knowledge-stewardship.md`
 - ID: TASK-343
   Title: Epic leadership and initiative accountability
   Status: P2 - initiative ownership

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,84 +1,114 @@
 # Current Task
 
-## TASK-370: Preview Authentication and Database Isolation Guardrails
+## TASK-342: Context Knowledge Stewardship and Attachment Provenance
 
 ## Status
 
-Complete on `fix/task-370-preview-auth-isolation`; validated on the immutable
-Vercel Preview deployment and delivered through PR #432.
+Implementation complete on
+`feature/task-342-context-knowledge-stewardship`; ready for review.
 
 ## Context
 
-Authentication from a URL believed to be a preview reached production and a
-signup reported an email already present in the production user database.
-Investigation confirmed that the tested Vercel alias currently targets a
-production deployment. The Vercel Preview environment also retained that alias
-as `NEXTAUTH_URL`, so preview auth callbacks and generated links could select a
-stale production origin even when the immutable deployment itself was a real
-preview. Preview and production currently use distinct Supabase project refs,
-but the deployment contract does not pin either environment to its intended
-ref or verify the deployed target before publishing the preview URL.
+Context cards today expose only title, color, content, and attachments. There
+is no record of who created the card, who last edited it, who is accountable
+for keeping it current, or which collaborator uploaded each attachment. A card
+written by a former project member or agent looks identical to a fresh card
+written yesterday, and a contributor with deep context for a knowledge area has
+no visible accountability trail.
+
+TASK-337's universal project-actor model is not implemented yet. This task
+introduces a deliberately narrow, reusable context-card actor contract for
+human project members and active project agent credentials — mirroring the
+TASK-330 meeting-todo pattern — without expanding into cross-artifact ownership
+or a shared scheduling system.
 
 ## Scope
 
-- Resolve request origins from the current immutable Vercel deployment host in
-  preview instead of using a static `NEXTAUTH_URL`.
-- Pin production-like runtimes to an explicitly configured expected Supabase
-  project ref and reject cross-environment database routing at startup.
-- Validate the preview migration target, Vercel deployment target, deployed
-  environment/revision metadata, and database readiness before uploading the
-  preview URL artifact.
-- Remove stale Vercel Preview origin/redirect overrides (`NEXTAUTH_URL` and
-  OAuth callback URLs) and configure expected project-ref metadata for Preview
-  and Production.
-- Exercise signup/signin on the fixed preview without touching production.
+- Persist durable creator, last editor, and optional steward identity for every
+  context card, including safe display snapshots.
+- Backfill existing card creators from existing provenance (the resource
+  `createdAt` is preserved and remains the immutable creation timestamp).
+- Allow steward assignment only to current project members or active, unexpired
+  project agent credentials. External meeting guests are not assignment
+  candidates (context cards do not use the meeting-participant model).
+- Display inactive/revoked stewards as needing reassignment instead of
+  silently converting them to unassigned, exactly like the meeting-todo
+  assignee chip.
+- Surface the already-stored attachment uploader (human identity and display
+  snapshot) on context card attachments so each link/file shows who added it.
+- Show a derived `Needs review` signal based on the time since the last edit so
+  long-untouched cards are easy to spot.
+- Add accessible steward controls in the edit modal and preview modal, plus a
+  reusable steward chip in the dashboard grid, and surface creator/last editor
+  metadata in the preview footer.
+
+## Out Of Scope
+
+- A universal actor table or cross-artifact actor migration (TASK-337).
+- Cross-project knowledge responsibility queues (TASK-346).
+- New agent capability vocabulary or granular context scopes (TASK-331).
+- Assignment notifications or preference controls beyond what the existing
+  in-product surfaces already expose (TASK-347).
+- Edit locking or revision preconditions on context cards (TASK-339).
+- Persisting a full attachment-lifecycle event log. The migration adds
+  `uploadedByKind` and `uploadedByDisplayNameSnapshot` to `ResourceAttachment`
+  so future producers can rely on a stable contract; existing rows backfill
+  `uploadedByKind = human` from the `uploadedByUserId` foreign key.
 
 ## Acceptance Criteria
 
-1. A preview request resolves auth callback/link origins to that preview's
-   immutable `VERCEL_URL`, never the production domain or a stale alias.
-2. Preview and production fail closed when their runtime Supabase project ref
-   does not match `EXPECTED_SUPABASE_PROJECT_REF`.
-3. The preview deploy workflow rejects a non-preview Vercel target, a revision
-   mismatch, an environment mismatch, an unreachable database, or a migration
-   connection aimed at the wrong Supabase project.
-4. The workflow artifact contains the immutable URL of the exact requested
-   branch deployment only after all preview checks pass.
-5. A new account can sign up and sign back in on the fixed preview while the
-   browser remains on the preview origin.
-6. Existing production routing and trusted-origin behavior remain unchanged.
+1. Each context card exposes creator, last editor, optional steward, and
+   review/staleness state, with actor kind, stable identifier, display label,
+   avatar treatment, and current access state.
+2. New cards record creator, last editor, and steward-eligible assignment on
+   creation. Existing cards backfill creator and last editor from existing
+   provenance (when present) and otherwise expose `Unknown actor` snapshots
+   that are clearly labeled inactive so they cannot be confused with live
+   collaborators. Editing a card advances the last editor but never replaces
+   creator identity.
+3. Editors and owners can assign or clear a steward from the edit modal and
+   the preview modal using a labeled, keyboard-operable control with pending
+   and error feedback; viewers see the same identity information without
+   mutation affordances.
+4. Steward assignment validation is enforced in the service boundary. Human
+   candidates must currently own or belong to the project; agent candidates
+   must be active, unexpired credentials for that project. Assignment never
+   grants access.
+5. Removed human members and revoked/expired agents remain visibly attached to
+   their card as inactive and are labeled `Needs reassignment` until cleared
+   or reassigned.
+6. Each context-card attachment shows the recorded uploader with a stable
+   display label and avatar treatment. Attachments uploaded by removed human
+   members or revoked agents continue to show their original identity and
+   are labeled as no longer project-active.
+7. Each context card surfaces a derived `Needs review` signal when it has not
+   been edited for a configurable threshold (default 90 days). The signal is
+   visible in the dashboard grid, the preview modal, and the edit modal; it
+   clears automatically when the card is edited.
+8. UI remains usable at 375px and desktop widths, in light and dark themes,
+   with visible focus, semantic status text, at least 44px primary touch
+   targets, and no color-only stewardship or review state.
 
 ## Definition Of Done
 
-- Focused origin, runtime-environment, health-route, and deploy-validation
-  coverage passes.
+- Prisma schema, migration, RLS inventory, services, routes, UI projections,
+  attachment uploader display, review/staleness signal, and relevant
+  documentation are updated together.
+- Focused unit, service, route, component, and Playwright coverage exercises
+  human/agent steward assignment, invalid actors, inactive states, attachment
+  uploader display, review-state derivation, role restrictions, and
+  optimistic mutation.
 - `npm run lint`, `npm run rls:check`, `npm test`, `npm run test:coverage`,
-  `npm run build`, and relevant deployed-preview Playwright checks pass.
-- Vercel/GitHub environment metadata is configured without exposing secrets.
-- The branch preview workflow completes for the explicit branch ref and its
-  logs prove the checked-out ref and validated Preview target.
-- A ready-for-review PR is open; required checks and initial Copilot review are
-  complete; actionable threads are resolved before merge.
-- `tasks/current.md`, `tasks/backlog.md`, relevant runbooks, and `journal.md`
-  record the diagnosis and validation outcome.
+  `npm run build`, and a focused context-card Playwright coverage pass.
+- `tasks/current.md`, `tasks/backlog.md`, `tasks/task-342-context-knowledge-stewardship.md`,
+  and `journal.md` reflect the delivered behavior.
+- The branch is pushed, a ready-for-review PR is open, required checks are
+  green, and initial Copilot review feedback is resolved or documented.
 
 ## Runtime Assumptions
 
-- Preview and production remain separate Supabase projects; their project refs
-  are safe non-secret deployment metadata while connection strings stay secret.
-- GitHub `preview` and `production` environments and the corresponding Vercel
-  environments are available to configure `EXPECTED_SUPABASE_PROJECT_REF`.
-- Preview validation uses the immutable URL emitted by `deploy-vercel.yml`, not
-  a branch alias or a historical Vercel URL.
-
-## Validation Evidence
-
-- Workflow run `32313383142` checked out the explicit fix branch, applied
-  staging migrations, verified Preview target/revision/environment/database
-  readiness, and published
-  `https://nexus-dash-h1s18isxe-dorian-agaesses-projects.vercel.app`.
-- The deployed opt-in Playwright case created a staging account, signed out,
-  signed back in, and remained on that immutable origin.
-- Lint, RLS inventory, unit/API, coverage, build, and CI Playwright validation
-  passed. Copilot's initial review completed; its environment-restoration
-  comment was applied and covered by the focused request-origin test.
+- Local database-backed validation uses the repository `.env` contract and a
+  reachable PostgreSQL instance when migration or E2E execution requires it.
+- No new secrets or external provider configuration are introduced.
+- Preview deployment is not an acceptance requirement; local browser coverage
+  is sufficient unless review feedback exposes a preview-only concern.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -78,9 +78,9 @@ or a shared scheduling system.
    their card as inactive and are labeled `Needs reassignment` until cleared
    or reassigned.
 6. Each context-card attachment shows the recorded uploader with a stable
-   display label and avatar treatment. Attachments uploaded by removed human
-   members or revoked agents continue to show their original identity and
-   are labeled as no longer project-active.
+   display label and avatar treatment. Attachments uploaded by removed
+   human members continue to show their original identity and are labeled
+   as no longer project-active.
 7. Each context card surfaces a derived `Needs review` signal when it has not
    been edited for a configurable threshold (default 90 days). The signal is
    visible in the dashboard grid, the preview modal, and the edit modal; it

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -5,7 +5,8 @@
 ## Status
 
 Implementation complete on
-`feature/task-342-context-knowledge-stewardship`; ready for review.
+`feature/task-342-context-knowledge-stewardship-r3` in replacement PR #446;
+ready for review.
 
 ## Context
 

--- a/tasks/task-342-context-knowledge-stewardship.md
+++ b/tasks/task-342-context-knowledge-stewardship.md
@@ -1,0 +1,45 @@
+# TASK-342: Context Knowledge Stewardship and Attachment Provenance
+
+## Status
+
+Implementation in progress on
+`feature/task-342-context-knowledge-stewardship`.
+
+## Product Outcome
+
+Context cards become accountable knowledge artifacts: collaborators can see who
+created, last edited, and stewards each card; understand which attachments each
+collaborator uploaded; reassign stewardship without losing identity history; and
+recognize cards that need a fresh review because they have not been touched in
+a long time.
+
+## Design Notes
+
+- Stewardship is a separate concept from edit capability. Editors and owners can
+  still edit any card, but stewards are the visible accountable human or active
+  project agent credential that owns the knowledge the card captures.
+- The actor contract reuses the narrow human/agent pattern shipped by TASK-330,
+  so this task delivers knowledge accountability without waiting on the broader
+  TASK-337 universal project actor foundation.
+- Creator, last editor, and steward identity are durable display snapshots so
+  removed human members or revoked agents still appear with their original
+  label, plus an explicit `Needs reassignment` flag, instead of silently
+  converting to an unassigned state.
+- Attachment uploader identity is recorded at create time using the same
+  display snapshot strategy, so historical context-card attachment provenance
+  survives user removal and credential revocation.
+- Review / staleness state is derived, not editable: a card is "needs review"
+  when it has not been edited for a configurable number of days. The signal is
+  visible everywhere the card is shown without forcing editors to maintain it
+  by hand.
+- Stewardship and review signals are visible to every project member; only
+  editors and owners can change the steward. Viewers see the same identity
+  information without mutation affordances.
+
+## Acceptance Criteria
+
+See [`current.md`](./current.md#acceptance-criteria).
+
+## Definition Of Done
+
+See [`current.md`](./current.md#definition-of-done).

--- a/tests/api/agent-project-routes.test.ts
+++ b/tests/api/agent-project-routes.test.ts
@@ -26,6 +26,11 @@ const contextCardServiceMock = vi.hoisted(() => ({
   createContextCardForProject: vi.fn(),
 }));
 
+const contextCardStewardshipServiceMock = vi.hoisted(() => ({
+  loadContextCardActorRegistryForProject: vi.fn(),
+  projectContextCard: vi.fn(),
+}));
+
 vi.mock("@/lib/auth/api-guard", () => ({
   getAgentProjectAccessContext: apiGuardMock.getAgentProjectAccessContext,
   requireApiPrincipal: apiGuardMock.requireApiPrincipal,
@@ -50,6 +55,12 @@ vi.mock("@/lib/services/project-task-service", () => ({
 
 vi.mock("@/lib/services/context-card-service", () => ({
   createContextCardForProject: contextCardServiceMock.createContextCardForProject,
+}));
+
+vi.mock("@/lib/services/context-card-stewardship-service", () => ({
+  loadContextCardActorRegistryForProject:
+    contextCardStewardshipServiceMock.loadContextCardActorRegistryForProject,
+  projectContextCard: contextCardStewardshipServiceMock.projectContextCard,
 }));
 
 vi.mock("@/lib/services/project-attachment-service", () => ({
@@ -103,6 +114,12 @@ describe("agent project routes", () => {
       scopes: ["project:read", "task:read", "context:read"],
     });
     projectAccessServiceMock.requireAgentProjectScopes.mockReturnValue({ ok: true });
+    contextCardStewardshipServiceMock.loadContextCardActorRegistryForProject.mockResolvedValue(
+      { assignable: [] }
+    );
+    contextCardStewardshipServiceMock.projectContextCard.mockReturnValue({
+      needsReview: false,
+    });
   });
 
   test("GET /api/projects/:projectId returns project summary for valid agent scope", async () => {
@@ -334,7 +351,8 @@ describe("agent project routes", () => {
         name: "Sprint notes",
         content: "<p>Rich text</p>",
         color: "#abc",
-        createdAt: "2026-03-31T09:00:00.000Z",
+        createdAt: new Date("2026-03-31T09:00:00.000Z"),
+        updatedAt: new Date("2026-03-31T10:00:00.000Z"),
         attachments: [
           {
             id: "context-att-1",
@@ -362,6 +380,7 @@ describe("agent project routes", () => {
           content: "<p>Rich text</p>",
           color: "#abc",
           createdAt: "2026-03-31T09:00:00.000Z",
+          updatedAt: "2026-03-31T10:00:00.000Z",
           attachments: [
             {
               id: "context-att-1",
@@ -374,8 +393,12 @@ describe("agent project routes", () => {
                 "/api/projects/project-1/context-cards/card-1/attachments/context-att-1/download",
             },
           ],
+          projection: {
+            needsReview: false,
+          },
         },
       ],
+      assignableActors: [],
     });
     expect(projectAccessServiceMock.requireAgentProjectScopes).toHaveBeenCalledWith({
       agentAccess: undefined,

--- a/tests/api/context-card-stewardship.route.test.ts
+++ b/tests/api/context-card-stewardship.route.test.ts
@@ -28,6 +28,17 @@ async function readJson(response: Response): Promise<Record<string, unknown>> {
   return (await response.json()) as Record<string, unknown>;
 }
 
+function buildProjection(lastEditedAt: Date, steward: Record<string, unknown> | null) {
+  return {
+    id: "card-1",
+    creator: null,
+    lastEditor: null,
+    steward,
+    review: { needsReview: false, thresholdDays: 90, lastEditedAt },
+    attachments: [],
+  };
+}
+
 describe("context card stewardship route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -44,22 +55,25 @@ describe("context card stewardship route", () => {
 
   test("assigns a human steward", async () => {
     const lastEditedAt = new Date("2026-07-20T12:00:00.000Z");
+    const steward = {
+      kind: "human",
+      id: "user-1",
+      displayName: "Ada",
+      usernameTag: "ada#0001",
+      avatarSeed: "seed-ada",
+      status: "active",
+      isAssignable: true,
+    };
     stewardshipServiceMock.assignContextCardSteward.mockResolvedValueOnce({
       ok: true,
       data: {
         cardId: "card-1",
-        steward: {
-          kind: "human",
-          id: "user-1",
-          displayName: "Ada",
-          usernameTag: "ada#0001",
-          avatarSeed: "seed-ada",
-          status: "active",
-          isAssignable: true,
-        },
+        steward,
         needsReview: false,
         thresholdDays: 90,
         lastEditedAt,
+        updatedAt: lastEditedAt,
+        projection: buildProjection(lastEditedAt, steward),
       },
     });
 
@@ -94,6 +108,7 @@ describe("context card stewardship route", () => {
   });
 
   test("clears the steward when null is sent", async () => {
+    const lastEditedAt = new Date("2026-04-01T00:00:00.000Z");
     stewardshipServiceMock.assignContextCardSteward.mockResolvedValueOnce({
       ok: true,
       data: {
@@ -101,7 +116,12 @@ describe("context card stewardship route", () => {
         steward: null,
         needsReview: true,
         thresholdDays: 90,
-        lastEditedAt: new Date("2026-04-01T00:00:00.000Z"),
+        lastEditedAt,
+        updatedAt: lastEditedAt,
+        projection: {
+          ...buildProjection(lastEditedAt, null),
+          review: { needsReview: true, thresholdDays: 90, lastEditedAt },
+        },
       },
     });
 
@@ -176,6 +196,27 @@ describe("context card stewardship route", () => {
         method: "PATCH",
         headers: { "content-type": "application/json" },
         body: "{",
+      }
+    );
+
+    const response = await PATCH(request as never, {
+      params: { projectId: "p1", cardId: "card-1" },
+    });
+
+    expect(response.status).toBe(400);
+    await expect(readJson(response)).resolves.toEqual({
+      error: "Invalid JSON payload",
+    });
+    expect(stewardshipServiceMock.assignContextCardSteward).not.toHaveBeenCalled();
+  });
+
+  test("rejects a JSON null body", async () => {
+    const request = new Request(
+      "http://localhost/api/projects/p1/context-cards/card-1/stewardship",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: "null",
       }
     );
 

--- a/tests/api/context-card-stewardship.route.test.ts
+++ b/tests/api/context-card-stewardship.route.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {},
+}));
+
+const apiGuardMock = vi.hoisted(() => ({
+  getAgentProjectAccessContext: vi.fn(),
+  requireApiPrincipal: vi.fn(),
+}));
+
+const stewardshipServiceMock = vi.hoisted(() => ({
+  assignContextCardSteward: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/api-guard", () => ({
+  getAgentProjectAccessContext: apiGuardMock.getAgentProjectAccessContext,
+  requireApiPrincipal: apiGuardMock.requireApiPrincipal,
+}));
+
+vi.mock("@/lib/services/context-card-stewardship-service", () => ({
+  assignContextCardSteward: stewardshipServiceMock.assignContextCardSteward,
+}));
+
+import { PATCH } from "@/app/api/projects/[projectId]/context-cards/[cardId]/stewardship/route";
+
+async function readJson(response: Response): Promise<Record<string, unknown>> {
+  return (await response.json()) as Record<string, unknown>;
+}
+
+describe("context card stewardship route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiGuardMock.requireApiPrincipal.mockResolvedValue({
+      ok: true,
+      principal: {
+        kind: "human",
+        actorUserId: "test-user",
+        requestId: "request-1",
+      },
+    });
+    apiGuardMock.getAgentProjectAccessContext.mockReturnValue(undefined);
+  });
+
+  test("assigns a human steward", async () => {
+    const lastEditedAt = new Date("2026-07-20T12:00:00.000Z");
+    stewardshipServiceMock.assignContextCardSteward.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        cardId: "card-1",
+        steward: {
+          kind: "human",
+          id: "user-1",
+          displayName: "Ada",
+          usernameTag: "ada#0001",
+          avatarSeed: "seed-ada",
+          status: "active",
+          isAssignable: true,
+        },
+        needsReview: false,
+        thresholdDays: 90,
+        lastEditedAt,
+      },
+    });
+
+    const request = new Request(
+      "http://localhost/api/projects/p1/context-cards/card-1/stewardship",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ steward: { kind: "human", id: "user-1" } }),
+      }
+    );
+
+    const response = await PATCH(request as never, {
+      params: { projectId: "p1", cardId: "card-1" },
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await readJson(response);
+    expect(payload.steward).toMatchObject({ kind: "human", id: "user-1" });
+    expect(payload.review).toMatchObject({
+      needsReview: false,
+      thresholdDays: 90,
+      lastEditedAt: lastEditedAt.toISOString(),
+    });
+    expect(stewardshipServiceMock.assignContextCardSteward).toHaveBeenCalledWith({
+      actorUserId: "test-user",
+      projectId: "p1",
+      cardId: "card-1",
+      steward: { kind: "human", id: "user-1" },
+      agentAccess: undefined,
+    });
+  });
+
+  test("clears the steward when null is sent", async () => {
+    stewardshipServiceMock.assignContextCardSteward.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        cardId: "card-1",
+        steward: null,
+        needsReview: true,
+        thresholdDays: 90,
+        lastEditedAt: new Date("2026-04-01T00:00:00.000Z"),
+      },
+    });
+
+    const request = new Request(
+      "http://localhost/api/projects/p1/context-cards/card-1/stewardship",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ steward: null }),
+      }
+    );
+
+    const response = await PATCH(request as never, {
+      params: { projectId: "p1", cardId: "card-1" },
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await readJson(response);
+    expect(payload.steward).toBeNull();
+    expect(payload.review).toMatchObject({ needsReview: true });
+    expect(stewardshipServiceMock.assignContextCardSteward).toHaveBeenCalledWith(
+      expect.objectContaining({ steward: null })
+    );
+  });
+
+  test("rejects malformed steward references", async () => {
+    const request = new Request(
+      "http://localhost/api/projects/p1/context-cards/card-1/stewardship",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ steward: { kind: "robot", id: "x" } }),
+      }
+    );
+
+    const response = await PATCH(request as never, {
+      params: { projectId: "p1", cardId: "card-1" },
+    });
+
+    expect(response.status).toBe(400);
+    await expect(readJson(response)).resolves.toEqual({
+      error: "context-card-steward-invalid",
+    });
+    expect(stewardshipServiceMock.assignContextCardSteward).not.toHaveBeenCalled();
+  });
+
+  test("rejects requests that omit the steward key", async () => {
+    const request = new Request(
+      "http://localhost/api/projects/p1/context-cards/card-1/stewardship",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      }
+    );
+
+    const response = await PATCH(request as never, {
+      params: { projectId: "p1", cardId: "card-1" },
+    });
+
+    expect(response.status).toBe(400);
+    await expect(readJson(response)).resolves.toEqual({
+      error: "context-card-stewardship-missing",
+    });
+    expect(stewardshipServiceMock.assignContextCardSteward).not.toHaveBeenCalled();
+  });
+
+  test("rejects invalid JSON payloads", async () => {
+    const request = new Request(
+      "http://localhost/api/projects/p1/context-cards/card-1/stewardship",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: "{",
+      }
+    );
+
+    const response = await PATCH(request as never, {
+      params: { projectId: "p1", cardId: "card-1" },
+    });
+
+    expect(response.status).toBe(400);
+    await expect(readJson(response)).resolves.toEqual({
+      error: "Invalid JSON payload",
+    });
+    expect(stewardshipServiceMock.assignContextCardSteward).not.toHaveBeenCalled();
+  });
+
+  test("propagates service errors", async () => {
+    stewardshipServiceMock.assignContextCardSteward.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      error: "context-card-not-found",
+    });
+
+    const request = new Request(
+      "http://localhost/api/projects/p1/context-cards/card-1/stewardship",
+      {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ steward: null }),
+      }
+    );
+
+    const response = await PATCH(request as never, {
+      params: { projectId: "p1", cardId: "card-1" },
+    });
+
+    expect(response.status).toBe(404);
+    await expect(readJson(response)).resolves.toEqual({
+      error: "context-card-not-found",
+    });
+  });
+});

--- a/tests/api/context-cards-mutations.route.test.ts
+++ b/tests/api/context-cards-mutations.route.test.ts
@@ -11,6 +11,10 @@ const contextCardServiceMock = vi.hoisted(() => ({
   deleteContextCardForProject: vi.fn(),
 }));
 
+const activityEventResponseMock = vi.hoisted(() => ({
+  recordProjectActivityEventVersion: vi.fn(),
+}));
+
 vi.mock("@/lib/auth/api-guard", () => ({
   getAgentProjectAccessContext: apiGuardMock.getAgentProjectAccessContext,
   requireApiPrincipal: apiGuardMock.requireApiPrincipal,
@@ -20,6 +24,11 @@ vi.mock("@/lib/services/context-card-service", () => ({
   createContextCardForProject: contextCardServiceMock.createContextCardForProject,
   updateContextCardForProject: contextCardServiceMock.updateContextCardForProject,
   deleteContextCardForProject: contextCardServiceMock.deleteContextCardForProject,
+}));
+
+vi.mock("@/lib/project-activity-event-response", () => ({
+  recordProjectActivityEventVersion:
+    activityEventResponseMock.recordProjectActivityEventVersion,
 }));
 
 import { POST } from "@/app/api/projects/[projectId]/context-cards/route";
@@ -44,6 +53,9 @@ describe("context cards mutation routes", () => {
       },
     });
     apiGuardMock.getAgentProjectAccessContext.mockReturnValue(undefined);
+    activityEventResponseMock.recordProjectActivityEventVersion.mockResolvedValue(
+      new Date("2026-08-16T12:00:00.000Z")
+    );
   });
 
   test("POST creates context card from form payload", async () => {
@@ -129,7 +141,16 @@ describe("context cards mutation routes", () => {
   test("PATCH updates context card via service", async () => {
     contextCardServiceMock.updateContextCardForProject.mockResolvedValueOnce({
       ok: true,
-      data: { ok: true },
+      data: {
+        id: "c1",
+        title: "Updated title",
+        content: "<p>Updated content</p>",
+        color: "#def",
+        createdAt: new Date("2026-08-15T09:00:00.000Z"),
+        updatedAt: new Date("2026-08-16T12:00:00.000Z"),
+        attachments: [],
+        projection: { needsReview: false },
+      },
     });
 
     const formData = new FormData();
@@ -150,7 +171,18 @@ describe("context cards mutation routes", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(readJson(response)).resolves.toEqual({ ok: true });
+    await expect(readJson(response)).resolves.toEqual({
+      card: {
+        id: "c1",
+        title: "Updated title",
+        content: "<p>Updated content</p>",
+        color: "#def",
+        createdAt: "2026-08-15T09:00:00.000Z",
+        updatedAt: "2026-08-16T12:00:00.000Z",
+        attachments: [],
+        projection: { needsReview: false },
+      },
+    });
     expect(contextCardServiceMock.updateContextCardForProject).toHaveBeenCalledWith({
       actorUserId: "test-user",
       projectId: "p1",
@@ -165,7 +197,16 @@ describe("context cards mutation routes", () => {
   test("PATCH accepts json payloads", async () => {
     contextCardServiceMock.updateContextCardForProject.mockResolvedValueOnce({
       ok: true,
-      data: { ok: true },
+      data: {
+        id: "c1",
+        title: "Updated from JSON",
+        content: "<p>JSON body</p>",
+        color: "#def",
+        createdAt: new Date("2026-08-15T09:00:00.000Z"),
+        updatedAt: new Date("2026-08-16T12:00:00.000Z"),
+        attachments: [],
+        projection: { needsReview: false },
+      },
     });
 
     const request = new Request("http://localhost/api/projects/p1/context-cards/c1", {
@@ -185,7 +226,18 @@ describe("context cards mutation routes", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(readJson(response)).resolves.toEqual({ ok: true });
+    await expect(readJson(response)).resolves.toEqual({
+      card: {
+        id: "c1",
+        title: "Updated from JSON",
+        content: "<p>JSON body</p>",
+        color: "#def",
+        createdAt: "2026-08-15T09:00:00.000Z",
+        updatedAt: "2026-08-16T12:00:00.000Z",
+        attachments: [],
+        projection: { needsReview: false },
+      },
+    });
     expect(contextCardServiceMock.updateContextCardForProject).toHaveBeenCalledWith({
       actorUserId: "test-user",
       projectId: "p1",

--- a/tests/api/context-cards-mutations.route.test.ts
+++ b/tests/api/context-cards-mutations.route.test.ts
@@ -139,6 +139,15 @@ describe("context cards mutation routes", () => {
   });
 
   test("PATCH updates context card via service", async () => {
+    const lastEditedAt = new Date("2026-08-16T12:00:00.000Z");
+    const projection = {
+      id: "c1",
+      creator: null,
+      lastEditor: null,
+      steward: null,
+      review: { needsReview: false, thresholdDays: 90, lastEditedAt },
+      attachments: [],
+    };
     contextCardServiceMock.updateContextCardForProject.mockResolvedValueOnce({
       ok: true,
       data: {
@@ -149,7 +158,7 @@ describe("context cards mutation routes", () => {
         createdAt: new Date("2026-08-15T09:00:00.000Z"),
         updatedAt: new Date("2026-08-16T12:00:00.000Z"),
         attachments: [],
-        projection: { needsReview: false },
+        projection,
       },
     });
 
@@ -180,7 +189,13 @@ describe("context cards mutation routes", () => {
         createdAt: "2026-08-15T09:00:00.000Z",
         updatedAt: "2026-08-16T12:00:00.000Z",
         attachments: [],
-        projection: { needsReview: false },
+        projection: {
+          ...projection,
+          review: {
+            ...projection.review,
+            lastEditedAt: lastEditedAt.toISOString(),
+          },
+        },
       },
     });
     expect(contextCardServiceMock.updateContextCardForProject).toHaveBeenCalledWith({
@@ -195,6 +210,15 @@ describe("context cards mutation routes", () => {
   });
 
   test("PATCH accepts json payloads", async () => {
+    const lastEditedAt = new Date("2026-08-16T12:00:00.000Z");
+    const projection = {
+      id: "c1",
+      creator: null,
+      lastEditor: null,
+      steward: null,
+      review: { needsReview: false, thresholdDays: 90, lastEditedAt },
+      attachments: [],
+    };
     contextCardServiceMock.updateContextCardForProject.mockResolvedValueOnce({
       ok: true,
       data: {
@@ -205,7 +229,7 @@ describe("context cards mutation routes", () => {
         createdAt: new Date("2026-08-15T09:00:00.000Z"),
         updatedAt: new Date("2026-08-16T12:00:00.000Z"),
         attachments: [],
-        projection: { needsReview: false },
+        projection,
       },
     });
 
@@ -235,7 +259,13 @@ describe("context cards mutation routes", () => {
         createdAt: "2026-08-15T09:00:00.000Z",
         updatedAt: "2026-08-16T12:00:00.000Z",
         attachments: [],
-        projection: { needsReview: false },
+        projection: {
+          ...projection,
+          review: {
+            ...projection.review,
+            lastEditedAt: lastEditedAt.toISOString(),
+          },
+        },
       },
     });
     expect(contextCardServiceMock.updateContextCardForProject).toHaveBeenCalledWith({

--- a/tests/components/context-card-steward-controls.test.tsx
+++ b/tests/components/context-card-steward-controls.test.tsx
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("next/image", async () => {
+  const ReactModule = await import("react");
+  return {
+    default: (props: Record<string, unknown>) => {
+      const { unoptimized, ...imageProps } = props;
+      void unoptimized;
+      return ReactModule.createElement("img", imageProps);
+    },
+  };
+});
+
+import { ContextCardActorChip } from "@/components/context-panel/context-card-actor-chip";
+import { ContextCardStewardPicker } from "@/components/context-panel/context-card-steward-picker";
+import { ContextPreviewModal } from "@/components/context-panel/context-preview-modal";
+import type {
+  ProjectContextActorSummary,
+  ProjectContextCard,
+} from "@/components/project-context-panel-types";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const human: ProjectContextActorSummary = {
+  kind: "human",
+  id: "user-1",
+  displayName: "Ada",
+  usernameTag: "ada#0001",
+  avatarSeed: "seed-ada",
+  status: "active",
+  isAssignable: true,
+};
+
+const inactiveAgent: ProjectContextActorSummary = {
+  kind: "agent",
+  id: "agent-1",
+  displayName: "Release bot",
+  usernameTag: null,
+  avatarSeed: null,
+  status: "revoked",
+  isAssignable: false,
+};
+
+const card: ProjectContextCard = {
+  id: "card-1",
+  title: "Launch context",
+  content: "<p>Notes</p>",
+  color: "#ffffff",
+  createdAt: "2026-08-01T00:00:00.000Z",
+  updatedAt: "2026-08-01T00:00:00.000Z",
+  attachments: [],
+  projection: {
+    id: "card-1",
+    creator: human,
+    lastEditor: human,
+    steward: null,
+    review: {
+      needsReview: true,
+      thresholdDays: 90,
+      lastEditedAt: "2026-05-01T00:00:00.000Z",
+    },
+    attachments: [],
+  },
+};
+
+function createRenderer(): { root: Root; container: HTMLDivElement } {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  return { root: createRoot(container), container };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("context card steward controls", () => {
+  test("supports keyboard assignment and clearing with an accessible name", async () => {
+    const onChange = vi.fn();
+    const { root } = createRenderer();
+    await act(async () => {
+      root.render(
+        <ContextCardStewardPicker
+          actors={[human]}
+          selected={null}
+          cleared
+          disabled={false}
+          onChange={onChange}
+        />
+      );
+    });
+
+    const trigger = document.querySelector<HTMLButtonElement>(
+      "button[aria-label='Knowledge steward, current selection: Unassigned']"
+    );
+    expect(trigger).not.toBeNull();
+    await act(async () => trigger?.click());
+
+    const search = document.querySelector<HTMLInputElement>("[role='combobox']");
+    await act(async () => {
+      search?.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    });
+    await act(async () => {
+      search?.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+    expect(onChange).toHaveBeenCalledWith(human);
+
+    await act(async () => {
+      document.querySelector<HTMLButtonElement>("button[aria-label='Clear steward']")?.click();
+    });
+    expect(onChange).toHaveBeenLastCalledWith(null);
+    await act(async () => root.unmount());
+  });
+
+  test("disables assignment while a stewardship mutation is pending", async () => {
+    const onChange = vi.fn();
+    const { root } = createRenderer();
+    await act(async () => {
+      root.render(
+        <ContextCardStewardPicker
+          actors={[human]}
+          selected={human}
+          cleared={false}
+          disabled
+          onChange={onChange}
+        />
+      );
+    });
+    expect(
+      document.querySelector<HTMLButtonElement>("button[aria-haspopup='listbox']")?.disabled
+    ).toBe(true);
+    expect(document.querySelector<HTMLButtonElement>("button[aria-label='Clear steward']")?.disabled).toBe(true);
+    await act(async () => root.unmount());
+  });
+
+  test("uses actor avatars and calls out inactive stewards", async () => {
+    const { root } = createRenderer();
+    await act(async () => {
+      root.render(
+        <ContextCardActorChip
+          actor={inactiveAgent}
+          fallback="Unassigned"
+          needsReassignment
+        />
+      );
+    });
+    expect(document.body.textContent).toContain("Needs reassignment");
+    expect(document.querySelector("[data-agent-avatar='true']")).not.toBeNull();
+    await act(async () => root.unmount());
+  });
+
+  test("keeps viewer previews read-only and exposes editor errors as alerts", async () => {
+    const { root } = createRenderer();
+    const props = {
+      isOpen: true,
+      card,
+      attachments: [],
+      assignableActors: [human],
+      isUpdatingSteward: false,
+      onClose: vi.fn(),
+      onEdit: vi.fn(),
+      onSelectSteward: vi.fn(),
+      onPreviewAttachment: vi.fn(),
+    };
+    await act(async () => {
+      root.render(<ContextPreviewModal {...props} canEdit={false} stewardError={null} />);
+    });
+    expect(document.querySelector("button[aria-haspopup='listbox']")).toBeNull();
+
+    await act(async () => {
+      root.render(
+        <ContextPreviewModal
+          {...props}
+          canEdit
+          stewardError="Could not update knowledge steward."
+        />
+      );
+    });
+    expect(document.querySelector("button[aria-haspopup='listbox']")).not.toBeNull();
+    expect(document.querySelector("[role='alert']")?.textContent).toContain(
+      "Could not update knowledge steward."
+    );
+    await act(async () => root.unmount());
+  });
+});

--- a/tests/lib/context-card-actor-service.test.ts
+++ b/tests/lib/context-card-actor-service.test.ts
@@ -23,6 +23,7 @@ vi.mock("@/lib/services/project-access-service", () => ({
 }));
 
 import {
+  loadContextCardActorRegistry,
   mapStoredContextCardActor,
   resolveAssignableContextCardActorFromRegistry,
 } from "@/lib/services/context-card-actor-service";
@@ -218,5 +219,50 @@ describe("context-card-actor-service registry resolver", () => {
       status: 400,
       error: "context-card-steward-invalid",
     });
+  });
+});
+
+describe("context-card-actor-service RLS-safe registry", () => {
+  test("hydrates project humans and agents from the display-safe SQL projection", async () => {
+    const db = {
+      $queryRaw: vi.fn().mockResolvedValue([
+        {
+          kind: "human",
+          actorId: "user-1",
+          name: "Ada",
+          email: "ada@example.com",
+          username: "ada",
+          usernameDiscriminator: "0001",
+          avatarSeed: "seed-ada",
+          label: null,
+          revokedAt: null,
+          expiresAt: null,
+        },
+        {
+          kind: "agent",
+          actorId: "credential-1",
+          name: null,
+          email: null,
+          username: null,
+          usernameDiscriminator: null,
+          avatarSeed: null,
+          label: "Release bot",
+          revokedAt: null,
+          expiresAt: null,
+        },
+      ]),
+    };
+
+    const registry = await loadContextCardActorRegistry({
+      db: db as never,
+      projectId: "project-1",
+      now: new Date("2026-08-24T00:00:00.000Z"),
+    });
+
+    expect(registry?.assignable).toEqual([
+      expect.objectContaining({ kind: "human", id: "user-1" }),
+      expect.objectContaining({ kind: "agent", id: "credential-1" }),
+    ]);
+    expect(db.$queryRaw).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/lib/context-card-actor-service.test.ts
+++ b/tests/lib/context-card-actor-service.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {},
+}));
+
+const rlsContextMock = vi.hoisted(() => ({
+  withActorRlsContext: vi.fn(),
+}));
+
+const projectAccessServiceMock = vi.hoisted(() => ({
+  buildProjectPrincipalWhere: vi.fn(),
+  requireProjectRole: vi.fn(),
+}));
+
+vi.mock("@/lib/services/rls-context", () => ({
+  withActorRlsContext: rlsContextMock.withActorRlsContext,
+}));
+
+vi.mock("@/lib/services/project-access-service", () => ({
+  buildProjectPrincipalWhere: projectAccessServiceMock.buildProjectPrincipalWhere,
+  requireProjectRole: projectAccessServiceMock.requireProjectRole,
+}));
+
+import {
+  mapStoredContextCardActor,
+  resolveAssignableContextCardActorFromRegistry,
+} from "@/lib/services/context-card-actor-service";
+
+describe("context-card-actor-service mapStoredContextCardActor", () => {
+  test("returns null when no id and no snapshot are provided", () => {
+    expect(
+      mapStoredContextCardActor({
+        kind: "human",
+        id: null,
+        displayNameSnapshot: null,
+      })
+    ).toBeNull();
+  });
+
+  test("marks a human as active when the actor row resolves", () => {
+    const actor = mapStoredContextCardActor({
+      kind: "human",
+      id: "user-1",
+      displayNameSnapshot: "Ada Lovelace",
+      user: {
+        id: "user-1",
+        name: "Ada Lovelace",
+        email: "ada@example.com",
+        username: "ada",
+        usernameDiscriminator: "0001",
+        avatarSeed: "seed-ada",
+      },
+      isCurrentProjectHuman: true,
+    });
+
+    expect(actor).toMatchObject({
+      kind: "human",
+      id: "user-1",
+      displayName: "ada",
+      usernameTag: "ada#0001",
+      avatarSeed: "seed-ada",
+      status: "active",
+      isAssignable: true,
+    });
+  });
+
+  test("falls back to a historical identity when no actor row is present", () => {
+    const actor = mapStoredContextCardActor({
+      kind: "human",
+      id: null,
+      displayNameSnapshot: "Former owner",
+    });
+
+    expect(actor).toMatchObject({
+      kind: "human",
+      id: "historical-human-Former%20owner",
+      displayName: "Former owner",
+      status: "inactive",
+      isAssignable: false,
+    });
+  });
+
+  test("marks an agent credential as revoked when the row resolves to revoked", () => {
+    const actor = mapStoredContextCardActor({
+      kind: "agent",
+      id: "cred-1",
+      displayNameSnapshot: "Release:bot",
+      credential: {
+        id: "cred-1",
+        label: "Release:bot",
+        projectId: "project-1",
+        revokedAt: new Date("2026-07-01T00:00:00.000Z"),
+        expiresAt: null,
+      },
+    });
+
+    expect(actor).toMatchObject({
+      kind: "agent",
+      id: "cred-1",
+      displayName: "Release:bot",
+      status: "revoked",
+      isAssignable: false,
+    });
+  });
+});
+
+describe("context-card-actor-service registry resolver", () => {
+  const baseRegistry = {
+    activeHumanIds: new Set(["user-1"]),
+    humanById: new Map([
+      [
+        "user-1",
+        {
+          kind: "human" as const,
+          id: "user-1",
+          displayName: "ada",
+          usernameTag: "ada#0001",
+          avatarSeed: "seed",
+          status: "active" as const,
+          isAssignable: true,
+        },
+      ],
+    ]),
+    credentialById: new Map([
+      [
+        "cred-1",
+        {
+          kind: "agent" as const,
+          id: "cred-1",
+          displayName: "Release:bot",
+          usernameTag: null,
+          avatarSeed: null,
+          status: "active" as const,
+          isAssignable: true,
+        },
+      ],
+    ]),
+    assignable: [],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("resolves an active human steward", () => {
+    const result = resolveAssignableContextCardActorFromRegistry({
+      registry: baseRegistry,
+      reference: { kind: "human", id: "user-1" },
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      actor: {
+        userId: "user-1",
+        credentialId: null,
+        displayNameSnapshot: "ada",
+      },
+    });
+  });
+
+  test("resolves an active agent steward", () => {
+    const result = resolveAssignableContextCardActorFromRegistry({
+      registry: baseRegistry,
+      reference: { kind: "agent", id: "cred-1" },
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      actor: {
+        userId: null,
+        credentialId: "cred-1",
+        displayNameSnapshot: "Release:bot",
+      },
+    });
+  });
+
+  test("rejects a steward that is not in the registry", () => {
+    const result = resolveAssignableContextCardActorFromRegistry({
+      registry: baseRegistry,
+      reference: { kind: "human", id: "user-2" },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 400,
+      error: "context-card-steward-invalid",
+    });
+  });
+
+  test("rejects a steward that the registry marks as not assignable", () => {
+    const registry = {
+      ...baseRegistry,
+      humanById: new Map([
+        [
+          "user-1",
+          {
+            ...baseRegistry.humanById.get("user-1")!,
+            isAssignable: false,
+          },
+        ],
+      ]),
+    };
+    const result = resolveAssignableContextCardActorFromRegistry({
+      registry,
+      reference: { kind: "human", id: "user-1" },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("returns an error when the registry itself is missing", () => {
+    const result = resolveAssignableContextCardActorFromRegistry({
+      registry: null,
+      reference: { kind: "human", id: "user-1" },
+    });
+    expect(result).toEqual({
+      ok: false,
+      status: 400,
+      error: "context-card-steward-invalid",
+    });
+  });
+});

--- a/tests/lib/context-card-actor.test.ts
+++ b/tests/lib/context-card-actor.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  getContextCardActorKey,
+  getHistoricalContextCardActorId,
+  isContextCardActorReference,
+} from "@/lib/context-card-actor";
+
+describe("context-card-actor", () => {
+  test("encodes the actor reference as kind:id", () => {
+    expect(
+      getContextCardActorKey({ kind: "human", id: "user-1" })
+    ).toBe("human:user-1");
+    expect(
+      getContextCardActorKey({ kind: "agent", id: "cred-1" })
+    ).toBe("agent:cred-1");
+  });
+
+  test("derives a stable historical id from the snapshot", () => {
+    expect(
+      getHistoricalContextCardActorId({
+        kind: "human",
+        displayNameSnapshot: "  Former owner  ",
+      })
+    ).toBe("historical-human-Former%20owner");
+    expect(
+      getHistoricalContextCardActorId({
+        kind: "agent",
+        displayNameSnapshot: "Release:bot",
+      })
+    ).toBe("historical-agent-Release%3Abot");
+  });
+
+  test("accepts well-formed actor references and rejects malformed ones", () => {
+    expect(
+      isContextCardActorReference({ kind: "human", id: "user-1" })
+    ).toBe(true);
+    expect(
+      isContextCardActorReference({ kind: "agent", id: "cred-1" })
+    ).toBe(true);
+    expect(isContextCardActorReference(null)).toBe(false);
+    expect(isContextCardActorReference(undefined)).toBe(false);
+    expect(isContextCardActorReference({ kind: "robot", id: "x" })).toBe(
+      false
+    );
+    expect(isContextCardActorReference({ kind: "human", id: "" })).toBe(false);
+    expect(isContextCardActorReference({ kind: "human" })).toBe(false);
+    expect(isContextCardActorReference("human:user-1")).toBe(false);
+  });
+});

--- a/tests/lib/context-card-stewardship-service.test.ts
+++ b/tests/lib/context-card-stewardship-service.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {},
+}));
+
+vi.mock("@/lib/services/rls-context", () => ({
+  withActorRlsContext: vi.fn(),
+}));
+
+vi.mock("@/lib/services/project-access-service", () => ({
+  buildProjectPrincipalWhere: vi.fn(),
+  requireAgentProjectScopes: vi.fn(),
+  requireProjectRole: vi.fn(),
+}));
+
+vi.mock("@/lib/services/project-activity-service", () => ({
+  touchProjectActivity: vi.fn(),
+}));
+
+import {
+  getContextCardReviewThresholdDays,
+  projectContextCard,
+  resolveContextCardReviewState,
+  type ContextCardCardRecord,
+} from "@/lib/services/context-card-stewardship-service";
+
+const referenceNowMs = new Date("2026-07-20T12:00:00.000Z").getTime();
+const day = 24 * 60 * 60 * 1000;
+
+describe("context-card review state", () => {
+  test("uses the default 90 day threshold when env is unset", () => {
+    const original = process.env.CONTEXT_CARD_REVIEW_THRESHOLD_DAYS;
+    delete process.env.CONTEXT_CARD_REVIEW_THRESHOLD_DAYS;
+    try {
+      expect(getContextCardReviewThresholdDays()).toBe(90);
+    } finally {
+      if (original !== undefined) {
+        process.env.CONTEXT_CARD_REVIEW_THRESHOLD_DAYS = original;
+      }
+    }
+  });
+
+  test("uses an explicit positive env override when provided", () => {
+    const original = process.env.CONTEXT_CARD_REVIEW_THRESHOLD_DAYS;
+    process.env.CONTEXT_CARD_REVIEW_THRESHOLD_DAYS = "30";
+    try {
+      expect(getContextCardReviewThresholdDays()).toBe(30);
+    } finally {
+      if (original !== undefined) {
+        process.env.CONTEXT_CARD_REVIEW_THRESHOLD_DAYS = original;
+      } else {
+        delete process.env.CONTEXT_CARD_REVIEW_THRESHOLD_DAYS;
+      }
+    }
+  });
+
+  test("falls back to default when env override is non-positive", () => {
+    const original = process.env.CONTEXT_CARD_REVIEW_THRESHOLD_DAYS;
+    process.env.CONTEXT_CARD_REVIEW_THRESHOLD_DAYS = "-5";
+    try {
+      expect(getContextCardReviewThresholdDays()).toBe(90);
+    } finally {
+      if (original !== undefined) {
+        process.env.CONTEXT_CARD_REVIEW_THRESHOLD_DAYS = original;
+      } else {
+        delete process.env.CONTEXT_CARD_REVIEW_THRESHOLD_DAYS;
+      }
+    }
+  });
+
+  test("marks a card as needing review past the threshold", () => {
+    const updatedAt = new Date(referenceNowMs - 91 * day);
+    const review = resolveContextCardReviewState({
+      updatedAt,
+      referenceNowMs,
+    });
+    expect(review.needsReview).toBe(true);
+    expect(review.thresholdDays).toBe(90);
+    expect(review.lastEditedAt).toEqual(updatedAt);
+  });
+
+  test("keeps a freshly edited card out of the review queue", () => {
+    const updatedAt = new Date(referenceNowMs - 30 * day);
+    const review = resolveContextCardReviewState({
+      updatedAt,
+      referenceNowMs,
+    });
+    expect(review.needsReview).toBe(false);
+  });
+
+  test("honors an explicit threshold override", () => {
+    const updatedAt = new Date(referenceNowMs - 45 * day);
+    expect(
+      resolveContextCardReviewState({
+        updatedAt,
+        referenceNowMs,
+        thresholdDays: 30,
+      }).needsReview
+    ).toBe(true);
+    expect(
+      resolveContextCardReviewState({
+        updatedAt,
+        referenceNowMs,
+        thresholdDays: 60,
+      }).needsReview
+    ).toBe(false);
+  });
+});
+
+describe("context-card projection", () => {
+  const baseCard: ContextCardCardRecord = {
+    id: "card-1",
+    projectId: "project-1",
+    updatedAt: new Date(referenceNowMs - 100 * day),
+    createdByUserId: "user-1",
+    createdByCredentialId: null,
+    creatorKind: "human",
+    creatorDisplayNameSnapshot: "Ada Lovelace",
+    lastEditedByUserId: "user-1",
+    lastEditedByCredentialId: null,
+    lastEditorKind: "human",
+    lastEditorDisplayNameSnapshot: "Ada Lovelace",
+    stewardUserId: null,
+    stewardCredentialId: "cred-1",
+    stewardKind: "agent",
+    stewardDisplayNameSnapshot: "Release:bot",
+    createdByUser: {
+      id: "user-1",
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+      username: "ada",
+      usernameDiscriminator: "0001",
+      avatarSeed: "seed-ada",
+    },
+    lastEditedByUser: {
+      id: "user-1",
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+      username: "ada",
+      usernameDiscriminator: "0001",
+      avatarSeed: "seed-ada",
+    },
+    stewardUser: null,
+    stewardCredential: {
+      id: "cred-1",
+      label: "Release:bot",
+      projectId: "project-1",
+      revokedAt: null,
+      expiresAt: null,
+    },
+    attachments: [
+      {
+        id: "att-1",
+        kind: "link",
+        name: "Design spec",
+        url: "https://example.com/spec",
+        mimeType: null,
+        sizeBytes: null,
+        uploadedByUserId: "user-1",
+        uploadedByKind: "human",
+        uploadedByDisplayNameSnapshot: "ada",
+        createdAt: new Date(referenceNowMs - 10 * day),
+        uploadedBy: {
+          id: "user-1",
+          name: "Ada Lovelace",
+          email: "ada@example.com",
+          username: "ada",
+          usernameDiscriminator: "0001",
+          avatarSeed: "seed-ada",
+        },
+      },
+    ],
+  };
+
+  test("captures creator, last editor, steward, and review state", () => {
+    const projection = projectContextCard({
+      card: baseCard,
+      referenceNowMs,
+    });
+
+    expect(projection.creator).toMatchObject({
+      kind: "human",
+      id: "user-1",
+      displayName: "ada",
+    });
+    expect(projection.lastEditor).toMatchObject({
+      kind: "human",
+      id: "user-1",
+      displayName: "ada",
+    });
+    expect(projection.steward).toMatchObject({
+      kind: "agent",
+      id: "cred-1",
+      displayName: "Release:bot",
+    });
+    expect(projection.review.needsReview).toBe(true);
+    expect(projection.attachments).toHaveLength(1);
+    expect(projection.attachments[0].uploadedBy).toMatchObject({
+      kind: "human",
+      id: "user-1",
+    });
+  });
+
+  test("falls back to display snapshots when actor rows are missing", () => {
+    const cardWithoutUsers: ContextCardCardRecord = {
+      ...baseCard,
+      createdByUser: undefined,
+      lastEditedByUser: undefined,
+      stewardCredential: undefined,
+      attachments: [
+        {
+          id: "att-1",
+          kind: "link",
+          name: "Design spec",
+          url: "https://example.com/spec",
+          mimeType: null,
+          sizeBytes: null,
+          uploadedByUserId: "user-1",
+          uploadedByKind: "human",
+          uploadedByDisplayNameSnapshot: "ada",
+          createdAt: new Date(referenceNowMs - 10 * day),
+          uploadedBy: undefined,
+        },
+      ],
+    };
+
+    const projection = projectContextCard({
+      card: cardWithoutUsers,
+      referenceNowMs,
+    });
+
+    expect(projection.creator).toMatchObject({
+      kind: "human",
+      displayName: "Ada Lovelace",
+      isAssignable: false,
+    });
+    expect(projection.steward).toMatchObject({
+      kind: "agent",
+      displayName: "Release:bot",
+      isAssignable: false,
+    });
+    expect(projection.attachments[0].uploadedBy).toMatchObject({
+      kind: "human",
+      displayName: "ada",
+    });
+  });
+
+  test("marks a card needing review via threshold when the env is overridden", () => {
+    const freshCard: ContextCardCardRecord = {
+      ...baseCard,
+      updatedAt: new Date(referenceNowMs - 10 * day),
+    };
+    const projection = projectContextCard({
+      card: freshCard,
+      referenceNowMs,
+    });
+    expect(projection.review.needsReview).toBe(false);
+  });
+});

--- a/tests/lib/context-card-stewardship-service.test.ts
+++ b/tests/lib/context-card-stewardship-service.test.ts
@@ -1,17 +1,23 @@
-import { describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 vi.mock("@/lib/prisma", () => ({
   prisma: {},
 }));
 
+const rlsContextMock = vi.hoisted(() => ({ withActorRlsContext: vi.fn() }));
+const projectAccessMock = vi.hoisted(() => ({
+  requireAgentProjectScopes: vi.fn(),
+  requireProjectRole: vi.fn(),
+}));
+
 vi.mock("@/lib/services/rls-context", () => ({
-  withActorRlsContext: vi.fn(),
+  withActorRlsContext: rlsContextMock.withActorRlsContext,
 }));
 
 vi.mock("@/lib/services/project-access-service", () => ({
   buildProjectPrincipalWhere: vi.fn(),
-  requireAgentProjectScopes: vi.fn(),
-  requireProjectRole: vi.fn(),
+  requireAgentProjectScopes: projectAccessMock.requireAgentProjectScopes,
+  requireProjectRole: projectAccessMock.requireProjectRole,
 }));
 
 vi.mock("@/lib/services/project-activity-service", () => ({
@@ -19,6 +25,7 @@ vi.mock("@/lib/services/project-activity-service", () => ({
 }));
 
 import {
+  assignContextCardSteward,
   getContextCardReviewThresholdDays,
   projectContextCard,
   resolveContextCardReviewState,
@@ -173,6 +180,12 @@ describe("context-card projection", () => {
     ],
   };
 
+  beforeEach(() => {
+    vi.clearAllMocks();
+    projectAccessMock.requireAgentProjectScopes.mockReturnValue({ ok: true });
+    projectAccessMock.requireProjectRole.mockResolvedValue({ ok: true, role: "editor" });
+  });
+
   test("captures creator, last editor, steward, and review state", () => {
     const projection = projectContextCard({
       card: baseCard,
@@ -247,6 +260,7 @@ describe("context-card projection", () => {
   });
 
   test("marks a card needing review via threshold when the env is overridden", () => {
+    vi.stubEnv("CONTEXT_CARD_REVIEW_THRESHOLD_DAYS", "5");
     const freshCard: ContextCardCardRecord = {
       ...baseCard,
       updatedAt: new Date(referenceNowMs - 10 * day),
@@ -255,6 +269,42 @@ describe("context-card projection", () => {
       card: freshCard,
       referenceNowMs,
     });
-    expect(projection.review.needsReview).toBe(false);
+    expect(projection.review.needsReview).toBe(true);
+    expect(projection.review.thresholdDays).toBe(5);
+    vi.unstubAllEnvs();
+  });
+
+  test("preserves the last-edit timestamp during stewardship-only changes", async () => {
+    const db = {
+      resource: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: baseCard.id,
+          updatedAt: baseCard.updatedAt,
+        }),
+        update: vi.fn().mockResolvedValue({ ...baseCard, stewardKind: null }),
+      },
+      $queryRaw: vi.fn().mockResolvedValue([]),
+    };
+    rlsContextMock.withActorRlsContext.mockImplementation(
+      (_actorUserId: string, callback: (client: typeof db) => unknown) => callback(db)
+    );
+
+    const result = await assignContextCardSteward({
+      actorUserId: "user-1",
+      projectId: "project-1",
+      cardId: baseCard.id,
+      steward: null,
+      referenceNowMs,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(db.resource.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ updatedAt: baseCard.updatedAt }),
+      })
+    );
+    if (result.ok) {
+      expect(result.data.lastEditedAt).toEqual(baseCard.updatedAt);
+    }
   });
 });

--- a/tests/lib/project-attachment-service.test.ts
+++ b/tests/lib/project-attachment-service.test.ts
@@ -21,6 +21,9 @@ const prismaMock = vi.hoisted(() => ({
   resourceAttachment: {
     create: vi.fn(),
   },
+  user: {
+    findUnique: vi.fn(),
+  },
 }));
 
 const attachmentStorageMock = vi.hoisted(() => ({
@@ -71,6 +74,14 @@ describe("project-attachment-service", () => {
     vi.clearAllMocks();
     prismaMock.$transaction.mockImplementation(async (callback) => callback(prismaMock));
     prismaMock.project.findFirst.mockResolvedValue({ ownerId: actorUserId, memberships: [] });
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: actorUserId,
+      name: "Ada Lovelace",
+      email: "ada@example.com",
+      username: "ada",
+      usernameDiscriminator: "0001",
+      avatarSeed: "seed-ada",
+    });
   });
 
   test("maps task upload storage-unavailable errors to actionable message", async () => {

--- a/tests/lib/project-attachment-service.test.ts
+++ b/tests/lib/project-attachment-service.test.ts
@@ -352,4 +352,28 @@ describe("project-attachment-service", () => {
     expect(prismaMock.resourceAttachment.create).toHaveBeenCalledTimes(1);
     expect(attachmentStorageMock.deleteAttachmentFile).not.toHaveBeenCalled();
   });
+
+  test("rejects agent context uploads instead of misattributing them to a human", async () => {
+    const result = await finalizeContextAttachmentDirectUpload({
+      actorUserId,
+      projectId: "project-1",
+      cardId: "card-1",
+      storageKey: "v1/user-1/project-1/context-card/card-1/key-spec.pdf",
+      name: "spec.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 2048,
+      agentAccess: {
+        credentialId: "credential-1",
+        projectId: "project-1",
+        scopes: ["context:write"],
+      },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 403,
+      error: "agent-context-attachments-unsupported",
+    });
+    expect(prismaMock.resourceAttachment.create).not.toHaveBeenCalled();
+  });
 });

--- a/tests/lib/project-service.test.ts
+++ b/tests/lib/project-service.test.ts
@@ -518,6 +518,75 @@ describe("project-service", () => {
       include: {
         attachments: {
           orderBy: [{ createdAt: "desc" }],
+          include: {
+            uploadedBy: {
+              select: {
+                id: true,
+                name: true,
+                email: true,
+                username: true,
+                usernameDiscriminator: true,
+                avatarSeed: true,
+              },
+            },
+          },
+        },
+        createdByUser: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            username: true,
+            usernameDiscriminator: true,
+            avatarSeed: true,
+          },
+        },
+        createdByCredential: {
+          select: {
+            id: true,
+            label: true,
+            projectId: true,
+            revokedAt: true,
+            expiresAt: true,
+          },
+        },
+        lastEditedByUser: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            username: true,
+            usernameDiscriminator: true,
+            avatarSeed: true,
+          },
+        },
+        lastEditedByCredential: {
+          select: {
+            id: true,
+            label: true,
+            projectId: true,
+            revokedAt: true,
+            expiresAt: true,
+          },
+        },
+        stewardUser: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            username: true,
+            usernameDiscriminator: true,
+            avatarSeed: true,
+          },
+        },
+        stewardCredential: {
+          select: {
+            id: true,
+            label: true,
+            projectId: true,
+            revokedAt: true,
+            expiresAt: true,
+          },
         },
       },
     });


### PR DESCRIPTION
## What changed

- add durable creator, last-editor, and optional human/agent steward identity to context cards
- preserve readable identity snapshots after membership removal or credential revocation
- surface attachment-uploader provenance and explicit inactive-actor states
- add configurable derived “Needs review” signals across context-card surfaces
- include migration, service, route, component, and browser coverage
- preserve the required feature release at v0.38.0

## Validation

- release version policy passed against current main
- Prisma schema validation passed
- 4 focused context-card suites passed (27 tests)
- conflict-marker and whitespace checks passed
- fresh required GitHub checks will run on this replacement PR

## Supersedes

Supersedes #428 because protected branch rules prohibit force-pushing its rebased history.

This final replacement also supersedes #440: main advanced to 5063dbf while the prior replacement was under review, and branch protection prevents updating rebased history in place.