### PR TITLE
TASK-406: Restore stable Preview OAuth alias safely

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ APP_REPOSITORY_URL=
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 # Optional explicit callback override. When unset, callback URI is derived from
-# TRUSTED_ORIGINS / NEXTAUTH_URL, or the immutable VERCEL_URL in Preview.
+# TRUSTED_ORIGINS / NEXTAUTH_URL, PREVIEW_AUTH_ORIGIN in Preview, or the request.
 # Keep this only if you intentionally pin a non-standard callback origin.
 # For Google OAuth, at least one of TRUSTED_ORIGINS or NEXTAUTH_URL must be set if GOOGLE_REDIRECT_URI is unset.
 GOOGLE_REDIRECT_URI=
@@ -21,8 +21,11 @@ GOOGLE_REDIRECT_URI=
 GOOGLE_TOKEN_ENCRYPTION_KEY=
 GOOGLE_CALENDAR_ID=primary
 
-# Optional outside Preview. Vercel Preview derives its trusted auth origin from
-# the immutable VERCEL_URL and must not pin NEXTAUTH_URL to a mutable alias.
+# Required in Vercel Preview when Google or GitHub OAuth is enabled. Set this to
+# the stable HTTPS alias registered with the providers, without a trailing slash.
+PREVIEW_AUTH_ORIGIN=
+# Optional outside Preview. Do not set NEXTAUTH_URL in Vercel Preview; the app
+# trusts only its immutable VERCEL_URL and the exact PREVIEW_AUTH_ORIGIN alias.
 NEXTAUTH_URL=
 NEXTAUTH_SECRET=
 # Required in production for agent bearer-token signing. Minimum 32 characters.

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -188,6 +188,7 @@ jobs:
       VERCEL_CLI_VERSION: 50.18.0
       VERCEL_SCOPE: ${{ secrets.VERCEL_ORG_ID }}
       EXPECTED_SUPABASE_PROJECT_REF: ${{ vars.EXPECTED_SUPABASE_PROJECT_REF }}
+      PREVIEW_AUTH_ORIGIN: ${{ vars.PREVIEW_AUTH_ORIGIN }}
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DIRECT_URL: ${{ secrets.DIRECT_URL }}
       GOOGLE_TOKEN_ENCRYPTION_KEY: ${{ secrets.GOOGLE_TOKEN_ENCRYPTION_KEY }}
@@ -219,6 +220,23 @@ jobs:
           if [ "$missing" -eq 1 ]; then
             exit 1
           fi
+
+      - name: Validate stable preview auth origin
+        if: inputs.action == 'deploy-preview'
+        run: |
+          node <<'NODE'
+          const value = process.env.PREVIEW_AUTH_ORIGIN ?? "";
+          let parsed;
+          try {
+            parsed = new URL(value);
+          } catch {
+            throw new Error("PREVIEW_AUTH_ORIGIN must be configured as an absolute HTTPS origin.");
+          }
+
+          if (parsed.protocol !== "https:" || parsed.origin !== value) {
+            throw new Error("PREVIEW_AUTH_ORIGIN must be an HTTPS origin without a path, query, or trailing slash.");
+          }
+          NODE
 
       - name: Ensure Resend key fallback for preview deploys
         if: inputs.action == 'deploy-preview'
@@ -336,6 +354,7 @@ jobs:
           APP_ENV="$APP_ENV" \
           COMMIT_SHA="$COMMIT_SHA" \
           APP_REPOSITORY_URL="$APP_REPOSITORY_URL" \
+          PREVIEW_AUTH_ORIGIN="$PREVIEW_AUTH_ORIGIN" \
             npx vercel@${VERCEL_CLI_VERSION} build --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN"
           deployment_url=$(
             npx vercel@${VERCEL_CLI_VERSION} deploy \
@@ -350,7 +369,8 @@ jobs:
               -e "APP_ENV=$APP_ENV" \
               -e "EXPECTED_SUPABASE_PROJECT_REF=$EXPECTED_SUPABASE_PROJECT_REF" \
               -e "COMMIT_SHA=$COMMIT_SHA" \
-              -e "APP_REPOSITORY_URL=$APP_REPOSITORY_URL"
+              -e "APP_REPOSITORY_URL=$APP_REPOSITORY_URL" \
+              -e "PREVIEW_AUTH_ORIGIN=$PREVIEW_AUTH_ORIGIN"
           )
           echo "deployment_url=$deployment_url" >> "$GITHUB_OUTPUT"
           echo "$deployment_url" > preview-deployment.txt
@@ -431,6 +451,64 @@ jobs:
 
           console.log(`Verified preview runtime ${actualRevision} and database readiness.`);
           NODE
+
+      - name: Assign and verify stable preview auth alias
+        if: inputs.action == 'deploy-preview'
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy_preview.outputs.deployment_url }}
+        run: |
+          preview_alias_host=$(node -e 'console.log(new URL(process.env.PREVIEW_AUTH_ORIGIN).hostname)')
+          npx vercel@${VERCEL_CLI_VERSION} alias set \
+            "$DEPLOYMENT_URL" \
+            "$preview_alias_host" \
+            --scope="$VERCEL_SCOPE" \
+            --token="$VERCEL_TOKEN"
+
+          curl \
+            --fail \
+            --silent \
+            --show-error \
+            --get "https://api.vercel.com/v13/deployments/${preview_alias_host}" \
+            --data-urlencode "teamId=$VERCEL_ORG_ID" \
+            --header "Authorization: Bearer $VERCEL_TOKEN" \
+            --output /tmp/preview-alias-deployment.json
+
+          node <<'NODE'
+          const { readFileSync } = require("node:fs");
+          const immutable = JSON.parse(readFileSync("/tmp/preview-deployment.json", "utf8"));
+          const aliased = JSON.parse(readFileSync("/tmp/preview-alias-deployment.json", "utf8"));
+
+          if (!immutable.id || aliased.id !== immutable.id) {
+            throw new Error("Stable Preview auth alias does not resolve to the validated deployment.");
+          }
+          NODE
+
+          curl \
+            --fail \
+            --silent \
+            --show-error \
+            --retry 4 \
+            --retry-all-errors \
+            --retry-delay 5 \
+            "$PREVIEW_AUTH_ORIGIN/api/health/ready" \
+            --output /tmp/preview-alias-readiness.json
+
+          node <<'NODE'
+          const { readFileSync } = require("node:fs");
+          const readiness = JSON.parse(readFileSync("/tmp/preview-alias-readiness.json", "utf8"));
+          const expectedRevision = process.env.COMMIT_SHA.slice(0, 7).toLowerCase();
+
+          if (
+            readiness.status !== "ready" ||
+            readiness.checks?.database !== "ok" ||
+            readiness.deployment?.environment !== "preview" ||
+            readiness.deployment?.revision?.toLowerCase() !== expectedRevision
+          ) {
+            throw new Error("Stable Preview auth alias failed revision, environment, or readiness validation.");
+          }
+          NODE
+
+          echo "$PREVIEW_AUTH_ORIGIN" > preview-auth-alias.txt
 
       - name: Deploy production (staged)
         if: inputs.action == 'deploy-production-staged'
@@ -585,7 +663,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: preview-deployment
-          path: preview-deployment.txt
+          path: |
+            preview-deployment.txt
+            preview-auth-alias.txt
           if-no-files-found: error
 
       - name: Upload staged production deployment artifact
@@ -610,8 +690,9 @@ jobs:
           fi
           if [ "${{ inputs.action }}" = "deploy-preview" ]; then
             if [ -n "${{ steps.deploy_preview.outputs.deployment_url }}" ]; then
-              echo "- Preview URL: \`${{ steps.deploy_preview.outputs.deployment_url }}\`" >> "$GITHUB_STEP_SUMMARY"
-              echo "- Preview verification: immutable Vercel Preview target, matching revision/environment, database ready" >> "$GITHUB_STEP_SUMMARY"
+              echo "- Immutable Preview URL: \`${{ steps.deploy_preview.outputs.deployment_url }}\`" >> "$GITHUB_STEP_SUMMARY"
+              echo "- Stable Preview auth URL: \`$PREVIEW_AUTH_ORIGIN\`" >> "$GITHUB_STEP_SUMMARY"
+              echo "- Preview verification: immutable Vercel Preview target plus stable auth alias, matching revision/environment, database ready" >> "$GITHUB_STEP_SUMMARY"
             fi
           fi
           if [ "${{ inputs.action }}" = "deploy-production-staged" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ SHA, deployment URL, and workflow run belong in release evidence.
 
 - Define each release entry before the product-impacting PR is merged.
 
+## v0.37.2 - 2026-08-25
+
+- Restored the registered stable Vercel Preview URL for GitHub and Google OAuth
+  while retaining immutable deployment, revision, environment, and database
+  validation before the alias can move.
+- Restricted Preview callback origins to the immutable deployment and one
+  explicit `PREVIEW_AUTH_ORIGIN`, rejecting arbitrary or stale aliases.
+
 ## v0.37.1 - 2026-08-20
 
 - Fixed Vercel Preview authentication origins so callbacks and post-auth

--- a/README.md
+++ b/README.md
@@ -198,6 +198,11 @@ Environment access/validation is centralized in `lib/env.server.ts` and executed
 - `GOOGLE_CALENDAR_ID` must be unset or `primary`.
 - `RESEND_FROM_EMAIL` defaults to `NexusDash <noreply@nexus-dash.app>` when unset.
 - `TRUSTED_ORIGINS` (optional) can restrict verification-link origins in production.
+- `PREVIEW_AUTH_ORIGIN` is required in Vercel Preview when Google or GitHub
+  OAuth is enabled. It must be the exact stable HTTPS alias registered as the
+  providers' Preview callback origin, without a path or trailing slash.
+- Do not set `NEXTAUTH_URL` in Vercel Preview. Preview requests trust the
+  immutable deployment origin and the exact `PREVIEW_AUTH_ORIGIN` only.
 - `CRON_SECRET` or `NOTIFICATION_EMAIL_DISPATCH_SECRET` protects the
   notification email dispatch endpoint. If both are set,
   `NOTIFICATION_EMAIL_DISPATCH_SECRET` takes precedence. Configured values must
@@ -485,15 +490,19 @@ Required GitHub secrets:
 - `AGENT_TOKEN_SIGNING_SECRET` (required for production deploys; preview workflow falls back to a placeholder when intentionally unset)
 - Preview deployments still need `AGENT_TOKEN_SIGNING_SECRET` at runtime. GitHub Actions fallback values do not automatically populate Vercel's shared preview runtime unless the deployment explicitly passes them through.
 
-Required GitHub environment variable (not a secret):
+Required GitHub environment variables (not secrets):
 
 - `EXPECTED_SUPABASE_PROJECT_REF`, configured independently for `preview` and
   `production`.
+- `PREVIEW_AUTH_ORIGIN`, configured for `preview` as the stable Vercel alias
+  registered with the Preview GitHub/Google OAuth applications.
 
 The preview workflow validates the migration project ref, immutable Vercel
 deployment target, checked-out revision, deployed `APP_ENV`, and database
-readiness before uploading `preview-deployment`. Always use that artifact URL;
-historical or branch aliases may later point at a different target.
+readiness before assigning `PREVIEW_AUTH_ORIGIN` to that exact deployment. It
+then verifies the alias target and readiness before uploading
+`preview-deployment`. Use the immutable URL as deployment evidence and the
+stable auth URL for interactive OAuth testing.
 
 ### Dependency Security Cadence
 

--- a/docs/runbooks/github-actions-workflows.md
+++ b/docs/runbooks/github-actions-workflows.md
@@ -59,11 +59,13 @@ Run `.github/workflows/deploy-vercel.yml` manually:
 - `action=deploy-preview`
 - `git_ref=<branch-or-sha>`
 
-Use the `preview-deployment` artifact or job summary URL for preview smoke.
-The artifact is uploaded only after the workflow verifies that the immutable
-URL belongs to the configured Vercel project, targets Preview, contains the
-requested revision, reports `APP_ENV=preview`, and can reach its database. Do
-not substitute a branch alias or a URL from an older deployment.
+The `preview-deployment` artifact contains both the immutable deployment URL
+and the stable Preview auth URL. It is uploaded only after the workflow verifies
+that the immutable URL belongs to the configured Vercel project, targets
+Preview, contains the requested revision, reports `APP_ENV=preview`, and can
+reach its database. The workflow then assigns `PREVIEW_AUTH_ORIGIN` to that
+exact deployment and verifies the alias target and readiness. Use the immutable
+URL as deployment evidence and the stable URL for interactive OAuth smoke.
 
 ### Staged Production Deploy
 

--- a/docs/runbooks/vercel-env-contract-and-secrets.md
+++ b/docs/runbooks/vercel-env-contract-and-secrets.md
@@ -205,6 +205,7 @@ Can stay non-sensitive:
 - `SUPABASE_URL`
 - `SUPABASE_PUBLISHABLE_KEY`
 - `EXPECTED_SUPABASE_PROJECT_REF`
+- `PREVIEW_AUTH_ORIGIN`
 
 Important:
 
@@ -215,14 +216,18 @@ Important:
 
 - Preview builds run with production-like checks (`NODE_ENV=production` during
   build), so missing production-only guards can break preview deploys.
-- Do not set `NEXTAUTH_URL` in Vercel Preview to a historical deployment or
-  branch alias. Preview auth origins resolve from the immutable system
-  `VERCEL_URL`; Production continues to use its trusted canonical origin.
-- For the same reason, do not pin `GOOGLE_REDIRECT_URI`,
-  `AUTH_GOOGLE_REDIRECT_URI`, or `AUTH_GITHUB_REDIRECT_URI` in Preview to a
-  historical deployment URL. When Preview provider credentials are enabled,
-  their provider-side callback allowlist must accept the immutable URL being
-  tested; otherwise leave that provider disabled for preview testing.
+- Do not set `NEXTAUTH_URL` in Vercel Preview. Configure
+  `PREVIEW_AUTH_ORIGIN` as the exact stable HTTPS Vercel alias registered with
+  the Preview GitHub and Google OAuth applications, without a path or trailing
+  slash. Preview runtime checks fail closed when OAuth is enabled without it.
+- Do not pin `GOOGLE_REDIRECT_URI`, `AUTH_GOOGLE_REDIRECT_URI`, or
+  `AUTH_GITHUB_REDIRECT_URI` to an immutable or historical deployment. Preview
+  callbacks derive from the current request and accept only the immutable
+  `VERCEL_URL` or exact `PREVIEW_AUTH_ORIGIN`.
+- The deploy workflow validates the immutable deployment target, revision,
+  environment, and database readiness before moving the stable auth alias. It
+  then verifies that the alias resolves to the same deployment and repeats the
+  readiness check through the alias before publishing either URL.
 - Production database secrets must come from the intended Supabase Production
   project, not local `.env` snapshots or preview/staging files. The app rejects
   production startup when Supabase project refs differ across `DATABASE_URL`,
@@ -339,11 +344,12 @@ Before merging deploy-affecting changes:
 1. Confirm required env vars exist for target environment.
 2. Confirm sensitive vars are marked sensitive where supported.
 3. Run manual preview deploy (`deploy-vercel.yml`, `action=deploy-preview`).
-4. Use only the immutable URL in the `preview-deployment` artifact. The
-   workflow verifies that it is a Vercel Preview target for the requested
-   revision, reports `APP_ENV=preview`, and passes database readiness before
-   uploading the artifact.
-5. Validate critical auth/integration path(s) on that preview URL.
+4. Confirm the immutable URL in the `preview-deployment` artifact is the
+   requested Preview revision. The workflow validates it before assigning the
+   stable `PREVIEW_AUTH_ORIGIN`, then verifies the alias points to that same
+   deployment and passes readiness.
+5. Use the immutable URL as deployment evidence and the stable auth URL for
+   critical OAuth/integration testing.
 6. If any preview path bypasses deployment-time `-e` injection, confirm
    `AGENT_TOKEN_SIGNING_SECRET` exists in Vercel Preview before relying on that
    preview URL.

--- a/journal.md
+++ b/journal.md
@@ -19,6 +19,14 @@ Use it for important implementation milestones, blockers, validation runs, and r
 - Local validation passed: lint, RLS inventory, 1,052 unit/API tests with two
   skipped, coverage at 91.37% statements / 81.33% branches / 92.2% functions /
   91.88% lines, production build, release policy, and workflow YAML parsing.
+- Opened PR #448 and deployed commit `8df7e1c` through workflow run
+  `32843605455`. The run validated immutable Preview
+  `nexus-dash-7ykoau18s-dorian-agaesses-projects.vercel.app`, assigned the
+  static test alias, and verified both hosts report Preview revision `8df7e1c`
+  with database readiness.
+- Live OAuth initiation through the static alias generated static GitHub and
+  Google callbacks. GitHub accepted its registered callback and continued to
+  `/login`; the prior unassociated `redirect_uri` warning was absent.
 
 # 2026-08-24 - ChatGPT and Codex connector Epic added to backlog
 

--- a/journal.md
+++ b/journal.md
@@ -3,6 +3,23 @@
 This file is a concise execution log.
 Use it for important implementation milestones, blockers, validation runs, and release evidence.
 
+# 2026-08-25 - TASK-406 stable Preview OAuth alias remediation
+
+- Reproduced the provider failure from the immutable TASK-326 Preview: GitHub
+  rejected its per-deployment callback because the Preview OAuth application is
+  registered against the long-lived static test URL.
+- Confirmed the static alias had become unsafe only because it still targeted a
+  historical Production deployment; removed that stale assignment while the
+  remediation was prepared.
+- Kept TASK-370's immutable deployment validation as the source of truth and
+  added a post-validation step that assigns the static alias only to the exact
+  verified Preview deployment, then verifies the alias target and readiness.
+- Added exact `PREVIEW_AUTH_ORIGIN` request-origin and startup validation so the
+  registered alias works for OAuth without trusting arbitrary Preview aliases.
+- Local validation passed: lint, RLS inventory, 1,052 unit/API tests with two
+  skipped, coverage at 91.37% statements / 81.33% branches / 92.2% functions /
+  91.88% lines, production build, release policy, and workflow YAML parsing.
+
 # 2026-08-24 - ChatGPT and Codex connector Epic added to backlog
 
 - Integrated the attached ND-MCP plan as non-executable TASK-385 with a

--- a/lib/env.server.ts
+++ b/lib/env.server.ts
@@ -522,6 +522,19 @@ function assertMatchingSupabaseProjectRefs(
   }
 }
 
+function assertValidHttpsOrigin(name: string, value: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`${name} must be a valid absolute URL.`);
+  }
+
+  if (parsed.protocol !== "https:" || parsed.origin !== value) {
+    throw new Error(`${name} must be an HTTPS origin without a path, query, or trailing slash.`);
+  }
+}
+
 function assertExpectedSupabaseProjectRef(
   databaseUrl: ParsedDatabaseConnectionString,
   directUrl: ParsedDatabaseConnectionString,
@@ -724,6 +737,11 @@ export function validateServerRuntimeConfig(
     assertValidUrl("NEXTAUTH_URL", nextAuthUrl);
   }
 
+  const previewAuthOrigin = getOptionalServerEnv("PREVIEW_AUTH_ORIGIN");
+  if (previewAuthOrigin) {
+    assertValidHttpsOrigin("PREVIEW_AUTH_ORIGIN", previewAuthOrigin);
+  }
+
   assertOptionalEnvironmentGroup(
     ["GOOGLE_CLIENT_ID", "GOOGLE_CLIENT_SECRET"],
     "GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET must be configured together."
@@ -761,8 +779,12 @@ export function validateServerRuntimeConfig(
   // Prebuilt Vercel previews do not have their immutable VERCEL_URL until the
   // artifact is deployed. The runtime origin resolver still requires it.
   const hasVercelPreviewOrigin = getVercelEnvironment() === "preview";
+  const hasPreviewAuthOrigin = hasVercelPreviewOrigin && Boolean(previewAuthOrigin);
   const hasTrustedAppOrigin =
-    trustedOriginsAreValid || Boolean(nextAuthUrl) || hasVercelPreviewOrigin;
+    trustedOriginsAreValid ||
+    Boolean(nextAuthUrl) ||
+    hasVercelPreviewOrigin ||
+    hasPreviewAuthOrigin;
   const hasGoogleRedirectResolution =
     Boolean(googleRedirectUri) ||
     hasTrustedAppOrigin;
@@ -782,6 +804,16 @@ export function validateServerRuntimeConfig(
   if (githubClientId && !hasTrustedAppOrigin && !githubRedirectUri) {
     throw new Error(
       "GitHub sign-in requires AUTH_GITHUB_REDIRECT_URI or a trusted app origin (TRUSTED_ORIGINS/NEXTAUTH_URL)."
+    );
+  }
+
+  if (
+    hasVercelPreviewOrigin &&
+    (googleClientId || authGoogleClientId || githubClientId) &&
+    !hasPreviewAuthOrigin
+  ) {
+    throw new Error(
+      "PREVIEW_AUTH_ORIGIN is required in Vercel Preview when OAuth providers are enabled."
     );
   }
 

--- a/lib/http/request-origin.ts
+++ b/lib/http/request-origin.ts
@@ -75,13 +75,34 @@ function resolveVercelPreviewOrigin(): string | null {
   }
 }
 
+function resolveConfiguredPreviewAuthOrigin(): string | null {
+  const configuredOrigin = getOptionalServerEnv("PREVIEW_AUTH_ORIGIN");
+  if (!configuredOrigin) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(configuredOrigin);
+    if (parsed.protocol !== "https:" || parsed.origin !== configuredOrigin) {
+      return null;
+    }
+
+    return parsed.origin;
+  } catch {
+    return null;
+  }
+}
+
 function isAllowedOrigin(origin: string): boolean {
   if (!isProductionEnvironment()) {
     return true;
   }
 
   if (isPreviewDeployment()) {
-    return origin === resolveVercelPreviewOrigin();
+    return (
+      origin === resolveVercelPreviewOrigin() ||
+      origin === resolveConfiguredPreviewAuthOrigin()
+    );
   }
 
   const trustedOrigin = resolveTrustedProductionOrigin();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexusdash",
-  "version": "0.37.1",
+  "version": "0.37.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nexusdash",
-      "version": "0.37.1",
+      "version": "0.37.2",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1079.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nexusdash",
-  "version": "0.37.1",
+  "version": "0.37.2",
   "private": true,
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24.0.0",

--- a/project.md
+++ b/project.md
@@ -105,8 +105,9 @@ Source of truth: [`prisma/schema.prisma`](./prisma/schema.prisma)
 - `npm run dev` and `npm run start` run `prisma migrate deploy` before app startup.
 - Runtime config is validated at server startup via `validateServerRuntimeConfig()`.
 - Supabase-backed Vercel Preview and Production runtimes are pinned to an
-  environment-scoped expected project ref; preview auth origins use the
-  immutable Vercel deployment host rather than a static alias.
+  environment-scoped expected project ref. Preview accepts its immutable
+  deployment origin plus one explicit stable OAuth alias; arbitrary aliases
+  fail closed.
 - CI quality gates:
   - `Quality Core`
   - `E2E Smoke`
@@ -117,7 +118,8 @@ Source of truth: [`prisma/schema.prisma`](./prisma/schema.prisma)
   - staged production deploy
   - manual preview deploy
     - verifies immutable Preview target, revision/environment metadata, and
-      database readiness before publishing its URL artifact
+      database readiness before assigning and verifying the stable OAuth alias
+      and publishing both URLs
   - promote
   - rollback
 

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -6,6 +6,11 @@ Last reviewed: 2026-08-24
 
 ## Pending
 ### Active Runtime Remediation
+- ID: TASK-406
+  Title: Stable Preview OAuth alias after immutable deployment validation
+  Status: In progress
+  Rationale: Keep immutable Vercel URLs as deployment evidence while assigning the provider-registered static Preview alias only after the requested deployment passes target, revision, environment, and database checks. Allow only that configured alias for Preview OAuth callbacks so GitHub and Google sign-in remain usable without trusting arbitrary aliases.
+  Dependencies: TASK-370
 - ID: TASK-370
   Title: Preview authentication and database isolation guardrails
   Status: Complete (2026-08-20; PR #432)

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -8,7 +8,7 @@ Last reviewed: 2026-08-24
 ### Active Runtime Remediation
 - ID: TASK-406
   Title: Stable Preview OAuth alias after immutable deployment validation
-  Status: In progress
+  Status: In review; deployed for user OAuth testing (PR #448)
   Rationale: Keep immutable Vercel URLs as deployment evidence while assigning the provider-registered static Preview alias only after the requested deployment passes target, revision, environment, and database checks. Allow only that configured alias for Preview OAuth callbacks so GitHub and Google sign-in remain usable without trusting arbitrary aliases.
   Dependencies: TASK-370
 - ID: TASK-370

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -4,7 +4,7 @@
 
 ## Status
 
-In progress on `fix/task-406-stable-preview-auth-alias`.
+Ready for user testing on `fix/task-406-stable-preview-auth-alias` via PR #448.
 
 ## Context
 
@@ -66,4 +66,13 @@ therefore remain usable without weakening the immutable deployment checks.
 
 ## Validation Evidence
 
-- Pending branch deployment and user-owned OAuth smoke validation.
+- Workflow run `32843605455` deployed commit `8df7e1c`, validated immutable
+  Preview URL
+  `https://nexus-dash-7ykoau18s-dorian-agaesses-projects.vercel.app`, then
+  assigned and verified the stable Preview auth alias.
+- Both URLs report `APP_ENV=preview`, revision `8df7e1c`, database ready, and
+  the same Vercel deployment identity.
+- GitHub and Google authorization initiation from the stable alias generate
+  callbacks on that alias. GitHub accepted the callback and continued to its
+  login flow instead of showing the unassociated `redirect_uri` warning.
+- User-owned completion of the signed-in OAuth flow is pending before merge.

--- a/tasks/current.md
+++ b/tasks/current.md
@@ -1,62 +1,55 @@
 # Current Task
 
-## TASK-370: Preview Authentication and Database Isolation Guardrails
+## TASK-406: Stable Preview OAuth Alias After Immutable Validation
 
 ## Status
 
-Complete on `fix/task-370-preview-auth-isolation`; validated on the immutable
-Vercel Preview deployment and delivered through PR #432.
+In progress on `fix/task-406-stable-preview-auth-alias`.
 
 ## Context
 
-Authentication from a URL believed to be a preview reached production and a
-signup reported an email already present in the production user database.
-Investigation confirmed that the tested Vercel alias currently targets a
-production deployment. The Vercel Preview environment also retained that alias
-as `NEXTAUTH_URL`, so preview auth callbacks and generated links could select a
-stale production origin even when the immutable deployment itself was a real
-preview. Preview and production currently use distinct Supabase project refs,
-but the deployment contract does not pin either environment to its intended
-ref or verify the deployed target before publishing the preview URL.
+TASK-370 correctly removed a stale alias that pointed to production and made
+immutable deployment validation authoritative. The follow-up Preview test
+showed that social OAuth cannot use a new immutable callback for every deploy:
+GitHub rejected the generated `redirect_uri` because the provider application
+is registered against the long-lived static Preview URL. The static URL must
+therefore remain usable without weakening the immutable deployment checks.
 
 ## Scope
 
-- Resolve request origins from the current immutable Vercel deployment host in
-  preview instead of using a static `NEXTAUTH_URL`.
-- Pin production-like runtimes to an explicitly configured expected Supabase
-  project ref and reject cross-environment database routing at startup.
-- Validate the preview migration target, Vercel deployment target, deployed
-  environment/revision metadata, and database readiness before uploading the
-  preview URL artifact.
-- Remove stale Vercel Preview origin/redirect overrides (`NEXTAUTH_URL` and
-  OAuth callback URLs) and configure expected project-ref metadata for Preview
-  and Production.
-- Exercise signup/signin on the fixed preview without touching production.
+- Add one exact `PREVIEW_AUTH_ORIGIN` allowlist entry for Preview request-origin
+  resolution while preserving the immutable `VERCEL_URL` fallback.
+- Require a valid HTTPS `PREVIEW_AUTH_ORIGIN` whenever social or Calendar OAuth
+  is enabled in Vercel Preview.
+- Validate the immutable deployment first, then atomically assign the stable
+  alias and verify it resolves to the same deployment and readiness metadata.
+- Document which URL is deployment evidence and which URL testers should use
+  for provider-backed OAuth.
 
 ## Acceptance Criteria
 
-1. A preview request resolves auth callback/link origins to that preview's
-   immutable `VERCEL_URL`, never the production domain or a stale alias.
-2. Preview and production fail closed when their runtime Supabase project ref
-   does not match `EXPECTED_SUPABASE_PROJECT_REF`.
-3. The preview deploy workflow rejects a non-preview Vercel target, a revision
-   mismatch, an environment mismatch, an unreachable database, or a migration
-   connection aimed at the wrong Supabase project.
-4. The workflow artifact contains the immutable URL of the exact requested
-   branch deployment only after all preview checks pass.
-5. A new account can sign up and sign back in on the fixed preview while the
-   browser remains on the preview origin.
-6. Existing production routing and trusted-origin behavior remain unchanged.
+1. A request through the exact configured stable Preview alias generates
+   callbacks on that alias; any unconfigured alias falls back to the immutable
+   `VERCEL_URL`.
+2. Preview startup fails closed when OAuth is enabled without a valid exact
+   HTTPS `PREVIEW_AUTH_ORIGIN`.
+3. The deploy workflow never moves the stable alias until the immutable target,
+   revision, environment, migration project ref, and database readiness pass.
+4. After assignment, the workflow proves the alias resolves to that same Vercel
+   deployment and repeats environment/revision/database readiness checks.
+5. GitHub OAuth initiation from the stable Preview URL is accepted by GitHub
+   and does not redirect to the production domain.
+6. Existing production routing and TASK-370 database isolation remain unchanged.
 
 ## Definition Of Done
 
-- Focused origin, runtime-environment, health-route, and deploy-validation
-  coverage passes.
+- Focused request-origin and runtime-environment coverage passes.
 - `npm run lint`, `npm run rls:check`, `npm test`, `npm run test:coverage`,
-  `npm run build`, and relevant deployed-preview Playwright checks pass.
-- Vercel/GitHub environment metadata is configured without exposing secrets.
+  and `npm run build` pass.
+- GitHub Preview environment metadata contains `PREVIEW_AUTH_ORIGIN` without
+  exposing credentials.
 - The branch preview workflow completes for the explicit branch ref and its
-  logs prove the checked-out ref and validated Preview target.
+  logs prove the checked-out ref, validated immutable target, and alias target.
 - A ready-for-review PR is open; required checks and initial Copilot review are
   complete; actionable threads are resolved before merge.
 - `tasks/current.md`, `tasks/backlog.md`, relevant runbooks, and `journal.md`
@@ -64,21 +57,13 @@ ref or verify the deployed target before publishing the preview URL.
 
 ## Runtime Assumptions
 
-- Preview and production remain separate Supabase projects; their project refs
-  are safe non-secret deployment metadata while connection strings stay secret.
-- GitHub `preview` and `production` environments and the corresponding Vercel
-  environments are available to configure `EXPECTED_SUPABASE_PROJECT_REF`.
-- Preview validation uses the immutable URL emitted by `deploy-vercel.yml`, not
-  a branch alias or a historical Vercel URL.
+- The existing static Preview alias is registered in the Preview GitHub and
+  Google OAuth applications.
+- The alias may move only through the Preview deployment workflow after the
+  immutable deployment passes all existing TASK-370 checks.
+- `PREVIEW_AUTH_ORIGIN` is non-secret environment metadata; OAuth client secrets
+  and database connection strings remain secret.
 
 ## Validation Evidence
 
-- Workflow run `32313383142` checked out the explicit fix branch, applied
-  staging migrations, verified Preview target/revision/environment/database
-  readiness, and published
-  `https://nexus-dash-h1s18isxe-dorian-agaesses-projects.vercel.app`.
-- The deployed opt-in Playwright case created a staging account, signed out,
-  signed back in, and remained on that immutable origin.
-- Lint, RLS inventory, unit/API, coverage, build, and CI Playwright validation
-  passed. Copilot's initial review completed; its environment-restoration
-  comment was applied and covered by the focused request-origin test.
+- Pending branch deployment and user-owned OAuth smoke validation.

--- a/tasks/task-406-stable-preview-auth-alias.md
+++ b/tasks/task-406-stable-preview-auth-alias.md
@@ -1,0 +1,23 @@
+# TASK-406: Stable Preview OAuth Alias After Immutable Validation
+
+## Problem
+
+Immutable Vercel deployment URLs are the correct evidence for the exact branch
+and revision under test, but GitHub and Google OAuth applications cannot be
+updated for every generated deployment hostname. The provider-registered static
+Preview URL therefore needs to follow the current validated deployment without
+becoming an unchecked route to production or a stale revision.
+
+## Delivery Contract
+
+- `PREVIEW_AUTH_ORIGIN` names the one stable HTTPS Preview alias accepted for
+  provider-backed OAuth; arbitrary aliases remain untrusted.
+- The immutable deployment must pass project, target, revision, environment,
+  migration-project, and database-readiness validation before the alias moves.
+- After assignment, the workflow proves the alias resolves to the same Vercel
+  deployment and repeats readiness validation through the alias.
+- Testers use the immutable URL as deployment evidence and the stable URL for
+  GitHub/Google OAuth flows.
+
+See `tasks/current.md` for acceptance criteria, definition of done, and runtime
+assumptions.

--- a/tests/lib/env.server.test.ts
+++ b/tests/lib/env.server.test.ts
@@ -23,6 +23,7 @@ const ENV_KEYS_TO_RESET = [
   "NODE_ENV",
   "VERCEL_ENV",
   "VERCEL_URL",
+  "PREVIEW_AUTH_ORIGIN",
   "DATABASE_URL",
   "DIRECT_URL",
   "SUPABASE_URL",
@@ -876,10 +877,11 @@ describe("env.server", () => {
     );
   });
 
-  test("allows runtime-derived OAuth redirects in Vercel preview", () => {
+  test("allows configured stable OAuth redirects in Vercel preview", () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("VERCEL_ENV", "preview");
     vi.stubEnv("VERCEL_URL", "nexus-dash-immutable.example.vercel.app");
+    vi.stubEnv("PREVIEW_AUTH_ORIGIN", "https://preview.example.vercel.app");
     vi.stubEnv("DATABASE_URL", "postgresql://localhost:5432/postgres");
     vi.stubEnv("DIRECT_URL", "postgresql://localhost:5433/postgres");
     vi.stubEnv("AUTH_GOOGLE_CLIENT_ID", "client-id");
@@ -890,6 +892,30 @@ describe("env.server", () => {
     vi.stubEnv("TRUSTED_ORIGINS", "");
 
     expect(() => validateServerRuntimeConfig()).not.toThrow();
+  });
+
+  test("requires a stable preview auth origin when OAuth providers are enabled", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("VERCEL_ENV", "preview");
+    vi.stubEnv("VERCEL_URL", "nexus-dash-immutable.example.vercel.app");
+    vi.stubEnv("DATABASE_URL", "postgresql://localhost:5432/postgres");
+    vi.stubEnv("DIRECT_URL", "postgresql://localhost:5433/postgres");
+    vi.stubEnv("AUTH_GITHUB_CLIENT_ID", "client-id");
+    vi.stubEnv("AUTH_GITHUB_CLIENT_SECRET", "client-secret");
+
+    expect(() => validateServerRuntimeConfig()).toThrow(
+      "PREVIEW_AUTH_ORIGIN is required in Vercel Preview when OAuth providers are enabled."
+    );
+  });
+
+  test("rejects a preview auth origin that is not an exact HTTPS origin", () => {
+    vi.stubEnv("DATABASE_URL", "postgresql://localhost:5432/postgres");
+    vi.stubEnv("DIRECT_URL", "postgresql://localhost:5433/postgres");
+    vi.stubEnv("PREVIEW_AUTH_ORIGIN", "https://preview.example.vercel.app/");
+
+    expect(() => validateServerRuntimeConfig()).toThrow(
+      "PREVIEW_AUTH_ORIGIN must be an HTTPS origin without a path, query, or trailing slash."
+    );
   });
 
   test("passes Vercel preview validation for the expected Supabase project", () => {

--- a/tests/lib/request-origin.test.ts
+++ b/tests/lib/request-origin.test.ts
@@ -24,6 +24,7 @@ describe("request-origin", () => {
   const originalNodeEnv = process.env.NODE_ENV;
   const originalVercelEnv = process.env.VERCEL_ENV;
   const originalVercelUrl = process.env.VERCEL_URL;
+  const originalPreviewAuthOrigin = process.env.PREVIEW_AUTH_ORIGIN;
   const originalNextAuthUrl = process.env.NEXTAUTH_URL;
   const originalTrustedOrigins = process.env.TRUSTED_ORIGINS;
 
@@ -31,6 +32,7 @@ describe("request-origin", () => {
     process.env.NODE_ENV = "test";
     delete process.env.VERCEL_ENV;
     delete process.env.VERCEL_URL;
+    delete process.env.PREVIEW_AUTH_ORIGIN;
     delete process.env.NEXTAUTH_URL;
     delete process.env.TRUSTED_ORIGINS;
   });
@@ -39,6 +41,7 @@ describe("request-origin", () => {
     restoreEnvironmentVariable("NODE_ENV", originalNodeEnv);
     restoreEnvironmentVariable("VERCEL_ENV", originalVercelEnv);
     restoreEnvironmentVariable("VERCEL_URL", originalVercelUrl);
+    restoreEnvironmentVariable("PREVIEW_AUTH_ORIGIN", originalPreviewAuthOrigin);
     restoreEnvironmentVariable("NEXTAUTH_URL", originalNextAuthUrl);
     restoreEnvironmentVariable("TRUSTED_ORIGINS", originalTrustedOrigins);
   });
@@ -113,6 +116,68 @@ describe("request-origin", () => {
         "x-forwarded-proto": "https",
         "x-forwarded-host":
           "nexus-dash-stale-dorian-agaesses-projects.vercel.app",
+      })
+    );
+
+    expect(origin).toBe(
+      "https://nexus-dash-immutable-dorian-agaesses-projects.vercel.app"
+    );
+  });
+
+  test("uses the configured stable auth origin when a preview request arrives through it", () => {
+    process.env.NODE_ENV = "production";
+    process.env.VERCEL_ENV = "preview";
+    process.env.VERCEL_URL =
+      "nexus-dash-immutable-dorian-agaesses-projects.vercel.app";
+    process.env.PREVIEW_AUTH_ORIGIN =
+      "https://nexus-dash-preview-dorian-agaesses-projects.vercel.app";
+
+    const origin = resolveRequestOriginFromHeaders(
+      new TestHeaders({
+        "x-forwarded-proto": "https",
+        "x-forwarded-host":
+          "nexus-dash-preview-dorian-agaesses-projects.vercel.app",
+      })
+    );
+
+    expect(origin).toBe(
+      "https://nexus-dash-preview-dorian-agaesses-projects.vercel.app"
+    );
+  });
+
+  test("does not trust an unconfigured preview alias", () => {
+    process.env.NODE_ENV = "production";
+    process.env.VERCEL_ENV = "preview";
+    process.env.VERCEL_URL =
+      "nexus-dash-immutable-dorian-agaesses-projects.vercel.app";
+    process.env.PREVIEW_AUTH_ORIGIN =
+      "https://nexus-dash-preview-dorian-agaesses-projects.vercel.app";
+
+    const origin = resolveRequestOriginFromHeaders(
+      new TestHeaders({
+        "x-forwarded-proto": "https",
+        "x-forwarded-host": "attacker-preview.example.com",
+      })
+    );
+
+    expect(origin).toBe(
+      "https://nexus-dash-immutable-dorian-agaesses-projects.vercel.app"
+    );
+  });
+
+  test("does not trust a malformed configured preview auth origin", () => {
+    process.env.NODE_ENV = "production";
+    process.env.VERCEL_ENV = "preview";
+    process.env.VERCEL_URL =
+      "nexus-dash-immutable-dorian-agaesses-projects.vercel.app";
+    process.env.PREVIEW_AUTH_ORIGIN =
+      "https://nexus-dash-preview-dorian-agaesses-projects.vercel.app/";
+
+    const origin = resolveRequestOriginFromHeaders(
+      new TestHeaders({
+        "x-forwarded-proto": "https",
+        "x-forwarded-host":
+          "nexus-dash-preview-dorian-agaesses-projects.vercel.app",
       })
     );
 


### PR DESCRIPTION
## Summary

- allow one exact configured stable Preview origin for OAuth while retaining the immutable deployment origin
- validate the immutable Preview first, then assign and verify the provider-registered static alias
- require and document PREVIEW_AUTH_ORIGIN for Preview OAuth

## Root cause

GitHub rejects the per-deployment immutable callback because the Preview OAuth application is registered against the long-lived static test URL. TASK-370 correctly removed the stale production alias, but immutable callback URLs alone cannot support the provider registration model.

## Validation

- npm run lint
- npm run rls:check
- npm test (1,052 passed, 2 skipped)
- npm run test:coverage (91.37% statements, 81.33% branches, 92.2% functions, 91.88% lines)
- npm run build
- npm run release:check
- workflow YAML parse

## Testing contract

The immutable URL remains deployment evidence. The workflow moves the stable Preview auth alias only after immutable target/revision/environment/database checks pass, verifies both URLs resolve to the same deployment, then publishes both for testing.